### PR TITLE
feat(harness): slot resilience and readiness vs liveness

### DIFF
--- a/.har/CLAUDE.agent.md
+++ b/.har/CLAUDE.agent.md
@@ -48,6 +48,10 @@ har env verify ${AGENT_ID} --full
 ./.har/verify.sh ${AGENT_ID} --full
 ```
 
+Full verify also runs `HARNESS_READINESS_CMD` when configured. This CLI harness
+does not need a runtime usability smoke today, so the readiness step skips by
+default.
+
 ## Definition of Done
 
 - [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)

--- a/.har/README.md
+++ b/.har/README.md
@@ -60,7 +60,7 @@ Use `har env launch 1 --no-worktree` or `./.har/launch.sh 1 --no-worktree` only 
 | Mode | Command | Typical steps |
 |------|---------|---------------|
 | Quick | `har env verify <id>` or `verify.sh <id>` | typecheck, build, unit tests |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint, **browser-e2e** when `stages/browser-e2e.sh` exists |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint, optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
 
 ## Run history
 

--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -50,7 +50,8 @@ try {
 # Writes the registry entry from SLOT_* variables:
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
-#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON, SLOT_PURPOSE
+#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -65,7 +66,7 @@ const entry = {
   mode: e.SLOT_MODE,
   workDir: e.SLOT_WORK_DIR,
   createdAt: new Date().toISOString(),
-  status: "active",
+  status: e.SLOT_STATUS || "active",
 };
 if (e.SLOT_SUFFIX) entry.suffix = e.SLOT_SUFFIX;
 if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
@@ -73,6 +74,7 @@ if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
 if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
+if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
 }
@@ -115,13 +117,15 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir purpose created dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
   purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
+  status="$(read_slot_field "$reg" status || true)"
+  last_error="$(read_slot_field "$reg" lastError || true)"
   dirty_summary="$(slot_dirty_summary "$wt")"
   if [ -n "$wt" ] && [ -d "$wt" ]; then
     head="$(git -C "$wt" rev-parse --short HEAD 2>/dev/null || true)"
@@ -133,6 +137,8 @@ print_slot_replace_warning() {
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
+  [ -n "$status" ] && echo "  Status:    ${status}" >&2
+  [ -n "$last_error" ] && echo "  Error:     ${last_error}" >&2
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
@@ -182,11 +188,30 @@ require_slot_replace_confirm() {
   exit 2
 }
 
+git_common_dir() {
+  local cwd="$1"
+  local out
+  out="$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$out" in
+    /*) echo "$out" ;;
+    *) (cd "$cwd" && cd "$out" && pwd) ;;
+  esac
+}
+
+same_git_checkout() {
+  local left right
+  left="$(git_common_dir "$1" || true)"
+  right="$(git_common_dir "$2" || true)"
+  [ -n "$left" ] && [ -n "$right" ] && [ "$left" = "$right" ]
+}
+
 # Echo the previous session's worktree path for a slot: registry first, then
-# the legacy fixed path (pre-registry sessions). Empty output when none exists.
+# legacy and randomized session worktree fallbacks. Empty output when none exists.
 existing_slot_worktree() {
   local agent_id="$1"
-  local reg path
+  local reg path candidate repo_root rel_prefix
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  rel_prefix="$(git -C "$repo_root" rev-parse --show-prefix 2>/dev/null || true)"
   reg="$(slot_registry_file "$agent_id")"
   if [ -f "$reg" ]; then
     path="$(read_slot_field "$reg" worktreePath || true)"
@@ -198,12 +223,20 @@ existing_slot_worktree() {
   path="$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}"
   if [ -d "$path" ]; then
     echo "$path"
+    return 0
   fi
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*; do
+    [ -d "$candidate" ] || continue
+    same_git_checkout "$repo_root" "$candidate" || continue
+    [ -f "$candidate/${rel_prefix}.env.agent.${agent_id}" ] || continue
+    echo "$candidate"
+    return 0
+  done
   return 0
 }
 
-# Resolve .env.agent.<id> — registry work dir first, then legacy locations
-# (repo root, pre-registry fixed worktree path).
+# Resolve .env.agent.<id> — registry work dir first, then legacy and
+# randomized session worktree fallbacks.
 resolve_agent_env_file() {
   local agent_id="$1"
   local repo_root="$2"
@@ -225,6 +258,15 @@ resolve_agent_env_file() {
     "$repo_root/.env.agent.${agent_id}" \
     "$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}/${rel_prefix}.env.agent.${agent_id}"; do
     if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  local candidate_dir
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*/${rel_prefix}.env.agent."${agent_id}"; do
+    if [ -f "$candidate" ]; then
+      candidate_dir="$(cd "$(dirname "$candidate")" && pwd)"
+      same_git_checkout "$repo_root" "$candidate_dir" || continue
       echo "$candidate"
       return 0
     fi
@@ -277,4 +319,15 @@ run_browser_e2e_if_present() {
   if [ -x "$e2e" ]; then
     "$e2e" "$agent_id"
   fi
+}
+
+# Optional project-owned "agent usable" smoke beyond health.
+run_readiness_if_configured() {
+  local agent_id="$1"
+  if [ -z "${HARNESS_READINESS_CMD:-}" ]; then
+    echo "No HARNESS_READINESS_CMD configured; skipping readiness smoke."
+    return 0
+  fi
+  local cmd="${HARNESS_READINESS_CMD//\{agentId\}/$agent_id}"
+  eval "$cmd"
 }

--- a/.har/launch.sh
+++ b/.har/launch.sh
@@ -94,6 +94,46 @@ WORKTREE_DIR=${WORKTREE_DIR}
 NODE_ENV=test
 EOF
 
+REGISTRY_WRITTEN=false
+mark_slot_failed() {
+  local exit_code="$?"
+  if [ "$exit_code" != "0" ] && [ "$REGISTRY_WRITTEN" = true ]; then
+    log "Launch failed after creating the session. Recording failed slot state..."
+    set +e
+    SLOT_AGENT_ID="$AGENT_ID" \
+    SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+    SLOT_WORK_DIR="$WORK_DIR" \
+    SLOT_SUFFIX="${SUFFIX:-}" \
+    SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+    SLOT_BRANCH="${BRANCH:-}" \
+    SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+    SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+    SLOT_PURPOSE="${PURPOSE}" \
+    SLOT_STATUS="failed" \
+    SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
+      write_slot_registry
+    log "  Work dir:  ${WORK_DIR}"
+    log "  Env file:  ${ENV_FILE}"
+    log "  Recovery:  fix the failure, then relaunch with --replace when ready."
+  fi
+}
+trap mark_slot_failed EXIT
+
+# Record the session before slow or fragile setup so verify/status/teardown can
+# recover partial launches that already created a worktree and env file.
+SLOT_AGENT_ID="$AGENT_ID" \
+SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+SLOT_WORK_DIR="$WORK_DIR" \
+SLOT_SUFFIX="${SUFFIX:-}" \
+SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+SLOT_BRANCH="${BRANCH:-}" \
+SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
+SLOT_STATUS="starting" \
+  write_slot_registry
+REGISTRY_WRITTEN=true
+
 if [ -f "$WORK_DIR/package.json" ]; then
   log "Installing dependencies..."
   (cd "$WORK_DIR" && npm install --silent)
@@ -118,6 +158,7 @@ SLOT_BRANCH="${BRANCH:-}" \
 SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
 SLOT_PURPOSE="${PURPOSE}" \
+SLOT_STATUS="active" \
   write_slot_registry
 
 log "Agent $AGENT_ID is ready."

--- a/.har/stages.json
+++ b/.har/stages.json
@@ -20,7 +20,7 @@
         {
           "path": ".env.agent.{agentId}",
           "kind": "file",
-          "description": "Generated per-agent environment file"
+          "description": "Generated per-agent environment file in the session work dir"
         }
       ]
     },

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -35,6 +35,14 @@ set +a
 WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE" "$AGENT_ID")"
 
 echo "==> Verifying agent ${AGENT_ID} in ${WORK_DIR}..." >&2
+REG_FILE="$(slot_registry_file "$AGENT_ID")"
+echo "    Work dir: ${WORK_DIR}" >&2
+echo "    Env file: ${ENV_FILE}" >&2
+if [ -f "$REG_FILE" ]; then
+  echo "    Registry: ${REG_FILE}" >&2
+else
+  echo "    Registry: missing (${REG_FILE})" >&2
+fi
 
 OVERALL_PASS=true
 START_TOTAL=$(now_ms)
@@ -88,6 +96,7 @@ run_step "unit-tests" "npm test" || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
   run_step "lint" "npm run lint" || true
+  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -48,7 +48,7 @@ har env teardown 1
 ./.har/teardown.sh 1
 ```
 
-Work happens in an isolated git worktree by default (`~/worktrees/<project>-agent-<id>`). Use `har env launch 1 --no-worktree` or `./.har/launch.sh 1 --no-worktree` only when you must use the repo root checkout.
+Work happens in an isolated session worktree by default (`~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>`) recorded in `.har/slots/agent-<id>.json`. Use `har env launch 1 --no-worktree` or `./.har/launch.sh 1 --no-worktree` only when you must use the repo root checkout.
 
 See [`.har/README.md`](.har/README.md) for harness details.
 

--- a/control/.har/CLAUDE.agent.md
+++ b/control/.har/CLAUDE.agent.md
@@ -26,6 +26,7 @@ This slot runs **only the primary application** (`HARNESS_PRIMARY_APP=web`, the 
 A task is complete only when:
 
 - [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)
+- [ ] The app is agent-usable for the documented smoke workflow, not only health-check green
 - [ ] When `stages/browser-e2e.sh` exists, full verify includes Playwright — adapt specs under `tests/` for UI changes
 - [ ] New or changed UI behavior has coverage in `tests/` (unit and/or Playwright as appropriate)
 - [ ] Changes are committed **in the session worktree** with a clear message

--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -63,7 +63,7 @@ Read **`stages.json`** for registered stages and **`verificationStages`** for th
 | Mode | Command | Typical steps |
 |------|---------|---------------|
 | Quick | `har env verify <id>` or `verify.sh <id>` | typecheck, unit tests, api-health |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint + optional readiness smoke + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
 
 Install Playwright stage: `har env add-stage playwright` (optional). UI changes should add or update specs under `tests/`.
 

--- a/control/.har/agent-cli.sh
+++ b/control/.har/agent-cli.sh
@@ -56,7 +56,13 @@ process.stdin.on('end', () => {
     fi
 
     if [ "$PM2_FOUND" = true ]; then
-      :
+      REG_FILE="$(slot_registry_file "$AGENT_ID")"
+      if [ ! -f "$REG_FILE" ]; then
+        echo "Warning: slot registry missing at $REG_FILE — verify/teardown may not resolve this slot."
+      fi
+      if [ -z "$ENV_FILE" ]; then
+        echo "Warning: .env.agent.${AGENT_ID} could not be resolved — relaunch with --replace when ready."
+      fi
     elif [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
       echo "Agent ${AGENT_ID}: active (no PM2 processes)"
       # shellcheck source=/dev/null

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -50,7 +50,8 @@ try {
 # Writes the registry entry from SLOT_* variables:
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
-#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON, SLOT_PURPOSE
+#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -65,7 +66,7 @@ const entry = {
   mode: e.SLOT_MODE,
   workDir: e.SLOT_WORK_DIR,
   createdAt: new Date().toISOString(),
-  status: "active",
+  status: e.SLOT_STATUS || "active",
 };
 if (e.SLOT_SUFFIX) entry.suffix = e.SLOT_SUFFIX;
 if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
@@ -73,6 +74,7 @@ if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
 if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
+if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
 }
@@ -115,13 +117,15 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir purpose created dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
   purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
+  status="$(read_slot_field "$reg" status || true)"
+  last_error="$(read_slot_field "$reg" lastError || true)"
   dirty_summary="$(slot_dirty_summary "$wt")"
   if [ -n "$wt" ] && [ -d "$wt" ]; then
     head="$(git -C "$wt" rev-parse --short HEAD 2>/dev/null || true)"
@@ -133,6 +137,8 @@ print_slot_replace_warning() {
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
+  [ -n "$status" ] && echo "  Status:    ${status}" >&2
+  [ -n "$last_error" ] && echo "  Error:     ${last_error}" >&2
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
@@ -182,11 +188,30 @@ require_slot_replace_confirm() {
   exit 2
 }
 
+git_common_dir() {
+  local cwd="$1"
+  local out
+  out="$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$out" in
+    /*) echo "$out" ;;
+    *) (cd "$cwd" && cd "$out" && pwd) ;;
+  esac
+}
+
+same_git_checkout() {
+  local left right
+  left="$(git_common_dir "$1" || true)"
+  right="$(git_common_dir "$2" || true)"
+  [ -n "$left" ] && [ -n "$right" ] && [ "$left" = "$right" ]
+}
+
 # Echo the previous session's worktree path for a slot: registry first, then
-# the legacy fixed path (pre-registry sessions). Empty output when none exists.
+# legacy and randomized session worktree fallbacks. Empty output when none exists.
 existing_slot_worktree() {
   local agent_id="$1"
-  local reg path
+  local reg path candidate repo_root rel_prefix
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  rel_prefix="$(git -C "$repo_root" rev-parse --show-prefix 2>/dev/null || true)"
   reg="$(slot_registry_file "$agent_id")"
   if [ -f "$reg" ]; then
     path="$(read_slot_field "$reg" worktreePath || true)"
@@ -198,12 +223,20 @@ existing_slot_worktree() {
   path="$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}"
   if [ -d "$path" ]; then
     echo "$path"
+    return 0
   fi
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*; do
+    [ -d "$candidate" ] || continue
+    same_git_checkout "$repo_root" "$candidate" || continue
+    [ -f "$candidate/${rel_prefix}.env.agent.${agent_id}" ] || continue
+    echo "$candidate"
+    return 0
+  done
   return 0
 }
 
-# Resolve .env.agent.<id> — registry work dir first, then legacy locations
-# (repo root, pre-registry fixed worktree path).
+# Resolve .env.agent.<id> — registry work dir first, then legacy and
+# randomized session worktree fallbacks.
 resolve_agent_env_file() {
   local agent_id="$1"
   local repo_root="$2"
@@ -225,6 +258,15 @@ resolve_agent_env_file() {
     "$repo_root/.env.agent.${agent_id}" \
     "$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}/${rel_prefix}.env.agent.${agent_id}"; do
     if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  local candidate_dir
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*/${rel_prefix}.env.agent."${agent_id}"; do
+    if [ -f "$candidate" ]; then
+      candidate_dir="$(cd "$(dirname "$candidate")" && pwd)"
+      same_git_checkout "$repo_root" "$candidate_dir" || continue
       echo "$candidate"
       return 0
     fi
@@ -277,4 +319,15 @@ run_browser_e2e_if_present() {
   if [ -x "$e2e" ]; then
     "$e2e" "$agent_id"
   fi
+}
+
+# Optional project-owned "agent usable" smoke beyond health.
+run_readiness_if_configured() {
+  local agent_id="$1"
+  if [ -z "${HARNESS_READINESS_CMD:-}" ]; then
+    echo "No HARNESS_READINESS_CMD configured; skipping readiness smoke."
+    return 0
+  fi
+  local cmd="${HARNESS_READINESS_CMD//\{agentId\}/$agent_id}"
+  eval "$cmd"
 }

--- a/control/.har/launch.sh
+++ b/control/.har/launch.sh
@@ -154,6 +154,55 @@ REPO_ROOT="$WORK_DIR" \
   envsubst '${AGENT_ID} ${API_PORT} ${FE_PORT} ${DEBUG_PORT} ${DB_PORT} ${MINIO_PORT} ${BROWSER_PORT} ${REPO_ROOT}' \
   < "$SCRIPT_DIR/env.template" > "$ENV_FILE"
 
+REGISTRY_WRITTEN=false
+mark_slot_failed() {
+  local exit_code="$?"
+  if [ "$exit_code" != "0" ] && [ "$REGISTRY_WRITTEN" = true ]; then
+    log "Launch failed after creating the session. Recording failed slot state..."
+    set +e
+    SLOT_AGENT_ID="$AGENT_ID" \
+    SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+    SLOT_WORK_DIR="$WORK_DIR" \
+    SLOT_SUFFIX="${SUFFIX:-}" \
+    SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+    SLOT_BRANCH="${BRANCH:-}" \
+    SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+    SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+    SLOT_PURPOSE="${PURPOSE}" \
+    SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT}}" \
+    SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+    SLOT_STATUS="failed" \
+    SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
+      write_slot_registry
+    log "  Work dir:  ${WORK_DIR}"
+    log "  Env file:  ${ENV_FILE}"
+    log "  Recovery:  fix the failure, then relaunch with --replace when ready."
+  fi
+}
+trap mark_slot_failed EXIT
+
+# Record the session before slow or fragile setup so verify/status/teardown can
+# recover partial launches that already created a worktree and env file.
+SLOT_AGENT_ID="$AGENT_ID" \
+SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+SLOT_WORK_DIR="$WORK_DIR" \
+SLOT_SUFFIX="${SUFFIX:-}" \
+SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+SLOT_BRANCH="${BRANCH:-}" \
+SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
+SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT}}" \
+SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+SLOT_STATUS="starting" \
+  write_slot_registry
+REGISTRY_WRITTEN=true
+
+if [ -n "${HARNESS_DB_MINIMAL_BOOTSTRAP_CMD:-}" ]; then
+  log "Running minimal data bootstrap..."
+  (cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$HARNESS_DB_MINIMAL_BOOTSTRAP_CMD")
+fi
+
 # Generate PM2 ecosystem config
 ECOSYSTEM_FILE="$WORK_DIR/ecosystem.agent.${AGENT_ID}.config.cjs"
 log "Generating $ECOSYSTEM_FILE..."
@@ -253,6 +302,7 @@ SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
 SLOT_PURPOSE="${PURPOSE}" \
 SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT}}" \
 SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+SLOT_STATUS="active" \
   write_slot_registry
 
 # Launch Claude Code in tmux (optional)

--- a/control/.har/stages.json
+++ b/control/.har/stages.json
@@ -30,7 +30,7 @@
         {
           "path": ".env.agent.{agentId}",
           "kind": "file",
-          "description": "Generated per-agent environment file"
+          "description": "Generated per-agent environment file in the session work dir"
         }
       ]
     },

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -38,6 +38,14 @@ WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
 API_PORT="${API_PORT:-$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))}"
 
 echo "==> Verifying agent ${AGENT_ID} (work dir: ${WORK_DIR})..." >&2
+REG_FILE="$(slot_registry_file "$AGENT_ID")"
+echo "    Work dir: ${WORK_DIR}" >&2
+echo "    Env file: ${ENV_FILE}" >&2
+if [ -f "$REG_FILE" ]; then
+  echo "    Registry: ${REG_FILE}" >&2
+else
+  echo "    Registry: missing (${REG_FILE})" >&2
+fi
 
 OVERALL_PASS=true
 START_TOTAL=$(now_ms)
@@ -133,6 +141,7 @@ run_http_step "api-health" "http://localhost:${API_PORT}${HARNESS_HEALTH_CHECK_P
 
 if [ -n "$FULL" ]; then
   run_step "lint" "npm run lint" || true
+  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi
 

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -253,7 +253,8 @@ export const SlotRegistryEntrySchema = z
     purpose: z.string().optional(),
     ports: z.record(z.number()).optional(),
     previewUrls: z.record(z.string()).optional(),
-    status: z.enum(['active', 'completed']).default('active'),
+    status: z.enum(['starting', 'active', 'failed', 'completed']).default('active'),
+    lastError: z.string().optional(),
   })
   .passthrough();
 
@@ -288,6 +289,8 @@ export const AgentSlotStatusSchema = z.object({
   baseCommit: z.string().optional(),
   sessionCreatedAt: z.string().optional(),
   purpose: z.string().optional(),
+  sessionStatus: z.enum(['starting', 'active', 'failed', 'completed']).optional(),
+  lastError: z.string().optional(),
   /** Worktree checked out to no branch (legacy failure mode; should not happen with sessions). */
   detachedHead: z.boolean().optional(),
   /** Worktree has uncommitted changes. */

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'crypto';
+import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -9,6 +10,37 @@ import { readSlotRegistry } from './slot-registry';
 import { ExecutionContext } from './types';
 
 const RUNS_DIR = 'runs';
+
+function gitCommonDir(cwd: string): string | undefined {
+  try {
+    const out = execSync('git rev-parse --git-common-dir', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    return out ? path.resolve(cwd, out) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sameGitCheckout(a: string, b: string): boolean {
+  const left = gitCommonDir(a);
+  const right = gitCommonDir(b);
+  return left !== undefined && right !== undefined && left === right;
+}
+
+function gitPrefix(cwd: string): string {
+  try {
+    return execSync('git rev-parse --show-prefix', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
 
 function getRunsDir(harnessRoot: string): string {
   return path.join(getHarnessDir(harnessRoot), RUNS_DIR);
@@ -85,10 +117,23 @@ export function resolveAgentWorkDir(harnessRoot: string, agentId?: number): stri
   const env = readHarnessEnv(harnessRoot);
   const projectName = env.HARNESS_PROJECT_NAME ?? path.basename(harnessRoot);
   const worktreeDir = path.join(os.homedir(), 'worktrees', `${projectName}-agent-${agentId}`);
+  const relPrefix = gitPrefix(harnessRoot);
+  const sessionEnvFiles: string[] = [];
+  const worktreesRoot = path.join(os.homedir(), 'worktrees');
+  if (fs.existsSync(worktreesRoot)) {
+    const suffix = `-har-agent-${agentId}-`;
+    for (const entry of fs.readdirSync(worktreesRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.includes(suffix)) continue;
+      const sessionDir = path.join(worktreesRoot, entry.name);
+      if (!sameGitCheckout(harnessRoot, sessionDir)) continue;
+      sessionEnvFiles.push(path.join(sessionDir, relPrefix, `.env.agent.${agentId}`));
+    }
+  }
 
   const candidates = [
     path.join(worktreeDir, `.env.agent.${agentId}`),
     path.join(harnessRoot, `.env.agent.${agentId}`),
+    ...sessionEnvFiles.sort(),
   ];
 
   for (const envFile of candidates) {

--- a/src/core/slot-launch-guard.ts
+++ b/src/core/slot-launch-guard.ts
@@ -20,6 +20,8 @@ function formatOccupiedSlot(slot: AgentSlotStatus): string {
     slot.worktreePath ? `  Worktree: ${slot.worktreePath}` : undefined,
     slot.branch ? `  Branch:   ${slot.branch}` : undefined,
     slot.workDir ? `  Work dir: ${slot.workDir}` : undefined,
+    slot.sessionStatus ? `  Status:   ${slot.sessionStatus}` : undefined,
+    slot.lastError ? `  Error:    ${slot.lastError}` : undefined,
     slot.sessionCreatedAt ? `  Since:    ${slot.sessionCreatedAt}` : undefined,
     slot.dirty
       ? '  Git:      dirty (uncommitted changes — commit or use force to discard)'

--- a/src/core/slot-status.ts
+++ b/src/core/slot-status.ts
@@ -47,6 +47,41 @@ function readWorktreeBranch(worktreePath: string): string | undefined {
   return runGit(worktreePath, 'rev-parse --abbrev-ref HEAD');
 }
 
+function gitCommonDir(cwd: string): string | undefined {
+  const out = runGit(cwd, 'rev-parse --git-common-dir');
+  return out ? path.resolve(cwd, out) : undefined;
+}
+
+function sameGitCheckout(a: string, b: string): boolean {
+  const left = gitCommonDir(a);
+  const right = gitCommonDir(b);
+  return left !== undefined && right !== undefined && left === right;
+}
+
+function gitPrefix(cwd: string): string {
+  const out = runGit(cwd, 'rev-parse --show-prefix');
+  return out ?? '';
+}
+
+function discoverSessionWorktreePath(harnessRoot: string, agentId: number): string | undefined {
+  const worktreesRoot = path.join(os.homedir(), 'worktrees');
+  if (!fs.existsSync(worktreesRoot)) return undefined;
+
+  const suffix = `-har-agent-${agentId}-`;
+  const relPrefix = gitPrefix(harnessRoot);
+  const matches = fs
+    .readdirSync(worktreesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.includes(suffix))
+    .map((entry) => path.join(worktreesRoot, entry.name))
+    .filter(
+      (candidate) =>
+        sameGitCheckout(harnessRoot, candidate) &&
+        fs.existsSync(path.join(candidate, relPrefix, `.env.agent.${agentId}`)),
+    );
+
+  return matches.sort()[0];
+}
+
 interface WorktreeDrift {
   detachedHead?: boolean;
   dirty?: boolean;
@@ -127,8 +162,8 @@ function collectSlotStatus(
 ): AgentSlotStatus {
   const env = readHarnessEnv(harnessRoot);
   const projectName = env.HARNESS_PROJECT_NAME ?? path.basename(harnessRoot);
-  // Session registry is the source of truth; the fixed path is a legacy
-  // fallback for pre-registry sessions.
+  // Session registry is the source of truth; fallback discovery keeps partial
+  // launches recoverable when a script failed after creating the worktree/env.
   const session = readSlotRegistry(harnessRoot, agentId);
   const legacyWorktreePath = path.join(
     os.homedir(),
@@ -140,7 +175,7 @@ function collectSlotStatus(
       ? session.worktreePath
       : fs.existsSync(legacyWorktreePath)
         ? legacyWorktreePath
-        : undefined;
+        : discoverSessionWorktreePath(harnessRoot, agentId);
 
   const workDir = resolveAgentWorkDir(harnessRoot, agentId);
   const envInWorkDir = workDir ? fs.existsSync(path.join(workDir, `.env.agent.${agentId}`)) : false;
@@ -149,7 +184,7 @@ function collectSlotStatus(
     ? fs.existsSync(path.join(worktreePath, `.env.agent.${agentId}`))
     : false;
   const active =
-    (session !== undefined && session.status === 'active') ||
+    (session !== undefined && session.status !== 'completed') ||
     envInWorkDir ||
     envInRoot ||
     envInWorktree;
@@ -188,6 +223,8 @@ function collectSlotStatus(
     baseCommit: session?.baseCommit,
     sessionCreatedAt: session?.createdAt,
     purpose: session?.purpose,
+    sessionStatus: session?.status,
+    lastError: session?.lastError,
     ...drift,
   };
 }

--- a/src/llm/prompts/system-authoring.md
+++ b/src/llm/prompts/system-authoring.md
@@ -58,6 +58,29 @@ PM2 processes for the primary application only, matching how it runs in dev.
 ### `.har/verify.sh`
 Real typecheck, lint, test, and health check commands — replace all TODOs.
 
+## Readiness vs liveness (required)
+Do not treat a passing health check as adaptation complete. A usable agent
+environment has layered readiness:
+
+1. **Infra ready** — shared services and template data stores exist.
+2. **Slot data ready** — every per-slot data store is created or cloned.
+3. **Process ready** — primary app processes are online and health passes.
+4. **Agent usable** — documented credentials/workflows work, required default
+   data exists, and UI/API smoke is not blocked by asset/dev-server issues.
+
+Compare the harness against the repository's full local-dev setup. If you skip
+heavy steps such as full seed, optional services, asset compilation modes, or
+background daemons, add the minimum substitute in `.har/` scripts or document
+why no substitute is needed. If the app has multiple databases/stores, provision
+all per-slot state. If launch generates config, validate the nested keys the app
+actually reads. Put agent-usability checks in full verify, a project-owned
+readiness script, or documented smoke URLs. Health alone is not sufficient for
+UI/auth apps.
+
+Ensure `launch.sh` writes the slot registry before slow or fragile steps, and
+`verify.sh` resolves env/work dir through `agent-slot.sh` so partial launches are
+recoverable.
+
 ### `.har/CLAUDE.agent.md`
 Detailed agent instructions: commands, credentials, architecture, definition of done.
 
@@ -101,4 +124,7 @@ Set slot limits in `.har/stages.json` (`agentSlots`) and `.har/harness.env` (`HA
    - unused harness files deleted (`deleteHarnessFile`), e.g. `attach.sh` when unused
    - `.har/README.md` file table matches the files that actually exist
    - `CLAUDE.agent.md` shows only real URLs/ports and commands that run
+   - skipped full-dev setup has a minimal bootstrap or clearly documented limitation
+   - all per-slot data stores are provisioned, not only the primary database
+   - `CLAUDE.agent.md` defines what "agent usable" means, including credentials or smoke checks when applicable
 8. **Call finishAuthoring** when complete

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -44,6 +44,39 @@ PM2 processes for the primary application only, matching how it runs in dev. Ski
 ### `.har/verify.sh`
 Real typecheck, lint, test, and health check commands — replace all TODOs.
 
+### Readiness vs liveness (required)
+Do not treat a passing health check as adaptation complete. Before finishing,
+make the harness explicit about the layers that apply to this repository:
+
+1. **Infra ready** — shared services are running and template data stores exist.
+2. **Slot data ready** — every per-slot data store is created or cloned, not only
+   the primary database.
+3. **Process ready** — the primary app processes are online and
+   `HARNESS_HEALTH_CHECK_PATH` passes.
+4. **Agent usable** — a real workflow an agent needs is possible: documented
+   credentials work, a tenant/org/project exists when the app requires one, the
+   UI is not blocked by dev-server overlays, or an authenticated API smoke works.
+
+Compare the harness against the project's full local-dev setup. If the harness
+intentionally skips slow or heavy steps (full seed, optional services, asset
+mode, background daemons), add the minimum substitute directly in `.har/`
+scripts or document why no substitute is needed. In particular:
+
+- If `HARNESS_DB_SEED_CMD` is empty or schema-only, add an idempotent minimal
+  bootstrap step for required tenants/users/settings, or document why schema-only
+  is enough.
+- If the app has multiple databases, schemas, queues, object stores, search
+  indexes, or other per-slot state, provision all of them in `setup-infra.sh`
+  and `launch.sh`.
+- If launch generates config, validate the nested keys the app actually reads
+  against upstream examples/defaults, not only top-level keys.
+- If the dev server can block agents with overlays or noisy HMR failures,
+  choose and document an agent-friendly asset mode.
+- Put Layer 3 checks in `verify --full`, a project-owned readiness script, or
+  documented smoke URLs. Health alone is not sufficient for UI/auth apps.
+- Ensure `launch.sh` writes the slot registry before slow or fragile steps, and
+  `verify.sh` resolves env/work dir through `agent-slot.sh`.
+
 ### Optional Playwright stage
 If the user ran `har env add-stage playwright` (or `@playwright/test` is in package.json):
 
@@ -65,7 +98,7 @@ Agents run in parallel on configurable slot ids. Ports: `BASE + (AGENT_ID × 10)
 Set slot limits in `.har/stages.json` (`agentSlots`) and `.har/harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`) based on machine capacity.
 
 ### Git worktree
-`launch.sh` creates an isolated worktree at `~/worktrees/<project>-agent-<id>` by default (`HARNESS_USE_WORKTREE=true`). Agents should commit from that worktree, not the main checkout.
+`launch.sh` creates an isolated session worktree at `~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>` by default (`HARNESS_USE_WORKTREE=true`) and records it in `.har/slots/agent-<id>.json`. Agents should commit from that worktree, not the main checkout.
 
 ## Step 3 — Update repo-root `AGENT.md`
 
@@ -112,6 +145,9 @@ The boilerplate ships more than any single repository needs. Strip it down to st
 - [ ] Unused harness files are deleted (e.g. `attach.sh` when tmux isn't part of the workflow; CLI profile: `ecosystem.agent.template.cjs`, `env.template`)
 - [ ] `.har/README.md` file table lists exactly the files that exist — no more, no less
 - [ ] `.har/CLAUDE.agent.md` shows only real URLs/ports/credentials (e.g. drop the Frontend row for an API-only project) and project commands that actually run
+- [ ] If full seed/setup is skipped, `.har/` provides a minimal bootstrap or clearly documents why none is needed
+- [ ] All per-slot data stores are provisioned, not just the primary database
+- [ ] `.har/CLAUDE.agent.md` defines what "agent usable" means for this repo: login/API smoke, credentials, required default data, and known skipped dev-setup steps
 
 ## Rules
 

--- a/src/templates/adaptation-prompt-maintain.md
+++ b/src/templates/adaptation-prompt-maintain.md
@@ -28,6 +28,36 @@ Align commands and instructions with the current stack.
 ### `.har/env.template`, `setup-infra.sh`, `docker-compose.agent.yml`
 Update only if infra changed.
 
+### Readiness vs liveness regression check
+Do not treat a passing health check as proof that the harness is still usable.
+When maintaining an existing harness, re-check the layers that apply:
+
+1. **Infra ready** — shared services and template data stores still match the app.
+2. **Slot data ready** — every per-slot data store is created or cloned, not only
+   the primary database.
+3. **Process ready** — app processes are online and `HARNESS_HEALTH_CHECK_PATH`
+   passes.
+4. **Agent usable** — documented credentials/workflows still work, required
+   default data exists, UI/API smoke is not blocked by asset/dev-server issues,
+   and any skipped full-dev setup has a minimal substitute or clear limitation.
+
+Look specifically for drift introduced since the last adaptation:
+
+- A seed command was removed or made schema-only without a minimal bootstrap.
+- A new database, schema, queue, object store, search index, or other per-slot
+  dependency was added but launch only provisions the original primary store.
+- Config generation writes plausible top-level keys while the app reads nested
+  defaults from another file.
+- The dev server mode is fine for humans but blocks browser automation or agents
+  with overlays/noisy HMR.
+- `verify.sh` became health-only and no longer checks the key workflow that makes
+  the slot usable.
+- `launch.sh` writes the slot registry only after fragile late steps; partial
+  launches must remain discoverable by verify/status/teardown.
+
+Update `.har/CLAUDE.agent.md` with skipped setup steps, substitutes, credentials,
+and the repo-specific definition of "agent usable."
+
 ### HAR platform upgrades checklist
 
 When upgrading `@osfactory/har` or adopting new harness standards:

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -15,9 +15,17 @@
 ./.har/agent-cli.sh ${AGENT_ID} status
 ```
 
+## Readiness
+
+Adapt this section for the repository. For pure CLI/library repos, full verify
+may be enough. If the project needs services, auth, seeded data, or a sample
+workflow, document the required credentials/default data and wire a smoke into
+`HARNESS_READINESS_CMD` or full verify.
+
 ## Definition of done
 
 - [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)
+- [ ] The slot is agent-usable for this repo's documented smoke workflow when runtime services are involved
 - [ ] When `stages/browser-e2e.sh` exists, full verify includes Playwright — adapt specs under `tests/` for UI changes
 - [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message

--- a/src/templates/har-boilerplate-cli/README.md
+++ b/src/templates/har-boilerplate-cli/README.md
@@ -59,7 +59,12 @@ Read **`stages.json`** and **`verificationStages`**. Optional: `har env add-stag
 | Mode | Command | Typical steps |
 |------|---------|---------------|
 | Quick | `har env verify <id>` or `verify.sh <id>` | typecheck, unit tests |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint, build, **browser-e2e** when `stages/browser-e2e.sh` exists |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint, optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
+
+For repos that need runtime services, distinguish health from usability. If the
+harness skips slow local-dev setup, document the skipped steps and add a minimal
+bootstrap/readiness check when agents need default data, credentials, or an
+authenticated workflow.
 
 Use `har env launch 1 --no-worktree` or `./.har/launch.sh 1 --no-worktree` only when working in the repo root.
 

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -50,7 +50,8 @@ try {
 # Writes the registry entry from SLOT_* variables:
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
-#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON, SLOT_PURPOSE
+#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -65,7 +66,7 @@ const entry = {
   mode: e.SLOT_MODE,
   workDir: e.SLOT_WORK_DIR,
   createdAt: new Date().toISOString(),
-  status: "active",
+  status: e.SLOT_STATUS || "active",
 };
 if (e.SLOT_SUFFIX) entry.suffix = e.SLOT_SUFFIX;
 if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
@@ -73,6 +74,7 @@ if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
 if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
+if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
 }
@@ -115,13 +117,15 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir purpose created dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
   purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
+  status="$(read_slot_field "$reg" status || true)"
+  last_error="$(read_slot_field "$reg" lastError || true)"
   dirty_summary="$(slot_dirty_summary "$wt")"
   if [ -n "$wt" ] && [ -d "$wt" ]; then
     head="$(git -C "$wt" rev-parse --short HEAD 2>/dev/null || true)"
@@ -133,6 +137,8 @@ print_slot_replace_warning() {
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
+  [ -n "$status" ] && echo "  Status:    ${status}" >&2
+  [ -n "$last_error" ] && echo "  Error:     ${last_error}" >&2
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
@@ -182,11 +188,30 @@ require_slot_replace_confirm() {
   exit 2
 }
 
+git_common_dir() {
+  local cwd="$1"
+  local out
+  out="$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$out" in
+    /*) echo "$out" ;;
+    *) (cd "$cwd" && cd "$out" && pwd) ;;
+  esac
+}
+
+same_git_checkout() {
+  local left right
+  left="$(git_common_dir "$1" || true)"
+  right="$(git_common_dir "$2" || true)"
+  [ -n "$left" ] && [ -n "$right" ] && [ "$left" = "$right" ]
+}
+
 # Echo the previous session's worktree path for a slot: registry first, then
-# the legacy fixed path (pre-registry sessions). Empty output when none exists.
+# legacy and randomized session worktree fallbacks. Empty output when none exists.
 existing_slot_worktree() {
   local agent_id="$1"
-  local reg path
+  local reg path candidate repo_root rel_prefix
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  rel_prefix="$(git -C "$repo_root" rev-parse --show-prefix 2>/dev/null || true)"
   reg="$(slot_registry_file "$agent_id")"
   if [ -f "$reg" ]; then
     path="$(read_slot_field "$reg" worktreePath || true)"
@@ -198,12 +223,20 @@ existing_slot_worktree() {
   path="$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}"
   if [ -d "$path" ]; then
     echo "$path"
+    return 0
   fi
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*; do
+    [ -d "$candidate" ] || continue
+    same_git_checkout "$repo_root" "$candidate" || continue
+    [ -f "$candidate/${rel_prefix}.env.agent.${agent_id}" ] || continue
+    echo "$candidate"
+    return 0
+  done
   return 0
 }
 
-# Resolve .env.agent.<id> — registry work dir first, then legacy locations
-# (repo root, pre-registry fixed worktree path).
+# Resolve .env.agent.<id> — registry work dir first, then legacy and
+# randomized session worktree fallbacks.
 resolve_agent_env_file() {
   local agent_id="$1"
   local repo_root="$2"
@@ -225,6 +258,15 @@ resolve_agent_env_file() {
     "$repo_root/.env.agent.${agent_id}" \
     "$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}/${rel_prefix}.env.agent.${agent_id}"; do
     if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  local candidate_dir
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*/${rel_prefix}.env.agent."${agent_id}"; do
+    if [ -f "$candidate" ]; then
+      candidate_dir="$(cd "$(dirname "$candidate")" && pwd)"
+      same_git_checkout "$repo_root" "$candidate_dir" || continue
       echo "$candidate"
       return 0
     fi
@@ -277,4 +319,15 @@ run_browser_e2e_if_present() {
   if [ -x "$e2e" ]; then
     "$e2e" "$agent_id"
   fi
+}
+
+# Optional project-owned "agent usable" smoke beyond health.
+run_readiness_if_configured() {
+  local agent_id="$1"
+  if [ -z "${HARNESS_READINESS_CMD:-}" ]; then
+    echo "No HARNESS_READINESS_CMD configured; skipping readiness smoke."
+    return 0
+  fi
+  local cmd="${HARNESS_READINESS_CMD//\{agentId\}/$agent_id}"
+  eval "$cmd"
 }

--- a/src/templates/har-boilerplate-cli/harness.env
+++ b/src/templates/har-boilerplate-cli/harness.env
@@ -38,3 +38,11 @@ har_pg() {
 
 export HARNESS_DB_MIGRATE_CMD="true"
 export HARNESS_DB_SEED_CMD="true"
+
+# Optional readiness/data hooks for repositories that need more than static
+# CLI/library checks. Enable only when this project needs them, and keep scripts
+# idempotent.
+#
+# export HARNESS_TEMPLATE_DBS="main:template___PROJECT_NAME__"
+# export HARNESS_DB_MINIMAL_BOOTSTRAP_CMD="./.har/bootstrap-data.sh"
+# export HARNESS_READINESS_CMD="./.har/readiness.sh"

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -94,6 +94,46 @@ WORKTREE_DIR=${WORKTREE_DIR}
 NODE_ENV=test
 EOF
 
+REGISTRY_WRITTEN=false
+mark_slot_failed() {
+  local exit_code="$?"
+  if [ "$exit_code" != "0" ] && [ "$REGISTRY_WRITTEN" = true ]; then
+    log "Launch failed after creating the session. Recording failed slot state..."
+    set +e
+    SLOT_AGENT_ID="$AGENT_ID" \
+    SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+    SLOT_WORK_DIR="$WORK_DIR" \
+    SLOT_SUFFIX="${SUFFIX:-}" \
+    SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+    SLOT_BRANCH="${BRANCH:-}" \
+    SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+    SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+    SLOT_PURPOSE="${PURPOSE}" \
+    SLOT_STATUS="failed" \
+    SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
+      write_slot_registry
+    log "  Work dir:  ${WORK_DIR}"
+    log "  Env file:  ${ENV_FILE}"
+    log "  Recovery:  fix the failure, then relaunch with --replace when ready."
+  fi
+}
+trap mark_slot_failed EXIT
+
+# Record the session before slow or fragile setup so verify/status/teardown can
+# recover partial launches that already created a worktree and env file.
+SLOT_AGENT_ID="$AGENT_ID" \
+SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+SLOT_WORK_DIR="$WORK_DIR" \
+SLOT_SUFFIX="${SUFFIX:-}" \
+SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+SLOT_BRANCH="${BRANCH:-}" \
+SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
+SLOT_STATUS="starting" \
+  write_slot_registry
+REGISTRY_WRITTEN=true
+
 if [ -f "$WORK_DIR/package.json" ]; then
   log "Installing dependencies..."
   (cd "$WORK_DIR" && npm install --silent)
@@ -118,6 +158,7 @@ SLOT_BRANCH="${BRANCH:-}" \
 SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
 SLOT_PURPOSE="${PURPOSE}" \
+SLOT_STATUS="active" \
   write_slot_registry
 
 log "Agent $AGENT_ID is ready."

--- a/src/templates/har-boilerplate-cli/stages.json
+++ b/src/templates/har-boilerplate-cli/stages.json
@@ -20,7 +20,7 @@
         {
           "path": ".env.agent.{agentId}",
           "kind": "file",
-          "description": "Generated per-agent environment file"
+          "description": "Generated per-agent environment file in the session work dir"
         }
       ]
     },

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -35,6 +35,14 @@ set +a
 WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
 
 echo "==> Verifying agent ${AGENT_ID} in ${WORK_DIR}..." >&2
+REG_FILE="$(slot_registry_file "$AGENT_ID")"
+echo "    Work dir: ${WORK_DIR}" >&2
+echo "    Env file: ${ENV_FILE}" >&2
+if [ -f "$REG_FILE" ]; then
+  echo "    Registry: ${REG_FILE}" >&2
+else
+  echo "    Registry: missing (${REG_FILE})" >&2
+fi
 
 OVERALL_PASS=true
 START_TOTAL=$(now_ms)
@@ -88,6 +96,7 @@ run_step "unit-tests" "npm test" || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
   run_step "lint" "npm run lint" || true
+  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi
 

--- a/src/templates/har-boilerplate-ios/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-ios/CLAUDE.agent.md
@@ -17,9 +17,17 @@
 ./.har/agent-cli.sh ${AGENT_ID} status
 ```
 
+## Readiness
+
+Adapt this section for the repository. A successful build/test run does not
+always mean an agent can use the app. If the app needs a backend, credentials,
+seeded data, or a simulator flow, document it here and wire the smoke into
+`HARNESS_READINESS_CMD`, RocketSim flows, or full verify.
+
 ## Definition of done
 
 - [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)
+- [ ] The slot is agent-usable for this repo's documented smoke workflow when runtime services are involved
 - [ ] When `stages/rocketsim-flows.sh` exists, full verify includes user-flow validation — add or update flow scripts in `flows/` for UI changes
 - [ ] New behavior has automated test coverage (unit tests via XCTest)
 - [ ] Changes committed **in the session worktree** with a clear message

--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -67,7 +67,11 @@ This installs `.har/stages/rocketsim-flows.sh` and a `flows/` directory. Add flo
 | Mode | Command | Typical steps |
 |------|---------|---------------|
 | Quick | `har env verify <id>` | build, unit-tests |
-| Full | `har env verify <id> --full` | + lint, **rocketsim-flows** when installed |
+| Full | `har env verify <id> --full` | + lint, optional readiness smoke, **rocketsim-flows** when installed |
+
+For apps that depend on local backends, auth, seeded state, or simulator flows,
+distinguish build/test health from agent usability. Document any skipped full
+dev setup and add a readiness command when agents need a real workflow to pass.
 
 ## Configuration
 

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -50,7 +50,8 @@ try {
 # Writes the registry entry from SLOT_* variables:
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
-#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON, SLOT_PURPOSE
+#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -65,7 +66,7 @@ const entry = {
   mode: e.SLOT_MODE,
   workDir: e.SLOT_WORK_DIR,
   createdAt: new Date().toISOString(),
-  status: "active",
+  status: e.SLOT_STATUS || "active",
 };
 if (e.SLOT_SUFFIX) entry.suffix = e.SLOT_SUFFIX;
 if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
@@ -73,6 +74,7 @@ if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
 if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
+if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
 }
@@ -115,13 +117,15 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir purpose created dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
   purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
+  status="$(read_slot_field "$reg" status || true)"
+  last_error="$(read_slot_field "$reg" lastError || true)"
   dirty_summary="$(slot_dirty_summary "$wt")"
   if [ -n "$wt" ] && [ -d "$wt" ]; then
     head="$(git -C "$wt" rev-parse --short HEAD 2>/dev/null || true)"
@@ -133,6 +137,8 @@ print_slot_replace_warning() {
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
+  [ -n "$status" ] && echo "  Status:    ${status}" >&2
+  [ -n "$last_error" ] && echo "  Error:     ${last_error}" >&2
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
@@ -182,11 +188,30 @@ require_slot_replace_confirm() {
   exit 2
 }
 
+git_common_dir() {
+  local cwd="$1"
+  local out
+  out="$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$out" in
+    /*) echo "$out" ;;
+    *) (cd "$cwd" && cd "$out" && pwd) ;;
+  esac
+}
+
+same_git_checkout() {
+  local left right
+  left="$(git_common_dir "$1" || true)"
+  right="$(git_common_dir "$2" || true)"
+  [ -n "$left" ] && [ -n "$right" ] && [ "$left" = "$right" ]
+}
+
 # Echo the previous session's worktree path for a slot: registry first, then
-# the legacy fixed path (pre-registry sessions). Empty output when none exists.
+# legacy and randomized session worktree fallbacks. Empty output when none exists.
 existing_slot_worktree() {
   local agent_id="$1"
-  local reg path
+  local reg path candidate repo_root rel_prefix
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  rel_prefix="$(git -C "$repo_root" rev-parse --show-prefix 2>/dev/null || true)"
   reg="$(slot_registry_file "$agent_id")"
   if [ -f "$reg" ]; then
     path="$(read_slot_field "$reg" worktreePath || true)"
@@ -198,12 +223,20 @@ existing_slot_worktree() {
   path="$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}"
   if [ -d "$path" ]; then
     echo "$path"
+    return 0
   fi
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*; do
+    [ -d "$candidate" ] || continue
+    same_git_checkout "$repo_root" "$candidate" || continue
+    [ -f "$candidate/${rel_prefix}.env.agent.${agent_id}" ] || continue
+    echo "$candidate"
+    return 0
+  done
   return 0
 }
 
-# Resolve .env.agent.<id> — registry work dir first, then legacy locations
-# (repo root, pre-registry fixed worktree path).
+# Resolve .env.agent.<id> — registry work dir first, then legacy and
+# randomized session worktree fallbacks.
 resolve_agent_env_file() {
   local agent_id="$1"
   local repo_root="$2"
@@ -225,6 +258,15 @@ resolve_agent_env_file() {
     "$repo_root/.env.agent.${agent_id}" \
     "$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}/${rel_prefix}.env.agent.${agent_id}"; do
     if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  local candidate_dir
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*/${rel_prefix}.env.agent."${agent_id}"; do
+    if [ -f "$candidate" ]; then
+      candidate_dir="$(cd "$(dirname "$candidate")" && pwd)"
+      same_git_checkout "$repo_root" "$candidate_dir" || continue
       echo "$candidate"
       return 0
     fi
@@ -277,4 +319,15 @@ run_browser_e2e_if_present() {
   if [ -x "$e2e" ]; then
     "$e2e" "$agent_id"
   fi
+}
+
+# Optional project-owned "agent usable" smoke beyond health.
+run_readiness_if_configured() {
+  local agent_id="$1"
+  if [ -z "${HARNESS_READINESS_CMD:-}" ]; then
+    echo "No HARNESS_READINESS_CMD configured; skipping readiness smoke."
+    return 0
+  fi
+  local cmd="${HARNESS_READINESS_CMD//\{agentId\}/$agent_id}"
+  eval "$cmd"
 }

--- a/src/templates/har-boilerplate-ios/harness.env
+++ b/src/templates/har-boilerplate-ios/harness.env
@@ -40,3 +40,7 @@ har_infra_enabled() {
     *) return 1 ;;
   esac
 }
+
+# Optional "agent usable" smoke beyond build/test, such as a simulator flow or
+# backend-auth check. Enable only when this project needs it.
+# export HARNESS_READINESS_CMD="./.har/readiness.sh"

--- a/src/templates/har-boilerplate-ios/launch.sh
+++ b/src/templates/har-boilerplate-ios/launch.sh
@@ -94,6 +94,46 @@ WORKTREE_DIR=${WORKTREE_DIR}
 NODE_ENV=test
 EOF
 
+REGISTRY_WRITTEN=false
+mark_slot_failed() {
+  local exit_code="$?"
+  if [ "$exit_code" != "0" ] && [ "$REGISTRY_WRITTEN" = true ]; then
+    log "Launch failed after creating the session. Recording failed slot state..."
+    set +e
+    SLOT_AGENT_ID="$AGENT_ID" \
+    SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+    SLOT_WORK_DIR="$WORK_DIR" \
+    SLOT_SUFFIX="${SUFFIX:-}" \
+    SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+    SLOT_BRANCH="${BRANCH:-}" \
+    SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+    SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+    SLOT_PURPOSE="${PURPOSE}" \
+    SLOT_STATUS="failed" \
+    SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
+      write_slot_registry
+    log "  Work dir:  ${WORK_DIR}"
+    log "  Env file:  ${ENV_FILE}"
+    log "  Recovery:  fix the failure, then relaunch with --replace when ready."
+  fi
+}
+trap mark_slot_failed EXIT
+
+# Record the session before slow or fragile setup so verify/status/teardown can
+# recover partial launches that already created a worktree and env file.
+SLOT_AGENT_ID="$AGENT_ID" \
+SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+SLOT_WORK_DIR="$WORK_DIR" \
+SLOT_SUFFIX="${SUFFIX:-}" \
+SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+SLOT_BRANCH="${BRANCH:-}" \
+SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
+SLOT_STATUS="starting" \
+  write_slot_registry
+REGISTRY_WRITTEN=true
+
 if [ -f "$WORK_DIR/package.json" ]; then
   log "Installing dependencies..."
   (cd "$WORK_DIR" && npm install --silent)
@@ -118,6 +158,7 @@ SLOT_BRANCH="${BRANCH:-}" \
 SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
 SLOT_PURPOSE="${PURPOSE}" \
+SLOT_STATUS="active" \
   write_slot_registry
 
 log "Agent $AGENT_ID is ready."

--- a/src/templates/har-boilerplate-ios/stages.json
+++ b/src/templates/har-boilerplate-ios/stages.json
@@ -20,7 +20,7 @@
         {
           "path": ".env.agent.{agentId}",
           "kind": "file",
-          "description": "Generated per-agent environment file"
+          "description": "Generated per-agent environment file in the session work dir"
         }
       ]
     },

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -38,6 +38,14 @@ set +a
 WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
 
 echo "==> Verifying agent ${AGENT_ID} in ${WORK_DIR}..." >&2
+REG_FILE="$(slot_registry_file "$AGENT_ID")"
+echo "    Work dir: ${WORK_DIR}" >&2
+echo "    Env file: ${ENV_FILE}" >&2
+if [ -f "$REG_FILE" ]; then
+  echo "    Registry: ${REG_FILE}" >&2
+else
+  echo "    Registry: missing (${REG_FILE})" >&2
+fi
 
 # Build xcodebuild project/workspace flags
 xc_target_flags() {
@@ -138,6 +146,8 @@ if [ -n "$FULL" ]; then
   # SwiftLint — optional, skip gracefully when not installed
   run_step "lint" "command -v \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" >/dev/null 2>&1 && \
     \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" --quiet 2>&1 || echo 'swiftlint not installed — skipping'" || true
+
+  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
 
   # RocketSim user-flow validation — installed via: har env add-stage rocketsim
   run_rocketsim_flows_if_present "$SCRIPT_DIR" "$AGENT_ID" || true

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -22,9 +22,23 @@ This slot runs **only the primary application** (`HARNESS_PRIMARY_APP`). Externa
 ./.har/agent-cli.sh ${AGENT_ID} health
 ```
 
+## Readiness
+
+Adapt this section for the repository. A passing health check means the process
+is alive; it does not automatically mean an agent can use the app.
+
+- **Health**: `./.har/agent-cli.sh ${AGENT_ID} health`
+- **Agent-usable smoke**: document the login/API/UI workflow agents should try,
+  or wire it into `HARNESS_READINESS_CMD` / full verify.
+- **Credentials/default data**: document any test users, tenants, projects, or
+  settings created by the harness.
+- **Skipped full-dev setup**: document anything intentionally omitted from the
+  upstream developer setup and the minimal substitute in `.har/`.
+
 ## Definition of done
 
 - [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)
+- [ ] The slot is agent-usable for this repo's documented smoke workflow, not only health-check green
 - [ ] When `stages/browser-e2e.sh` exists, full verify includes Playwright — adapt specs under `tests/` for UI changes
 - [ ] New behavior has automated test coverage (unit and/or browser as appropriate)
 - [ ] Changes committed **in the session worktree** with a clear message

--- a/src/templates/har-boilerplate/README.md
+++ b/src/templates/har-boilerplate/README.md
@@ -61,9 +61,26 @@ Read **`stages.json`** for registered stages and **`verificationStages`** for th
 | Mode | Command | Typical steps |
 |------|---------|---------------|
 | Quick | `har env verify <id>` or `verify.sh <id>` | Project checks in `verify.sh` (stops early on failure) |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | Quick steps + lint + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | Quick steps + lint + optional readiness smoke + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
 
 Install Playwright stage: `har env add-stage playwright` (optional). UI changes should add or update specs under `tests/`.
+
+## Readiness layers
+
+Do not treat a health endpoint as the whole definition of success. Adapt this
+section for the repository:
+
+| Layer | What it means | Where to encode it |
+|-------|---------------|--------------------|
+| Infra ready | Shared services and template data stores exist | `setup-infra.sh`, `docker-compose.agent.yml` |
+| Slot data ready | Every per-slot data store is created/cloned | `launch.sh` |
+| Process ready | Primary app is running and health passes | `launch.sh`, `verify.sh` |
+| Agent usable | Login/API/UI smoke works with documented data | `HARNESS_READINESS_CMD`, browser-e2e, `CLAUDE.agent.md` |
+
+If full local-dev setup is too heavy to run in the harness, document the skipped
+steps and add the minimum substitute directly in `.har/` scripts (for example an
+idempotent bootstrap for required users/tenants/settings). Health alone is not
+enough for UI/auth apps.
 
 ## Run history
 

--- a/src/templates/har-boilerplate/agent-cli.sh
+++ b/src/templates/har-boilerplate/agent-cli.sh
@@ -56,7 +56,13 @@ process.stdin.on('end', () => {
     fi
 
     if [ "$PM2_FOUND" = true ]; then
-      :
+      REG_FILE="$(slot_registry_file "$AGENT_ID")"
+      if [ ! -f "$REG_FILE" ]; then
+        echo "Warning: slot registry missing at $REG_FILE — verify/teardown may not resolve this slot."
+      fi
+      if [ -z "$ENV_FILE" ]; then
+        echo "Warning: .env.agent.${AGENT_ID} could not be resolved — relaunch with --replace when ready."
+      fi
     elif [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
       echo "Agent ${AGENT_ID}: active (no PM2 processes)"
       # shellcheck source=/dev/null

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -50,7 +50,8 @@ try {
 # Writes the registry entry from SLOT_* variables:
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
-#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON, SLOT_PURPOSE
+#             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -65,7 +66,7 @@ const entry = {
   mode: e.SLOT_MODE,
   workDir: e.SLOT_WORK_DIR,
   createdAt: new Date().toISOString(),
-  status: "active",
+  status: e.SLOT_STATUS || "active",
 };
 if (e.SLOT_SUFFIX) entry.suffix = e.SLOT_SUFFIX;
 if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
@@ -73,6 +74,7 @@ if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
 if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
+if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
 }
@@ -115,13 +117,15 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir purpose created dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
   purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
+  status="$(read_slot_field "$reg" status || true)"
+  last_error="$(read_slot_field "$reg" lastError || true)"
   dirty_summary="$(slot_dirty_summary "$wt")"
   if [ -n "$wt" ] && [ -d "$wt" ]; then
     head="$(git -C "$wt" rev-parse --short HEAD 2>/dev/null || true)"
@@ -133,6 +137,8 @@ print_slot_replace_warning() {
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
+  [ -n "$status" ] && echo "  Status:    ${status}" >&2
+  [ -n "$last_error" ] && echo "  Error:     ${last_error}" >&2
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
@@ -182,11 +188,30 @@ require_slot_replace_confirm() {
   exit 2
 }
 
+git_common_dir() {
+  local cwd="$1"
+  local out
+  out="$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  case "$out" in
+    /*) echo "$out" ;;
+    *) (cd "$cwd" && cd "$out" && pwd) ;;
+  esac
+}
+
+same_git_checkout() {
+  local left right
+  left="$(git_common_dir "$1" || true)"
+  right="$(git_common_dir "$2" || true)"
+  [ -n "$left" ] && [ -n "$right" ] && [ "$left" = "$right" ]
+}
+
 # Echo the previous session's worktree path for a slot: registry first, then
-# the legacy fixed path (pre-registry sessions). Empty output when none exists.
+# legacy and randomized session worktree fallbacks. Empty output when none exists.
 existing_slot_worktree() {
   local agent_id="$1"
-  local reg path
+  local reg path candidate repo_root rel_prefix
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  rel_prefix="$(git -C "$repo_root" rev-parse --show-prefix 2>/dev/null || true)"
   reg="$(slot_registry_file "$agent_id")"
   if [ -f "$reg" ]; then
     path="$(read_slot_field "$reg" worktreePath || true)"
@@ -198,12 +223,20 @@ existing_slot_worktree() {
   path="$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}"
   if [ -d "$path" ]; then
     echo "$path"
+    return 0
   fi
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*; do
+    [ -d "$candidate" ] || continue
+    same_git_checkout "$repo_root" "$candidate" || continue
+    [ -f "$candidate/${rel_prefix}.env.agent.${agent_id}" ] || continue
+    echo "$candidate"
+    return 0
+  done
   return 0
 }
 
-# Resolve .env.agent.<id> — registry work dir first, then legacy locations
-# (repo root, pre-registry fixed worktree path).
+# Resolve .env.agent.<id> — registry work dir first, then legacy and
+# randomized session worktree fallbacks.
 resolve_agent_env_file() {
   local agent_id="$1"
   local repo_root="$2"
@@ -225,6 +258,15 @@ resolve_agent_env_file() {
     "$repo_root/.env.agent.${agent_id}" \
     "$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${agent_id}/${rel_prefix}.env.agent.${agent_id}"; do
     if [ -f "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  local candidate_dir
+  for candidate in "$HOME"/worktrees/*-har-agent-"${agent_id}"-*/${rel_prefix}.env.agent."${agent_id}"; do
+    if [ -f "$candidate" ]; then
+      candidate_dir="$(cd "$(dirname "$candidate")" && pwd)"
+      same_git_checkout "$repo_root" "$candidate_dir" || continue
       echo "$candidate"
       return 0
     fi
@@ -277,4 +319,15 @@ run_browser_e2e_if_present() {
   if [ -x "$e2e" ]; then
     "$e2e" "$agent_id"
   fi
+}
+
+# Optional project-owned "agent usable" smoke beyond health.
+run_readiness_if_configured() {
+  local agent_id="$1"
+  if [ -z "${HARNESS_READINESS_CMD:-}" ]; then
+    echo "No HARNESS_READINESS_CMD configured; skipping readiness smoke."
+    return 0
+  fi
+  local cmd="${HARNESS_READINESS_CMD//\{agentId\}/$agent_id}"
+  eval "$cmd"
 }

--- a/src/templates/har-boilerplate/harness.env
+++ b/src/templates/har-boilerplate/harness.env
@@ -48,3 +48,18 @@ har_pg() {
 # Database setup commands (run once against template DB in setup-infra.sh)
 export HARNESS_DB_MIGRATE_CMD="echo 'TODO: set migrate command'"
 export HARNESS_DB_SEED_CMD="echo 'TODO: set seed command'"
+
+# Optional readiness/data hooks for larger apps. Enable only when this project
+# needs them, and keep the scripts idempotent.
+#
+# Multiple per-slot data stores can be represented as logical_name:template_db
+# pairs and handled directly in setup-infra.sh / launch.sh.
+# export HARNESS_TEMPLATE_DBS="main:template___PROJECT_NAME__"
+#
+# Use a minimal bootstrap when full seed is too slow/heavy but the app still
+# needs default tenants, users, settings, feature flags, or similar data.
+# export HARNESS_DB_MINIMAL_BOOTSTRAP_CMD="./.har/bootstrap-data.sh"
+#
+# Use readiness checks for "agent usable" smoke beyond a health endpoint:
+# login/API auth, representative UI page, required data, secondary stores.
+# export HARNESS_READINESS_CMD="./.har/readiness.sh"

--- a/src/templates/har-boilerplate/launch.sh
+++ b/src/templates/har-boilerplate/launch.sh
@@ -147,6 +147,55 @@ REPO_ROOT="$WORK_DIR" \
   envsubst '${AGENT_ID} ${API_PORT} ${FE_PORT} ${DEBUG_PORT} ${DB_PORT} ${MINIO_PORT} ${BROWSER_PORT} ${REPO_ROOT}' \
   < "$SCRIPT_DIR/env.template" > "$ENV_FILE"
 
+REGISTRY_WRITTEN=false
+mark_slot_failed() {
+  local exit_code="$?"
+  if [ "$exit_code" != "0" ] && [ "$REGISTRY_WRITTEN" = true ]; then
+    log "Launch failed after creating the session. Recording failed slot state..."
+    set +e
+    SLOT_AGENT_ID="$AGENT_ID" \
+    SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+    SLOT_WORK_DIR="$WORK_DIR" \
+    SLOT_SUFFIX="${SUFFIX:-}" \
+    SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+    SLOT_BRANCH="${BRANCH:-}" \
+    SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+    SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+    SLOT_PURPOSE="${PURPOSE}" \
+    SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT}}" \
+    SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+    SLOT_STATUS="failed" \
+    SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
+      write_slot_registry
+    log "  Work dir:  ${WORK_DIR}"
+    log "  Env file:  ${ENV_FILE}"
+    log "  Recovery:  fix the failure, then relaunch with --replace when ready."
+  fi
+}
+trap mark_slot_failed EXIT
+
+# Record the session before slow or fragile setup so verify/status/teardown can
+# recover partial launches that already created a worktree and env file.
+SLOT_AGENT_ID="$AGENT_ID" \
+SLOT_MODE="$([ "$USE_WORKTREE" = true ] && echo worktree || echo root)" \
+SLOT_WORK_DIR="$WORK_DIR" \
+SLOT_SUFFIX="${SUFFIX:-}" \
+SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
+SLOT_BRANCH="${BRANCH:-}" \
+SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
+SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
+SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT}}" \
+SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+SLOT_STATUS="starting" \
+  write_slot_registry
+REGISTRY_WRITTEN=true
+
+if [ -n "${HARNESS_DB_MINIMAL_BOOTSTRAP_CMD:-}" ]; then
+  log "Running minimal data bootstrap..."
+  (cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$HARNESS_DB_MINIMAL_BOOTSTRAP_CMD")
+fi
+
 # Generate PM2 ecosystem config
 ECOSYSTEM_FILE="$WORK_DIR/ecosystem.agent.${AGENT_ID}.config.cjs"
 log "Generating $ECOSYSTEM_FILE..."
@@ -199,6 +248,7 @@ SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
 SLOT_PURPOSE="${PURPOSE}" \
 SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT}}" \
 SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+SLOT_STATUS="active" \
   write_slot_registry
 
 # Launch Claude Code in tmux (optional)

--- a/src/templates/har-boilerplate/stages.json
+++ b/src/templates/har-boilerplate/stages.json
@@ -20,7 +20,7 @@
         {
           "path": ".env.agent.{agentId}",
           "kind": "file",
-          "description": "Generated per-agent environment file"
+          "description": "Generated per-agent environment file in the session work dir"
         }
       ]
     },

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -38,6 +38,14 @@ WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
 API_PORT="${API_PORT:-$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))}"
 
 echo "==> Verifying agent ${AGENT_ID} (work dir: ${WORK_DIR})..." >&2
+REG_FILE="$(slot_registry_file "$AGENT_ID")"
+echo "    Work dir: ${WORK_DIR}" >&2
+echo "    Env file: ${ENV_FILE}" >&2
+if [ -f "$REG_FILE" ]; then
+  echo "    Registry: ${REG_FILE}" >&2
+else
+  echo "    Registry: missing (${REG_FILE})" >&2
+fi
 
 OVERALL_PASS=true
 START_TOTAL=$(now_ms)
@@ -134,6 +142,7 @@ run_http_step "api-health" "http://localhost:${API_PORT}${HARNESS_HEALTH_CHECK_P
 
 if [ -n "$FULL" ]; then
   run_step "lint" "echo 'TODO: npm run lint'" || true
+  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi
 

--- a/tests/slot-registry.test.ts
+++ b/tests/slot-registry.test.ts
@@ -63,6 +63,23 @@ describe('slot registry', () => {
     expect(listSlotRegistryEntries(repoPath).length).toBe(1);
   });
 
+  it('keeps failed launch entries readable for recovery', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slot-registry-'));
+    const harDir = writeHarness(repoPath);
+    writeRegistryEntry(harDir, 1, {
+      status: 'failed',
+      lastError: 'launch.sh exited with code 1',
+    });
+
+    const entry = readSlotRegistry(repoPath, 1);
+    expect(entry?.status).toBe('failed');
+    expect(entry?.lastError).toContain('launch.sh exited');
+    const status = collectEnvironmentStatus(repoPath).slots[0];
+    expect(status.active).toBe(true);
+    expect(status.sessionStatus).toBe('failed');
+    expect(status.lastError).toContain('launch.sh exited');
+  });
+
   it('returns undefined for invalid entries', () => {
     const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slot-registry-'));
     const harDir = writeHarness(repoPath);
@@ -78,6 +95,39 @@ describe('slot registry', () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-workdir-'));
     writeRegistryEntry(harDir, 1, { workDir });
     expect(resolveAgentWorkDir(repoPath, 1)).toBe(workDir);
+  });
+
+  it('resolveAgentWorkDir discovers randomized session worktrees when registry is missing', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slot-registry-'));
+    writeHarness(repoPath);
+    git(repoPath, 'init -b main');
+    git(repoPath, 'config user.email test@example.com');
+    git(repoPath, 'config user.name Test');
+    fs.writeFileSync(path.join(repoPath, 'file.txt'), 'one\n');
+    git(repoPath, 'add -A');
+    git(repoPath, 'commit -m one');
+
+    const worktreesRoot = path.join(os.homedir(), 'worktrees');
+    const sessionDir = path.join(
+      worktreesRoot,
+      `zz-test-${Date.now()}-har-agent-2-${Math.random().toString(36).slice(2, 6)}`,
+    );
+    fs.mkdirSync(worktreesRoot, { recursive: true });
+    git(repoPath, `worktree add ${sessionDir} -b zz-test-har-agent-2`);
+    fs.writeFileSync(path.join(sessionDir, '.env.agent.2'), `AGENT_ID=2\nREPO_ROOT=${sessionDir}\n`);
+
+    try {
+      expect(resolveAgentWorkDir(repoPath, 2)).toBe(sessionDir);
+      const status = collectEnvironmentStatus(repoPath).slots.find((slot) => slot.agentId === 2);
+      expect(status?.active).toBe(true);
+      expect(status?.worktreePath).toBe(sessionDir);
+    } finally {
+      try {
+        git(repoPath, `worktree remove --force ${sessionDir}`);
+      } catch {
+        fs.rmSync(sessionDir, { recursive: true, force: true });
+      }
+    }
   });
 
   it('slot status surfaces session fields and drift from a real worktree', () => {


### PR DESCRIPTION
## Summary

- **Slot registry resilience**: write registry early with `starting` status, mark `failed` on launch trap exit, and set `active` only after successful launch; extend schema with `sessionStatus` and `lastError`.
- **Env discovery fallbacks**: resolve `.env.agent.N` from registry, legacy paths, repo root, and randomized session worktrees (scoped by git checkout and monorepo harness subpath) so verify/status/teardown work after partial launches.
- **Readiness vs liveness**: add optional `HARNESS_READINESS_CMD` / bootstrap hooks to templates and document four readiness layers in adapt prompts and authoring guidance; warn when PM2 is up but registry/env is missing.

## Test plan

- [x] `./.har/verify.sh 3` (fast loop)
- [x] `./.har/verify.sh 3 --full` (typecheck, build, unit tests, lint, browser-e2e)
- [x] `tests/slot-registry.test.ts` — failed registry entries and randomized worktree discovery


Made with [Cursor](https://cursor.com)