### PR TITLE
feat: language-agnostic launch provisioning across HAR profiles

### DIFF
--- a/benchmarks/swebench-har/scripts/lib/har_utils.py
+++ b/benchmarks/swebench-har/scripts/lib/har_utils.py
@@ -31,23 +31,22 @@ def har_init_scaffold(repo_path: Path, profile: str, env: dict[str, str] | None 
 
 PROFILE_HINTS: dict[str, str] = {
     "default": (
-        "Web app profile — Docker Compose for shared infra (HARNESS_INFRA_SERVICES), "
-        "PM2 for the primary application only, git worktree per agent slot by default. "
-        "Identify the primary app agents modify; run supporting services shared. "
-        "Adapt docker-compose, setup-infra, and ecosystem templates for this stack."
+        "Web app profile (SaaS/full-stack) — Docker Compose for shared infra "
+        "(HARNESS_INFRA_SERVICES), PM2 for the primary application only, git worktree "
+        "per agent slot by default. Launch provisions toolchain via harness.env and "
+        "writes paths to .env.agent.<id>. Identify the primary app agents modify."
     ),
     "cli": (
-        "CLI/library profile — no PM2. Optional Docker Compose via the "
-        "`HARNESS_INFRA_SERVICES` list in harness.env. Agents work in an isolated "
-        "git worktree by default (`--no-worktree` to use the repo root). Remove any "
-        "leftover PM2/ecosystem files; keep docker-compose when shared services are enabled."
+        "CLI/library profile (typical SWE-bench) — no PM2. Optional Docker Compose via "
+        "HARNESS_INFRA_SERVICES. Git worktree by default. Launch provisions toolchain "
+        "declaratively (HARNESS_ECOSYSTEM auto-detects common ecosystems); verify must "
+        "use resolved tool paths from .env.agent.<id>, never hardcoded interpreter or "
+        "package-manager paths."
     ),
     "ios": (
-        "iOS mobile app profile — no PM2, no web ports. Agents build and test via "
-        "xcodebuild in an isolated git worktree. Set HARNESS_XCODE_SCHEME, "
-        "HARNESS_XCODE_WORKSPACE/PROJECT, HARNESS_SIMULATOR_NAME, and HARNESS_BUNDLE_ID "
-        "in harness.env. Adapt setup-infra.sh to boot the target simulator. Install "
-        "the RocketSim stage template (har env add-stage rocketsim) for user-flow validation."
+        "iOS mobile app profile — xcodebuild + iOS Simulator in an isolated git worktree. "
+        "Set HARNESS_XCODE_SCHEME, workspace/project, HARNESS_SIMULATOR_NAME, "
+        "HARNESS_BUNDLE_ID. Launch writes XCODEBUILD_BIN to .env.agent.<id>; verify uses it."
     ),
 }
 

--- a/src/harness/adaptation-prompt.ts
+++ b/src/harness/adaptation-prompt.ts
@@ -9,11 +9,11 @@ export const ADAPTATION_PROMPT_FILE = 'ADAPT-PROMPT.md';
 
 const PROFILE_HINTS: Record<HarnessProfile, string> = {
   default:
-    'Web app profile — Docker Compose for shared infra (HARNESS_INFRA_SERVICES), PM2 for the primary application only, git worktree per agent slot by default. Identify the primary app agents modify; run supporting services shared. Adapt docker-compose, setup-infra, and ecosystem templates for this stack.',
+    'Web app profile (SaaS/full-stack) — Docker Compose for shared infra (HARNESS_INFRA_SERVICES), PM2 for the primary application only, git worktree per agent slot by default. Launch provisions toolchain via harness.env (HARNESS_ECOSYSTEM, HARNESS_INSTALL_CMD) and writes paths to .env.agent.<id>. Identify the primary app agents modify; run supporting services shared.',
   cli:
-    'CLI/library profile — no PM2. Optional Docker Compose via the `HARNESS_INFRA_SERVICES` list in harness.env. Agents work in an isolated git worktree by default (`--no-worktree` to use the repo root). Remove any leftover PM2/ecosystem files; keep docker-compose when shared services are enabled.',
+    'CLI/library profile (typical SWE-bench) — no PM2. Optional Docker Compose via HARNESS_INFRA_SERVICES. Git worktree by default. Launch provisions toolchain declaratively (HARNESS_ECOSYSTEM auto-detects common ecosystems); verify must use resolved tool paths from .env.agent.<id>, never hardcoded interpreter or package-manager paths.',
   ios:
-    'iOS mobile app profile — no PM2, no web ports. Agents build and test via xcodebuild in an isolated git worktree. Set HARNESS_XCODE_SCHEME, HARNESS_XCODE_WORKSPACE/PROJECT, HARNESS_SIMULATOR_NAME, and HARNESS_BUNDLE_ID in harness.env. Adapt setup-infra.sh to boot the target simulator. Install the RocketSim stage template (har env add-stage rocketsim) for user-flow validation.',
+    'iOS mobile app profile — xcodebuild + iOS Simulator in an isolated git worktree. Set HARNESS_XCODE_SCHEME, workspace/project, HARNESS_SIMULATOR_NAME, HARNESS_BUNDLE_ID. Launch writes XCODEBUILD_BIN to .env.agent.<id>; verify uses it. Install RocketSim stage (har env add-stage rocketsim) for user-flow validation.',
 };
 
 function loadTemplate(name: string): string {

--- a/src/harness/validator.ts
+++ b/src/harness/validator.ts
@@ -21,6 +21,7 @@ const REQUIRED_FILES_DEFAULT = [
   'harness.env',
   'setup-infra.sh',
   'launch.sh',
+  'provision-toolchain.sh',
   'verify.sh',
   'teardown.sh',
   'agent-cli.sh',
@@ -41,6 +42,7 @@ const REQUIRED_FILES_IOS = [
   'harness.env',
   'setup-infra.sh',
   'launch.sh',
+  'provision-toolchain.sh',
   'verify.sh',
   'teardown.sh',
   'agent-cli.sh',
@@ -59,6 +61,7 @@ function getRequiredFiles(repoPath: string): string[] {
 const SHELL_SCRIPTS = [
   'setup-infra.sh',
   'launch.sh',
+  'provision-toolchain.sh',
   'verify.sh',
   'teardown.sh',
   'agent-cli.sh',

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -6,6 +6,24 @@ Explore this repository, then edit files in `.har/` directly to make the harness
 
 **Do NOT** create a YAML config or JSON mapping file for runtime behavior. Put behavior directly in the harness scripts and templates.
 
+## HAR profiles (pick the right one at init)
+
+`har env init` scaffolds from one of three boilerplate profiles — **choose the profile that matches this repository**:
+
+| Profile | Best for | What you get |
+|---------|----------|--------------|
+| `default` | **SaaS / web apps** (Next.js, Rails, full-stack, etc.) | Docker Compose shared infra, PM2 for primary app, per-slot ports and preview URLs |
+| `cli` | **CLI tools, libraries, test-suite repos** (typical SWE-bench) | Git worktree by default, no PM2; optional Docker for databases; run project commands in isolation |
+| `ios` | **Mobile iOS / Swift** | xcodebuild + iOS Simulator; scheme/project/simulator in `harness.env` |
+
+```bash
+har env init                  # default (SaaS/web)
+har env init --profile cli    # libraries / CLI / polyglot test repos
+har env init --profile ios    # iOS apps
+```
+
+Do **not** disable worktrees, rewrite launch into repo-root-only mode, or pick the wrong profile unless the project truly requires it.
+
 ## Profile: {{PROFILE}}
 
 {{PROFILE_HINT}}
@@ -38,13 +56,18 @@ Clear index of the harness: what each file does, quick start, architecture, how 
 ### `.har/harness.env`
 Primary app, ports, `HARNESS_INFRA_SERVICES`, migrate/seed commands, health check path.
 
+**Toolchain provisioning:** set `HARNESS_ECOSYSTEM` (`auto` detects from manifests) and optional `HARNESS_INSTALL_CMD`. Launch runs `provision-toolchain.sh`, writes resolved paths (`PYTHON_BIN`, `NODE_BIN`, `NPM_BIN`, `XCODEBUILD_BIN`, …) into `.env.agent.<id>`. Verify steps **must** use those paths — never hardcode venv or interpreter locations.
+
 ### `.har/ecosystem.agent.template.cjs` (default profile only)
 PM2 processes for the primary application only, matching how it runs in dev. Skip entirely for the CLI profile.
 
 ### `.har/verify.sh`
 Adapt verification for this repository's toolchain. Step lists in the template are
 **examples, not exhaustive** — add, remove, or reorder `run_step` calls to match
-how this project is built and tested.
+how this project is built and tested. Use toolchain variables from `.env.agent.<id>`
+(e.g. `${NPM_BIN:-npm}`, `${PYTHON_BIN:-python3}`, `${XCODEBUILD_BIN:-xcodebuild}`).
+The stock verify section is keyed by `HARNESS_ECOSYSTEM`; it is a starting point,
+not the repo's final contract. Replace conventions that do not match this project.
 
 **Tier contract:**
 
@@ -56,6 +79,7 @@ how this project is built and tested.
 - **Quick** must stay fast and minimal (syntax, compile, import smoke) — not the full test suite.
 - **Full** holds unit tests, lint, and heavier checks; optional Playwright runs on `--full` when installed.
 - Reuse real commands from `package.json`, `Makefile`, CI, `pyproject.toml`, etc.
+- Remove stock npm/pytest/go/cargo/maven/gradle examples that do not apply.
 - Replace all TODO placeholders in both tiers.
 
 ### Readiness vs liveness (required)
@@ -88,8 +112,9 @@ scripts or document why no substitute is needed. In particular:
   choose and document an agent-friendly asset mode.
 - Put Layer 3 checks in `verify --full`, a project-owned readiness script, or
   documented smoke URLs. Health alone is not sufficient for UI/auth apps.
-- Ensure `launch.sh` writes the slot registry before slow or fragile steps, and
-  `verify.sh` resolves env/work dir through `agent-slot.sh`.
+- Ensure `launch.sh` writes the slot registry before slow or fragile steps, runs
+  `provision-toolchain.sh` to install deps and record toolchain paths in
+  `.env.agent.<id>`, and `verify.sh` resolves env/work dir through `agent-slot.sh`.
 
 ### Optional Playwright stage
 If the user ran `har env add-stage playwright` (or `@playwright/test` is in package.json):

--- a/src/templates/adaptation-prompt-maintain.md
+++ b/src/templates/adaptation-prompt-maintain.md
@@ -22,8 +22,8 @@ Prefer targeted edits over full rewrites. Key files to review:
 ### `.har/README.md` (required)
 Keep this accurate — it is the harness index. Update whenever scripts, stages, or workflow change.
 
-### `.har/harness.env`, `verify.sh`, `ecosystem.agent.template.cjs`, `CLAUDE.agent.md`
-Align commands and instructions with the current stack.
+### `.har/harness.env`, `verify.sh`, `provision-toolchain.sh`, `ecosystem.agent.template.cjs`, `CLAUDE.agent.md`
+Align commands and instructions with the current stack. Verify steps must use toolchain paths from `.env.agent.<id>` (`PYTHON_BIN`, `NPM_BIN`, `XCODEBUILD_BIN`, …) — never hardcoded venv or interpreter paths. Replace stock ecosystem conventions that do not match the repository; do not leave npm/pytest/go/cargo/maven/gradle examples in place by accident.
 
 ### `.har/env.template`, `setup-infra.sh`, `docker-compose.agent.yml`
 Update only if infra changed.

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -36,9 +36,12 @@ Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har
 ## Project commands
 
 ```bash
-# TODO: adapt for this repository
-# npm run typecheck
+# TODO: adapt for this repository. Examples:
 # npm test
+# pytest -q
+# go test ./...
+# cargo test
+# make test
 ```
 
 ## Do not

--- a/src/templates/har-boilerplate-cli/README.md
+++ b/src/templates/har-boilerplate-cli/README.md
@@ -12,14 +12,15 @@ Generated and maintained by [`har`](https://github.com/antoineFrau/har). Run `ha
 |------|---------|
 | `README.md` | This file — index of the harness |
 | `manifest.json` | Generator metadata (version, profile, checksums) — do not edit |
-| `harness.env` | Shared config: worktree default, `HARNESS_INFRA_SERVICES`, migrate/seed commands |
+| `harness.env` | Shared config: worktree default, `HARNESS_INFRA_SERVICES`, toolchain provisioning (`HARNESS_ECOSYSTEM`, `HARNESS_INSTALL_CMD`), migrate/seed commands |
 | `stages.json` | Machine-readable registry of runnable harness stages |
 | `stages/` | Optional custom stage scripts registered from `stages.json` |
 | `runs/` | Run history from `har env` / MCP only — `.har/runs/YYYY-MM-DD/HH-mm-ss_<stageId>_agent-<id>.json` (gitignore) |
 | `artifacts/` | Stage outputs: reports, traces, screenshots, logs |
 | `agent-slot.sh` | Shared agent-id validation (reads limits from `harness.env`) |
 | `setup-infra.sh` | Start optional Docker Compose stack + template database |
-| `launch.sh` | Launch one agent slot (git worktree by default, deps, env file) |
+| `launch.sh` | Launch one agent slot (git worktree by default, toolchain provisioning, env file) |
+| `provision-toolchain.sh` | Install deps and write toolchain paths (`PYTHON_BIN`, `NPM_BIN`, …) to `.env.agent.<id>` |
 | `verify.sh` | Verification pipeline (smoke by default; --full adds tests, lint, e2e) |
 | `teardown.sh` | Tear down one agent slot (worktree + env file) |
 | `agent-cli.sh` | Inspect slot status, run commands in the work dir |
@@ -47,8 +48,8 @@ In Cursor with HAR MCP configured: use `har_launch_environment`, `har_run_verifi
 ```bash
 ./.har/setup-infra.sh          # when HARNESS_INFRA_SERVICES is non-empty
 ./.har/launch.sh 1
-./.har/verify.sh 1             # quick: smoke (typecheck + build)
-./.har/verify.sh 1 --full      # + unit tests, lint, browser-e2e (if Playwright installed)
+./.har/verify.sh 1             # quick: ecosystem smoke (compile/import/build)
+./.har/verify.sh 1 --full      # + conventional tests, lint, browser-e2e (if installed)
 ./.har/teardown.sh 1
 ```
 
@@ -62,8 +63,13 @@ each tier's intent, not a fixed command list.
 
 | Mode | Command | Typical steps |
 |------|---------|---------------|
-| Quick | `har env verify <id>` or `verify.sh <id>` | Smoke: compile / typecheck / build (language-agnostic) |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + unit tests, lint, optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
+| Quick | `har env verify <id>` or `verify.sh <id>` | Stock ecosystem smoke: compile / import / build conventions |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | Stock conventional tests/lint + optional readiness smoke, **browser-e2e** when `stages/browser-e2e.sh` exists |
+
+The stock commands are deliberately generic conventions keyed by
+`HARNESS_ECOSYSTEM`. Replace them with the repository's real commands during
+adaptation; do not leave Node/npm, Python, Go, Rust, Java, or Ruby defaults in
+place when they do not match the project.
 
 For repos that need runtime services, distinguish health from usability. If the
 harness skips slow local-dev setup, document the skipped steps and add a minimal

--- a/src/templates/har-boilerplate-cli/agent-cli.sh
+++ b/src/templates/har-boilerplate-cli/agent-cli.sh
@@ -61,7 +61,7 @@ case "$COMMAND" in
   logs)
     echo "CLI profile has no managed processes (no PM2)." >&2
     echo "Run project commands in the work dir, e.g.:" >&2
-    echo "  ./.har/agent-cli.sh ${AGENT_ID} exec npm test" >&2
+    echo "  ./.har/agent-cli.sh ${AGENT_ID} exec make test" >&2
     exit 1
     ;;
 

--- a/src/templates/har-boilerplate-cli/harness.env
+++ b/src/templates/har-boilerplate-cli/harness.env
@@ -11,6 +11,12 @@ export HARNESS_HEALTH_CHECK_PATH=
 export HARNESS_AGENT_SLOT_MIN=1
 export HARNESS_AGENT_SLOT_MAX=3
 
+# Toolchain provisioning — launch writes resolved paths into .env.agent.<id>
+# Ecosystem: auto (detect from manifests) | node | python | go | rust | java | ruby | none
+export HARNESS_ECOSYSTEM="auto"
+# Optional install override (eval in work dir after env file is created)
+# export HARNESS_INSTALL_CMD="make deps"
+
 # Shared infrastructure — space-separated docker compose service names from
 # docker-compose.agent.yml, started ONCE by setup-infra.sh and shared by all
 # agent slots on fixed ports. Empty = no containers. Prune/add services in the

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -79,7 +79,7 @@ fi
 # whose .gitignore doesn't know about har (applies to all worktrees too).
 GIT_EXCLUDE="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)/info/exclude"
 if [ -n "$GIT_EXCLUDE" ] && [ -d "$(dirname "$GIT_EXCLUDE")" ]; then
-  for pattern in '.env.agent.*' 'ecosystem.agent.*.config.cjs'; do
+  for pattern in '.env.agent.*' 'ecosystem.agent.*.config.cjs' '.har/venv'; do
     grep -qxF "$pattern" "$GIT_EXCLUDE" 2>/dev/null || echo "$pattern" >> "$GIT_EXCLUDE"
   done
 fi
@@ -134,18 +134,13 @@ SLOT_STATUS="starting" \
   write_slot_registry
 REGISTRY_WRITTEN=true
 
-if [ -f "$WORK_DIR/package.json" ]; then
-  log "Installing dependencies..."
-  (cd "$WORK_DIR" && npm install --silent)
-elif [ -f "$WORK_DIR/go.mod" ]; then
-  log "Go module detected in work dir (run go mod download if needed)"
-fi
-
-# Monorepo: file:/workspace deps may resolve modules from the repo root — install there too
-if [ -n "${REL_PREFIX:-}" ] && [ -f "$WORKTREE_DIR/package.json" ] && [ ! -d "$WORKTREE_DIR/node_modules" ]; then
-  log "Installing monorepo root dependencies in $WORKTREE_DIR..."
-  (cd "$WORKTREE_DIR" && npm install --silent)
-fi
+log "Provisioning toolchain (see harness.env: HARNESS_ECOSYSTEM, HARNESS_INSTALL_CMD)..."
+HAR_WORK_DIR="$WORK_DIR" \
+HAR_ENV_FILE="$ENV_FILE" \
+HAR_WORKTREE_DIR="${WORKTREE_DIR:-}" \
+HAR_REL_PREFIX="${REL_PREFIX:-}" \
+HAR_AGENT_ID="$AGENT_ID" \
+  "$SCRIPT_DIR/provision-toolchain.sh"
 
 # Record the session in the slot registry — the source of truth for where
 # this slot's code lives (status/verify/teardown resolve through it).

--- a/src/templates/har-boilerplate-cli/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-cli/provision-toolchain.sh
@@ -123,7 +123,20 @@ provision_python() {
 
   if [ ! -d "$venv_dir" ]; then
     pt_log "Creating Python venv at $venv_rel..."
-    python3 -m venv "$venv_dir"
+    if ! python3 -m venv "$venv_dir"; then
+      rm -rf "$venv_dir"
+      pt_log "python3 -m venv failed (on Debian/Ubuntu install python3-venv) — using system python3"
+      append_env "HARNESS_ECOSYSTEM" "python"
+      append_env "PYTHON_BIN" "$(command -v python3)"
+      return
+    fi
+  fi
+
+  if [ ! -x "$venv_dir/bin/python" ]; then
+    pt_log "Python venv at $venv_rel is missing or broken — using system python3"
+    append_env "HARNESS_ECOSYSTEM" "python"
+    append_env "PYTHON_BIN" "$(command -v python3)"
+    return
   fi
 
   python_bin="$venv_dir/bin/python"

--- a/src/templates/har-boilerplate-cli/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-cli/provision-toolchain.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Provision the project toolchain and append resolved paths to .env.agent.<id>.
+# Called from launch.sh after the agent env file is created.
+#
+# Configure in harness.env:
+#   HARNESS_ECOSYSTEM   — auto (default) | node | python | go | rust | java | ruby | ios | none
+#   HARNESS_INSTALL_CMD — optional override (eval in HAR_WORK_DIR)
+# Ecosystem-specific optional overrides:
+#   HARNESS_PYTHON_VENV_DIR — Python venv path relative to HAR_WORK_DIR (default: .har/venv)
+#
+# Required env from caller: HAR_WORK_DIR, HAR_ENV_FILE
+# Optional: HAR_WORKTREE_DIR, HAR_REL_PREFIX, HAR_AGENT_ID (for logging)
+set -euo pipefail
+
+: "${HAR_WORK_DIR:?HAR_WORK_DIR is required}"
+: "${HAR_ENV_FILE:?HAR_ENV_FILE is required}"
+
+HAR_WORKTREE_DIR="${HAR_WORKTREE_DIR:-}"
+HAR_REL_PREFIX="${HAR_REL_PREFIX:-}"
+HAR_AGENT_ID="${HAR_AGENT_ID:-}"
+
+pt_log() {
+  if [ -n "$HAR_AGENT_ID" ]; then
+    echo "==> [agent-${HAR_AGENT_ID}] toolchain: $*" >&2
+  else
+    echo "==> [provision-toolchain] $*" >&2
+  fi
+}
+
+append_env() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value" >> "$HAR_ENV_FILE"
+}
+
+append_path_prefix() {
+  local prefix="$1"
+  [ -n "$prefix" ] && [ -d "$prefix" ] || return 0
+  append_env "PATH" "${prefix}:${PATH:-$PATH}"
+}
+
+detect_ecosystem() {
+  local dir="$1"
+  local configured="${HARNESS_ECOSYSTEM:-auto}"
+  if [ -n "$configured" ] && [ "$configured" != "auto" ]; then
+    echo "$configured"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then echo node; return; fi
+  if [ -f "$dir/pyproject.toml" ] || [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ] \
+    || [ -f "$dir/requirements.txt" ] || [ -f "$dir/Pipfile" ]; then
+    echo python
+    return
+  fi
+  if [ -f "$dir/go.mod" ]; then echo go; return; fi
+  if [ -f "$dir/Cargo.toml" ]; then echo rust; return; fi
+  if [ -f "$dir/pom.xml" ] || [ -f "$dir/build.gradle" ] || [ -f "$dir/build.gradle.kts" ]; then
+    echo java
+    return
+  fi
+  if [ -f "$dir/Gemfile" ]; then echo ruby; return; fi
+  if [ -n "${HARNESS_XCODE_SCHEME:-}" ] || [ -n "${HARNESS_XCODE_PROJECT:-}" ] \
+    || [ -n "${HARNESS_XCODE_WORKSPACE:-}" ]; then
+    echo ios
+    return
+  fi
+  echo none
+}
+
+run_install_cmd() {
+  local dir="$1"
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    pt_log "Running HARNESS_INSTALL_CMD..."
+    (cd "$dir" && eval "$HARNESS_INSTALL_CMD")
+    return
+  fi
+  return 1
+}
+
+provision_node() {
+  local dir="$1"
+  local npm_bin="npm"
+  local node_bin="node"
+
+  if ! run_install_cmd "$dir"; then
+    pt_log "Installing Node dependencies..."
+    if [ -f "$dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
+      (cd "$dir" && pnpm install --silent)
+      npm_bin="pnpm"
+    elif [ -f "$dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
+      (cd "$dir" && yarn install --silent)
+      npm_bin="yarn"
+    else
+      (cd "$dir" && npm install --silent)
+    fi
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    node_bin="$(command -v node)"
+  fi
+  if [ "$npm_bin" = "npm" ] && command -v npm >/dev/null 2>&1; then
+    npm_bin="$(command -v npm)"
+  fi
+
+  append_env "HARNESS_ECOSYSTEM" "node"
+  append_env "NODE_BIN" "$node_bin"
+  append_env "NPM_BIN" "$npm_bin"
+  append_path_prefix "$dir/node_modules/.bin"
+}
+
+provision_python() {
+  local dir="$1"
+  local venv_rel="${HARNESS_PYTHON_VENV_DIR:-.har/venv}"
+  local venv_dir="$dir/$venv_rel"
+  local python_bin="python3"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    pt_log "python3 not found on PATH — skipping venv provisioning"
+    append_env "HARNESS_ECOSYSTEM" "python"
+    append_env "PYTHON_BIN" "${PYTHON_BIN:-python3}"
+    return
+  fi
+
+  if [ ! -d "$venv_dir" ]; then
+    pt_log "Creating Python venv at $venv_rel..."
+    python3 -m venv "$venv_dir"
+  fi
+
+  python_bin="$venv_dir/bin/python"
+  # shellcheck disable=SC1091
+  source "$venv_dir/bin/activate"
+
+  if ! run_install_cmd "$dir"; then
+    pt_log "Installing Python dependencies..."
+    if [ -f "$dir/pyproject.toml" ]; then
+      (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
+    elif [ -f "$dir/requirements.txt" ]; then
+      (cd "$dir" && pip install -q -r requirements.txt)
+    elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+      (cd "$dir" && pip install -q -e .)
+    elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
+      (cd "$dir" && pipenv install --dev)
+      python_bin="$(cd "$dir" && pipenv --py)"
+    fi
+  fi
+
+  append_env "HARNESS_ECOSYSTEM" "python"
+  append_env "PYTHON_BIN" "$python_bin"
+  append_env "VIRTUAL_ENV" "$venv_dir"
+  append_path_prefix "$venv_dir/bin"
+}
+
+provision_go() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v go >/dev/null 2>&1; then
+      pt_log "Downloading Go modules..."
+      (cd "$dir" && go mod download)
+    else
+      pt_log "go not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "go"
+  append_env "GO_BIN" "$(command -v go 2>/dev/null || echo go)"
+  if [ -n "${GOPATH:-}" ]; then append_env "GOPATH" "$GOPATH"; fi
+  if [ -n "${GOROOT:-}" ]; then append_env "GOROOT" "$GOROOT"; fi
+}
+
+provision_rust() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v cargo >/dev/null 2>&1; then
+      pt_log "Fetching Rust dependencies..."
+      (cd "$dir" && cargo fetch)
+    else
+      pt_log "cargo not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "rust"
+  append_env "CARGO_BIN" "$(command -v cargo 2>/dev/null || echo cargo)"
+  append_env "RUSTC_BIN" "$(command -v rustc 2>/dev/null || echo rustc)"
+}
+
+provision_java() {
+  local dir="$1"
+  run_install_cmd "$dir" || true
+  append_env "HARNESS_ECOSYSTEM" "java"
+  if [ -n "${JAVA_HOME:-}" ]; then
+    append_env "JAVA_HOME" "$JAVA_HOME"
+    append_path_prefix "$JAVA_HOME/bin"
+  fi
+  if command -v mvn >/dev/null 2>&1; then
+    append_env "MVN_BIN" "$(command -v mvn)"
+  elif [ -f "$dir/gradlew" ]; then
+    append_env "GRADLE_BIN" "$dir/gradlew"
+  elif command -v gradle >/dev/null 2>&1; then
+    append_env "GRADLE_BIN" "$(command -v gradle)"
+  fi
+}
+
+provision_ruby() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v bundle >/dev/null 2>&1; then
+      pt_log "Installing Ruby gems..."
+      (cd "$dir" && bundle install --quiet)
+    else
+      pt_log "bundle not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "ruby"
+  append_env "RUBY_BIN" "$(command -v ruby 2>/dev/null || echo ruby)"
+  append_env "BUNDLE_BIN" "$(command -v bundle 2>/dev/null || echo bundle)"
+  append_path_prefix "$dir/vendor/bundle/bin"
+}
+
+provision_ios() {
+  local dir="$1"
+  run_install_cmd "$dir" || true
+  append_env "HARNESS_ECOSYSTEM" "ios"
+  append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
+  if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then
+    append_env "HARNESS_XCODE_SCHEME" "$HARNESS_XCODE_SCHEME"
+  fi
+  if [ -n "${HARNESS_SIMULATOR_NAME:-}" ]; then
+    append_env "HARNESS_SIMULATOR_NAME" "$HARNESS_SIMULATOR_NAME"
+  fi
+  if [ -n "${HARNESS_BUNDLE_ID:-}" ]; then
+    append_env "HARNESS_BUNDLE_ID" "$HARNESS_BUNDLE_ID"
+  fi
+  if [ -n "${DEVELOPER_DIR:-}" ]; then
+    append_env "DEVELOPER_DIR" "$DEVELOPER_DIR"
+  fi
+}
+
+provision_monorepo_root() {
+  [ -n "$HAR_REL_PREFIX" ] || return 0
+  [ -n "$HAR_WORKTREE_DIR" ] || return 0
+  [ -f "$HAR_WORKTREE_DIR/package.json" ] || return 0
+  [ -d "$HAR_WORKTREE_DIR/node_modules" ] && return 0
+  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
+  (cd "$HAR_WORKTREE_DIR" && npm install --silent)
+}
+
+provision_ecosystem() {
+  local dir="$1"
+  local ecosystem
+  ecosystem="$(detect_ecosystem "$dir")"
+  pt_log "Toolchain ecosystem: ${ecosystem} (work dir: ${dir})"
+
+  case "$ecosystem" in
+    node) provision_node "$dir" ;;
+    python) provision_python "$dir" ;;
+    go) provision_go "$dir" ;;
+    rust) provision_rust "$dir" ;;
+    java) provision_java "$dir" ;;
+    ruby) provision_ruby "$dir" ;;
+    ios) provision_ios "$dir" ;;
+    none)
+      if run_install_cmd "$dir"; then
+        append_env "HARNESS_ECOSYSTEM" "custom"
+      else
+        pt_log "No ecosystem manifest detected — set HARNESS_ECOSYSTEM or HARNESS_INSTALL_CMD in harness.env"
+        append_env "HARNESS_ECOSYSTEM" "none"
+      fi
+      ;;
+  esac
+}
+
+append_env "HARNESS_TOOLCHAIN_PROVISIONED" "true"
+provision_ecosystem "$HAR_WORK_DIR"
+provision_monorepo_root

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -4,9 +4,9 @@
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
-# Quick (default): smoke — compile / typecheck / build only
-# Full (--full):   + unit tests, lint, optional readiness + browser-e2e
-# Step lists are examples — not exhaustive. Adapt commands to this repo's stack.
+# Quick (default): ecosystem smoke — compile/import/build only
+# Full (--full):   + conventional tests, lint, optional readiness + browser-e2e
+# Stock steps are examples. Replace them during adaptation to match this repo.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -61,7 +61,7 @@ run_step() {
   start=$(now_ms)
 
   set +e
-  output=$(cd "$WORK_DIR" && eval "$cmd" 2>&1)
+  output=$(cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$cmd" 2>&1)
   exit_code=$?
   set -e
 
@@ -93,16 +93,97 @@ process.stdout.write(JSON.stringify(arr));
   fi
 }
 
-# ── Quick (default): smoke only ──────────────────────────────────────────────
-# Customize for this repo: compile / import / build — not the full test suite.
-run_step "typecheck" "npm run typecheck" || { [ -z "$FULL" ] && true; }
-# Some unit tests exec dist/index.js (e.g. stage-templates CLI add-stage).
-run_step "build" "npm run build" || { [ -z "$FULL" ] && true; }
+node_package_script_exists() {
+  local script="$1"
+  "${NODE_BIN:-node}" -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const script = process.argv[1];
+process.exit(pkg.scripts && pkg.scripts[script] ? 0 : 1);
+" "$script"
+}
+
+run_node_script_or_skip() {
+  local name="$1"
+  local script="$2"
+  if node_package_script_exists "$script"; then
+    run_step "$name" "${NPM_BIN:-npm} run ${script}"
+  else
+    run_step "$name" "echo 'No ${script} script configured; skipping.'"
+  fi
+}
+
+run_node_quick_smoke() {
+  if node_package_script_exists typecheck; then
+    run_step "node-typecheck" '${NPM_BIN:-npm} run typecheck'
+  elif node_package_script_exists build; then
+    run_step "node-build" '${NPM_BIN:-npm} run build'
+  else
+    run_step "node-package-load" '${NODE_BIN:-node} -e "require(\"./package.json\")"'
+  fi
+}
+
+run_quick_smoke() {
+  case "${HARNESS_ECOSYSTEM:-none}" in
+    node)
+      run_node_quick_smoke
+      ;;
+    python)
+      run_step "python-compile" '${PYTHON_BIN:-python3} -m compileall -q .'
+      ;;
+    go)
+      run_step "go-build" '${GO_BIN:-go} build ./...'
+      ;;
+    rust)
+      run_step "rust-check" '${CARGO_BIN:-cargo} check'
+      ;;
+    java)
+      run_step "java-compile" 'if [ -x ./mvnw ]; then ./mvnw -q -DskipTests compile; elif command -v mvn >/dev/null 2>&1; then mvn -q -DskipTests compile; elif [ -x ./gradlew ]; then ./gradlew classes; elif command -v gradle >/dev/null 2>&1; then gradle classes; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi'
+      ;;
+    ruby)
+      run_step "ruby-smoke" '${RUBY_BIN:-ruby} -e "puts RUBY_VERSION"'
+      ;;
+    custom|none|*)
+      run_step "smoke-not-configured" 'echo "No stock smoke for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."'
+      ;;
+  esac
+}
+
+run_full_checks() {
+  case "${HARNESS_ECOSYSTEM:-none}" in
+    node)
+      run_node_script_or_skip "unit-tests" test || true
+      run_node_script_or_skip "lint" lint || true
+      ;;
+    python)
+      run_step "unit-tests" 'if ${PYTHON_BIN:-python3} -c "import pytest" >/dev/null 2>&1; then ${PYTHON_BIN:-python3} -m pytest -q; else echo "pytest not installed; adapt verify.sh for this Python repo."; fi' || true
+      ;;
+    go)
+      run_step "unit-tests" '${GO_BIN:-go} test ./...' || true
+      ;;
+    rust)
+      run_step "unit-tests" '${CARGO_BIN:-cargo} test' || true
+      ;;
+    java)
+      run_step "unit-tests" 'if [ -x ./mvnw ]; then ./mvnw -q test; elif command -v mvn >/dev/null 2>&1; then mvn -q test; elif [ -x ./gradlew ]; then ./gradlew test; elif command -v gradle >/dev/null 2>&1; then gradle test; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi' || true
+      ;;
+    ruby)
+      run_step "unit-tests" 'if command -v "${BUNDLE_BIN:-bundle}" >/dev/null 2>&1 && [ -f Gemfile ]; then "${BUNDLE_BIN:-bundle}" exec rake test 2>/dev/null || "${BUNDLE_BIN:-bundle}" exec rspec; else echo "No Ruby test command detected; adapt verify.sh for this Ruby repo."; fi' || true
+      ;;
+    custom|none|*)
+      run_step "unit-tests" 'echo "No stock full checks for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."' || true
+      ;;
+  esac
+}
+
+# ── Verification stages ─────────────────────────────────────────────────────
+# These stock steps are intentionally generic conventions. Adapt this section
+# to the repository's real commands from package.json, Makefile, CI, pyproject,
+# Cargo.toml, go.mod, pom.xml, etc.
+run_quick_smoke || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
-  # ── Full: project-specific checks (examples — add/remove/reorder as needed) ─
-  run_step "unit-tests" "npm test" || true
-  run_step "lint" "npm run lint" || true
+  run_full_checks
   run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi

--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -12,14 +12,15 @@ Generated and maintained by [`har`](https://github.com/antoineFrau/har). Run `ha
 |------|---------|
 | `README.md` | This file — index of the harness |
 | `manifest.json` | Generator metadata (version, profile, checksums) — do not edit |
-| `harness.env` | Shared config: Xcode scheme, simulator name, bundle ID, infra flags |
+| `harness.env` | Shared config: Xcode scheme, simulator name, bundle ID, toolchain provisioning, infra flags |
 | `stages.json` | Machine-readable registry of runnable harness stages |
 | `stages/` | Optional custom stage scripts registered from `stages.json` |
 | `runs/` | Run history from `har env` / MCP — gitignored |
 | `artifacts/` | Stage outputs: test results, screenshots, logs |
 | `agent-slot.sh` | Shared agent-id validation and slot registry helpers |
 | `setup-infra.sh` | Boot the iOS Simulator; start optional Docker services |
-| `launch.sh` | Launch one agent slot (git worktree, CocoaPods/SPM deps, env file) |
+| `launch.sh` | Launch one agent slot (git worktree, toolchain provisioning, env file) |
+| `provision-toolchain.sh` | Write Xcode/simulator paths (`XCODEBUILD_BIN`, …) to `.env.agent.<id>` |
 | `verify.sh` | Verification pipeline (build smoke by default; --full adds tests, lint, flows) |
 | `teardown.sh` | Tear down one agent slot (worktree + env file) |
 | `agent-cli.sh` | Inspect slot status, run xcodebuild commands, install/launch app |

--- a/src/templates/har-boilerplate-ios/harness.env
+++ b/src/templates/har-boilerplate-ios/harness.env
@@ -7,6 +7,10 @@ export HARNESS_USE_WORKTREE=true
 export HARNESS_AGENT_SLOT_MIN=1
 export HARNESS_AGENT_SLOT_MAX=3
 
+# Toolchain provisioning — launch writes Xcode/simulator paths into .env.agent.<id>
+export HARNESS_ECOSYSTEM="ios"
+# export HARNESS_INSTALL_CMD="xcodebuild -resolvePackageDependencies ..."
+
 # ── Xcode project ─────────────────────────────────────────────────────────────
 # Set one of HARNESS_XCODE_WORKSPACE or HARNESS_XCODE_PROJECT (workspace wins).
 export HARNESS_XCODE_WORKSPACE=""     # e.g. MyApp.xcworkspace (relative to repo root)

--- a/src/templates/har-boilerplate-ios/launch.sh
+++ b/src/templates/har-boilerplate-ios/launch.sh
@@ -79,7 +79,7 @@ fi
 # whose .gitignore doesn't know about har (applies to all worktrees too).
 GIT_EXCLUDE="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)/info/exclude"
 if [ -n "$GIT_EXCLUDE" ] && [ -d "$(dirname "$GIT_EXCLUDE")" ]; then
-  for pattern in '.env.agent.*' 'ecosystem.agent.*.config.cjs'; do
+  for pattern in '.env.agent.*' 'ecosystem.agent.*.config.cjs' '.har/venv'; do
     grep -qxF "$pattern" "$GIT_EXCLUDE" 2>/dev/null || echo "$pattern" >> "$GIT_EXCLUDE"
   done
 fi
@@ -134,18 +134,13 @@ SLOT_STATUS="starting" \
   write_slot_registry
 REGISTRY_WRITTEN=true
 
-if [ -f "$WORK_DIR/package.json" ]; then
-  log "Installing dependencies..."
-  (cd "$WORK_DIR" && npm install --silent)
-elif [ -f "$WORK_DIR/go.mod" ]; then
-  log "Go module detected in work dir (run go mod download if needed)"
-fi
-
-# Monorepo: file:/workspace deps may resolve modules from the repo root — install there too
-if [ -n "${REL_PREFIX:-}" ] && [ -f "$WORKTREE_DIR/package.json" ] && [ ! -d "$WORKTREE_DIR/node_modules" ]; then
-  log "Installing monorepo root dependencies in $WORKTREE_DIR..."
-  (cd "$WORKTREE_DIR" && npm install --silent)
-fi
+log "Provisioning toolchain (see harness.env: HARNESS_ECOSYSTEM, HARNESS_INSTALL_CMD)..."
+HAR_WORK_DIR="$WORK_DIR" \
+HAR_ENV_FILE="$ENV_FILE" \
+HAR_WORKTREE_DIR="${WORKTREE_DIR:-}" \
+HAR_REL_PREFIX="${REL_PREFIX:-}" \
+HAR_AGENT_ID="$AGENT_ID" \
+  "$SCRIPT_DIR/provision-toolchain.sh"
 
 # Record the session in the slot registry — the source of truth for where
 # this slot's code lives (status/verify/teardown resolve through it).

--- a/src/templates/har-boilerplate-ios/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-ios/provision-toolchain.sh
@@ -123,7 +123,20 @@ provision_python() {
 
   if [ ! -d "$venv_dir" ]; then
     pt_log "Creating Python venv at $venv_rel..."
-    python3 -m venv "$venv_dir"
+    if ! python3 -m venv "$venv_dir"; then
+      rm -rf "$venv_dir"
+      pt_log "python3 -m venv failed (on Debian/Ubuntu install python3-venv) — using system python3"
+      append_env "HARNESS_ECOSYSTEM" "python"
+      append_env "PYTHON_BIN" "$(command -v python3)"
+      return
+    fi
+  fi
+
+  if [ ! -x "$venv_dir/bin/python" ]; then
+    pt_log "Python venv at $venv_rel is missing or broken — using system python3"
+    append_env "HARNESS_ECOSYSTEM" "python"
+    append_env "PYTHON_BIN" "$(command -v python3)"
+    return
   fi
 
   python_bin="$venv_dir/bin/python"

--- a/src/templates/har-boilerplate-ios/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-ios/provision-toolchain.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Provision the project toolchain and append resolved paths to .env.agent.<id>.
+# Called from launch.sh after the agent env file is created.
+#
+# Configure in harness.env:
+#   HARNESS_ECOSYSTEM   — auto (default) | node | python | go | rust | java | ruby | ios | none
+#   HARNESS_INSTALL_CMD — optional override (eval in HAR_WORK_DIR)
+# Ecosystem-specific optional overrides:
+#   HARNESS_PYTHON_VENV_DIR — Python venv path relative to HAR_WORK_DIR (default: .har/venv)
+#
+# Required env from caller: HAR_WORK_DIR, HAR_ENV_FILE
+# Optional: HAR_WORKTREE_DIR, HAR_REL_PREFIX, HAR_AGENT_ID (for logging)
+set -euo pipefail
+
+: "${HAR_WORK_DIR:?HAR_WORK_DIR is required}"
+: "${HAR_ENV_FILE:?HAR_ENV_FILE is required}"
+
+HAR_WORKTREE_DIR="${HAR_WORKTREE_DIR:-}"
+HAR_REL_PREFIX="${HAR_REL_PREFIX:-}"
+HAR_AGENT_ID="${HAR_AGENT_ID:-}"
+
+pt_log() {
+  if [ -n "$HAR_AGENT_ID" ]; then
+    echo "==> [agent-${HAR_AGENT_ID}] toolchain: $*" >&2
+  else
+    echo "==> [provision-toolchain] $*" >&2
+  fi
+}
+
+append_env() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value" >> "$HAR_ENV_FILE"
+}
+
+append_path_prefix() {
+  local prefix="$1"
+  [ -n "$prefix" ] && [ -d "$prefix" ] || return 0
+  append_env "PATH" "${prefix}:${PATH:-$PATH}"
+}
+
+detect_ecosystem() {
+  local dir="$1"
+  local configured="${HARNESS_ECOSYSTEM:-auto}"
+  if [ -n "$configured" ] && [ "$configured" != "auto" ]; then
+    echo "$configured"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then echo node; return; fi
+  if [ -f "$dir/pyproject.toml" ] || [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ] \
+    || [ -f "$dir/requirements.txt" ] || [ -f "$dir/Pipfile" ]; then
+    echo python
+    return
+  fi
+  if [ -f "$dir/go.mod" ]; then echo go; return; fi
+  if [ -f "$dir/Cargo.toml" ]; then echo rust; return; fi
+  if [ -f "$dir/pom.xml" ] || [ -f "$dir/build.gradle" ] || [ -f "$dir/build.gradle.kts" ]; then
+    echo java
+    return
+  fi
+  if [ -f "$dir/Gemfile" ]; then echo ruby; return; fi
+  if [ -n "${HARNESS_XCODE_SCHEME:-}" ] || [ -n "${HARNESS_XCODE_PROJECT:-}" ] \
+    || [ -n "${HARNESS_XCODE_WORKSPACE:-}" ]; then
+    echo ios
+    return
+  fi
+  echo none
+}
+
+run_install_cmd() {
+  local dir="$1"
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    pt_log "Running HARNESS_INSTALL_CMD..."
+    (cd "$dir" && eval "$HARNESS_INSTALL_CMD")
+    return
+  fi
+  return 1
+}
+
+provision_node() {
+  local dir="$1"
+  local npm_bin="npm"
+  local node_bin="node"
+
+  if ! run_install_cmd "$dir"; then
+    pt_log "Installing Node dependencies..."
+    if [ -f "$dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
+      (cd "$dir" && pnpm install --silent)
+      npm_bin="pnpm"
+    elif [ -f "$dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
+      (cd "$dir" && yarn install --silent)
+      npm_bin="yarn"
+    else
+      (cd "$dir" && npm install --silent)
+    fi
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    node_bin="$(command -v node)"
+  fi
+  if [ "$npm_bin" = "npm" ] && command -v npm >/dev/null 2>&1; then
+    npm_bin="$(command -v npm)"
+  fi
+
+  append_env "HARNESS_ECOSYSTEM" "node"
+  append_env "NODE_BIN" "$node_bin"
+  append_env "NPM_BIN" "$npm_bin"
+  append_path_prefix "$dir/node_modules/.bin"
+}
+
+provision_python() {
+  local dir="$1"
+  local venv_rel="${HARNESS_PYTHON_VENV_DIR:-.har/venv}"
+  local venv_dir="$dir/$venv_rel"
+  local python_bin="python3"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    pt_log "python3 not found on PATH — skipping venv provisioning"
+    append_env "HARNESS_ECOSYSTEM" "python"
+    append_env "PYTHON_BIN" "${PYTHON_BIN:-python3}"
+    return
+  fi
+
+  if [ ! -d "$venv_dir" ]; then
+    pt_log "Creating Python venv at $venv_rel..."
+    python3 -m venv "$venv_dir"
+  fi
+
+  python_bin="$venv_dir/bin/python"
+  # shellcheck disable=SC1091
+  source "$venv_dir/bin/activate"
+
+  if ! run_install_cmd "$dir"; then
+    pt_log "Installing Python dependencies..."
+    if [ -f "$dir/pyproject.toml" ]; then
+      (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
+    elif [ -f "$dir/requirements.txt" ]; then
+      (cd "$dir" && pip install -q -r requirements.txt)
+    elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+      (cd "$dir" && pip install -q -e .)
+    elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
+      (cd "$dir" && pipenv install --dev)
+      python_bin="$(cd "$dir" && pipenv --py)"
+    fi
+  fi
+
+  append_env "HARNESS_ECOSYSTEM" "python"
+  append_env "PYTHON_BIN" "$python_bin"
+  append_env "VIRTUAL_ENV" "$venv_dir"
+  append_path_prefix "$venv_dir/bin"
+}
+
+provision_go() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v go >/dev/null 2>&1; then
+      pt_log "Downloading Go modules..."
+      (cd "$dir" && go mod download)
+    else
+      pt_log "go not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "go"
+  append_env "GO_BIN" "$(command -v go 2>/dev/null || echo go)"
+  if [ -n "${GOPATH:-}" ]; then append_env "GOPATH" "$GOPATH"; fi
+  if [ -n "${GOROOT:-}" ]; then append_env "GOROOT" "$GOROOT"; fi
+}
+
+provision_rust() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v cargo >/dev/null 2>&1; then
+      pt_log "Fetching Rust dependencies..."
+      (cd "$dir" && cargo fetch)
+    else
+      pt_log "cargo not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "rust"
+  append_env "CARGO_BIN" "$(command -v cargo 2>/dev/null || echo cargo)"
+  append_env "RUSTC_BIN" "$(command -v rustc 2>/dev/null || echo rustc)"
+}
+
+provision_java() {
+  local dir="$1"
+  run_install_cmd "$dir" || true
+  append_env "HARNESS_ECOSYSTEM" "java"
+  if [ -n "${JAVA_HOME:-}" ]; then
+    append_env "JAVA_HOME" "$JAVA_HOME"
+    append_path_prefix "$JAVA_HOME/bin"
+  fi
+  if command -v mvn >/dev/null 2>&1; then
+    append_env "MVN_BIN" "$(command -v mvn)"
+  elif [ -f "$dir/gradlew" ]; then
+    append_env "GRADLE_BIN" "$dir/gradlew"
+  elif command -v gradle >/dev/null 2>&1; then
+    append_env "GRADLE_BIN" "$(command -v gradle)"
+  fi
+}
+
+provision_ruby() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v bundle >/dev/null 2>&1; then
+      pt_log "Installing Ruby gems..."
+      (cd "$dir" && bundle install --quiet)
+    else
+      pt_log "bundle not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "ruby"
+  append_env "RUBY_BIN" "$(command -v ruby 2>/dev/null || echo ruby)"
+  append_env "BUNDLE_BIN" "$(command -v bundle 2>/dev/null || echo bundle)"
+  append_path_prefix "$dir/vendor/bundle/bin"
+}
+
+provision_ios() {
+  local dir="$1"
+  run_install_cmd "$dir" || true
+  append_env "HARNESS_ECOSYSTEM" "ios"
+  append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
+  if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then
+    append_env "HARNESS_XCODE_SCHEME" "$HARNESS_XCODE_SCHEME"
+  fi
+  if [ -n "${HARNESS_SIMULATOR_NAME:-}" ]; then
+    append_env "HARNESS_SIMULATOR_NAME" "$HARNESS_SIMULATOR_NAME"
+  fi
+  if [ -n "${HARNESS_BUNDLE_ID:-}" ]; then
+    append_env "HARNESS_BUNDLE_ID" "$HARNESS_BUNDLE_ID"
+  fi
+  if [ -n "${DEVELOPER_DIR:-}" ]; then
+    append_env "DEVELOPER_DIR" "$DEVELOPER_DIR"
+  fi
+}
+
+provision_monorepo_root() {
+  [ -n "$HAR_REL_PREFIX" ] || return 0
+  [ -n "$HAR_WORKTREE_DIR" ] || return 0
+  [ -f "$HAR_WORKTREE_DIR/package.json" ] || return 0
+  [ -d "$HAR_WORKTREE_DIR/node_modules" ] && return 0
+  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
+  (cd "$HAR_WORKTREE_DIR" && npm install --silent)
+}
+
+provision_ecosystem() {
+  local dir="$1"
+  local ecosystem
+  ecosystem="$(detect_ecosystem "$dir")"
+  pt_log "Toolchain ecosystem: ${ecosystem} (work dir: ${dir})"
+
+  case "$ecosystem" in
+    node) provision_node "$dir" ;;
+    python) provision_python "$dir" ;;
+    go) provision_go "$dir" ;;
+    rust) provision_rust "$dir" ;;
+    java) provision_java "$dir" ;;
+    ruby) provision_ruby "$dir" ;;
+    ios) provision_ios "$dir" ;;
+    none)
+      if run_install_cmd "$dir"; then
+        append_env "HARNESS_ECOSYSTEM" "custom"
+      else
+        pt_log "No ecosystem manifest detected — set HARNESS_ECOSYSTEM or HARNESS_INSTALL_CMD in harness.env"
+        append_env "HARNESS_ECOSYSTEM" "none"
+      fi
+      ;;
+  esac
+}
+
+append_env "HARNESS_TOOLCHAIN_PROVISIONED" "true"
+provision_ecosystem "$HAR_WORK_DIR"
+provision_monorepo_root

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -83,7 +83,7 @@ run_step() {
   start=$(now_ms)
 
   set +e
-  output=$(cd "$WORK_DIR" && eval "$cmd" 2>&1)
+  output=$(cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$cmd" 2>&1)
   exit_code=$?
   set -e
 
@@ -115,34 +115,34 @@ process.stdout.write(JSON.stringify(arr));
   fi
 }
 
-# Quick (default): compile-only — catches syntax errors and missing symbols
-run_step "build" "xcodebuild build \
+# Quick (default): compile-only — use XCODEBUILD_BIN from .env.agent.<id> (written by launch)
+run_step "build" '${XCODEBUILD_BIN:-xcodebuild} build \
   ${XC_FLAGS} \
-  -scheme \"${XC_SCHEME}\" \
-  -destination \"${XC_DESTINATION}\" \
-  -derivedDataPath \"${XC_DERIVED}\" \
+  -scheme "${XC_SCHEME}" \
+  -destination "${XC_DESTINATION}" \
+  -derivedDataPath "${XC_DERIVED}" \
   CODE_SIGNING_ALLOWED=NO \
-  | xcbeautify 2>/dev/null || xcodebuild build \
+  | xcbeautify 2>/dev/null || ${XCODEBUILD_BIN:-xcodebuild} build \
     ${XC_FLAGS} \
-    -scheme \"${XC_SCHEME}\" \
-    -destination \"${XC_DESTINATION}\" \
-    -derivedDataPath \"${XC_DERIVED}\" \
-    CODE_SIGNING_ALLOWED=NO" || { [ -z "$FULL" ] && true; }
+    -scheme "${XC_SCHEME}" \
+    -destination "${XC_DESTINATION}" \
+    -derivedDataPath "${XC_DERIVED}" \
+    CODE_SIGNING_ALLOWED=NO' || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
   # Full: project-specific checks — add/remove/reorder steps for this repo.
-  run_step "unit-tests" "xcodebuild test \
+  run_step "unit-tests" '${XCODEBUILD_BIN:-xcodebuild} test \
     ${XC_FLAGS} \
-    -scheme \"${XC_SCHEME}\" \
-    -destination \"${XC_DESTINATION}\" \
-    -derivedDataPath \"${XC_DERIVED}\" \
+    -scheme "${XC_SCHEME}" \
+    -destination "${XC_DESTINATION}" \
+    -derivedDataPath "${XC_DERIVED}" \
     CODE_SIGNING_ALLOWED=NO \
-    | xcbeautify 2>/dev/null || xcodebuild test \
+    | xcbeautify 2>/dev/null || ${XCODEBUILD_BIN:-xcodebuild} test \
       ${XC_FLAGS} \
-      -scheme \"${XC_SCHEME}\" \
-      -destination \"${XC_DESTINATION}\" \
-      -derivedDataPath \"${XC_DERIVED}\" \
-      CODE_SIGNING_ALLOWED=NO" || true
+      -scheme "${XC_SCHEME}" \
+      -destination "${XC_DESTINATION}" \
+      -derivedDataPath "${XC_DERIVED}" \
+      CODE_SIGNING_ALLOWED=NO' || true
 
   # SwiftLint — optional, skip gracefully when not installed
   run_step "lint" "command -v \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" >/dev/null 2>&1 && \

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -50,10 +50,12 @@ Quick loop during development: MCP `har_run_verification`, `har env verify ${AGE
 ## Project commands
 
 ```bash
-# TODO: adapt for this repository (see package.json, Makefile, etc.)
+# TODO: adapt for this repository (see package.json, Makefile, pyproject.toml, CI, etc.)
 # npm run typecheck
-# npm test
-# npm run lint
+# pytest -q
+# go test ./...
+# cargo test
+# make test
 ```
 
 ## Do not

--- a/src/templates/har-boilerplate/README.md
+++ b/src/templates/har-boilerplate/README.md
@@ -12,14 +12,15 @@ Generated and maintained by [`har`](https://github.com/antoineFrau/har). Run `ha
 |------|---------|
 | `README.md` | This file — index of the harness |
 | `manifest.json` | Generator metadata (version, checksums) — do not edit |
-| `harness.env` | Shared config: primary app, ports, agent slot limits, `HARNESS_INFRA_SERVICES`, migrate/seed commands |
+| `harness.env` | Shared config: primary app, ports, agent slot limits, `HARNESS_INFRA_SERVICES`, toolchain provisioning, migrate/seed commands |
 | `stages.json` | Machine-readable registry of runnable harness stages |
 | `stages/` | Optional custom stage scripts registered from `stages.json` |
 | `runs/` | Run history from `har env` / MCP only — `.har/runs/YYYY-MM-DD/HH-mm-ss_<stageId>_agent-<id>.json` (gitignore) |
 | `artifacts/` | Stage outputs: reports, traces, screenshots, logs |
 | `agent-slot.sh` | Shared agent-id validation (reads limits from `harness.env`) |
 | `setup-infra.sh` | Start shared Docker infra + create template database |
-| `launch.sh` | Launch one agent slot (ports, DB clone, PM2 processes) |
+| `launch.sh` | Launch one agent slot (ports, DB clone, toolchain provisioning, PM2 processes) |
+| `provision-toolchain.sh` | Install deps and write toolchain paths to `.env.agent.<id>` |
 | `verify.sh` | Verification pipeline (smoke by default; --full adds tests, lint, e2e) |
 | `teardown.sh` | Tear down one agent slot |
 | `agent-cli.sh` | Manage a running agent (status, logs, psql, health) |
@@ -49,8 +50,8 @@ In Cursor with HAR MCP configured: use `har_launch_environment`, `har_run_verifi
 ```bash
 ./.har/setup-infra.sh          # when HARNESS_INFRA_SERVICES is non-empty
 ./.har/launch.sh 1
-./.har/verify.sh 1             # quick: smoke (typecheck + health)
-./.har/verify.sh 1 --full      # + unit tests, lint, browser-e2e (if Playwright stage installed)
+./.har/verify.sh 1             # quick: ecosystem smoke + health
+./.har/verify.sh 1 --full      # + conventional tests/lint, browser-e2e (if installed)
 ./.har/teardown.sh 1
 ```
 
@@ -64,8 +65,13 @@ not a fixed command list.
 
 | Mode | Command | Typical steps |
 |------|---------|---------------|
-| Quick | `har env verify <id>` or `verify.sh <id>` | Smoke: compile / typecheck / health (stops early on failure) |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + unit tests, lint, optional readiness smoke + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
+| Quick | `har env verify <id>` or `verify.sh <id>` | Stock ecosystem smoke + health (stops early on failure) |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | Stock conventional tests/lint, optional readiness smoke + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
+
+The stock commands are deliberately generic conventions keyed by
+`HARNESS_ECOSYSTEM`. Replace them with the repository's real commands during
+adaptation; do not leave Node/npm, Python, Go, Rust, Java, or Ruby defaults in
+place when they do not match the project.
 
 Install Playwright stage: `har env add-stage playwright` (optional). UI changes should add or update specs under `tests/`.
 

--- a/src/templates/har-boilerplate/ecosystem.agent.template.cjs
+++ b/src/templates/har-boilerplate/ecosystem.agent.template.cjs
@@ -23,6 +23,8 @@ module.exports = {
     // .har/ecosystem.shared.config.cjs (started by setup-infra.sh, processes
     // named "har-shared-<name>", fixed ports). A primary app may still need two
     // processes (e.g. api + frontend) — add one entry per process.
+    // Example Node dev process. Replace with this repo's actual primary app
+    // command (Rails, Django, Go, Java, etc. should not keep this npm entry).
     {
       name: 'agent-${AGENT_ID}-api',
       script: 'npm',

--- a/src/templates/har-boilerplate/env.template
+++ b/src/templates/har-boilerplate/env.template
@@ -32,6 +32,9 @@ S3_FORCE_PATH_STYLE=true
 # Headless browser (if enabled)
 HEADLESS_BROWSER_URL=http://localhost:${BROWSER_PORT}
 
+# Toolchain paths — appended by provision-toolchain.sh during launch
+# NODE_BIN=  NPM_BIN=  PYTHON_BIN=  VIRTUAL_ENV=  GO_BIN=  CARGO_BIN=  JAVA_HOME=
+
 # Mail (if enabled)
 SMTP_HOST=localhost
 SMTP_PORT=11025

--- a/src/templates/har-boilerplate/harness.env
+++ b/src/templates/har-boilerplate/harness.env
@@ -19,6 +19,11 @@ export HARNESS_HEALTH_CHECK_PATH=/health
 export HARNESS_AGENT_SLOT_MIN=1
 export HARNESS_AGENT_SLOT_MAX=5
 
+# Toolchain provisioning — launch writes resolved paths into .env.agent.<id>
+# Ecosystem: auto (detect from manifests) | node | python | go | rust | java | ruby | none
+export HARNESS_ECOSYSTEM="auto"
+# export HARNESS_INSTALL_CMD="make deps"
+
 # Shared infrastructure — space-separated docker compose service names from
 # docker-compose.agent.yml. Started ONCE by setup-infra.sh and shared by all
 # agent slots on fixed ports. Prune/add services in the compose file, then

--- a/src/templates/har-boilerplate/launch.sh
+++ b/src/templates/har-boilerplate/launch.sh
@@ -110,26 +110,12 @@ else
   log "Using repo root (worktree disabled)"
 fi
 
-# Install dependencies (fresh worktrees have no node_modules — PM2 config needs them at load time)
-if [ -f "$WORK_DIR/package.json" ] && [ ! -d "$WORK_DIR/node_modules" ]; then
-  log "Installing dependencies in $WORK_DIR..."
-  (cd "$WORK_DIR" && npm install --silent)
-elif [ -f "$WORK_DIR/go.mod" ] && [ ! -d "$WORK_DIR/vendor" ]; then
-  log "Go module detected in work dir (run go mod download if needed)"
-fi
-
-# Monorepo: file:/workspace deps may resolve modules from the repo root — install there too
-if [ -n "${REL_PREFIX:-}" ] && [ -f "$WORKTREE_DIR/package.json" ] && [ ! -d "$WORKTREE_DIR/node_modules" ]; then
-  log "Installing monorepo root dependencies in $WORKTREE_DIR..."
-  (cd "$WORKTREE_DIR" && npm install --silent)
-fi
-
 # Generate .env.agent.N
 # Keep harness-generated files out of accidental `git add -A` commits in repos
 # whose .gitignore doesn't know about har (applies to all worktrees too).
 GIT_EXCLUDE="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)/info/exclude"
 if [ -n "$GIT_EXCLUDE" ] && [ -d "$(dirname "$GIT_EXCLUDE")" ]; then
-  for pattern in '.env.agent.*' 'ecosystem.agent.*.config.cjs'; do
+  for pattern in '.env.agent.*' 'ecosystem.agent.*.config.cjs' '.har/venv'; do
     grep -qxF "$pattern" "$GIT_EXCLUDE" 2>/dev/null || echo "$pattern" >> "$GIT_EXCLUDE"
   done
 fi
@@ -190,6 +176,14 @@ SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"
 SLOT_STATUS="starting" \
   write_slot_registry
 REGISTRY_WRITTEN=true
+
+log "Provisioning toolchain (see harness.env: HARNESS_ECOSYSTEM, HARNESS_INSTALL_CMD)..."
+HAR_WORK_DIR="$WORK_DIR" \
+HAR_ENV_FILE="$ENV_FILE" \
+HAR_WORKTREE_DIR="${WORKTREE_DIR:-}" \
+HAR_REL_PREFIX="${REL_PREFIX:-}" \
+HAR_AGENT_ID="$AGENT_ID" \
+  "$SCRIPT_DIR/provision-toolchain.sh"
 
 if [ -n "${HARNESS_DB_MINIMAL_BOOTSTRAP_CMD:-}" ]; then
   log "Running minimal data bootstrap..."

--- a/src/templates/har-boilerplate/provision-toolchain.sh
+++ b/src/templates/har-boilerplate/provision-toolchain.sh
@@ -123,7 +123,20 @@ provision_python() {
 
   if [ ! -d "$venv_dir" ]; then
     pt_log "Creating Python venv at $venv_rel..."
-    python3 -m venv "$venv_dir"
+    if ! python3 -m venv "$venv_dir"; then
+      rm -rf "$venv_dir"
+      pt_log "python3 -m venv failed (on Debian/Ubuntu install python3-venv) — using system python3"
+      append_env "HARNESS_ECOSYSTEM" "python"
+      append_env "PYTHON_BIN" "$(command -v python3)"
+      return
+    fi
+  fi
+
+  if [ ! -x "$venv_dir/bin/python" ]; then
+    pt_log "Python venv at $venv_rel is missing or broken — using system python3"
+    append_env "HARNESS_ECOSYSTEM" "python"
+    append_env "PYTHON_BIN" "$(command -v python3)"
+    return
   fi
 
   python_bin="$venv_dir/bin/python"

--- a/src/templates/har-boilerplate/provision-toolchain.sh
+++ b/src/templates/har-boilerplate/provision-toolchain.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Provision the project toolchain and append resolved paths to .env.agent.<id>.
+# Called from launch.sh after the agent env file is created.
+#
+# Configure in harness.env:
+#   HARNESS_ECOSYSTEM   — auto (default) | node | python | go | rust | java | ruby | ios | none
+#   HARNESS_INSTALL_CMD — optional override (eval in HAR_WORK_DIR)
+# Ecosystem-specific optional overrides:
+#   HARNESS_PYTHON_VENV_DIR — Python venv path relative to HAR_WORK_DIR (default: .har/venv)
+#
+# Required env from caller: HAR_WORK_DIR, HAR_ENV_FILE
+# Optional: HAR_WORKTREE_DIR, HAR_REL_PREFIX, HAR_AGENT_ID (for logging)
+set -euo pipefail
+
+: "${HAR_WORK_DIR:?HAR_WORK_DIR is required}"
+: "${HAR_ENV_FILE:?HAR_ENV_FILE is required}"
+
+HAR_WORKTREE_DIR="${HAR_WORKTREE_DIR:-}"
+HAR_REL_PREFIX="${HAR_REL_PREFIX:-}"
+HAR_AGENT_ID="${HAR_AGENT_ID:-}"
+
+pt_log() {
+  if [ -n "$HAR_AGENT_ID" ]; then
+    echo "==> [agent-${HAR_AGENT_ID}] toolchain: $*" >&2
+  else
+    echo "==> [provision-toolchain] $*" >&2
+  fi
+}
+
+append_env() {
+  local key="$1"
+  local value="$2"
+  printf '%s=%s\n' "$key" "$value" >> "$HAR_ENV_FILE"
+}
+
+append_path_prefix() {
+  local prefix="$1"
+  [ -n "$prefix" ] && [ -d "$prefix" ] || return 0
+  append_env "PATH" "${prefix}:${PATH:-$PATH}"
+}
+
+detect_ecosystem() {
+  local dir="$1"
+  local configured="${HARNESS_ECOSYSTEM:-auto}"
+  if [ -n "$configured" ] && [ "$configured" != "auto" ]; then
+    echo "$configured"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then echo node; return; fi
+  if [ -f "$dir/pyproject.toml" ] || [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ] \
+    || [ -f "$dir/requirements.txt" ] || [ -f "$dir/Pipfile" ]; then
+    echo python
+    return
+  fi
+  if [ -f "$dir/go.mod" ]; then echo go; return; fi
+  if [ -f "$dir/Cargo.toml" ]; then echo rust; return; fi
+  if [ -f "$dir/pom.xml" ] || [ -f "$dir/build.gradle" ] || [ -f "$dir/build.gradle.kts" ]; then
+    echo java
+    return
+  fi
+  if [ -f "$dir/Gemfile" ]; then echo ruby; return; fi
+  if [ -n "${HARNESS_XCODE_SCHEME:-}" ] || [ -n "${HARNESS_XCODE_PROJECT:-}" ] \
+    || [ -n "${HARNESS_XCODE_WORKSPACE:-}" ]; then
+    echo ios
+    return
+  fi
+  echo none
+}
+
+run_install_cmd() {
+  local dir="$1"
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    pt_log "Running HARNESS_INSTALL_CMD..."
+    (cd "$dir" && eval "$HARNESS_INSTALL_CMD")
+    return
+  fi
+  return 1
+}
+
+provision_node() {
+  local dir="$1"
+  local npm_bin="npm"
+  local node_bin="node"
+
+  if ! run_install_cmd "$dir"; then
+    pt_log "Installing Node dependencies..."
+    if [ -f "$dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
+      (cd "$dir" && pnpm install --silent)
+      npm_bin="pnpm"
+    elif [ -f "$dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
+      (cd "$dir" && yarn install --silent)
+      npm_bin="yarn"
+    else
+      (cd "$dir" && npm install --silent)
+    fi
+  fi
+
+  if command -v node >/dev/null 2>&1; then
+    node_bin="$(command -v node)"
+  fi
+  if [ "$npm_bin" = "npm" ] && command -v npm >/dev/null 2>&1; then
+    npm_bin="$(command -v npm)"
+  fi
+
+  append_env "HARNESS_ECOSYSTEM" "node"
+  append_env "NODE_BIN" "$node_bin"
+  append_env "NPM_BIN" "$npm_bin"
+  append_path_prefix "$dir/node_modules/.bin"
+}
+
+provision_python() {
+  local dir="$1"
+  local venv_rel="${HARNESS_PYTHON_VENV_DIR:-.har/venv}"
+  local venv_dir="$dir/$venv_rel"
+  local python_bin="python3"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    pt_log "python3 not found on PATH — skipping venv provisioning"
+    append_env "HARNESS_ECOSYSTEM" "python"
+    append_env "PYTHON_BIN" "${PYTHON_BIN:-python3}"
+    return
+  fi
+
+  if [ ! -d "$venv_dir" ]; then
+    pt_log "Creating Python venv at $venv_rel..."
+    python3 -m venv "$venv_dir"
+  fi
+
+  python_bin="$venv_dir/bin/python"
+  # shellcheck disable=SC1091
+  source "$venv_dir/bin/activate"
+
+  if ! run_install_cmd "$dir"; then
+    pt_log "Installing Python dependencies..."
+    if [ -f "$dir/pyproject.toml" ]; then
+      (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
+    elif [ -f "$dir/requirements.txt" ]; then
+      (cd "$dir" && pip install -q -r requirements.txt)
+    elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+      (cd "$dir" && pip install -q -e .)
+    elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
+      (cd "$dir" && pipenv install --dev)
+      python_bin="$(cd "$dir" && pipenv --py)"
+    fi
+  fi
+
+  append_env "HARNESS_ECOSYSTEM" "python"
+  append_env "PYTHON_BIN" "$python_bin"
+  append_env "VIRTUAL_ENV" "$venv_dir"
+  append_path_prefix "$venv_dir/bin"
+}
+
+provision_go() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v go >/dev/null 2>&1; then
+      pt_log "Downloading Go modules..."
+      (cd "$dir" && go mod download)
+    else
+      pt_log "go not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "go"
+  append_env "GO_BIN" "$(command -v go 2>/dev/null || echo go)"
+  if [ -n "${GOPATH:-}" ]; then append_env "GOPATH" "$GOPATH"; fi
+  if [ -n "${GOROOT:-}" ]; then append_env "GOROOT" "$GOROOT"; fi
+}
+
+provision_rust() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v cargo >/dev/null 2>&1; then
+      pt_log "Fetching Rust dependencies..."
+      (cd "$dir" && cargo fetch)
+    else
+      pt_log "cargo not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "rust"
+  append_env "CARGO_BIN" "$(command -v cargo 2>/dev/null || echo cargo)"
+  append_env "RUSTC_BIN" "$(command -v rustc 2>/dev/null || echo rustc)"
+}
+
+provision_java() {
+  local dir="$1"
+  run_install_cmd "$dir" || true
+  append_env "HARNESS_ECOSYSTEM" "java"
+  if [ -n "${JAVA_HOME:-}" ]; then
+    append_env "JAVA_HOME" "$JAVA_HOME"
+    append_path_prefix "$JAVA_HOME/bin"
+  fi
+  if command -v mvn >/dev/null 2>&1; then
+    append_env "MVN_BIN" "$(command -v mvn)"
+  elif [ -f "$dir/gradlew" ]; then
+    append_env "GRADLE_BIN" "$dir/gradlew"
+  elif command -v gradle >/dev/null 2>&1; then
+    append_env "GRADLE_BIN" "$(command -v gradle)"
+  fi
+}
+
+provision_ruby() {
+  local dir="$1"
+  if ! run_install_cmd "$dir"; then
+    if command -v bundle >/dev/null 2>&1; then
+      pt_log "Installing Ruby gems..."
+      (cd "$dir" && bundle install --quiet)
+    else
+      pt_log "bundle not found on PATH — record paths only"
+    fi
+  fi
+  append_env "HARNESS_ECOSYSTEM" "ruby"
+  append_env "RUBY_BIN" "$(command -v ruby 2>/dev/null || echo ruby)"
+  append_env "BUNDLE_BIN" "$(command -v bundle 2>/dev/null || echo bundle)"
+  append_path_prefix "$dir/vendor/bundle/bin"
+}
+
+provision_ios() {
+  local dir="$1"
+  run_install_cmd "$dir" || true
+  append_env "HARNESS_ECOSYSTEM" "ios"
+  append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
+  if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then
+    append_env "HARNESS_XCODE_SCHEME" "$HARNESS_XCODE_SCHEME"
+  fi
+  if [ -n "${HARNESS_SIMULATOR_NAME:-}" ]; then
+    append_env "HARNESS_SIMULATOR_NAME" "$HARNESS_SIMULATOR_NAME"
+  fi
+  if [ -n "${HARNESS_BUNDLE_ID:-}" ]; then
+    append_env "HARNESS_BUNDLE_ID" "$HARNESS_BUNDLE_ID"
+  fi
+  if [ -n "${DEVELOPER_DIR:-}" ]; then
+    append_env "DEVELOPER_DIR" "$DEVELOPER_DIR"
+  fi
+}
+
+provision_monorepo_root() {
+  [ -n "$HAR_REL_PREFIX" ] || return 0
+  [ -n "$HAR_WORKTREE_DIR" ] || return 0
+  [ -f "$HAR_WORKTREE_DIR/package.json" ] || return 0
+  [ -d "$HAR_WORKTREE_DIR/node_modules" ] && return 0
+  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
+  (cd "$HAR_WORKTREE_DIR" && npm install --silent)
+}
+
+provision_ecosystem() {
+  local dir="$1"
+  local ecosystem
+  ecosystem="$(detect_ecosystem "$dir")"
+  pt_log "Toolchain ecosystem: ${ecosystem} (work dir: ${dir})"
+
+  case "$ecosystem" in
+    node) provision_node "$dir" ;;
+    python) provision_python "$dir" ;;
+    go) provision_go "$dir" ;;
+    rust) provision_rust "$dir" ;;
+    java) provision_java "$dir" ;;
+    ruby) provision_ruby "$dir" ;;
+    ios) provision_ios "$dir" ;;
+    none)
+      if run_install_cmd "$dir"; then
+        append_env "HARNESS_ECOSYSTEM" "custom"
+      else
+        pt_log "No ecosystem manifest detected — set HARNESS_ECOSYSTEM or HARNESS_INSTALL_CMD in harness.env"
+        append_env "HARNESS_ECOSYSTEM" "none"
+      fi
+      ;;
+  esac
+}
+
+append_env "HARNESS_TOOLCHAIN_PROVISIONED" "true"
+provision_ecosystem "$HAR_WORK_DIR"
+provision_monorepo_root

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -4,9 +4,9 @@
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
-# Quick (default): smoke — compile / typecheck / health only
-# Full (--full):   + unit tests, lint, optional readiness + browser-e2e
-# Step lists are examples — not exhaustive. Adapt commands to this repo's stack.
+# Quick (default): ecosystem smoke + health only
+# Full (--full):   + conventional tests, lint, optional readiness + browser-e2e
+# Stock steps are examples. Replace them during adaptation to match this repo.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -136,18 +136,98 @@ process.stdout.write(JSON.stringify(arr));
   fi
 }
 
-# ── Verification stages ─────────────────────────────────────────────────────
-# Customize these steps for your project — lists below are examples, not exhaustive.
-# Edit this section directly — do not use a separate config file.
+node_package_script_exists() {
+  local script="$1"
+  "${NODE_BIN:-node}" -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const script = process.argv[1];
+process.exit(pkg.scripts && pkg.scripts[script] ? 0 : 1);
+" "$script"
+}
 
-# Quick (default): smoke — prove the slot can compile/load, not full test suites.
-run_step "typecheck" "echo 'TODO: npm run typecheck'" || { [ -z "$FULL" ] && true; }
+run_node_script_or_skip() {
+  local name="$1"
+  local script="$2"
+  if node_package_script_exists "$script"; then
+    run_step "$name" "${NPM_BIN:-npm} run ${script}"
+  else
+    run_step "$name" "echo 'No ${script} script configured; skipping.'"
+  fi
+}
+
+run_node_quick_smoke() {
+  if node_package_script_exists typecheck; then
+    run_step "node-typecheck" '${NPM_BIN:-npm} run typecheck'
+  elif node_package_script_exists build; then
+    run_step "node-build" '${NPM_BIN:-npm} run build'
+  else
+    run_step "node-package-load" '${NODE_BIN:-node} -e "require(\"./package.json\")"'
+  fi
+}
+
+run_quick_smoke() {
+  case "${HARNESS_ECOSYSTEM:-none}" in
+    node)
+      run_node_quick_smoke
+      ;;
+    python)
+      run_step "python-compile" '${PYTHON_BIN:-python3} -m compileall -q .'
+      ;;
+    go)
+      run_step "go-build" '${GO_BIN:-go} build ./...'
+      ;;
+    rust)
+      run_step "rust-check" '${CARGO_BIN:-cargo} check'
+      ;;
+    java)
+      run_step "java-compile" 'if [ -x ./mvnw ]; then ./mvnw -q -DskipTests compile; elif command -v mvn >/dev/null 2>&1; then mvn -q -DskipTests compile; elif [ -x ./gradlew ]; then ./gradlew classes; elif command -v gradle >/dev/null 2>&1; then gradle classes; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi'
+      ;;
+    ruby)
+      run_step "ruby-smoke" '${RUBY_BIN:-ruby} -e "puts RUBY_VERSION"'
+      ;;
+    custom|none|*)
+      run_step "smoke-not-configured" 'echo "No stock smoke for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."'
+      ;;
+  esac
+}
+
+run_full_checks() {
+  case "${HARNESS_ECOSYSTEM:-none}" in
+    node)
+      run_node_script_or_skip "unit-tests" test || true
+      run_node_script_or_skip "lint" lint || true
+      ;;
+    python)
+      run_step "unit-tests" 'if ${PYTHON_BIN:-python3} -c "import pytest" >/dev/null 2>&1; then ${PYTHON_BIN:-python3} -m pytest -q; else echo "pytest not installed; adapt verify.sh for this Python repo."; fi' || true
+      ;;
+    go)
+      run_step "unit-tests" '${GO_BIN:-go} test ./...' || true
+      ;;
+    rust)
+      run_step "unit-tests" '${CARGO_BIN:-cargo} test' || true
+      ;;
+    java)
+      run_step "unit-tests" 'if [ -x ./mvnw ]; then ./mvnw -q test; elif command -v mvn >/dev/null 2>&1; then mvn -q test; elif [ -x ./gradlew ]; then ./gradlew test; elif command -v gradle >/dev/null 2>&1; then gradle test; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi' || true
+      ;;
+    ruby)
+      run_step "unit-tests" 'if command -v "${BUNDLE_BIN:-bundle}" >/dev/null 2>&1 && [ -f Gemfile ]; then "${BUNDLE_BIN:-bundle}" exec rake test 2>/dev/null || "${BUNDLE_BIN:-bundle}" exec rspec; else echo "No Ruby test command detected; adapt verify.sh for this Ruby repo."; fi' || true
+      ;;
+    custom|none|*)
+      run_step "unit-tests" 'echo "No stock full checks for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."' || true
+      ;;
+  esac
+}
+
+# ── Verification stages ─────────────────────────────────────────────────────
+# These stock steps are intentionally generic conventions. Adapt this section
+# to the repository's real commands from package.json, Makefile, CI, pyproject,
+# Cargo.toml, go.mod, pom.xml, etc.
+run_quick_smoke || { [ -z "$FULL" ] && true; }
 run_http_step "api-health" "http://localhost:${API_PORT}${HARNESS_HEALTH_CHECK_PATH}" || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
-  # Full: project-specific checks — add/remove/reorder steps for this repo.
-  run_step "unit-tests" "echo 'TODO: npm test'" || true
-  run_step "lint" "echo 'TODO: npm run lint'" || true
+  run_full_checks
   run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi

--- a/tests/adaptation-prompt.test.ts
+++ b/tests/adaptation-prompt.test.ts
@@ -15,6 +15,8 @@ describe('adaptation prompts', () => {
     expect(defaultPrompt).toContain('AGENT.md');
     expect(defaultPrompt).toContain('Profile: default');
     expect(defaultPrompt).toContain('Docker');
+    expect(defaultPrompt).toContain('HAR profiles');
+    expect(defaultPrompt).toContain('provision-toolchain.sh');
 
     const cliPrompt = buildInitAdaptationPrompt('/tmp/app', 'cli');
     expect(cliPrompt).toContain('Profile: cli');

--- a/tests/harness-contract.test.ts
+++ b/tests/harness-contract.test.ts
@@ -98,6 +98,9 @@ describe('harness stage contract', () => {
     const harnessEnv = fs.readFileSync(path.join(repoPath, '.har', 'harness.env'), 'utf8');
     expect(harnessEnv).toContain('HARNESS_INFRA_SERVICES=""');
     expect(harnessEnv).toContain('HARNESS_USE_WORKTREE=true');
+    expect(harnessEnv).toContain('HARNESS_ECOSYSTEM');
+
+    expect(fs.existsSync(path.join(repoPath, '.har', 'provision-toolchain.sh'))).toBe(true);
 
     expect(fs.existsSync(path.join(repoPath, '.har', 'ecosystem.agent.template.cjs'))).toBe(false);
     expect(fs.existsSync(path.join(repoPath, '.har', 'env.template'))).toBe(false);
@@ -106,7 +109,8 @@ describe('harness stage contract', () => {
     expect(manifest.profile).toBe('cli');
 
     const verifyScript = fs.readFileSync(path.join(repoPath, '.har', 'verify.sh'), 'utf8');
-    expect(verifyScript).toContain('npm run typecheck');
+    expect(verifyScript).toContain('run_quick_smoke');
+    expect(verifyScript).toContain('HARNESS_ECOSYSTEM');
     expect(verifyScript).not.toContain("echo 'TODO:");
 
     const registry = readStageRegistry(repoPath);

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -1,0 +1,98 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { run } from '../src/utils/shell';
+import { resolveTemplatesDir } from '../src/utils/paths';
+
+const PROFILES = ['har-boilerplate', 'har-boilerplate-cli', 'har-boilerplate-ios'] as const;
+
+describe('provision-toolchain.sh template contract', () => {
+  for (const profile of PROFILES) {
+    it(`${profile} ships provision-toolchain.sh with valid bash syntax`, () => {
+      const scriptPath = path.join(resolveTemplatesDir(), profile, 'provision-toolchain.sh');
+      expect(fs.existsSync(scriptPath)).toBe(true);
+      const result = run(`bash -n "${scriptPath}"`);
+      expect(result.code).toBe(0);
+    });
+
+    it(`${profile} launch.sh invokes provision-toolchain.sh`, () => {
+      const launchPath = path.join(resolveTemplatesDir(), profile, 'launch.sh');
+      const content = fs.readFileSync(launchPath, 'utf8');
+      expect(content).toContain('provision-toolchain.sh');
+      expect(content).toContain('HAR_WORK_DIR');
+      expect(content).toContain('HAR_ENV_FILE');
+    });
+
+    it(`${profile} harness.env documents HARNESS_ECOSYSTEM`, () => {
+      const harnessEnvPath = path.join(resolveTemplatesDir(), profile, 'harness.env');
+      const content = fs.readFileSync(harnessEnvPath, 'utf8');
+      expect(content).toContain('HARNESS_ECOSYSTEM');
+      if (profile !== 'har-boilerplate-ios') {
+        expect(content).not.toContain('HARNESS_PYTHON_VENV_DIR');
+      }
+    });
+  }
+
+  it('auto-detects python and writes PYTHON_BIN to agent env', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-python-'));
+    const scriptPath = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'provision-toolchain.sh');
+    const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+
+    fs.writeFileSync(path.join(tmpDir, 'requirements.txt'), '# empty fixture\n');
+
+    const envFile = path.join(tmpDir, '.env.agent.1');
+    fs.writeFileSync(envFile, 'AGENT_ID=1\nREPO_ROOT=' + tmpDir + '\n');
+
+    const result = run(
+      `set -a && source "${harnessEnv}" && set +a && ` +
+        `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
+        `bash "${scriptPath}"`,
+    );
+
+    expect(result.code).toBe(0);
+    const envContent = fs.readFileSync(envFile, 'utf8');
+    expect(envContent).toContain('HARNESS_ECOSYSTEM=python');
+    expect(envContent).toContain('PYTHON_BIN=');
+    expect(envContent).toContain('VIRTUAL_ENV=');
+  });
+
+  it('auto-detects node and writes NPM_BIN to agent env', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-node-'));
+    const scriptPath = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'provision-toolchain.sh');
+    const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'fixture', scripts: { test: 'true' } }),
+    );
+
+    const envFile = path.join(tmpDir, '.env.agent.1');
+    fs.writeFileSync(envFile, 'AGENT_ID=1\nREPO_ROOT=' + tmpDir + '\n');
+
+    const result = run(
+      `set -a && source "${harnessEnv}" && set +a && ` +
+        `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
+        `bash "${scriptPath}"`,
+    );
+
+    expect(result.code).toBe(0);
+    const envContent = fs.readFileSync(envFile, 'utf8');
+    expect(envContent).toContain('HARNESS_ECOSYSTEM=node');
+    expect(envContent).toContain('NPM_BIN=');
+    expect(envContent).toContain('NODE_BIN=');
+    expect(envContent).toContain('HARNESS_TOOLCHAIN_PROVISIONED=true');
+  });
+
+  it('verify.sh dispatches stock smoke by ecosystem', () => {
+    for (const profile of ['har-boilerplate', 'har-boilerplate-cli'] as const) {
+      const verifyPath = path.join(resolveTemplatesDir(), profile, 'verify.sh');
+      const content = fs.readFileSync(verifyPath, 'utf8');
+      expect(content).toContain('run_quick_smoke');
+      expect(content).toContain('HARNESS_ECOSYSTEM');
+      expect(content).toContain('python-compile');
+      expect(content).toContain('go-build');
+      expect(content).toContain('rust-check');
+      expect(content).not.toMatch(/run_step "[^"]+" "npm /);
+    }
+  });
+});

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -44,7 +44,7 @@ describe('provision-toolchain.sh template contract', () => {
     fs.writeFileSync(envFile, 'AGENT_ID=1\nREPO_ROOT=' + tmpDir + '\n');
 
     const result = run(
-      `set -a && source "${harnessEnv}" && set +a && ` +
+      `set -a && . "${harnessEnv}" && set +a && ` +
         `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
         `bash "${scriptPath}"`,
     );
@@ -53,7 +53,9 @@ describe('provision-toolchain.sh template contract', () => {
     const envContent = fs.readFileSync(envFile, 'utf8');
     expect(envContent).toContain('HARNESS_ECOSYSTEM=python');
     expect(envContent).toContain('PYTHON_BIN=');
-    expect(envContent).toContain('VIRTUAL_ENV=');
+    if (envContent.includes('VIRTUAL_ENV=')) {
+      expect(fs.existsSync(path.join(tmpDir, '.har/venv'))).toBe(true);
+    }
   });
 
   it('auto-detects node and writes NPM_BIN to agent env', () => {
@@ -70,7 +72,7 @@ describe('provision-toolchain.sh template contract', () => {
     fs.writeFileSync(envFile, 'AGENT_ID=1\nREPO_ROOT=' + tmpDir + '\n');
 
     const result = run(
-      `set -a && source "${harnessEnv}" && set +a && ` +
+      `set -a && . "${harnessEnv}" && set +a && ` +
         `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
         `bash "${scriptPath}"`,
     );


### PR DESCRIPTION
## Summary

- Add `provision-toolchain.sh` to all HAR boilerplate profiles so launch provisions toolchains declaratively via `HARNESS_ECOSYSTEM` / `HARNESS_INSTALL_CMD` and writes resolved paths (`PYTHON_BIN`, `NPM_BIN`, `XCODEBUILD_BIN`, etc.) into `.env.agent.<id>`
- Replace stock npm-first `verify.sh` steps with ecosystem-aware quick/full smoke conventions keyed by `HARNESS_ECOSYSTEM`, while keeping them clearly documented as examples to adapt per repo
- Document `default` / `cli` / `ios` profile selection in adaptation prompts and remove Python/npm-specific bias from generic `harness.env` comments

Closes #21

## Test plan

- [x] `npm test -- tests/provision-toolchain.test.ts tests/harness-contract.test.ts tests/adaptation-prompt.test.ts`
- [x] `npm run build`
- [x] `./.har/verify.sh 1 --full`
- [x] Scaffold `har env init --profile cli` on a non-Node fixture and confirm quick verify uses the detected ecosystem smoke, not npm
- [ ] Re-run a SWE-bench HAR setup instance after merge to confirm launch/toolchain failures are reduced


Made with [Cursor](https://cursor.com)