### PR TITLE
fix(verify): use portable millisecond clock on macOS/BSD

### DIFF
--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# Portable millisecond clock (GNU date %N is unavailable on macOS/BSD).
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0
+}
+
 # JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
 escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -37,7 +37,7 @@ WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE" "$AGENT_ID")"
 echo "==> Verifying agent ${AGENT_ID} in ${WORK_DIR}..." >&2
 
 OVERALL_PASS=true
-START_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+START_TOTAL=$(now_ms)
 RESULTS_JSON="[]"
 
 run_step() {
@@ -46,14 +46,14 @@ run_step() {
   local start end elapsed exit_code output
 
   printf "  → %-40s" "$name..." >&2
-  start=$(date +%s%3N 2>/dev/null || echo "0")
+  start=$(now_ms)
 
   set +e
   output=$(cd "$WORK_DIR" && eval "$cmd" 2>&1)
   exit_code=$?
   set -e
 
-  end=$(date +%s%3N 2>/dev/null || echo "0")
+  end=$(now_ms)
   elapsed=$(( end - start ))
 
   local pass_bool step_output_escaped
@@ -91,7 +91,7 @@ if [ -n "$FULL" ]; then
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi
 
-END_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+END_TOTAL=$(now_ms)
 TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
 
 node -e "

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# Portable millisecond clock (GNU date %N is unavailable on macOS/BSD).
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0
+}
+
 # JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
 escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -40,7 +40,7 @@ API_PORT="${API_PORT:-$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))}"
 echo "==> Verifying agent ${AGENT_ID} (work dir: ${WORK_DIR})..." >&2
 
 OVERALL_PASS=true
-START_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+START_TOTAL=$(now_ms)
 RESULTS_JSON="[]"
 
 run_step() {
@@ -49,14 +49,14 @@ run_step() {
   local start end elapsed exit_code output
 
   printf "  → %-40s" "$name..." >&2
-  start=$(date +%s%3N 2>/dev/null || echo "0")
+  start=$(now_ms)
 
   set +e
   output=$(cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$cmd" 2>&1)
   exit_code=$?
   set -e
 
-  end=$(date +%s%3N 2>/dev/null || echo "0")
+  end=$(now_ms)
   elapsed=$(( end - start ))
 
   local pass_bool step_output_escaped
@@ -90,14 +90,14 @@ run_http_step() {
   local start end elapsed exit_code output
 
   printf "  → %-40s" "$name..." >&2
-  start=$(date +%s%3N 2>/dev/null || echo "0")
+  start=$(now_ms)
 
   set +e
   output=$(curl -sf "$url" 2>&1)
   exit_code=$?
   set -e
 
-  end=$(date +%s%3N 2>/dev/null || echo "0")
+  end=$(now_ms)
   elapsed=$(( end - start ))
 
   local pass_bool step_output_escaped
@@ -138,7 +138,7 @@ fi
 
 # ── Output results ────────────────────────────────────────────────────────────
 
-END_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+END_TOTAL=$(now_ms)
 TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
 
 node -e "

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# Portable millisecond clock (GNU date %N is unavailable on macOS/BSD).
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0
+}
+
 # JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
 escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -37,7 +37,7 @@ WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
 echo "==> Verifying agent ${AGENT_ID} in ${WORK_DIR}..." >&2
 
 OVERALL_PASS=true
-START_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+START_TOTAL=$(now_ms)
 RESULTS_JSON="[]"
 
 run_step() {
@@ -46,14 +46,14 @@ run_step() {
   local start end elapsed exit_code output
 
   printf "  → %-40s" "$name..." >&2
-  start=$(date +%s%3N 2>/dev/null || echo "0")
+  start=$(now_ms)
 
   set +e
   output=$(cd "$WORK_DIR" && eval "$cmd" 2>&1)
   exit_code=$?
   set -e
 
-  end=$(date +%s%3N 2>/dev/null || echo "0")
+  end=$(now_ms)
   elapsed=$(( end - start ))
 
   local pass_bool step_output_escaped
@@ -91,7 +91,7 @@ if [ -n "$FULL" ]; then
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi
 
-END_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+END_TOTAL=$(now_ms)
 TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
 
 node -e "

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# Portable millisecond clock (GNU date %N is unavailable on macOS/BSD).
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0
+}
+
 # JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
 escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -62,7 +62,7 @@ XC_DESTINATION="${HARNESS_IOS_DESTINATION:-platform=iOS Simulator,name=iPhone 16
 XC_DERIVED="${WORK_DIR}/build/DerivedData"
 
 OVERALL_PASS=true
-START_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+START_TOTAL=$(now_ms)
 RESULTS_JSON="[]"
 
 run_step() {
@@ -71,14 +71,14 @@ run_step() {
   local start end elapsed exit_code output
 
   printf "  → %-40s" "$name..." >&2
-  start=$(date +%s%3N 2>/dev/null || echo "0")
+  start=$(now_ms)
 
   set +e
   output=$(cd "$WORK_DIR" && eval "$cmd" 2>&1)
   exit_code=$?
   set -e
 
-  end=$(date +%s%3N 2>/dev/null || echo "0")
+  end=$(now_ms)
   elapsed=$(( end - start ))
 
   local pass_bool step_output_escaped
@@ -143,7 +143,7 @@ if [ -n "$FULL" ]; then
   run_rocketsim_flows_if_present "$SCRIPT_DIR" "$AGENT_ID" || true
 fi
 
-END_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+END_TOTAL=$(now_ms)
 TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
 
 node -e "

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# Portable millisecond clock (GNU date %N is unavailable on macOS/BSD).
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0
+}
+
 # JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
 escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -40,7 +40,7 @@ API_PORT="${API_PORT:-$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))}"
 echo "==> Verifying agent ${AGENT_ID} (work dir: ${WORK_DIR})..." >&2
 
 OVERALL_PASS=true
-START_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+START_TOTAL=$(now_ms)
 RESULTS_JSON="[]"
 
 run_step() {
@@ -49,14 +49,14 @@ run_step() {
   local start end elapsed exit_code output
 
   printf "  → %-40s" "$name..." >&2
-  start=$(date +%s%3N 2>/dev/null || echo "0")
+  start=$(now_ms)
 
   set +e
   output=$(cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$cmd" 2>&1)
   exit_code=$?
   set -e
 
-  end=$(date +%s%3N 2>/dev/null || echo "0")
+  end=$(now_ms)
   elapsed=$(( end - start ))
 
   local pass_bool step_output_escaped
@@ -90,14 +90,14 @@ run_http_step() {
   local start end elapsed exit_code output
 
   printf "  → %-40s" "$name..." >&2
-  start=$(date +%s%3N 2>/dev/null || echo "0")
+  start=$(now_ms)
 
   set +e
   output=$(curl -sf "$url" 2>&1)
   exit_code=$?
   set -e
 
-  end=$(date +%s%3N 2>/dev/null || echo "0")
+  end=$(now_ms)
   elapsed=$(( end - start ))
 
   local pass_bool step_output_escaped
@@ -139,7 +139,7 @@ fi
 
 # ── Output results ────────────────────────────────────────────────────────────
 
-END_TOTAL=$(date +%s%3N 2>/dev/null || echo "0")
+END_TOTAL=$(now_ms)
 TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
 
 node -e "

--- a/tests/verify-shell-timing.test.ts
+++ b/tests/verify-shell-timing.test.ts
@@ -5,7 +5,11 @@ import { execSync } from 'child_process';
 const AGENT_SLOT = path.join(__dirname, '..', '.har', 'agent-slot.sh');
 
 function sh(command: string): string {
-  return execSync(command, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  return execSync(command, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    shell: '/bin/bash',
+  }).trim();
 }
 
 describe('verify.sh portable timing', () => {

--- a/tests/verify-shell-timing.test.ts
+++ b/tests/verify-shell-timing.test.ts
@@ -1,0 +1,31 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const AGENT_SLOT = path.join(__dirname, '..', '.har', 'agent-slot.sh');
+
+function sh(command: string): string {
+  return execSync(command, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+}
+
+describe('verify.sh portable timing', () => {
+  it('now_ms returns a numeric millisecond timestamp', () => {
+    const out = sh(`source "${AGENT_SLOT}" && now_ms`);
+    expect(out).toMatch(/^\d+$/);
+    expect(Number(out)).toBeGreaterThan(0);
+  });
+
+  const verifyPaths = [
+    '.har/verify.sh',
+    'control/.har/verify.sh',
+    'src/templates/har-boilerplate/verify.sh',
+    'src/templates/har-boilerplate-cli/verify.sh',
+    'src/templates/har-boilerplate-ios/verify.sh',
+  ];
+
+  it.each(verifyPaths)('%s uses now_ms instead of GNU date', (relPath) => {
+    const verifyScript = fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8');
+    expect(verifyScript).toContain('$(now_ms)');
+    expect(verifyScript).not.toContain('date +%s%3N');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `now_ms()` to `agent-slot.sh` using Node's `Date.now()` instead of GNU-only `date +%s%3N`
- Update all shipped `verify.sh` templates and repo harness copies to use `$(now_ms)` for step and total timing
- Add regression tests in `tests/verify-shell-timing.test.ts`

Fixes #12

## Problem

On macOS/BSD, `date +%s%3N` emits a literal `N` suffix while still exiting 0, so bash arithmetic in `verify.sh` fails and the script breaks out of the box.

## Test plan

- [x] `npm test -- tests/verify-shell-timing.test.ts`
- [x] `npm ci && npm run build && node dist/index.js env launch 1 && node dist/index.js env verify 1 --full` (matches CI)