### PR TITLE
feat(benchmark): two-phase setup agents (task readiness + budget retry)

### DIFF
--- a/benchmarks/swebench-har/README.md
+++ b/benchmarks/swebench-har/README.md
@@ -98,8 +98,10 @@ benchmarks/swebench-har/
 
 The HAR arm records:
 
-- `har_cache_hit` / `har_cache_saved` — per-repo `.har/` reuse
-- `har_gate_initial` / `har_gate_attempt_*` — pre-fix gate before Codex fix (launch + smoke)
+- `har_cache_hit` / `har_cache_saved` / `har_cache_invalidated` — per-repo `.har/` reuse and invalidation
+- `har_bootstrap_attempts` / `har_task_readiness` — two-phase setup (repo bootstrap vs task readiness)
+- `har_setup_budget_minutes` / `har_setup_budget_used_seconds` / `har_setup_rounds` — budget-based retries
+- `har_gate_initial` / `har_gate_round_*` — pre-fix gate before Codex fix (launch + smoke)
 - `har_gate_launch` / `har_gate_smoke` — split launch readiness vs quick smoke verify
 - `har_ready_for_fix` — slot launched and smoke verify passed (not full test suite)
 - `har_launch.ok`
@@ -118,6 +120,27 @@ The HAR arm records:
 
 Quick verify must be **language-agnostic** — compile/import/build smoke, not full pytest/Django runtests/Sphinx extension graphs.
 
+## Two-phase HAR setup
+
+Setup is split into two agent phases with different scope, models, and cache behavior:
+
+| Phase | When | Model | Cached |
+|-------|------|-------|--------|
+| **Repo bootstrap** | Cache miss, or gate failure after cache hit | `setup_model` (default GPT-5.5) | Yes — saved to `.har-cache/<repo>/` |
+| **Task readiness** | Every instance | `model` (default GPT-5-mini) | No — per-run overlay under `runs/<id>/har/task-overlay/` |
+
+```text
+Cache hit?
+  → task readiness (mini) → pre-fix gate → fix
+
+Cache miss / gate fail?
+  → repo bootstrap (5.5) → task readiness (mini) → gate
+  → retry until setup_budget_minutes or setup_max_rounds
+  → invalidate cache on gate failure after cache hit
+```
+
+Task readiness receives the `problem_statement` and may add one lightweight task-scoped smoke check as an ephemeral overlay — it does not rewrite repo-generic cached harness defaults.
+
 ## Per-repo `.har/` cache
 
 Adapted harness files are cached under `.har-cache/<repo>/` and reused across instances of the same repository (different `base_commit` values). Before the fix stage the runner always:
@@ -126,7 +149,7 @@ Adapted harness files are cached under `.har-cache/<repo>/` and reused across in
 2. runs `har env launch 1 --replace --force` (with `HAR_CONFIRM_REPLACE=1`)
 3. runs quick `har env verify 1` (smoke only — no `--full`)
 
-If the gate fails, the setup model re-adapts `.har/` (up to `setup_max_attempts`, default 2) and the cache is refreshed on success.
+If the gate fails after a cache hit, the cache is **invalidated** and repo bootstrap runs again. Retries continue until `setup_budget_minutes` (default 120) is exhausted or `setup_max_rounds` (default 6) is reached. Structured gate JSON is passed to setup retries.
 
 ## Profile selection
 
@@ -136,11 +159,10 @@ If the gate fails, the setup model re-adapts `.har/` (up to `setup_max_attempts`
 - `default` — web-app repos with frontend dev-server signals
 - `ios` — iOS / Swift mobile apps (xcodebuild, simulator)
 
-## HAR setup prompt
+## HAR setup prompts
 
-The setup agent receives `prompts/har-setup.md`, which embeds the same text as
-`.har/ADAPT-PROMPT.md` from `har env init`, plus SWE-bench-specific constraints
-(no `launch.sh` edits, smoke-only pre-fix gate, no slot launch during setup).
+- **Repo bootstrap** — `prompts/har-setup.md` (GPT-5.5): embeds `.har/ADAPT-PROMPT.md`, repo-generic harness adaptation, no `launch.sh` edits
+- **Task readiness** — `prompts/har-task-readiness.md` (GPT-5-mini): per-instance check with `problem_statement`, optional ephemeral task overlay
 
 ## Smoke tests
 

--- a/benchmarks/swebench-har/config.yaml
+++ b/benchmarks/swebench-har/config.yaml
@@ -2,9 +2,12 @@ dataset_name: SWE-bench/SWE-bench_Lite
 split: test
 model: gpt-5-mini
 setup_model: gpt-5.5
-setup_timeout_minutes: 45
 solve_timeout_minutes: 60
-setup_max_attempts: 2
+# HAR setup phase (bootstrap + task readiness + gate retries)
+setup_budget_minutes: 120
+setup_timeout_minutes: 45
+readiness_timeout_minutes: 20
+setup_max_rounds: 6
 har_verify_full: false
 har_cache_dir: .har-cache
 runs_dir: runs

--- a/benchmarks/swebench-har/prompts/har-task-readiness.md
+++ b/benchmarks/swebench-har/prompts/har-task-readiness.md
@@ -1,0 +1,44 @@
+# SWE-bench HAR task readiness
+
+Repository: {{repo}}
+Instance: {{instance_id}}
+Base commit: {{base_commit}}
+HAR profile: {{har_profile}}
+
+## Problem statement
+
+{{problem_statement}}
+
+## Your role
+
+Confirm the cached repo harness works at **this** `base_commit` for fixing the issue above.
+You run **after** repo bootstrap (or on a cache hit) — do **not** re-bootstrap the whole repo.
+
+The benchmark runner validates readiness **after** your edits — do not launch or verify slots yourself.
+
+## Allowed actions
+
+- Confirm generic quick verify will pass at this commit (adjust `harness.env` or quick-mode steps in `verify.sh` only if needed)
+- Add **one** lightweight task-scoped smoke check derived from the issue (e.g. import mentioned module, compile mentioned file)
+- Write ephemeral per-run overlay files under:
+
+  `{{task_overlay_dir}}`
+
+  Examples: `task-verify.sh`, `task.env` — the runner may source these before the pre-fix gate.
+
+## Forbidden
+
+- Do **not** edit `launch.sh` or `agent-slot.sh` (repo bootstrap only)
+- Do **not** run full test suites or replicate SWE-bench grading
+- Do **not** use evaluator-only fields (`FAIL_TO_PASS`, `PASS_TO_PASS`, gold patch)
+- Do **not** run `har env init`, `har env launch`, `./.har/launch.sh`, `./.har/teardown.sh`, or `./.har/verify.sh`
+- Do **not** overwrite repo-generic defaults in `.har-cache/` — task overlays are per-run only
+
+## Task overlay
+
+If you add a task-scoped check, put it in `{{task_overlay_dir}}/task-verify.sh` (executable) or
+`{{task_overlay_dir}}/task.env` (key=value lines). Keep it minimal — one command or short script.
+
+{{readiness_failure_context}}
+
+When finished, summarize whether quick verify should pass at this commit and any overlay you added.

--- a/benchmarks/swebench-har/scripts/lib/har_cache.py
+++ b/benchmarks/swebench-har/scripts/lib/har_cache.py
@@ -58,6 +58,15 @@ def load_har_cache(repo_slug: str, harness_root: Path) -> bool:
     return True
 
 
+def invalidate_har_cache(repo_slug: str) -> bool:
+    """Remove cached harness for a repo (e.g. after gate failure on a cache hit)."""
+    cache_dir = cache_dir_for_repo(repo_slug)
+    if not cache_dir.exists():
+        return False
+    shutil.rmtree(cache_dir)
+    return True
+
+
 def save_har_cache(repo_slug: str, harness_root: Path, profile: str) -> Path:
     dest_root = cache_dir_for_repo(repo_slug)
     har_src = harness_root / ".har"

--- a/benchmarks/swebench-har/scripts/run_batch.py
+++ b/benchmarks/swebench-har/scripts/run_batch.py
@@ -59,9 +59,11 @@ def run_one_instance(
     arm: str,
     dry_run: bool,
     setup_timeout_minutes: int,
+    readiness_timeout_minutes: int,
     solve_timeout_minutes: int,
     post_fix_verify_full: bool,
-    setup_max_attempts: int,
+    setup_budget_minutes: int,
+    setup_max_rounds: int,
 ) -> dict[str, Any]:
     instance, run_dir = prepare_instance_row(row, seed)
     record: dict[str, Any] = {
@@ -95,9 +97,11 @@ def run_one_instance(
             env=env,
             dry_run=dry_run,
             setup_timeout_minutes=setup_timeout_minutes,
+            readiness_timeout_minutes=readiness_timeout_minutes,
             solve_timeout_minutes=solve_timeout_minutes,
-            post_fix_verify_full=verify_full,
-            setup_max_attempts=setup_max_attempts,
+            post_fix_verify_full=post_fix_verify_full,
+            setup_budget_minutes=setup_budget_minutes,
+            setup_max_rounds=setup_max_rounds,
         )
 
     record["finished_at"] = now_iso()
@@ -123,8 +127,10 @@ def main() -> int:
     setup_model = args.setup_model or env.get("OPENAI_SETUP_MODEL") or cfg.get("setup_model", "gpt-5.5")
     solve_timeout = args.solve_timeout_minutes or int(cfg.get("solve_timeout_minutes", 60))
     setup_timeout = args.setup_timeout_minutes or int(cfg.get("setup_timeout_minutes", 45))
-    setup_max_attempts = int(cfg.get("setup_max_attempts", 2))
-    verify_full = bool(cfg.get("har_verify_full", False))
+    readiness_timeout = int(cfg.get("readiness_timeout_minutes", 20))
+    setup_budget = int(cfg.get("setup_budget_minutes", 120))
+    setup_max_rounds = int(cfg.get("setup_max_rounds", 6))
+    post_fix_verify_full = bool(cfg.get("har_verify_full", False))
 
     rows = load_split(cfg["dataset_name"], cfg["split"])
     selected = sample_rows(rows, args.count, args.seed)
@@ -164,9 +170,11 @@ def main() -> int:
                 arm=args.arm,
                 dry_run=args.dry_run,
                 setup_timeout_minutes=setup_timeout,
+                readiness_timeout_minutes=readiness_timeout,
                 solve_timeout_minutes=solve_timeout,
-                verify_full=verify_full,
-                setup_max_attempts=setup_max_attempts,
+                post_fix_verify_full=post_fix_verify_full,
+                setup_budget_minutes=setup_budget,
+                setup_max_rounds=setup_max_rounds,
             )
             entry["run_id"] = result["run_id"]
             entry["status"] = "completed"

--- a/benchmarks/swebench-har/scripts/run_one.py
+++ b/benchmarks/swebench-har/scripts/run_one.py
@@ -37,6 +37,12 @@ from lib.har_utils import (  # noqa: E402
     har_verify,
     read_har_adapt_prompt,
 )
+from lib.har_cache import (  # noqa: E402
+    har_cache_exists,
+    invalidate_har_cache,
+    load_har_cache,
+    save_har_cache,
+)
 from lib.patch import extract_model_patch, filter_changed_files
 from lib.profile import infer_har_profile
 
@@ -150,9 +156,11 @@ def run_har_arm(
     env: dict[str, str],
     dry_run: bool,
     setup_timeout_minutes: int,
+    readiness_timeout_minutes: int,
     solve_timeout_minutes: int,
     post_fix_verify_full: bool,
-    setup_max_attempts: int,
+    setup_budget_minutes: int,
+    setup_max_rounds: int,
 ) -> dict[str, Any]:
     cfg = benchmark_config()
     harness_root = run_dir / "har" / "repo"
@@ -174,72 +182,140 @@ def run_har_arm(
     profile = infer_har_profile(harness_root)
     record["har_profile"] = profile
 
-    from lib.har_cache import har_cache_exists, load_har_cache, save_har_cache
-
     gate_timeout = max(setup_timeout_minutes, solve_timeout_minutes) * 60
-    cache_used = False
-    if har_cache_exists(instance["repo"], profile):
-        cache_used = load_har_cache(instance["repo"], harness_root)
-        record["har_cache_hit"] = cache_used
-
-    gate = har_validate_ready(
-        harness_root,
-        timeout_seconds=gate_timeout,
-        env=env,
-    )
-    record["har_gate_initial"] = gate
-
-    setup_attempts: list[dict[str, Any]] = []
+    setup_budget_seconds = setup_budget_minutes * 60
     setup_started = time.time()
+    task_overlay_dir = run_dir / "har" / "task-overlay"
+    task_overlay_dir.mkdir(parents=True, exist_ok=True)
 
-    if not gate["ready"]:
-        failure_context = _format_gate_failure(gate)
-        for attempt in range(1, setup_max_attempts + 1):
+    cache_hit = False
+    if har_cache_exists(instance["repo"], profile):
+        cache_hit = load_har_cache(instance["repo"], harness_root)
+        record["har_cache_hit"] = cache_hit
+
+    need_bootstrap = not cache_hit
+    bootstrap_attempts: list[dict[str, Any]] = []
+    readiness_attempts: list[dict[str, Any]] = []
+    gate_rounds: list[dict[str, Any]] = []
+    cache_invalidated = False
+    gate: dict[str, Any] = {"ready": False}
+    failure_context = ""
+    readiness_failure_context = ""
+
+    for round_index in range(1, setup_max_rounds + 1):
+        elapsed = time.time() - setup_started
+        if elapsed >= setup_budget_seconds:
+            record["har_setup_budget_exhausted"] = True
+            break
+        remaining_seconds = max(1, int(setup_budget_seconds - elapsed))
+
+        if need_bootstrap:
             har_init_scaffold(harness_root, profile, env=env)
-            setup_prompt = render_template(
+            bootstrap_prompt = render_template(
                 PROMPTS / "har-setup.md",
                 prompt_values(
                     instance,
                     har_profile=profile,
                     har_adapt_prompt=read_har_adapt_prompt(harness_root, profile),
-                    setup_failure_context=failure_context if attempt > 1 or cache_used else "",
+                    setup_failure_context=failure_context,
                 ),
             )
-            setup_codex = run_codex_turn(
+            bootstrap_codex = run_codex_turn(
                 cwd=harness_root,
-                prompt=setup_prompt,
+                prompt=bootstrap_prompt,
                 model=setup_model,
                 api_key=env.get("OPENAI_API_KEY"),
-                timeout_seconds=setup_timeout_minutes * 60,
-                artifacts_dir=run_dir / "har" / f"codex-setup-{attempt}",
+                timeout_seconds=min(setup_timeout_minutes * 60, remaining_seconds),
+                artifacts_dir=run_dir / "har" / f"codex-bootstrap-r{round_index}",
             )
-            setup_attempts.append(
+            bootstrap_attempts.append(
                 {
-                    "attempt": attempt,
-                    "codex": setup_codex.result,
-                    "wall_clock_seconds": setup_codex.wall_clock_seconds,
+                    "round": round_index,
+                    "phase": "repo_bootstrap",
+                    "codex": bootstrap_codex.result,
+                    "wall_clock_seconds": bootstrap_codex.wall_clock_seconds,
                 }
             )
             har_teardown_slot(harness_root, env=env)
+            need_bootstrap = False
 
-            gate = har_validate_ready(
-                harness_root,
-                timeout_seconds=gate_timeout,
-                env=env,
-            )
-            record[f"har_gate_attempt_{attempt}"] = gate
-            if gate["ready"]:
-                save_har_cache(instance["repo"], harness_root, profile)
-                record["har_cache_saved"] = True
-                break
-            failure_context = _format_gate_failure(gate)
+        readiness_prompt = render_template(
+            PROMPTS / "har-task-readiness.md",
+            prompt_values(
+                instance,
+                har_profile=profile,
+                task_overlay_dir=str(task_overlay_dir),
+                readiness_failure_context=readiness_failure_context,
+            ),
+        )
+        readiness_codex = run_codex_turn(
+            cwd=harness_root,
+            prompt=readiness_prompt,
+            model=model,
+            api_key=env.get("OPENAI_API_KEY"),
+            timeout_seconds=min(readiness_timeout_minutes * 60, remaining_seconds),
+            artifacts_dir=run_dir / "har" / f"codex-readiness-r{round_index}",
+        )
+        readiness_attempts.append(
+            {
+                "round": round_index,
+                "phase": "task_readiness",
+                "codex": readiness_codex.result,
+                "wall_clock_seconds": readiness_codex.wall_clock_seconds,
+                "task_overlay_dir": str(task_overlay_dir),
+                "task_overlay_files": _list_task_overlay_files(task_overlay_dir),
+            }
+        )
+        har_teardown_slot(harness_root, env=env)
+
+        gate = har_validate_ready(
+            harness_root,
+            timeout_seconds=gate_timeout,
+            env=_merge_task_overlay_env(env, task_overlay_dir),
+        )
+        gate_rounds.append({"round": round_index, "gate": gate})
+        record[f"har_gate_round_{round_index}"] = gate
+
+        if gate["ready"]:
+            save_har_cache(instance["repo"], harness_root, profile)
+            record["har_cache_saved"] = True
+            break
+
+        if cache_hit or har_cache_exists(instance["repo"], profile):
+            if invalidate_har_cache(instance["repo"]):
+                cache_invalidated = True
+        cache_hit = False
+        need_bootstrap = True
+        failure_context = _format_gate_failure(gate, structured=True)
+        readiness_failure_context = _format_readiness_failure(gate, round_index)
 
     record["har_setup_seconds"] = round(time.time() - setup_started, 2)
-    record["har_setup_attempts"] = setup_attempts
-    if setup_attempts:
-        record["codex_setup"] = setup_attempts[-1]["codex"]
-    elif cache_used and gate["ready"]:
+    record["har_setup_budget_minutes"] = setup_budget_minutes
+    record["har_setup_budget_used_seconds"] = record["har_setup_seconds"]
+    record["har_setup_rounds"] = len(gate_rounds)
+    record["har_setup_max_rounds"] = setup_max_rounds
+    record["har_cache_invalidated"] = cache_invalidated
+    record["har_bootstrap_attempts"] = bootstrap_attempts
+    record["har_task_readiness"] = {
+        "attempts": readiness_attempts,
+        "rounds": len(readiness_attempts),
+        "skipped_bootstrap": bool(record.get("har_cache_hit")) and not bootstrap_attempts,
+        "overlay_dir": str(task_overlay_dir),
+        "overlay_files": _list_task_overlay_files(task_overlay_dir),
+        "status": "passed" if gate.get("ready") else "failed",
+    }
+    if bootstrap_attempts:
+        record["codex_bootstrap"] = bootstrap_attempts[-1]["codex"]
+    elif record.get("har_cache_hit") and gate.get("ready"):
+        record["codex_bootstrap"] = {"status": "skipped", "reason": "har_cache_valid"}
+    if readiness_attempts:
+        record["codex_readiness"] = readiness_attempts[-1]["codex"]
+    record["har_setup_attempts"] = bootstrap_attempts
+    if bootstrap_attempts:
+        record["codex_setup"] = bootstrap_attempts[-1]["codex"]
+    elif record.get("har_cache_hit") and gate.get("ready"):
         record["codex_setup"] = {"status": "skipped", "reason": "har_cache_valid"}
+    record["har_gate_initial"] = gate_rounds[0]["gate"] if gate_rounds else gate
 
     if not gate["ready"] or not gate.get("workdir"):
         record["har_launch"] = {
@@ -316,10 +392,59 @@ def run_har_arm(
     return record
 
 
-def _format_gate_failure(gate: dict[str, Any]) -> str:
+def _list_task_overlay_files(task_overlay_dir: Path) -> list[str]:
+    if not task_overlay_dir.exists():
+        return []
+    return sorted(
+        str(path.relative_to(task_overlay_dir))
+        for path in task_overlay_dir.rglob("*")
+        if path.is_file()
+    )
+
+
+def _merge_task_overlay_env(env: dict[str, str], task_overlay_dir: Path) -> dict[str, str]:
+    merged = dict(env)
+    task_env = task_overlay_dir / "task.env"
+    if not task_env.exists():
+        return merged
+    for line in task_env.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        merged[key.strip()] = value.strip().strip('"').strip("'")
+    return merged
+
+
+def _format_readiness_failure(gate: dict[str, Any], round_index: int) -> str:
+    return (
+        f"\n## Previous task readiness round {round_index} failed the pre-fix gate\n"
+        f"{_format_gate_failure(gate, structured=True)}\n"
+    )
+
+
+def _format_gate_failure(gate: dict[str, Any], *, structured: bool = False) -> str:
     launch = gate.get("launch") or {}
     smoke = gate.get("smoke") or {}
     verify = smoke.get("verify") or gate.get("verify") or {}
+
+    if structured:
+        payload = {
+            "ready": gate.get("ready"),
+            "launch_ok": launch.get("launch_ok", gate.get("launch_ok")),
+            "workdir": launch.get("workdir", gate.get("workdir")),
+            "agent_env_exists": launch.get("agent_env_exists", gate.get("agent_env_exists")),
+            "smoke_ready": smoke.get("ready"),
+            "verify_exit_code": verify.get("exit_code"),
+            "verify_stderr_tail": (verify.get("stderr") or "")[-2000:],
+            "launch_log_tail": (launch.get("launch_log", gate.get("launch_log", "")))[-2000:],
+        }
+        return (
+            "\n## Previous pre-fix gate failed (structured)\n"
+            "Fix harness.env and verify.sh quick-mode steps only — do not edit launch.sh.\n\n"
+            f"```json\n{json.dumps(payload, indent=2)}\n```\n"
+        )
+
     return (
         "\n## Previous pre-fix gate failed\n"
         "The benchmark runner could not launch the slot or pass quick smoke verify. "
@@ -353,7 +478,9 @@ def main() -> int:
     setup_model = args.setup_model or env.get("OPENAI_SETUP_MODEL") or cfg.get("setup_model", "gpt-5.5")
     solve_timeout = args.solve_timeout_minutes or int(cfg.get("solve_timeout_minutes", 60))
     setup_timeout = args.setup_timeout_minutes or int(cfg.get("setup_timeout_minutes", 45))
-    setup_max_attempts = int(cfg.get("setup_max_attempts", 2))
+    readiness_timeout = int(cfg.get("readiness_timeout_minutes", 20))
+    setup_budget = int(cfg.get("setup_budget_minutes", 120))
+    setup_max_rounds = int(cfg.get("setup_max_rounds", 6))
 
     instance, run_dir = load_or_sample_instance(
         seed=args.seed,
@@ -392,9 +519,11 @@ def main() -> int:
             env=env,
             dry_run=args.dry_run,
             setup_timeout_minutes=setup_timeout,
+            readiness_timeout_minutes=readiness_timeout,
             solve_timeout_minutes=solve_timeout,
             post_fix_verify_full=bool(cfg.get("har_verify_full", False)),
-            setup_max_attempts=setup_max_attempts,
+            setup_budget_minutes=setup_budget,
+            setup_max_rounds=setup_max_rounds,
         )
 
     run_record["finished_at"] = now_iso()

--- a/benchmarks/swebench-har/scripts/test_swebench_har.py
+++ b/benchmarks/swebench-har/scripts/test_swebench_har.py
@@ -14,7 +14,7 @@ SCRIPTS = ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from lib.common import benchmark_config, render_template, sanitize_instance_row  # noqa: E402
-from lib.har_cache import har_cache_exists, load_har_cache, save_har_cache  # noqa: E402
+from lib.har_cache import har_cache_exists, invalidate_har_cache, load_har_cache, save_har_cache  # noqa: E402
 from lib.har_utils import (  # noqa: E402
     build_init_adapt_prompt,
     har_validate_launch,
@@ -35,7 +35,9 @@ def test_config_loads() -> None:
     assert cfg["dataset_name"] == "SWE-bench/SWE-bench_Lite"
     assert cfg["model"] == "gpt-5-mini"
     assert cfg["setup_model"] == "gpt-5.5"
-    assert cfg["setup_max_attempts"] == 2
+    assert cfg["setup_budget_minutes"] == 120
+    assert cfg["setup_max_rounds"] == 6
+    assert cfg["readiness_timeout_minutes"] == 20
 
 
 def test_har_cache_roundtrip() -> None:
@@ -67,6 +69,48 @@ def test_har_cache_roundtrip() -> None:
             assert not (dest / ".har" / "slots").exists()
         finally:
             har_cache.cache_root = original_cache_root  # type: ignore[method-assign]
+
+
+def test_har_cache_invalidate() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        harness_root = tmp_path / "repo"
+        harness_root.mkdir()
+        har_dir = harness_root / ".har"
+        har_dir.mkdir()
+        (har_dir / "launch.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+
+        import lib.har_cache as har_cache
+
+        original_cache_root = har_cache.cache_root
+        try:
+            har_cache.cache_root = lambda: tmp_path / "har-cache"  # type: ignore[method-assign]
+            repo_slug = "test/invalidate-repo"
+            save_har_cache(repo_slug, harness_root, "cli")
+            assert har_cache_exists(repo_slug, "cli")
+            assert invalidate_har_cache(repo_slug)
+            assert not har_cache_exists(repo_slug, "cli")
+        finally:
+            har_cache.cache_root = original_cache_root  # type: ignore[method-assign]
+
+
+def test_task_readiness_prompt_render() -> None:
+    text = render_template(
+        ROOT / "prompts" / "har-task-readiness.md",
+        {
+            "repo": "django/django",
+            "instance_id": "django__django-11099",
+            "base_commit": "abc123",
+            "har_profile": "cli",
+            "problem_statement": "Fix URL validator edge case",
+            "task_overlay_dir": "/tmp/task-overlay",
+            "readiness_failure_context": "",
+        },
+    )
+    assert "Fix URL validator edge case" in text
+    assert "task-overlay" in text
+    assert "Do **not** edit `launch.sh`" in text
+    assert "{{" not in text
 
 
 def test_sanitize_instance() -> None:
@@ -207,6 +251,8 @@ def main() -> int:
     tests = [
         test_config_loads,
         test_har_cache_roundtrip,
+        test_har_cache_invalidate,
+        test_task_readiness_prompt_render,
         test_sanitize_instance,
         test_profile_inference,
         test_patch_filtering,


### PR DESCRIPTION
## Summary

- Split HAR setup into **repo bootstrap** (GPT-5.5, cached per repo) and **task readiness** (GPT-5-mini, every instance with `problem_statement`)
- Replace fixed `setup_max_attempts: 2` with a **time budget** (`setup_budget_minutes: 120`, `setup_max_rounds: 6`)
- **Invalidate `.har-cache/`** when a cached harness fails the pre-fix gate; pass structured gate JSON to retries
- Add ephemeral per-run task overlays under `runs/<id>/har/task-overlay/`

Closes #28, #19

## Flow

```text
Cache hit?
  → task readiness (mini) → pre-fix gate → fix

Cache miss / gate fail?
  → repo bootstrap (5.5) → task readiness (mini) → gate
  → retry until budget exhausted
```

## Test plan

- [x] `uv run scripts/test_swebench_har.py` — 15/15 smoke tests pass
- [x] `./.har/verify.sh 1 --full` — typecheck, unit tests, lint, build pass
- [ ] Re-run failed django/matplotlib instances from batch `20260708-173731` to confirm budget retries help


Made with [Cursor](https://cursor.com)