### PR TITLE
chore: prepare repository for public release

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "har": {
-      "command": "har",
-      "args": ["mcp", "--repo", "/home/antoine/Documents/assistants/har-project"]
-    }
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ control/node_modules/
 control/.next/
 control/.env
 .cursor/mcp.json
+.har/runs/
+.har/validations/
+.har/slots/
+.env.agent.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Commit prefixes map to bumps via [Conventional Commits](https://www.conventional
 
 ## [Unreleased]
 
+### Changed
+
+- Public license is **AGPL-3.0-only** with dual-licensing docs (CLA, commercial license, trademark policy)
+- GitHub home moved to [antoineFrau/har](https://github.com/antoineFrau/har)
+
 ## [0.1.0] - 2026-07-02
 
 First public npm release of `@dotharness/cli`.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ HAR does not own the coding LLM and does not replace CI/CD. It gives agents a st
 
 ## Install
 
-**From npm** (end users):
+**From npm** (after the first GitHub Release — `@dotharness/cli` is not on npm yet):
 
 ```bash
 npm install -g @dotharness/cli
 ```
 
-**From source** (local development):
+**From source** (recommended until the first release):
 
 ```bash
 git clone https://github.com/antoineFrau/har har-project && cd har-project


### PR DESCRIPTION
## Summary
- Remove tracked `.cursor/mcp.json` (contained a local filesystem path)
- Ignore `.har/runs/`, `.har/validations/`, `.har/slots/`, and `.env.agent.*`
- Clarify README: `@dotharness/cli` is not on npm until the first GitHub Release
- Document AGPL dual-licensing move in CHANGELOG

## Test plan
- [x] No secrets in staged diff
- [x] Repo is now public on GitHub

Made with [Cursor](https://cursor.com)