### PR TITLE
feat: tiered verify, smoke pre-fix gate, and benchmark adapt prompt reuse

### DIFF
--- a/.har/README.md
+++ b/.har/README.md
@@ -20,7 +20,7 @@ Generated and maintained by [`har`](https://github.com/antoineFrau/har). Run `ha
 | `agent-slot.sh` | Shared agent-id validation (reads limits from `harness.env`) |
 | `setup-infra.sh` | Start optional Docker Compose stack + template database |
 | `launch.sh` | Launch one agent slot (git worktree by default, deps, env file) |
-| `verify.sh` | Verification pipeline (typecheck, tests, lint, build) |
+| `verify.sh` | Verification pipeline (smoke by default; --full adds tests, lint, e2e) |
 | `teardown.sh` | Tear down one agent slot (worktree + env file) |
 | `agent-cli.sh` | Inspect slot status, run commands in the work dir |
 | `docker-compose.agent.yml` | Shared infrastructure containers (services listed in `HARNESS_INFRA_SERVICES`) |
@@ -48,8 +48,8 @@ In Cursor with HAR MCP configured: use `har_launch_environment`, `har_run_verifi
 ```bash
 ./.har/setup-infra.sh          # when HARNESS_INFRA_SERVICES is non-empty
 ./.har/launch.sh 1
-./.har/verify.sh 1
-./.har/verify.sh 1 --full      # + lint, browser-e2e (if Playwright installed)
+./.har/verify.sh 1             # quick: smoke (typecheck + build)
+./.har/verify.sh 1 --full      # + unit tests, lint, browser-e2e (if Playwright installed)
 ./.har/teardown.sh 1
 ```
 
@@ -57,10 +57,14 @@ Use `har env launch 1 --no-worktree` or `./.har/launch.sh 1 --no-worktree` only 
 
 ## Verification contract
 
+Steps in `verify.sh` are adapted for **@osfactory/har** — when using this as a
+pattern elsewhere, treat the step list as non-exhaustive and match each repo's
+toolchain.
+
 | Mode | Command | Typical steps |
 |------|---------|---------------|
-| Quick | `har env verify <id>` or `verify.sh <id>` | typecheck, build, unit tests |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint, optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
+| Quick | `har env verify <id>` or `verify.sh <id>` | Smoke: typecheck + build |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + unit tests, lint, optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
 
 ## Run history
 

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
-# Verification pipeline for @osfactory/har — typecheck, test, lint, build.
+# Verification pipeline for @osfactory/har.
 # Outputs JSON to stdout, human-readable progress to stderr.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
+#
+# Quick (default): smoke — typecheck + build
+# Full (--full):   + unit tests, lint, optional readiness + browser-e2e
+# Steps below are adapted for @osfactory/har — not a universal checklist.
+# Add, remove, or reorder run_step calls to match each repository's toolchain.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -92,9 +97,10 @@ process.stdout.write(JSON.stringify(arr));
 run_step "typecheck" "npm run typecheck" || { [ -z "$FULL" ] && true; }
 # Some unit tests exec dist/index.js (e.g. stage-templates CLI add-stage).
 run_step "build" "npm run build" || { [ -z "$FULL" ] && true; }
-run_step "unit-tests" "npm test" || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
+  # Full-mode steps for this repo — customize when adapting the harness elsewhere.
+  run_step "unit-tests" "npm test" || true
   run_step "lint" "npm run lint" || true
   run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true

--- a/benchmarks/swebench-har/README.md
+++ b/benchmarks/swebench-har/README.md
@@ -3,7 +3,7 @@
 Paired one-instance benchmark comparing **raw Codex (GPT-5 Mini)** against **HAR-assisted Codex** on a SWE-bench Lite task.
 
 - **Raw arm:** Codex solves the issue directly in a checkout at `base_commit` (default: `gpt-5-mini`).
-- **HAR arm:** scaffold-only `har env init` (no `--auto`), **GPT-5.5** adapts `.har/` when needed, runner enforces launch + verify gates, **GPT-5 Mini** fixes inside the slot.
+- **HAR arm:** scaffold-only `har env init` (no `--auto`), **GPT-5.5** adapts `.har/` using the init `ADAPT-PROMPT.md` plus benchmark constraints, runner enforces launch + smoke gates, **GPT-5 Mini** fixes inside the slot.
 - **Scoring:** official SWE-bench Docker harness via `swebench.harness.run_evaluation`.
 
 ## Prerequisites
@@ -99,14 +99,24 @@ benchmarks/swebench-har/
 The HAR arm records:
 
 - `har_cache_hit` / `har_cache_saved` — per-repo `.har/` reuse
-- `har_gate_initial` / `har_gate_attempt_*` — runner launch+verify gate before fix
-- `har_ready_for_fix` — slot launched and verify passed before Codex fix
+- `har_gate_initial` / `har_gate_attempt_*` — pre-fix gate before Codex fix (launch + smoke)
+- `har_gate_launch` / `har_gate_smoke` — split launch readiness vs quick smoke verify
+- `har_ready_for_fix` — slot launched and smoke verify passed (not full test suite)
 - `har_launch.ok`
-- `har_verify_attempted` / `har_verify_passed` (runner-enforced)
+- `har_verify_attempted` / `har_verify_passed` — post-fix verify (optionally `--full` via `har_verify_full` config)
 - `.har/runs/**` artifacts
 - `har_valid` and `har_invalid_reasons`
 
 `model_patch` excludes `.har/**`, `.cursor/**`, and other harness scaffolding so SWE-bench grading only sees product-code changes.
+
+## Pre-fix gate vs post-fix verify
+
+| Phase | What runs | Purpose |
+|-------|-----------|---------|
+| **Pre-fix gate** | `har env launch 1` + quick `har env verify 1` | Prove the agent can work in the slot (compile/import/build smoke) |
+| **Post-fix** | `har env verify 1` (or `--full` when `har_verify_full: true`) | Optional harness check after the patch; SWE-bench grading is separate |
+
+Quick verify must be **language-agnostic** — compile/import/build smoke, not full pytest/Django runtests/Sphinx extension graphs.
 
 ## Per-repo `.har/` cache
 
@@ -114,7 +124,7 @@ Adapted harness files are cached under `.har-cache/<repo>/` and reused across in
 
 1. tears down any occupied slot
 2. runs `har env launch 1 --replace --force` (with `HAR_CONFIRM_REPLACE=1`)
-3. runs `har env verify 1`
+3. runs quick `har env verify 1` (smoke only — no `--full`)
 
 If the gate fails, the setup model re-adapts `.har/` (up to `setup_max_attempts`, default 2) and the cache is refreshed on success.
 
@@ -124,8 +134,13 @@ If the gate fails, the setup model re-adapts `.har/` (up to `setup_max_attempts`
 
 - `cli` — Python/library/test-suite repos (typical for SWE-bench Lite)
 - `default` — web-app repos with frontend dev-server signals
+- `ios` — iOS / Swift mobile apps (xcodebuild, simulator)
 
-The benchmark never uses `har env init --auto`.
+## HAR setup prompt
+
+The setup agent receives `prompts/har-setup.md`, which embeds the same text as
+`.har/ADAPT-PROMPT.md` from `har env init`, plus SWE-bench-specific constraints
+(no `launch.sh` edits, smoke-only pre-fix gate, no slot launch during setup).
 
 ## Smoke tests
 

--- a/benchmarks/swebench-har/prompts/har-setup.md
+++ b/benchmarks/swebench-har/prompts/har-setup.md
@@ -1,47 +1,54 @@
-Adapt this repository's `.har/` harness for coding agents working on SWE-bench style bug fixes.
+# SWE-bench HAR setup
 
 Repository: {{repo}}
 Instance: {{instance_id}}
-HAR profile used for scaffold: {{har_profile}}
+HAR profile: {{har_profile}}
 
-## Context
+## Benchmark context
 
-`har env init --profile {{har_profile}}` has already been run. The boilerplate `.har/` directory exists but is not yet adapted for this repository.
+`har env init --profile {{har_profile}}` has already been run. The generic harness
+adaptation prompt from that init is included below.
 
-Do **not** run `har env init --auto`. You must edit the generated harness files directly.
+Do **not** run `har env init --auto`. Edit harness files directly.
 
-The benchmark runner validates harness readiness **after** your edits. You do not need to launch slots yourself.
+The benchmark runner validates readiness **after** your edits — do not launch or
+verify slots yourself.
 
-## Objectives
+**SWE-bench grading is external.** Harness quick verify is smoke-only (compile /
+import / build); it does not need to pass the repo's full test suite.
 
-1. Make `har env launch 1` succeed for this repository at the current commit.
-2. Make `har env verify 1` run meaningful fast checks for this repo (typecheck/lint/unit tests as appropriate).
-3. Keep the harness lightweight — SWE-bench grading uses the repo's own test suite, not browser e2e.
-4. Document how agents should use the harness in `.har/CLAUDE.agent.md` and `.har/README.md` if needed.
+## Benchmark constraints (override the generic prompt where they conflict)
 
-## Explore first
+| Topic | Benchmark rule |
+|-------|----------------|
+| `launch.sh` / `agent-slot.sh` | **Do not edit** — runner owns worktrees, slot registry, `--replace` / `--force` |
+| Allowed edits | `harness.env`, `verify.sh` (especially quick-mode smoke steps), `CLAUDE.agent.md`, `README.md` |
+| During setup | Do **not** run `har env launch`, `./.har/launch.sh`, `./.har/teardown.sh`, or `./.har/verify.sh` |
+| Quick verify | Language-agnostic smoke only — not full pytest/Django runtests/Sphinx graphs |
+| Full verify | Optional stricter checks (`--full`); not required for the pre-fix gate |
+| Profile | Stay on `{{har_profile}}` — do not re-init with a different profile |
 
-- `README`, `pyproject.toml`, `setup.py`, `setup.cfg`, `tox.ini`, `Makefile`, CI configs
-- how tests are invoked (`pytest`, `python -m pytest`, etc.)
-- install / dependency setup commands
+Pre-fix gate the runner enforces: `har env launch 1` + quick `har env verify 1`.
 
-## Adapt
+Quick-mode examples (pick what fits this stack):
 
-- `.har/harness.env` — primary app label, any port bases if needed
-- `.har/verify.sh` or stage wiring — real verification commands for this repo
-- `.har/launch.sh` — keep worktree-based behavior and **preserve** `--replace` / `--force` flag parsing from the template; do not disable worktrees (`HARNESS_USE_WORKTREE` must stay `true`)
-- remove TODO placeholders that would cause verify to fail
+- Python: `python -m compileall`, `pip install -e .`, import smoke
+- Node: `npm run build`, `npm run typecheck`
+- Java: `mvn -q compile`, `./gradlew compileJava`
+- Go: `go build ./...`
+- Rust: `cargo check`
 
-## Do NOT during setup
+## Generic HAR adaptation prompt (from `har env init`)
 
-- Do **not** run `har env launch`, `./.har/launch.sh`, or `./.har/verify.sh` — the runner performs launch/verify gates after you finish.
-- Do **not** rewrite `launch.sh` into a minimal repo-root-only launcher unless worktree creation is impossible; prefer adapting verify commands and `harness.env`.
+The following is the same prompt saved to `.har/ADAPT-PROMPT.md` — follow it except
+where the benchmark constraints above take precedence.
 
-## Definition of done
+---
 
-- Edited harness files are ready for the runner to execute `har env launch 1` and `har env verify 1`
-- no unused template services or placeholder commands remain
+{{har_adapt_prompt}}
 
-When finished, summarize what you changed and which verify commands will run.
+---
 
 {{setup_failure_context}}
+
+When finished, summarize what you changed and which **smoke** commands quick verify will run.

--- a/benchmarks/swebench-har/scripts/lib/har_utils.py
+++ b/benchmarks/swebench-har/scripts/lib/har_utils.py
@@ -29,6 +29,63 @@ def har_init_scaffold(repo_path: Path, profile: str, env: dict[str, str] | None 
     )
 
 
+PROFILE_HINTS: dict[str, str] = {
+    "default": (
+        "Web app profile — Docker Compose for shared infra (HARNESS_INFRA_SERVICES), "
+        "PM2 for the primary application only, git worktree per agent slot by default. "
+        "Identify the primary app agents modify; run supporting services shared. "
+        "Adapt docker-compose, setup-infra, and ecosystem templates for this stack."
+    ),
+    "cli": (
+        "CLI/library profile — no PM2. Optional Docker Compose via the "
+        "`HARNESS_INFRA_SERVICES` list in harness.env. Agents work in an isolated "
+        "git worktree by default (`--no-worktree` to use the repo root). Remove any "
+        "leftover PM2/ecosystem files; keep docker-compose when shared services are enabled."
+    ),
+    "ios": (
+        "iOS mobile app profile — no PM2, no web ports. Agents build and test via "
+        "xcodebuild in an isolated git worktree. Set HARNESS_XCODE_SCHEME, "
+        "HARNESS_XCODE_WORKSPACE/PROJECT, HARNESS_SIMULATOR_NAME, and HARNESS_BUNDLE_ID "
+        "in harness.env. Adapt setup-infra.sh to boot the target simulator. Install "
+        "the RocketSim stage template (har env add-stage rocketsim) for user-flow validation."
+    ),
+}
+
+
+def _resolve_init_adapt_template() -> Path | None:
+    from .common import HAR_PROJECT_ROOT
+
+    for candidate in (
+        HAR_PROJECT_ROOT / "dist" / "templates" / "adaptation-prompt-init.md",
+        HAR_PROJECT_ROOT / "src" / "templates" / "adaptation-prompt-init.md",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def build_init_adapt_prompt(profile: str) -> str:
+    """Mirror har's buildInitAdaptationPrompt when .har/ADAPT-PROMPT.md is missing."""
+    template_path = _resolve_init_adapt_template()
+    if template_path is None:
+        raise RuntimeError(
+            "adaptation-prompt-init.md not found in HAR checkout; run npm run build"
+        )
+    content = template_path.read_text(encoding="utf-8")
+    hint = PROFILE_HINTS.get(profile, PROFILE_HINTS["default"])
+    return (
+        content.replace("{{PROFILE}}", profile).replace("{{PROFILE_HINT}}", hint)
+    )
+
+
+def read_har_adapt_prompt(harness_root: Path, profile: str) -> str:
+    """Load the init adaptation prompt written by har env init."""
+    adapt_path = harness_root / ".har" / "ADAPT-PROMPT.md"
+    if adapt_path.exists():
+        return adapt_path.read_text(encoding="utf-8").strip()
+    return build_init_adapt_prompt(profile)
+
+
 def read_har_slot_workdir(harness_root: Path, agent_id: int = 1) -> Path | None:
     slot_path = harness_root / ".har" / "slots" / f"agent-{agent_id}.json"
     if not slot_path.exists():
@@ -94,15 +151,14 @@ def har_teardown_slot(harness_root: Path, agent_id: int = 1, env: dict[str, str]
     run_command([*har_cmd("teardown", str(agent_id), env=env)], cwd=harness_root)
 
 
-def har_validate_ready(
+def har_validate_launch(
     harness_root: Path,
     agent_id: int = 1,
     *,
     timeout_seconds: int = 3600,
     env: dict[str, str] | None = None,
-    verify_full: bool = False,
 ) -> dict[str, Any]:
-    """Runner gate: teardown, launch, and quick verify before the fix stage."""
+    """Pre-fix gate (launch): teardown, launch, workdir, and agent env file."""
     launch_env = har_launch_env(env)
     har_teardown_slot(harness_root, agent_id=agent_id, env=launch_env)
 
@@ -113,40 +169,82 @@ def har_validate_ready(
         env=launch_env,
     )
 
-    if launch_ok:
-        verify_result = har_verify(
-            harness_root,
-            agent_id=agent_id,
-            full=verify_full,
-            env=launch_env,
-        )
-    else:
-        verify_result = {
-            "verified": False,
-            "full": verify_full,
-            "details": "skipped (launch failed)",
-            "stdout": "",
-            "stderr": "",
-            "exit_code": -1,
-        }
-
     agent_env = workdir / f".env.agent.{agent_id}" if workdir else None
-    ready = bool(
+    agent_env_exists = bool(agent_env and agent_env.exists())
+    launch_ready = bool(
         launch_ok
         and workdir is not None
         and workdir.exists()
-        and agent_env is not None
-        and agent_env.exists()
-        and verify_result["verified"]
+        and agent_env_exists
     )
 
     return {
-        "ready": ready,
+        "ready": launch_ready,
         "launch_ok": launch_ok,
         "workdir": str(workdir) if workdir else None,
         "launch_log": launch_log[-4000:],
+        "agent_env_exists": agent_env_exists,
+    }
+
+
+def har_validate_smoke(
+    harness_root: Path,
+    agent_id: int = 1,
+    *,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Pre-fix gate (smoke): quick verify only — compile/import/build, not full test suites."""
+    verify_result = har_verify(harness_root, agent_id=agent_id, full=False, env=env)
+    return {
+        "ready": verify_result["verified"],
+        "smoke_ok": verify_result["verified"],
         "verify": verify_result,
-        "agent_env_exists": agent_env.exists() if agent_env else False,
+    }
+
+
+def har_validate_ready(
+    harness_root: Path,
+    agent_id: int = 1,
+    *,
+    timeout_seconds: int = 3600,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Pre-fix gate: launch readiness + quick smoke verify before the fix stage."""
+    launch = har_validate_launch(
+        harness_root,
+        agent_id=agent_id,
+        timeout_seconds=timeout_seconds,
+        env=env,
+    )
+
+    if launch["ready"]:
+        smoke = har_validate_smoke(harness_root, agent_id=agent_id, env=env)
+    else:
+        smoke = {
+            "ready": False,
+            "smoke_ok": False,
+            "verify": {
+                "verified": False,
+                "full": False,
+                "details": "skipped (launch failed)",
+                "stdout": "",
+                "stderr": "",
+                "exit_code": -1,
+            },
+        }
+
+    ready = bool(launch["ready"] and smoke["ready"])
+
+    return {
+        "ready": ready,
+        "launch": launch,
+        "smoke": smoke,
+        # Backward-compatible fields for gate failure formatting
+        "launch_ok": launch["launch_ok"],
+        "workdir": launch["workdir"],
+        "launch_log": launch["launch_log"],
+        "agent_env_exists": launch["agent_env_exists"],
+        "verify": smoke["verify"],
     }
 
 

--- a/benchmarks/swebench-har/scripts/run_batch.py
+++ b/benchmarks/swebench-har/scripts/run_batch.py
@@ -60,7 +60,7 @@ def run_one_instance(
     dry_run: bool,
     setup_timeout_minutes: int,
     solve_timeout_minutes: int,
-    verify_full: bool,
+    post_fix_verify_full: bool,
     setup_max_attempts: int,
 ) -> dict[str, Any]:
     instance, run_dir = prepare_instance_row(row, seed)
@@ -96,7 +96,7 @@ def run_one_instance(
             dry_run=dry_run,
             setup_timeout_minutes=setup_timeout_minutes,
             solve_timeout_minutes=solve_timeout_minutes,
-            verify_full=verify_full,
+            post_fix_verify_full=verify_full,
             setup_max_attempts=setup_max_attempts,
         )
 

--- a/benchmarks/swebench-har/scripts/run_one.py
+++ b/benchmarks/swebench-har/scripts/run_one.py
@@ -35,6 +35,7 @@ from lib.har_utils import (  # noqa: E402
     har_teardown_slot,
     har_validate_ready,
     har_verify,
+    read_har_adapt_prompt,
 )
 from lib.patch import extract_model_patch, filter_changed_files
 from lib.profile import infer_har_profile
@@ -150,7 +151,7 @@ def run_har_arm(
     dry_run: bool,
     setup_timeout_minutes: int,
     solve_timeout_minutes: int,
-    verify_full: bool,
+    post_fix_verify_full: bool,
     setup_max_attempts: int,
 ) -> dict[str, Any]:
     cfg = benchmark_config()
@@ -185,7 +186,6 @@ def run_har_arm(
         harness_root,
         timeout_seconds=gate_timeout,
         env=env,
-        verify_full=verify_full,
     )
     record["har_gate_initial"] = gate
 
@@ -201,6 +201,7 @@ def run_har_arm(
                 prompt_values(
                     instance,
                     har_profile=profile,
+                    har_adapt_prompt=read_har_adapt_prompt(harness_root, profile),
                     setup_failure_context=failure_context if attempt > 1 or cache_used else "",
                 ),
             )
@@ -225,7 +226,6 @@ def run_har_arm(
                 harness_root,
                 timeout_seconds=gate_timeout,
                 env=env,
-                verify_full=verify_full,
             )
             record[f"har_gate_attempt_{attempt}"] = gate
             if gate["ready"]:
@@ -249,7 +249,7 @@ def run_har_arm(
         }
         record["har_verify"] = gate.get("verify")
         record["status"] = "failed"
-        record["error"] = "HAR launch/verify gate failed before fix stage"
+        record["error"] = "HAR pre-fix gate failed (launch or smoke verify) before fix stage"
         record["finished_at"] = now_iso()
         return record
 
@@ -259,7 +259,8 @@ def run_har_arm(
         "log": gate.get("launch_log", ""),
         "workdir": str(workdir),
     }
-    record["har_gate_verify"] = gate.get("verify")
+    record["har_gate_launch"] = gate.get("launch")
+    record["har_gate_smoke"] = gate.get("smoke")
     record["har_ready_for_fix"] = True
 
     solve_started = time.time()
@@ -278,7 +279,7 @@ def run_har_arm(
     record["codex_fix"] = fix_codex.result
     record["solve_seconds"] = round(time.time() - solve_started, 2)
 
-    verify_result = har_verify(harness_root, full=verify_full, env=env)
+    verify_result = har_verify(harness_root, full=post_fix_verify_full, env=env)
     record["har_verify"] = verify_result
     record["har_verify_attempted"] = True
     record["har_verify_passed"] = verify_result["verified"]
@@ -316,15 +317,19 @@ def run_har_arm(
 
 
 def _format_gate_failure(gate: dict[str, Any]) -> str:
-    verify = gate.get("verify") or {}
+    launch = gate.get("launch") or {}
+    smoke = gate.get("smoke") or {}
+    verify = smoke.get("verify") or gate.get("verify") or {}
     return (
-        "\n## Previous launch/verify gate failed\n"
-        "The benchmark runner could not launch or verify this harness. Fix the harness files.\n\n"
-        f"Launch ok: {gate.get('launch_ok')}\n"
-        f"Agent env exists: {gate.get('agent_env_exists')}\n"
-        f"Launch log (tail):\n```\n{gate.get('launch_log', '')}\n```\n"
-        f"Verify exit code: {verify.get('exit_code')}\n"
-        f"Verify stderr (tail):\n```\n{verify.get('stderr', '')}\n```\n"
+        "\n## Previous pre-fix gate failed\n"
+        "The benchmark runner could not launch the slot or pass quick smoke verify. "
+        "Fix harness.env and verify.sh quick-mode steps only — do not edit launch.sh.\n\n"
+        f"Launch ready: {launch.get('ready', gate.get('launch_ok'))}\n"
+        f"Agent env exists: {launch.get('agent_env_exists', gate.get('agent_env_exists'))}\n"
+        f"Smoke ready: {smoke.get('ready')}\n"
+        f"Launch log (tail):\n```\n{launch.get('launch_log', gate.get('launch_log', ''))}\n```\n"
+        f"Smoke verify exit code: {verify.get('exit_code')}\n"
+        f"Smoke verify stderr (tail):\n```\n{verify.get('stderr', '')}\n```\n"
     )
 
 
@@ -388,7 +393,7 @@ def main() -> int:
             dry_run=args.dry_run,
             setup_timeout_minutes=setup_timeout,
             solve_timeout_minutes=solve_timeout,
-            verify_full=bool(cfg.get("har_verify_full", False)),
+            post_fix_verify_full=bool(cfg.get("har_verify_full", False)),
             setup_max_attempts=setup_max_attempts,
         )
 

--- a/benchmarks/swebench-har/scripts/test_swebench_har.py
+++ b/benchmarks/swebench-har/scripts/test_swebench_har.py
@@ -15,6 +15,13 @@ sys.path.insert(0, str(SCRIPTS))
 
 from lib.common import benchmark_config, render_template, sanitize_instance_row  # noqa: E402
 from lib.har_cache import har_cache_exists, load_har_cache, save_har_cache  # noqa: E402
+from lib.har_utils import (  # noqa: E402
+    build_init_adapt_prompt,
+    har_validate_launch,
+    har_validate_ready,
+    har_validate_smoke,
+    read_har_adapt_prompt,
+)
 from lib.patch import extract_model_patch, filter_changed_files  # noqa: E402
 from lib.profile import infer_har_profile  # noqa: E402
 
@@ -137,10 +144,48 @@ def test_prompt_render() -> None:
             "repo": "foo/bar",
             "instance_id": "foo__bar-1",
             "har_profile": "cli",
+            "har_adapt_prompt": build_init_adapt_prompt("cli"),
             "setup_failure_context": "",
         },
     )
     assert "Do **not** run `har env launch`" in setup
+    assert "Do not edit" in setup and "launch.sh" in setup
+    assert "Generic HAR adaptation prompt" in setup
+    assert "Adapt the `.har/` harness" in setup
+    assert "smoke-only" in setup
+
+
+def test_read_har_adapt_prompt_prefers_file() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        harness_root = Path(tmp) / "repo"
+        har_dir = harness_root / ".har"
+        har_dir.mkdir(parents=True)
+        (har_dir / "ADAPT-PROMPT.md").write_text("custom adapt prompt\n", encoding="utf-8")
+        assert read_har_adapt_prompt(harness_root, "cli") == "custom adapt prompt"
+
+
+def test_build_init_adapt_prompt_fills_profile() -> None:
+    prompt = build_init_adapt_prompt("cli")
+    assert "## Profile: cli" in prompt
+    assert "CLI/library profile" in prompt
+    assert "{{PROFILE}}" not in prompt
+
+
+def test_har_validate_helpers_exported() -> None:
+    assert callable(har_validate_launch)
+    assert callable(har_validate_smoke)
+    assert callable(har_validate_ready)
+
+
+def test_har_validate_ready_shape() -> None:
+    """Gate result exposes split launch/smoke without calling HAR CLI."""
+    import inspect
+
+    source = inspect.getsource(har_validate_ready)
+    assert "har_validate_launch" in source
+    assert "har_validate_smoke" in source
+    assert '"launch"' in source
+    assert '"smoke"' in source
 
 
 def test_dry_run_orchestration() -> None:
@@ -167,6 +212,10 @@ def main() -> int:
         test_patch_filtering,
         test_patch_extraction_excludes_har,
         test_prompt_render,
+        test_read_har_adapt_prompt_prefers_file,
+        test_build_init_adapt_prompt_fills_profile,
+        test_har_validate_helpers_exported,
+        test_har_validate_ready_shape,
         test_dry_run_orchestration,
         test_evaluate_dry_run,
     ]

--- a/src/harness/stage-templates.ts
+++ b/src/harness/stage-templates.ts
@@ -162,7 +162,7 @@ function patchStageRegistry(
     stages[verifyIdx] = {
       ...stages[verifyIdx],
       description:
-        'Verification pipeline (quick by default; --full adds lint and browser-e2e when installed)',
+        'Verification pipeline (quick smoke by default; --full adds tests, lint, and browser-e2e when installed)',
       acceptsArgs: ['--full'],
     };
   }

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -42,7 +42,21 @@ Primary app, ports, `HARNESS_INFRA_SERVICES`, migrate/seed commands, health chec
 PM2 processes for the primary application only, matching how it runs in dev. Skip entirely for the CLI profile.
 
 ### `.har/verify.sh`
-Real typecheck, lint, test, and health check commands — replace all TODOs.
+Adapt verification for this repository's toolchain. Step lists in the template are
+**examples, not exhaustive** — add, remove, or reorder `run_step` calls to match
+how this project is built and tested.
+
+**Tier contract:**
+
+| Mode | Command | Intent |
+|------|---------|--------|
+| Quick (default) | `har env verify 1` | Smoke — compile / import / build / health only |
+| Full | `har env verify 1 --full` | Stricter — unit tests, lint, readiness, optional browser-e2e |
+
+- **Quick** must stay fast and minimal (syntax, compile, import smoke) — not the full test suite.
+- **Full** holds unit tests, lint, and heavier checks; optional Playwright runs on `--full` when installed.
+- Reuse real commands from `package.json`, `Makefile`, CI, `pyproject.toml`, etc.
+- Replace all TODO placeholders in both tiers.
 
 ### Readiness vs liveness (required)
 Do not treat a passing health check as adaptation complete. Before finishing,

--- a/src/templates/har-boilerplate-cli/README.md
+++ b/src/templates/har-boilerplate-cli/README.md
@@ -20,7 +20,7 @@ Generated and maintained by [`har`](https://github.com/antoineFrau/har). Run `ha
 | `agent-slot.sh` | Shared agent-id validation (reads limits from `harness.env`) |
 | `setup-infra.sh` | Start optional Docker Compose stack + template database |
 | `launch.sh` | Launch one agent slot (git worktree by default, deps, env file) |
-| `verify.sh` | Verification pipeline (typecheck, tests, lint, build) |
+| `verify.sh` | Verification pipeline (smoke by default; --full adds tests, lint, e2e) |
 | `teardown.sh` | Tear down one agent slot (worktree + env file) |
 | `agent-cli.sh` | Inspect slot status, run commands in the work dir |
 | `docker-compose.agent.yml` | Shared infrastructure containers (services listed in `HARNESS_INFRA_SERVICES`) |
@@ -47,8 +47,8 @@ In Cursor with HAR MCP configured: use `har_launch_environment`, `har_run_verifi
 ```bash
 ./.har/setup-infra.sh          # when HARNESS_INFRA_SERVICES is non-empty
 ./.har/launch.sh 1
-./.har/verify.sh 1
-./.har/verify.sh 1 --full      # + lint, build, browser-e2e (if Playwright installed)
+./.har/verify.sh 1             # quick: smoke (typecheck + build)
+./.har/verify.sh 1 --full      # + unit tests, lint, browser-e2e (if Playwright installed)
 ./.har/teardown.sh 1
 ```
 
@@ -56,10 +56,14 @@ Read **`stages.json`** and **`verificationStages`**. Optional: `har env add-stag
 
 ## Verification contract
 
+Steps in `verify.sh` are **project-specific examples** — adapt them to your stack
+during `har env init` / `har env maintain` / benchmark setup. The table describes
+each tier's intent, not a fixed command list.
+
 | Mode | Command | Typical steps |
 |------|---------|---------------|
-| Quick | `har env verify <id>` or `verify.sh <id>` | typecheck, unit tests |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint, optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
+| Quick | `har env verify <id>` or `verify.sh <id>` | Smoke: compile / typecheck / build (language-agnostic) |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + unit tests, lint, optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
 
 For repos that need runtime services, distinguish health from usability. If the
 harness skips slow local-dev setup, document the skipped steps and add a minimal

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# Verification pipeline for CLI/library repos — typecheck, test, lint, build.
+# Verification pipeline for CLI/library repos.
 # Outputs JSON to stdout, human-readable progress to stderr.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
+#
+# Quick (default): smoke — compile / typecheck / build only
+# Full (--full):   + unit tests, lint, optional readiness + browser-e2e
+# Step lists are examples — not exhaustive. Adapt commands to this repo's stack.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -89,12 +93,15 @@ process.stdout.write(JSON.stringify(arr));
   fi
 }
 
+# ── Quick (default): smoke only ──────────────────────────────────────────────
+# Customize for this repo: compile / import / build — not the full test suite.
 run_step "typecheck" "npm run typecheck" || { [ -z "$FULL" ] && true; }
 # Some unit tests exec dist/index.js (e.g. stage-templates CLI add-stage).
 run_step "build" "npm run build" || { [ -z "$FULL" ] && true; }
-run_step "unit-tests" "npm test" || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
+  # ── Full: project-specific checks (examples — add/remove/reorder as needed) ─
+  run_step "unit-tests" "npm test" || true
   run_step "lint" "npm run lint" || true
   run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true

--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -20,7 +20,7 @@ Generated and maintained by [`har`](https://github.com/antoineFrau/har). Run `ha
 | `agent-slot.sh` | Shared agent-id validation and slot registry helpers |
 | `setup-infra.sh` | Boot the iOS Simulator; start optional Docker services |
 | `launch.sh` | Launch one agent slot (git worktree, CocoaPods/SPM deps, env file) |
-| `verify.sh` | Verification pipeline (build + unit-tests; --full adds lint + user-flow validation) |
+| `verify.sh` | Verification pipeline (build smoke by default; --full adds tests, lint, flows) |
 | `teardown.sh` | Tear down one agent slot (worktree + env file) |
 | `agent-cli.sh` | Inspect slot status, run xcodebuild commands, install/launch app |
 | `docker-compose.agent.yml` | Optional shared backend services |
@@ -47,8 +47,8 @@ In Cursor with HAR MCP configured: use `har_launch_environment`, `har_run_verifi
 ```bash
 ./.har/setup-infra.sh          # boots the iOS Simulator
 ./.har/launch.sh 1
-./.har/verify.sh 1             # build + unit-tests
-./.har/verify.sh 1 --full      # + lint + rocketsim-flows (if installed)
+./.har/verify.sh 1             # quick: build smoke (compile-only)
+./.har/verify.sh 1 --full      # + unit tests, lint, rocketsim-flows (if installed)
 ./.har/teardown.sh 1
 ```
 
@@ -64,10 +64,13 @@ This installs `.har/stages/rocketsim-flows.sh` and a `flows/` directory. Add flo
 
 ## Verification contract
 
+Steps in `verify.sh` are **project-specific examples** — adapt them to your stack.
+The table describes each tier's intent, not a fixed command list.
+
 | Mode | Command | Typical steps |
 |------|---------|---------------|
-| Quick | `har env verify <id>` | build, unit-tests |
-| Full | `har env verify <id> --full` | + lint, optional readiness smoke, **rocketsim-flows** when installed |
+| Quick | `har env verify <id>` | build smoke (compile-only) |
+| Full | `har env verify <id> --full` | + unit tests, lint, optional readiness smoke, **rocketsim-flows** when installed |
 
 For apps that depend on local backends, auth, seeded state, or simulator flows,
 distinguish build/test health from agent usability. Document any skipped full

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -4,8 +4,9 @@
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
-# Quick (default): build + unit-tests
-# Full (--full):   + lint (SwiftLint) + rocketsim-flows (if installed)
+# Quick (default): build smoke (compile-only)
+# Full (--full):   + unit tests, lint (SwiftLint), rocketsim-flows (if installed)
+# Step lists are examples — not exhaustive. Adapt commands to this repo's stack.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -114,7 +115,7 @@ process.stdout.write(JSON.stringify(arr));
   fi
 }
 
-# Build (compile-only — catches syntax errors and missing symbols)
+# Quick (default): compile-only — catches syntax errors and missing symbols
 run_step "build" "xcodebuild build \
   ${XC_FLAGS} \
   -scheme \"${XC_SCHEME}\" \
@@ -128,21 +129,21 @@ run_step "build" "xcodebuild build \
     -derivedDataPath \"${XC_DERIVED}\" \
     CODE_SIGNING_ALLOWED=NO" || { [ -z "$FULL" ] && true; }
 
-# Unit tests
-run_step "unit-tests" "xcodebuild test \
-  ${XC_FLAGS} \
-  -scheme \"${XC_SCHEME}\" \
-  -destination \"${XC_DESTINATION}\" \
-  -derivedDataPath \"${XC_DERIVED}\" \
-  CODE_SIGNING_ALLOWED=NO \
-  | xcbeautify 2>/dev/null || xcodebuild test \
+if [ -n "$FULL" ]; then
+  # Full: project-specific checks — add/remove/reorder steps for this repo.
+  run_step "unit-tests" "xcodebuild test \
     ${XC_FLAGS} \
     -scheme \"${XC_SCHEME}\" \
     -destination \"${XC_DESTINATION}\" \
     -derivedDataPath \"${XC_DERIVED}\" \
-    CODE_SIGNING_ALLOWED=NO" || { [ -z "$FULL" ] && true; }
+    CODE_SIGNING_ALLOWED=NO \
+    | xcbeautify 2>/dev/null || xcodebuild test \
+      ${XC_FLAGS} \
+      -scheme \"${XC_SCHEME}\" \
+      -destination \"${XC_DESTINATION}\" \
+      -derivedDataPath \"${XC_DERIVED}\" \
+      CODE_SIGNING_ALLOWED=NO" || true
 
-if [ -n "$FULL" ]; then
   # SwiftLint — optional, skip gracefully when not installed
   run_step "lint" "command -v \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" >/dev/null 2>&1 && \
     \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" --quiet 2>&1 || echo 'swiftlint not installed — skipping'" || true

--- a/src/templates/har-boilerplate/README.md
+++ b/src/templates/har-boilerplate/README.md
@@ -20,7 +20,7 @@ Generated and maintained by [`har`](https://github.com/antoineFrau/har). Run `ha
 | `agent-slot.sh` | Shared agent-id validation (reads limits from `harness.env`) |
 | `setup-infra.sh` | Start shared Docker infra + create template database |
 | `launch.sh` | Launch one agent slot (ports, DB clone, PM2 processes) |
-| `verify.sh` | Verification pipeline (typecheck, tests, health) |
+| `verify.sh` | Verification pipeline (smoke by default; --full adds tests, lint, e2e) |
 | `teardown.sh` | Tear down one agent slot |
 | `agent-cli.sh` | Manage a running agent (status, logs, psql, health) |
 | `attach.sh` | Attach to agent tmux session |
@@ -49,8 +49,8 @@ In Cursor with HAR MCP configured: use `har_launch_environment`, `har_run_verifi
 ```bash
 ./.har/setup-infra.sh          # when HARNESS_INFRA_SERVICES is non-empty
 ./.har/launch.sh 1
-./.har/verify.sh 1             # quick: typecheck, tests, health
-./.har/verify.sh 1 --full      # done gate: + lint + browser-e2e (if Playwright stage installed)
+./.har/verify.sh 1             # quick: smoke (typecheck + health)
+./.har/verify.sh 1 --full      # + unit tests, lint, browser-e2e (if Playwright stage installed)
 ./.har/teardown.sh 1
 ```
 
@@ -58,10 +58,14 @@ Read **`stages.json`** for registered stages and **`verificationStages`** for th
 
 ## Verification contract
 
+Steps in `verify.sh` are **project-specific examples** — adapt them to your stack
+during `har env init` / `har env maintain`. The table describes each tier's intent,
+not a fixed command list.
+
 | Mode | Command | Typical steps |
 |------|---------|---------------|
-| Quick | `har env verify <id>` or `verify.sh <id>` | Project checks in `verify.sh` (stops early on failure) |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | Quick steps + lint + optional readiness smoke + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
+| Quick | `har env verify <id>` or `verify.sh <id>` | Smoke: compile / typecheck / health (stops early on failure) |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + unit tests, lint, optional readiness smoke + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
 
 Install Playwright stage: `har env add-stage playwright` (optional). UI changes should add or update specs under `tests/`.
 

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -3,6 +3,10 @@
 # Outputs JSON to stdout, human-readable progress to stderr.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
+#
+# Quick (default): smoke — compile / typecheck / health only
+# Full (--full):   + unit tests, lint, optional readiness + browser-e2e
+# Step lists are examples — not exhaustive. Adapt commands to this repo's stack.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -133,14 +137,16 @@ process.stdout.write(JSON.stringify(arr));
 }
 
 # ── Verification stages ─────────────────────────────────────────────────────
-# TODO: Customize these steps for your project.
+# Customize these steps for your project — lists below are examples, not exhaustive.
 # Edit this section directly — do not use a separate config file.
 
+# Quick (default): smoke — prove the slot can compile/load, not full test suites.
 run_step "typecheck" "echo 'TODO: npm run typecheck'" || { [ -z "$FULL" ] && true; }
-run_step "unit-tests" "echo 'TODO: npm test'" || { [ -z "$FULL" ] && true; }
 run_http_step "api-health" "http://localhost:${API_PORT}${HARNESS_HEALTH_CHECK_PATH}" || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
+  # Full: project-specific checks — add/remove/reorder steps for this repo.
+  run_step "unit-tests" "echo 'TODO: npm test'" || true
   run_step "lint" "echo 'TODO: npm run lint'" || true
   run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true


### PR DESCRIPTION
Split quick smoke verify from --full test suites in HAR templates, separate benchmark launch/smoke gates from post-fix verify, and embed ADAPT-PROMPT.md in SWE-bench setup with a thin benchmark overlay.

Closes #22, #20, #23