### PR TITLE
fix(verify): keep failed steps when output exceeds 50 lines

### DIFF
--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
 # Run browser-e2e on verify --full when the Playwright stage template is installed.
 run_browser_e2e_if_present() {
   local script_dir="$1"

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -67,9 +67,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(echo "$output" | head -50 | \
-    node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d.trim())))" \
-    2>/dev/null || echo '""')
+  step_output_escaped=$(escape_step_output "$output")
 
   RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
 const fs = require('fs');

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
 # Run browser-e2e on verify --full when the Playwright stage template is installed.
 run_browser_e2e_if_present() {
   local script_dir="$1"

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -70,9 +70,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(echo "$output" | head -50 | \
-    node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d.trim())))" \
-    2>/dev/null || echo '""')
+  step_output_escaped=$(escape_step_output "$output")
 
   RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
 const fs = require('fs');
@@ -112,9 +110,7 @@ run_http_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(echo "$output" | head -50 | \
-    node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d.trim())))" \
-    2>/dev/null || echo '""')
+  step_output_escaped=$(escape_step_output "$output")
 
   RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
 const fs = require('fs');

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
 # Run browser-e2e on verify --full when the Playwright stage template is installed.
 run_browser_e2e_if_present() {
   local script_dir="$1"

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -67,9 +67,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(echo "$output" | head -50 | \
-    node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d.trim())))" \
-    2>/dev/null || echo '""')
+  step_output_escaped=$(escape_step_output "$output")
 
   RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
 const fs = require('fs');

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
 # Run browser-e2e on verify --full when the Playwright stage template is installed.
 run_browser_e2e_if_present() {
   local script_dir="$1"

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -92,9 +92,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(echo "$output" | head -50 | \
-    node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d.trim())))" \
-    2>/dev/null || echo '""')
+  step_output_escaped=$(escape_step_output "$output")
 
   RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
 const fs = require('fs');

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -259,6 +259,11 @@ resolve_agent_work_dir() {
   echo "$work_dir"
 }
 
+# JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
 # Run browser-e2e on verify --full when the Playwright stage template is installed.
 run_browser_e2e_if_present() {
   local script_dir="$1"

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -70,9 +70,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(echo "$output" | head -50 | \
-    node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d.trim())))" \
-    2>/dev/null || echo '""')
+  step_output_escaped=$(escape_step_output "$output")
 
   RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
 const fs = require('fs');
@@ -112,9 +110,7 @@ run_http_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(echo "$output" | head -50 | \
-    node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>process.stdout.write(JSON.stringify(d.trim())))" \
-    2>/dev/null || echo '""')
+  step_output_escaped=$(escape_step_output "$output")
 
   RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
 const fs = require('fs');

--- a/tests/verify-shell-output.test.ts
+++ b/tests/verify-shell-output.test.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const AGENT_SLOT = path.join(__dirname, '..', '.har', 'agent-slot.sh');
+
+function sh(command: string, cwd?: string): string {
+  return execSync(command, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+}
+
+describe('verify.sh step output escaping', () => {
+  it('escape_step_output retains failed steps with >50 lines of output', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-verify-shell-'));
+    const script = path.join(dir, 'repro.sh');
+    fs.writeFileSync(
+      script,
+      `#!/usr/bin/env bash
+set -euo pipefail
+source "${AGENT_SLOT}"
+RESULTS_JSON='[{"name":"a","pass":true,"ms":1,"output":""}]'
+output="$(seq 1 100)"
+name="b"
+pass_bool="false"
+elapsed="1"
+step_output_escaped=$(escape_step_output "$output")
+RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
+const fs=require('fs');
+let arr=JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
+process.stdout.write(JSON.stringify(arr));")
+node -e "const r=$RESULTS_JSON;process.stdout.write(String(r.length)+':'+r.every(x=>x.pass))"
+`,
+    );
+    fs.chmodSync(script, 0o755);
+    const out = sh(`bash "${script}"`, dir);
+    expect(out).toBe('2:false');
+  });
+
+  const verifyPaths = [
+    '.har/verify.sh',
+    'control/.har/verify.sh',
+    'src/templates/har-boilerplate/verify.sh',
+    'src/templates/har-boilerplate-cli/verify.sh',
+    'src/templates/har-boilerplate-ios/verify.sh',
+  ];
+
+  it.each(verifyPaths)('%s escapes output without head -50 pipefail trap', (relPath) => {
+    const verifyScript = fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8');
+    expect(verifyScript).toContain('escape_step_output "$output"');
+    expect(verifyScript).not.toMatch(/step_output_escaped=\$\(echo "\$output" \| head -50/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `escape_step_output()` to `agent-slot.sh` to JSON-escape and truncate step output inside Node
- Replace the `head -50 | node` pipeline in all shipped `verify.sh` copies
- Add regression tests in `tests/verify-shell-output.test.ts`

Fixes #13

## Problem

When a gated step fails with more than 50 lines of output, `head -50` closes the pipe early. Under `set -o pipefail`, the pipeline exits non-zero even though Node already produced valid JSON, the fallback appends `""`, and the failed step is dropped from results while the run is reported as pass.

## Test plan

- [x] `npm test -- tests/verify-shell-output.test.ts`
- [x] Reproduced the issue #13 scenario (>50 lines, failed step) and confirmed the failure is retained
- [x] Verified all `verify.sh` copies use `escape_step_output "$output"` instead of `head -50`

Made with [Cursor](https://cursor.com)