### PR TITLE
feat(preflight): cross-repo slot isolation and launch preflight

### DIFF
--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -92,6 +92,108 @@ har_allocate_slot_app_ports() {
   export FE_PORT API_PORT DEBUG_PORT
 }
 
+# ── Launch preflight (#36) ─────────────────────────────────────────────────────
+
+har_harness_uses_pm2() {
+  [ -f "${SCRIPT_DIR}/ecosystem.agent.template.cjs" ]
+}
+
+har_port_docker_occupant() {
+  local port="$1"
+  docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true
+}
+
+har_check_control_port_conflict() {
+  local port="$1"
+  local name
+  name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -i control | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true)"
+  if [ -n "$name" ]; then
+    echo "ERROR: Mission Control container \"${name}\" occupies port ${port}." >&2
+    echo "  Run: har control down — or use a different agent slot." >&2
+    return 1
+  fi
+  return 0
+}
+
+har_check_foreign_pm2() {
+  local agent_id="$1"
+  local pm2_raw
+  har_harness_uses_pm2 || return 0
+  pm2_raw="$(npx --yes pm2 jlist 2>/dev/null || true)"
+  [ -n "$pm2_raw" ] || return 0
+  set +e
+  echo "$pm2_raw" | node -e "
+const agentId = process.argv[1];
+const project = process.argv[2];
+const slotPrefix = 'har-' + project + '-agent-' + agentId + '-';
+const legacyPrefix = 'agent-' + agentId + '-';
+let raw = '';
+process.stdin.on('data', c => raw += c);
+process.stdin.on('end', () => {
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) process.exit(0);
+    const foreign = arr.filter(x =>
+      x.name && (
+        (x.name.startsWith('har-') && x.name.includes('-agent-' + agentId + '-') && !x.name.startsWith(slotPrefix)) ||
+        (x.name.startsWith(legacyPrefix) && !x.name.startsWith('har-'))
+      ));
+    if (foreign.length === 0) process.exit(0);
+    console.error('ERROR: foreign PM2 processes match agent ' + agentId + ':');
+    foreign.forEach(p => {
+      const cwd = p.pm2_env?.pm_cwd || p.pm2_env?.cwd || 'unknown';
+      console.error('  ' + p.name + '  cwd=' + cwd);
+    });
+    console.error('  Stop the other harness session or use a different slot.');
+    process.exit(1);
+  } catch {
+    process.exit(0);
+  }
+});
+" "$agent_id" "$HARNESS_PROJECT_NAME"
+  local rc=$?
+  set -e
+  return "$rc"
+}
+
+har_launch_preflight() {
+  local agent_id="$1"
+  local force="${2:-false}"
+  local replace="${3:-false}"
+
+  if slot_is_occupied "$agent_id"; then
+    if [ "$replace" != true ] && [ "${HAR_CONFIRM_REPLACE:-}" != "1" ]; then
+      print_slot_replace_warning "$agent_id"
+      echo "ERROR: slot ${agent_id} is occupied — pass --replace to proceed." >&2
+      return 2
+    fi
+    local wt
+    wt="$(existing_slot_worktree "$agent_id")"
+    if [ -n "$wt" ] && slot_worktree_dirty "$wt" && [ "$force" != true ]; then
+      echo "ERROR: dirty worktree requires --force after explicit user approval." >&2
+      return 2
+    fi
+  fi
+
+  if har_harness_uses_pm2; then
+    har_check_foreign_pm2 "$agent_id" || return 1
+    har_allocate_slot_app_ports "$agent_id" || return 1
+    local port occupant
+    for port in $(printf '%s\n' "$FE_PORT" "$API_PORT" | sort -u); do
+      har_check_control_port_conflict "$port" || return 1
+      occupant="$(har_port_docker_occupant "$port")"
+      if [ -n "$occupant" ] && [[ "$occupant" != har-${HARNESS_PROJECT_NAME}-* ]]; then
+        echo "ERROR: Docker container \"${occupant}\" binds port ${port}." >&2
+        echo "  Stop it with: docker stop ${occupant}" >&2
+        return 1
+      fi
+    done
+  fi
+  return 0
+}
+
 # Load persisted app/infra ports from .env.agent.<id> or the slot registry.
 load_agent_ports() {
   local agent_id="$1"

--- a/.har/launch.sh
+++ b/.har/launch.sh
@@ -40,6 +40,9 @@ validate_agent_id "$AGENT_ID"
 
 log() { echo "==> [agent-$AGENT_ID] $*" >&2; }
 
+# Preflight before worktree/install — occupied slot gate for CLI harnesses.
+har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE" || exit $?
+
 # Replace any previous session for this slot — requires explicit confirmation.
 if slot_is_occupied "$AGENT_ID"; then
   require_slot_replace_confirm "$AGENT_ID" "$FORCE" "$REPLACE"

--- a/.har/preflight.sh
+++ b/.har/preflight.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Launch readiness gate for CLI/library harnesses (occupied slot only).
+# Usage: ./.har/preflight.sh <agent-id> [--replace] [--force]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/harness.env"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/agent-slot.sh"
+
+AGENT_ID="${1:-}"
+FORCE=false
+REPLACE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --replace) REPLACE=true ;;
+    --force)   FORCE=true ;;
+  esac
+done
+
+if [[ -z "$AGENT_ID" ]]; then
+  echo "Usage: $0 <agent-id> [--replace] [--force]" >&2
+  exit 1
+fi
+
+validate_agent_id "$AGENT_ID"
+
+if har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE"; then
+  echo "Slot ${AGENT_ID}: ready to launch."
+  exit 0
+fi
+
+exit $?

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -92,6 +92,108 @@ har_allocate_slot_app_ports() {
   export FE_PORT API_PORT DEBUG_PORT
 }
 
+# ── Launch preflight (#36) ─────────────────────────────────────────────────────
+
+har_harness_uses_pm2() {
+  [ -f "${SCRIPT_DIR}/ecosystem.agent.template.cjs" ]
+}
+
+har_port_docker_occupant() {
+  local port="$1"
+  docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true
+}
+
+har_check_control_port_conflict() {
+  local port="$1"
+  local name
+  name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -i control | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true)"
+  if [ -n "$name" ]; then
+    echo "ERROR: Mission Control container \"${name}\" occupies port ${port}." >&2
+    echo "  Run: har control down — or use a different agent slot." >&2
+    return 1
+  fi
+  return 0
+}
+
+har_check_foreign_pm2() {
+  local agent_id="$1"
+  local pm2_raw
+  har_harness_uses_pm2 || return 0
+  pm2_raw="$(npx --yes pm2 jlist 2>/dev/null || true)"
+  [ -n "$pm2_raw" ] || return 0
+  set +e
+  echo "$pm2_raw" | node -e "
+const agentId = process.argv[1];
+const project = process.argv[2];
+const slotPrefix = 'har-' + project + '-agent-' + agentId + '-';
+const legacyPrefix = 'agent-' + agentId + '-';
+let raw = '';
+process.stdin.on('data', c => raw += c);
+process.stdin.on('end', () => {
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) process.exit(0);
+    const foreign = arr.filter(x =>
+      x.name && (
+        (x.name.startsWith('har-') && x.name.includes('-agent-' + agentId + '-') && !x.name.startsWith(slotPrefix)) ||
+        (x.name.startsWith(legacyPrefix) && !x.name.startsWith('har-'))
+      ));
+    if (foreign.length === 0) process.exit(0);
+    console.error('ERROR: foreign PM2 processes match agent ' + agentId + ':');
+    foreign.forEach(p => {
+      const cwd = p.pm2_env?.pm_cwd || p.pm2_env?.cwd || 'unknown';
+      console.error('  ' + p.name + '  cwd=' + cwd);
+    });
+    console.error('  Stop the other harness session or use a different slot.');
+    process.exit(1);
+  } catch {
+    process.exit(0);
+  }
+});
+" "$agent_id" "$HARNESS_PROJECT_NAME"
+  local rc=$?
+  set -e
+  return "$rc"
+}
+
+har_launch_preflight() {
+  local agent_id="$1"
+  local force="${2:-false}"
+  local replace="${3:-false}"
+
+  if slot_is_occupied "$agent_id"; then
+    if [ "$replace" != true ] && [ "${HAR_CONFIRM_REPLACE:-}" != "1" ]; then
+      print_slot_replace_warning "$agent_id"
+      echo "ERROR: slot ${agent_id} is occupied — pass --replace to proceed." >&2
+      return 2
+    fi
+    local wt
+    wt="$(existing_slot_worktree "$agent_id")"
+    if [ -n "$wt" ] && slot_worktree_dirty "$wt" && [ "$force" != true ]; then
+      echo "ERROR: dirty worktree requires --force after explicit user approval." >&2
+      return 2
+    fi
+  fi
+
+  if har_harness_uses_pm2; then
+    har_check_foreign_pm2 "$agent_id" || return 1
+    har_allocate_slot_app_ports "$agent_id" || return 1
+    local port occupant
+    for port in $(printf '%s\n' "$FE_PORT" "$API_PORT" | sort -u); do
+      har_check_control_port_conflict "$port" || return 1
+      occupant="$(har_port_docker_occupant "$port")"
+      if [ -n "$occupant" ] && [[ "$occupant" != har-${HARNESS_PROJECT_NAME}-* ]]; then
+        echo "ERROR: Docker container \"${occupant}\" binds port ${port}." >&2
+        echo "  Stop it with: docker stop ${occupant}" >&2
+        return 1
+      fi
+    done
+  fi
+  return 0
+}
+
 # Load persisted app/infra ports from .env.agent.<id> or the slot registry.
 load_agent_ports() {
   local agent_id="$1"

--- a/control/.har/launch.sh
+++ b/control/.har/launch.sh
@@ -42,6 +42,9 @@ validate_agent_id "$AGENT_ID"
 
 log() { echo "==> [agent-$AGENT_ID] $*" >&2; }
 
+# Preflight before worktree/install — ports, foreign PM2, Docker, occupied slot.
+har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE" || exit $?
+
 # Replace any previous session for this slot — requires explicit confirmation.
 if slot_is_occupied "$AGENT_ID"; then
   require_slot_replace_confirm "$AGENT_ID" "$FORCE" "$REPLACE"
@@ -49,9 +52,9 @@ if slot_is_occupied "$AGENT_ID"; then
   "$SCRIPT_DIR/teardown.sh" "$AGENT_ID" >&2
 fi
 
-# Preflight port allocation before worktree/install — scan when defaults are busy.
-har_allocate_slot_app_ports "$AGENT_ID"
-log "Ports: frontend=$FE_PORT api=$API_PORT debug=$DEBUG_PORT"
+if har_harness_uses_pm2; then
+  log "Ports: frontend=$FE_PORT api=$API_PORT debug=$DEBUG_PORT"
+fi
 
 # Ensure shared infra is running (persists host ports in .har/state/infra.env).
 "$SCRIPT_DIR/setup-infra.sh"

--- a/control/.har/preflight.sh
+++ b/control/.har/preflight.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Launch readiness gate — run before launch.sh or standalone.
+# Usage: ./.har/preflight.sh <agent-id> [--replace] [--force]
+# JSON:  har env preflight <id> --json
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/harness.env"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/agent-slot.sh"
+
+AGENT_ID="${1:-}"
+FORCE=false
+REPLACE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --replace) REPLACE=true ;;
+    --force)   FORCE=true ;;
+  esac
+done
+
+if [[ -z "$AGENT_ID" ]]; then
+  echo "Usage: $0 <agent-id> [--replace] [--force]" >&2
+  exit 1
+fi
+
+validate_agent_id "$AGENT_ID"
+
+if har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE"; then
+  echo "Slot ${AGENT_ID}: ready to launch."
+  if har_harness_uses_pm2; then
+    echo "  Ports: frontend=${FE_PORT} api=${API_PORT} debug=${DEBUG_PORT}"
+  fi
+  exit 0
+fi
+
+exit $?

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -271,6 +271,28 @@ export const AgentSlotHarnessUsageSchema = z.enum([
 
 export type AgentSlotHarnessUsage = z.infer<typeof AgentSlotHarnessUsageSchema>;
 
+/** One actionable launch blocker from preflight / readiness inspection. */
+export const PreflightBlockerSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  remediation: z.string().optional(),
+  details: z.record(z.unknown()).optional(),
+});
+
+export type PreflightBlocker = z.infer<typeof PreflightBlockerSchema>;
+
+/** Readiness verdict for a slot — observability in status, hard gate before launch. */
+export const SlotReadinessSchema = z.object({
+  canLaunch: z.boolean(),
+  verdict: z.enum(['ready', 'blocked']),
+  blockers: z.array(PreflightBlockerSchema),
+  remediations: z.array(z.string()),
+  ports: z.record(z.number()).optional(),
+  allocatedPorts: z.boolean().optional(),
+});
+
+export type SlotReadiness = z.infer<typeof SlotReadinessSchema>;
+
 export const AgentSlotStatusSchema = z.object({
   agentId: z.number().int().min(HAR_AGENT_SLOT_MIN),
   active: z.boolean(),
@@ -304,6 +326,8 @@ export const AgentSlotStatusSchema = z.object({
   ports: z.record(z.number()).optional(),
   /** PM2 namespace mismatch — foreign or legacy processes for this slot id. */
   pm2Issue: z.enum(['foreign_pm2', 'registry_missing', 'project_mismatch']).optional(),
+  /** Launch readiness slice — same core as `har env preflight`. */
+  readiness: SlotReadinessSchema.optional(),
 });
 
 export type AgentSlotStatus = z.infer<typeof AgentSlotStatusSchema>;

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -14,13 +14,14 @@ import {
   completeEnvironment,
   getEnvironmentStatus,
   launchEnvironment,
+  preflightEnvironment,
   runVerification,
   teardownEnvironment,
 } from '../../core/run-service';
 import { checkLaunchGuard } from '../../core/slot-launch-guard';
 import { listRuns, getRun } from '../../core/runs';
 import { collectEnvironmentStatus } from '../../core/slot-status';
-import { EnvironmentStatusSchema } from '../../harness/schema';
+import { EnvironmentStatusSchema, SlotReadinessSchema } from '../../harness/schema';
 import { recordRepoForControlSync } from '../../core/control-registry';
 import { writeFileSafe } from '../../utils/file-ops';
 import { requireApiKey, validateAgentId } from '../../utils/validation';
@@ -151,6 +152,26 @@ export const envCommand = {
                 'Discard uncommitted changes when replacing a dirty worktree (only after explicit approval)',
             }),
         handleLaunch,
+      )
+      .command(
+        'preflight <id>',
+        'Check whether a slot can launch now (ports, PM2, Docker, occupied slot)',
+        (y: Argv) =>
+          y
+            .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
+            .option('repo', { type: 'string', default: '.' })
+            .option('json', { type: 'boolean', default: false, describe: 'Structured JSON output' })
+            .option('replace', {
+              type: 'boolean',
+              default: false,
+              describe: 'Treat an occupied slot as replaceable (same as launch --replace)',
+            })
+            .option('force', {
+              type: 'boolean',
+              default: false,
+              describe: 'Allow replacing a dirty worktree (only after explicit approval)',
+            }),
+        handlePreflight,
       )
       .command(
         'verify <id>',
@@ -453,6 +474,33 @@ export async function handleAddStage(argv: {
     error((err as Error).message);
     process.exit(1);
   }
+}
+
+export async function handlePreflight(argv: {
+  id?: number;
+  repo: string;
+  json?: boolean;
+  replace: boolean;
+  force: boolean;
+}): Promise<void> {
+  const repo = path.resolve(argv.repo);
+  const agentId = validateAgentId(argv.id, repo);
+  const result = await preflightEnvironment({
+    repoPath: repo,
+    agentId,
+    confirmReplace: argv.replace,
+    force: argv.force,
+  });
+
+  if (argv.json) {
+    const output = SlotReadinessSchema.parse(result.readiness);
+    process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+    process.exit(result.code);
+    return;
+  }
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  process.exit(result.code);
 }
 
 export async function handleLaunch(argv: {

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -4,6 +4,7 @@ import { syncRepoWithControlAsync } from './control-sync';
 import { createRun, finishRun, resolveAgentWorkDir } from './runs';
 import { readSlotRegistry } from './slot-registry';
 import { checkLaunchGuard } from './slot-launch-guard';
+import { formatPreflightReport, inspectSlotReadiness } from './slot-preflight';
 import { recordValidation } from './validations';
 import { resolveHarnessRoot } from '../harness/manifest';
 import { getAgentSlotIds, resolveStage } from '../harness/stages';
@@ -15,6 +16,8 @@ import {
   ExecutionContext,
   LaunchOptions,
   LogsOptions,
+  PreflightOptions,
+  PreflightResult,
   StageExecutor,
   StageRunOptions,
   VerificationRunResult,
@@ -129,6 +132,21 @@ export class RunService {
 
   listArtifacts(options: { repoPath: string; stageId?: string }): ArtifactEntry[] {
     return this.executor.listArtifacts({ repoPath: options.repoPath }, { stageId: options.stageId });
+  }
+
+  async preflightEnvironment(options: PreflightOptions): Promise<PreflightResult> {
+    const readiness = inspectSlotReadiness(options.repoPath, options.agentId, {
+      confirmReplace: options.confirmReplace,
+      force: options.force,
+    });
+    const report = formatPreflightReport(options.agentId, readiness);
+    return {
+      code: readiness.canLaunch ? 0 : 1,
+      stdout: report + '\n',
+      stderr: readiness.canLaunch ? '' : report + '\n',
+      readiness,
+      blocked: !readiness.canLaunch,
+    };
   }
 
   async launchEnvironment(options: LaunchOptions): Promise<EnvironmentRunResult> {
@@ -392,6 +410,7 @@ export function createRunService(executor: StageExecutor = localScriptExecutor):
 export const runStage = defaultRunService.runStage.bind(defaultRunService);
 export const listArtifacts = defaultRunService.listArtifacts.bind(defaultRunService);
 export const launchEnvironment = defaultRunService.launchEnvironment.bind(defaultRunService);
+export const preflightEnvironment = defaultRunService.preflightEnvironment.bind(defaultRunService);
 export const runVerification = defaultRunService.runVerification.bind(defaultRunService);
 export const teardownEnvironment = defaultRunService.teardownEnvironment.bind(defaultRunService);
 export const completeEnvironment = defaultRunService.completeEnvironment.bind(defaultRunService);
@@ -405,6 +424,8 @@ export type {
   EnvironmentRunResult,
   LaunchOptions,
   LogsOptions,
+  PreflightOptions,
+  PreflightResult,
   StageRunOptions,
   VerificationRunResult,
 } from './types';

--- a/src/core/slot-launch-guard-occupied.ts
+++ b/src/core/slot-launch-guard-occupied.ts
@@ -1,0 +1,164 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { readHarnessEnv } from '../harness/env';
+import { resolveHarnessRoot } from '../harness/manifest';
+import type { AgentSlotStatus } from '../harness/schema';
+import { readSlotRegistry } from './slot-registry';
+
+export interface LaunchGuardOptions {
+  confirmReplace?: boolean;
+  force?: boolean;
+}
+
+export interface LaunchGuardResult {
+  allowed: boolean;
+  blocked?: boolean;
+  reason?: string;
+  slot?: AgentSlotStatus;
+}
+
+function runGit(cwd: string, args: string): string | undefined {
+  try {
+    return execSync(`git ${args}`, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function worktreeDirty(worktreePath: string): boolean {
+  const porcelain = runGit(worktreePath, 'status --porcelain');
+  return porcelain !== undefined && porcelain.length > 0;
+}
+
+function gitCommonDir(cwd: string): string | undefined {
+  const out = runGit(cwd, 'rev-parse --git-common-dir');
+  return out ? path.resolve(cwd, out) : undefined;
+}
+
+function sameGitCheckout(a: string, b: string): boolean {
+  const left = gitCommonDir(a);
+  const right = gitCommonDir(b);
+  return left !== undefined && right !== undefined && left === right;
+}
+
+function discoverWorktree(harnessRoot: string, agentId: number, projectName: string): string | undefined {
+  const session = readSlotRegistry(harnessRoot, agentId);
+  if (session?.worktreePath && fs.existsSync(session.worktreePath)) {
+    return session.worktreePath;
+  }
+  const legacy = path.join(os.homedir(), 'worktrees', `${projectName}-agent-${agentId}`);
+  if (fs.existsSync(legacy) && sameGitCheckout(harnessRoot, legacy)) return legacy;
+  const worktreesRoot = path.join(os.homedir(), 'worktrees');
+  if (!fs.existsSync(worktreesRoot)) return undefined;
+  const suffix = `-har-agent-${agentId}-`;
+  const relPrefix = runGit(harnessRoot, 'rev-parse --show-prefix') ?? '';
+  for (const name of fs.readdirSync(worktreesRoot)) {
+    if (!name.includes(suffix)) continue;
+    const candidate = path.join(worktreesRoot, name);
+    if (!sameGitCheckout(harnessRoot, candidate)) continue;
+    if (!fs.existsSync(path.join(candidate, relPrefix, `.env.agent.${agentId}`))) continue;
+    return candidate;
+  }
+  return undefined;
+}
+
+/** Lightweight occupied check — avoids full collectEnvironmentStatus (and PM2 polling). */
+function collectOccupiedSlot(repoPath: string, agentId: number): AgentSlotStatus | undefined {
+  const harnessRoot = resolveHarnessRoot(repoPath);
+  const env = readHarnessEnv(harnessRoot);
+  const projectName = env.HARNESS_PROJECT_NAME ?? path.basename(harnessRoot);
+  const session = readSlotRegistry(harnessRoot, agentId);
+  const worktreePath = discoverWorktree(harnessRoot, agentId, projectName);
+  const workDir = session?.workDir;
+  const envInWorkDir = workDir ? fs.existsSync(path.join(workDir, `.env.agent.${agentId}`)) : false;
+  const envInRoot = fs.existsSync(path.join(harnessRoot, `.env.agent.${agentId}`));
+  const envInWorktree = worktreePath
+    ? fs.existsSync(path.join(worktreePath, `.env.agent.${agentId}`))
+    : false;
+  const active =
+    (session !== undefined && session.status !== 'completed') ||
+    envInWorkDir ||
+    envInRoot ||
+    envInWorktree;
+
+  if (!active) return undefined;
+
+  const dirty = worktreePath ? worktreeDirty(worktreePath) : undefined;
+  return {
+    agentId,
+    active: true,
+    workDir: workDir ?? worktreePath,
+    worktreePath,
+    branch: session?.branch,
+    sessionStatus: session?.status,
+    lastError: session?.lastError,
+    sessionCreatedAt: session?.createdAt,
+    dirty,
+    harnessUsage: 'none',
+  };
+}
+
+function formatOccupiedSlot(slot: AgentSlotStatus): string {
+  const lines = [
+    `Slot ${slot.agentId} is already in use.`,
+    slot.worktreePath ? `  Worktree: ${slot.worktreePath}` : undefined,
+    slot.branch ? `  Branch:   ${slot.branch}` : undefined,
+    slot.workDir ? `  Work dir: ${slot.workDir}` : undefined,
+    slot.sessionStatus ? `  Status:   ${slot.sessionStatus}` : undefined,
+    slot.lastError ? `  Error:    ${slot.lastError}` : undefined,
+    slot.sessionCreatedAt ? `  Since:    ${slot.sessionCreatedAt}` : undefined,
+    slot.dirty
+      ? '  Git:      dirty (uncommitted changes — commit or use force to discard)'
+      : '  Git:      clean',
+    '',
+    'Replacing removes the worktree. The session branch is kept only if you committed.',
+    'Gitignored paths (state/, runs/, local clones) are NOT preserved.',
+    '',
+    'To replace: pass confirmReplace=true (MCP), --replace (CLI), or answer y at the prompt.',
+    'If the worktree is dirty, also pass force=true / --force after explicit user approval.',
+  ];
+  return lines.filter(Boolean).join('\n');
+}
+
+/** Occupied-slot guard only — used by inspectSlotReadiness and the combined launch guard. */
+export function checkLaunchGuard(
+  repoPath: string,
+  agentId: number,
+  options: LaunchGuardOptions = {},
+): LaunchGuardResult {
+  const slot = collectOccupiedSlot(repoPath, agentId);
+  if (!slot?.active) {
+    return { allowed: true };
+  }
+
+  if (!options.confirmReplace) {
+    return {
+      allowed: false,
+      blocked: true,
+      slot,
+      reason: formatOccupiedSlot(slot),
+    };
+  }
+
+  if (slot.dirty && !options.force) {
+    return {
+      allowed: false,
+      blocked: true,
+      slot,
+      reason: [
+        formatOccupiedSlot(slot),
+        '',
+        'The occupied worktree has uncommitted changes.',
+        'Pass force=true / --force to discard them (only after explicit user approval).',
+      ].join('\n'),
+    };
+  }
+
+  return { allowed: true, slot };
+}

--- a/src/core/slot-launch-guard.ts
+++ b/src/core/slot-launch-guard.ts
@@ -1,78 +1,35 @@
-import { collectEnvironmentStatus } from './slot-status';
-import type { AgentSlotStatus } from '../harness/schema';
+import { inspectSlotReadiness, formatPreflightReport } from './slot-preflight';
+import { checkLaunchGuard as checkOccupiedSlotGuard, type LaunchGuardOptions } from './slot-launch-guard-occupied';
+import type { AgentSlotStatus, SlotReadiness } from '../harness/schema';
 
-export interface LaunchGuardOptions {
-  confirmReplace?: boolean;
-  force?: boolean;
-}
+export type { LaunchGuardOptions };
 
 export interface LaunchGuardResult {
   allowed: boolean;
-  /** Set when launch is blocked because the slot is already in use. */
   blocked?: boolean;
   reason?: string;
   slot?: AgentSlotStatus;
+  readiness?: SlotReadiness;
 }
 
-function formatOccupiedSlot(slot: AgentSlotStatus): string {
-  const lines = [
-    `Slot ${slot.agentId} is already in use.`,
-    slot.worktreePath ? `  Worktree: ${slot.worktreePath}` : undefined,
-    slot.branch ? `  Branch:   ${slot.branch}` : undefined,
-    slot.workDir ? `  Work dir: ${slot.workDir}` : undefined,
-    slot.sessionStatus ? `  Status:   ${slot.sessionStatus}` : undefined,
-    slot.lastError ? `  Error:    ${slot.lastError}` : undefined,
-    slot.sessionCreatedAt ? `  Since:    ${slot.sessionCreatedAt}` : undefined,
-    slot.dirty
-      ? '  Git:      dirty (uncommitted changes — commit or use force to discard)'
-      : '  Git:      clean',
-    '',
-    'Replacing removes the worktree. The session branch is kept only if you committed.',
-    'Gitignored paths (state/, runs/, local clones) are NOT preserved.',
-    '',
-    'To replace: pass confirmReplace=true (MCP), --replace (CLI), or answer y at the prompt.',
-    'If the worktree is dirty, also pass force=true / --force after explicit user approval.',
-  ];
-  return lines.filter(Boolean).join('\n');
-}
-
-/**
- * Preflight before launch: refuse to replace an occupied slot unless the caller
- * explicitly confirms. Dirty worktrees additionally require force.
- */
+/** Preflight before launch: occupied-slot guard plus machine readiness (ports, PM2, Docker). */
 export function checkLaunchGuard(
   repoPath: string,
   agentId: number,
   options: LaunchGuardOptions = {},
 ): LaunchGuardResult {
-  const status = collectEnvironmentStatus(repoPath);
-  const slot = status.slots.find((s) => s.agentId === agentId);
-  if (!slot?.active) {
-    return { allowed: true };
-  }
+  const readiness = inspectSlotReadiness(repoPath, agentId, options);
 
-  if (!options.confirmReplace) {
+  if (!readiness.canLaunch) {
     return {
       allowed: false,
       blocked: true,
-      slot,
-      reason: formatOccupiedSlot(slot),
+      reason: formatPreflightReport(agentId, readiness),
+      slot: checkOccupiedSlotGuard(repoPath, agentId, options).slot,
+      readiness,
     };
   }
 
-  if (slot.dirty && !options.force) {
-    return {
-      allowed: false,
-      blocked: true,
-      slot,
-      reason: [
-        formatOccupiedSlot(slot),
-        '',
-        'The occupied worktree has uncommitted changes.',
-        'Pass force=true / --force to discard them (only after explicit user approval).',
-      ].join('\n'),
-    };
-  }
-
-  return { allowed: true, slot };
+  const occupied = checkOccupiedSlotGuard(repoPath, agentId, options);
+  return { allowed: true, slot: occupied.slot, readiness };
 }

--- a/src/core/slot-ports.ts
+++ b/src/core/slot-ports.ts
@@ -1,0 +1,89 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { readHarnessEnv } from '../harness/env';
+import { resolveHarnessRoot } from '../harness/manifest';
+
+export interface AllocatedAppPorts {
+  frontend: number;
+  api: number;
+  debug: number;
+  /** True when any port differed from the configured default for this slot. */
+  allocated: boolean;
+}
+
+export function portStep(env: Record<string, string>): number {
+  return Number(env.HARNESS_PORT_STEP ?? 10);
+}
+
+export function defaultAppPort(base: number, agentId: number, step: number): number {
+  return base + agentId * step;
+}
+
+export function slotPortLaneEnd(defaultPort: number, step: number): number {
+  return defaultPort + step - 1;
+}
+
+/** Returns true when something is listening on the host port (TCP connect probe). */
+export function isPortInUse(port: number, host = '127.0.0.1'): boolean {
+  try {
+    execSync(`bash -c 'exec 3<>/dev/tcp/${host}/${port}'`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function pickFreePort(start: number, end: number): number | undefined {
+  for (let port = start; port <= end; port++) {
+    if (!isPortInUse(port)) return port;
+  }
+  return undefined;
+}
+
+export function allocatePort(
+  defaultPort: number,
+  scanStart: number,
+  scanEnd: number,
+): number | undefined {
+  if (!isPortInUse(defaultPort)) return defaultPort;
+  return pickFreePort(scanStart, scanEnd);
+}
+
+export function allocateAppPorts(
+  repoPath: string,
+  agentId: number,
+): AllocatedAppPorts | { error: string } {
+  const harnessRoot = resolveHarnessRoot(repoPath);
+  const env = readHarnessEnv(harnessRoot);
+  const step = portStep(env);
+  const feDefault = defaultAppPort(Number(env.HARNESS_FE_BASE_PORT ?? 3000), agentId, step);
+  const apiDefault = defaultAppPort(Number(env.HARNESS_API_BASE_PORT ?? 8000), agentId, step);
+  const debugDefault = 9200 + agentId * step;
+
+  const frontend = allocatePort(feDefault, feDefault, slotPortLaneEnd(feDefault, step));
+  const api = allocatePort(apiDefault, apiDefault, slotPortLaneEnd(apiDefault, step));
+  const debug = allocatePort(debugDefault, debugDefault, debugDefault + step - 1);
+
+  if (frontend === undefined) {
+    return { error: `No free frontend port in range ${feDefault}-${slotPortLaneEnd(feDefault, step)}` };
+  }
+  if (api === undefined) {
+    return { error: `No free API port in range ${apiDefault}-${slotPortLaneEnd(apiDefault, step)}` };
+  }
+  if (debug === undefined) {
+    return { error: `No free debug port in range ${debugDefault}-${debugDefault + step - 1}` };
+  }
+
+  return {
+    frontend,
+    api,
+    debug,
+    allocated: frontend !== feDefault || api !== apiDefault || debug !== debugDefault,
+  };
+}
+
+export function harnessUsesPm2(repoPath: string): boolean {
+  const harnessRoot = resolveHarnessRoot(repoPath);
+  return fs.existsSync(path.join(harnessRoot, '.har', 'ecosystem.agent.template.cjs'));
+}

--- a/src/core/slot-preflight.ts
+++ b/src/core/slot-preflight.ts
@@ -1,0 +1,339 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import { readHarnessEnv } from '../harness/env';
+import { resolveHarnessRoot } from '../harness/manifest';
+import type { SlotReadiness } from '../harness/schema';
+import { checkLaunchGuard as checkOccupiedSlotGuard } from './slot-launch-guard-occupied';
+import type { LaunchGuardOptions } from './slot-launch-guard-occupied';
+import {
+  allocateAppPorts,
+  harnessUsesPm2,
+  isPortInUse,
+  pickFreePort,
+  portStep,
+  defaultAppPort,
+  slotPortLaneEnd,
+} from './slot-ports';
+import { readSlotRegistry } from './slot-registry';
+
+export interface PreflightOptions extends LaunchGuardOptions {
+  /** When true, include port allocation in the result (default true for PM2 harnesses). */
+  allocatePorts?: boolean;
+  /**
+   * Precomputed occupied state — pass from collectSlotStatus to avoid recursion
+   * through collectEnvironmentStatus.
+   */
+  occupied?: { active: boolean; dirty?: boolean };
+}
+
+interface Pm2Process {
+  name?: string;
+  pm2_env?: { pm_cwd?: string; cwd?: string; status?: string };
+}
+
+interface DockerRow {
+  name: string;
+  ports: string;
+}
+
+function listPm2Processes(): Pm2Process[] | undefined {
+  try {
+    const raw = execSync('npx --yes pm2 jlist', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 3000,
+    });
+    const procs = JSON.parse(raw) as Pm2Process[];
+    return Array.isArray(procs) ? procs : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function listDockerContainers(): DockerRow[] {
+  try {
+    const raw = execSync('docker ps --format {{.Names}}\\t{{.Ports}}', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 3000,
+    });
+    return raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const tab = line.indexOf('\t');
+        if (tab === -1) return { name: line, ports: '' };
+        return { name: line.slice(0, tab), ports: line.slice(tab + 1) };
+      });
+  } catch {
+    return [];
+  }
+}
+
+function dockerOnPort(containers: DockerRow[], port: number): DockerRow | undefined {
+  const re = new RegExp(`:${port}->|:${port}/`);
+  return containers.find((c) => re.test(c.ports));
+}
+
+function controlContainerOnPort(containers: DockerRow[], port: number): DockerRow | undefined {
+  return containers.find(
+    (c) =>
+      /control/i.test(c.name) &&
+      (new RegExp(`:${port}->|:${port}/`).test(c.ports) || c.ports.includes(`0.0.0.0:${port}`)),
+  );
+}
+
+function detectForeignPm2(
+  projectName: string,
+  agentId: number,
+  procs: Pm2Process[] | undefined,
+): { processes: Array<{ name: string; cwd?: string }> } | undefined {
+  if (!procs) return undefined;
+
+  const slotPrefix = `har-${projectName}-agent-${agentId}-`;
+  const legacyPrefix = `agent-${agentId}-`;
+  const foreign = procs.filter(
+    (p) =>
+      p.name &&
+      ((p.name.startsWith('har-') &&
+        p.name.includes(`-agent-${agentId}-`) &&
+        !p.name.startsWith(slotPrefix)) ||
+        (p.name.startsWith(legacyPrefix) && !p.name.startsWith('har-'))),
+  );
+
+  if (foreign.length === 0) return undefined;
+  return {
+    processes: foreign.map((p) => ({
+      name: p.name!,
+      cwd: p.pm2_env?.pm_cwd ?? p.pm2_env?.cwd,
+    })),
+  };
+}
+
+function infraEnabled(env: Record<string, string>, service: string): boolean {
+  return ` ${env.HARNESS_INFRA_SERVICES ?? ''} `.includes(` ${service} `);
+}
+
+function checkInfraPort(
+  env: Record<string, string>,
+  varName: string,
+  defaultPort: number,
+  scanStart: number,
+  scanEnd: number,
+): { port?: number; error?: string } {
+  const current = env[varName] ? Number(env[varName]) : undefined;
+  if (current !== undefined && !isPortInUse(current)) {
+    return { port: current };
+  }
+  if (current !== undefined && isPortInUse(current)) {
+    const alt = pickFreePort(scanStart, scanEnd);
+    if (alt !== undefined) return { port: alt };
+    return { error: `No free ${varName} port in range ${scanStart}-${scanEnd}` };
+  }
+  const port = pickFreePort(defaultPort, scanEnd) ?? pickFreePort(scanStart, scanEnd);
+  if (port === undefined) {
+    return { error: `No free ${varName} port in range ${scanStart}-${scanEnd}` };
+  }
+  return { port };
+}
+
+/**
+ * Readiness gate for launch: machine/slot checks with an explicit verdict.
+ * Shared by `har env preflight`, `har env status --json` (readiness block), and launch guard.
+ */
+export function inspectSlotReadiness(
+  repoPath: string,
+  agentId: number,
+  options: PreflightOptions = {},
+): SlotReadiness {
+  const harnessRoot = resolveHarnessRoot(repoPath);
+  const env = readHarnessEnv(harnessRoot);
+  const projectName = env.HARNESS_PROJECT_NAME ?? path.basename(harnessRoot);
+  const usesPm2 = harnessUsesPm2(repoPath);
+  const blockers: SlotReadiness['blockers'] = [];
+  const remediations: string[] = [];
+  const ports: Record<string, number> = {};
+
+  const guard =
+    options.occupied !== undefined
+      ? options.occupied.active
+        ? !options.confirmReplace
+          ? {
+              allowed: false,
+              blocked: true,
+              reason: `Slot ${agentId} is already in use.`,
+            }
+          : options.occupied.dirty && !options.force
+            ? {
+                allowed: false,
+                blocked: true,
+                reason: `Slot ${agentId} worktree has uncommitted changes.`,
+              }
+            : { allowed: true }
+        : { allowed: true }
+      : checkOccupiedSlotGuard(repoPath, agentId, options);
+  if (!guard.allowed) {
+    blockers.push({
+      code: options.occupied?.dirty ? 'slot_dirty' : 'slot_occupied',
+      message: guard.reason ?? `Slot ${agentId} is occupied.`,
+      remediation: guard.slot?.dirty
+        ? 'Commit changes in the worktree, or pass --force after explicit user approval.'
+        : 'Pass --replace (CLI), confirmReplace=true (MCP), or answer y at the launch prompt.',
+    });
+    remediations.push(
+      guard.slot?.dirty
+        ? 'har env preflight <id> --replace --force'
+        : 'har env preflight <id> --replace',
+    );
+  }
+
+  const pm2Procs = usesPm2 ? listPm2Processes() : undefined;
+  const foreign = usesPm2 ? detectForeignPm2(projectName, agentId, pm2Procs) : undefined;
+  if (foreign) {
+    const names = foreign.processes.map((p) => p.name).join(', ');
+    blockers.push({
+      code: 'foreign_pm2',
+      message: `Foreign PM2 processes match agent ${agentId}: ${names}`,
+      remediation:
+        'Stop the other harness session (./.har/teardown.sh in that repo) or use a different agent slot.',
+      details: { processes: foreign.processes },
+    });
+    remediations.push('Inspect with: npx pm2 jlist | grep agent-' + agentId);
+  }
+
+  const session = readSlotRegistry(harnessRoot, agentId);
+  if (usesPm2 && pm2Procs) {
+    const slotPrefix = `har-${projectName}-agent-${agentId}-`;
+    const owned = pm2Procs.filter((p) => p.name?.startsWith(slotPrefix));
+    if (owned.length > 0 && !session) {
+      blockers.push({
+        code: 'registry_missing',
+        message: `PM2 processes exist for ${projectName} agent ${agentId} but the slot registry is missing.`,
+        remediation: 'Run teardown in this harness or delete PM2 processes manually, then relaunch.',
+      });
+    }
+    if (owned.length > 0 && session?.projectName && session.projectName !== projectName) {
+      blockers.push({
+        code: 'project_mismatch',
+        message: `Slot registry projectName=${session.projectName} does not match harness ${projectName}.`,
+        remediation: 'Teardown the stale session and relaunch with --replace.',
+      });
+    }
+  }
+
+  let allocatedPorts = false;
+  if (usesPm2 && (options.allocatePorts ?? true)) {
+    const alloc = allocateAppPorts(repoPath, agentId);
+    if ('error' in alloc) {
+      blockers.push({
+        code: 'ports_exhausted',
+        message: alloc.error,
+        remediation: 'Free a port in the slot lane or stop the process/container using it.',
+      });
+    } else {
+      ports.frontend = alloc.frontend;
+      ports.api = alloc.api;
+      ports.debug = alloc.debug;
+      allocatedPorts = alloc.allocated;
+
+      const containers = listDockerContainers();
+      for (const [label, port] of Object.entries({ frontend: alloc.frontend, api: alloc.api })) {
+        const control = controlContainerOnPort(containers, port);
+        if (control) {
+          blockers.push({
+            code: 'control_port_conflict',
+            message: `Mission Control container "${control.name}" occupies port ${port} (${label}).`,
+            remediation: 'Run: har control down — or launch a different slot id.',
+            details: { container: control.name, port, label },
+          });
+          remediations.push('har control down');
+        } else {
+          const occupant = dockerOnPort(containers, port);
+          if (occupant && !occupant.name.startsWith(`har-${projectName}-`)) {
+            blockers.push({
+              code: 'docker_port_conflict',
+              message: `Docker container "${occupant.name}" binds port ${port} (${label}).`,
+              remediation: `Stop the container: docker stop ${occupant.name}`,
+              details: { container: occupant.name, port, label },
+            });
+          }
+        }
+      }
+    }
+  }
+
+  if (infraEnabled(env, 'db')) {
+    const dbDefault = Number(env.HARNESS_DB_PORT_DEFAULT ?? 15432);
+    const dbStart = Number(env.HARNESS_DB_PORT_SCAN_START ?? dbDefault);
+    const dbEnd = Number(env.HARNESS_DB_PORT_SCAN_END ?? dbDefault + 67);
+    const dbCheck = checkInfraPort(env, 'AGENT_DB_PORT', dbDefault, dbStart, dbEnd);
+    if (dbCheck.error) {
+      blockers.push({
+        code: 'db_port_exhausted',
+        message: dbCheck.error,
+        remediation: `Free a port in ${dbStart}-${dbEnd} or stop har-*-db-1 containers from other projects.`,
+      });
+    } else if (dbCheck.port !== undefined) {
+      ports.db = dbCheck.port;
+      const occupant = dockerOnPort(listDockerContainers(), dbCheck.port);
+      if (
+        occupant &&
+        !occupant.name.startsWith(`har-${projectName}-`) &&
+        !occupant.name.includes('-db-')
+      ) {
+        blockers.push({
+          code: 'db_port_conflict',
+          message: `Port ${dbCheck.port} (database) is held by "${occupant.name}".`,
+          remediation: `Stop the container or pick another slot.`,
+          details: { container: occupant.name, port: dbCheck.port },
+        });
+      }
+    }
+  }
+
+  const canLaunch = blockers.length === 0;
+  return {
+    canLaunch,
+    verdict: canLaunch ? 'ready' : 'blocked',
+    blockers,
+    remediations: [...new Set(remediations)],
+    ports: Object.keys(ports).length > 0 ? ports : undefined,
+    allocatedPorts: allocatedPorts || undefined,
+  };
+}
+
+export function formatPreflightReport(agentId: number, readiness: SlotReadiness): string {
+  const lines: string[] = [];
+  if (readiness.canLaunch) {
+    lines.push(`Slot ${agentId}: ready to launch.`);
+    if (readiness.ports) {
+      const p = readiness.ports;
+      const parts = [
+        p.frontend !== undefined ? `frontend=${p.frontend}` : undefined,
+        p.api !== undefined ? `api=${p.api}` : undefined,
+        p.debug !== undefined ? `debug=${p.debug}` : undefined,
+        p.db !== undefined ? `db=${p.db}` : undefined,
+      ].filter(Boolean);
+      if (parts.length) lines.push(`  Ports: ${parts.join(' ')}`);
+      if (readiness.allocatedPorts) {
+        lines.push('  (alternate ports selected — defaults were busy)');
+      }
+    }
+    return lines.join('\n');
+  }
+
+  lines.push(`Slot ${agentId}: launch blocked.`);
+  for (const b of readiness.blockers) {
+    lines.push(`  [${b.code}] ${b.message}`);
+    if (b.remediation) lines.push(`    → ${b.remediation}`);
+  }
+  return lines.join('\n');
+}
+
+/** Whether this harness expects per-slot app ports (PM2 / web profile). */
+export function harnessExpectsAppPorts(repoPath: string): boolean {
+  return harnessUsesPm2(repoPath);
+}
+
+export { defaultAppPort, portStep, slotPortLaneEnd };

--- a/src/core/slot-status.ts
+++ b/src/core/slot-status.ts
@@ -15,6 +15,7 @@ import { getAgentSlotIds } from '../harness/stages';
 import { computePreviewUrls } from './local-executor';
 import { listRuns, resolveAgentWorkDir } from './runs';
 import { readSlotRegistry } from './slot-registry';
+import { inspectSlotReadiness } from './slot-preflight';
 
 const BYPASS_WARNING_MS = 15 * 60 * 1000;
 
@@ -160,6 +161,7 @@ function listPm2Processes(): Array<{ name?: string }> | undefined {
     const raw = execSync('npx --yes pm2 jlist', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 3000,
     });
     const procs = JSON.parse(raw) as Array<{ name?: string }>;
     return Array.isArray(procs) ? procs : undefined;
@@ -250,6 +252,10 @@ function collectSlotStatus(
     : {};
 
   const pm2Issue = detectPm2Issue(projectName, agentId, session, pm2Procs);
+  const readiness = inspectSlotReadiness(harnessRoot, agentId, {
+    allocatePorts: true,
+    occupied: { active, dirty: drift.dirty },
+  });
 
   return {
     agentId,
@@ -260,6 +266,7 @@ function collectSlotStatus(
     previewUrls,
     ports: session?.ports,
     pm2Issue,
+    readiness,
     harnessUsage: deriveHarnessUsage(latest, active),
     lastRunId: latest?.runId,
     lastRunAt: latest?.startedAt,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,11 @@
 import type { ShellResult } from '../utils/shell';
-import type { RunRecordTriggerSchema, StageKind, StageResult, VerificationResult } from '../harness/schema';
+import type {
+  RunRecordTriggerSchema,
+  SlotReadiness,
+  StageKind,
+  StageResult,
+  VerificationResult,
+} from '../harness/schema';
 import { z } from 'zod';
 
 export type ShellRunResult = ShellResult;
@@ -41,6 +47,21 @@ export interface LaunchOptions {
   confirmReplace?: boolean;
   force?: boolean;
   capture?: boolean;
+}
+
+export interface PreflightOptions {
+  repoPath: string;
+  agentId: number;
+  confirmReplace?: boolean;
+  force?: boolean;
+}
+
+export interface PreflightResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  readiness: SlotReadiness;
+  blocked?: boolean;
 }
 
 export interface EnvironmentRunResult {

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -5,6 +5,7 @@ import {
   HarnessStageSchema,
   RunRecordSchema,
   ShellRunOutputSchema,
+  SlotReadinessSchema,
   StageKindSchema,
   StageResultSchema,
   VerificationResultSchema,
@@ -100,6 +101,24 @@ export const LaunchEnvironmentOutputSchema = ShellRunOutputSchema.extend({
       sessionCreatedAt: z.string().optional(),
     })
     .optional(),
+});
+
+export const PreflightEnvironmentInputSchema = z.object({
+  repo: z.string().default('.'),
+  agentId: agentIdSchema,
+  confirmReplace: z
+    .boolean()
+    .default(false)
+    .describe('Treat an occupied slot as replaceable (same as launch confirmReplace).'),
+  force: z
+    .boolean()
+    .default(false)
+    .describe('Allow replacing a dirty worktree (requires explicit user approval).'),
+});
+
+export const PreflightEnvironmentOutputSchema = ShellRunOutputSchema.extend({
+  readiness: SlotReadinessSchema,
+  blocked: z.boolean().optional(),
 });
 
 export const CompleteEnvironmentInputSchema = z.object({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,6 +16,7 @@ import {
   getEnvironmentStatus,
   launchEnvironment,
   listArtifacts,
+  preflightEnvironment,
   runStage,
   runVerification,
   teardownEnvironment,
@@ -38,6 +39,8 @@ import {
   InitHarnessInputSchema,
   LaunchEnvironmentInputSchema,
   LaunchEnvironmentOutputSchema,
+  PreflightEnvironmentInputSchema,
+  PreflightEnvironmentOutputSchema,
   ListArtifactsInputSchema,
   ListArtifactsOutputSchema,
   ListRunsInputSchema,
@@ -88,6 +91,26 @@ export const HAR_MCP_TOOLS: Tool[] = [
           type: 'boolean',
           description:
             'Discard uncommitted changes when replacing a dirty worktree. Requires confirmReplace=true and explicit user approval.',
+        },
+      },
+      ['agentId'],
+    ),
+  },
+  {
+    name: 'har_preflight_environment',
+    description:
+      'Readiness gate before launch: checks ports, foreign PM2, Docker conflicts, and occupied slot. Returns canLaunch with actionable blockers. Call before har_launch_environment.',
+    inputSchema: objectJsonSchema(
+      {
+        repo: repoJsonProperty,
+        agentId: agentIdJsonProperty,
+        confirmReplace: {
+          type: 'boolean',
+          description: 'Treat an occupied slot as replaceable (same as launch confirmReplace).',
+        },
+        force: {
+          type: 'boolean',
+          description: 'Allow replacing a dirty worktree (only after explicit user approval).',
         },
       },
       ['agentId'],
@@ -255,6 +278,22 @@ export async function handleMcpToolCall(
         capture: true,
       });
       const parsed = LaunchEnvironmentOutputSchema.parse(result);
+      return {
+        ...jsonContent(parsed),
+        ...(result.blocked ? { isError: true } : {}),
+      };
+    }
+
+    case 'har_preflight_environment': {
+      const input = PreflightEnvironmentInputSchema.parse({ ...args, repo });
+      const agentId = validateAgentId(input.agentId, repo);
+      const result = await preflightEnvironment({
+        repoPath: repo,
+        agentId,
+        confirmReplace: input.confirmReplace,
+        force: input.force,
+      });
+      const parsed = PreflightEnvironmentOutputSchema.parse(result);
       return {
         ...jsonContent(parsed),
         ...(result.blocked ? { isError: true } : {}),

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -92,6 +92,108 @@ har_allocate_slot_app_ports() {
   export FE_PORT API_PORT DEBUG_PORT
 }
 
+# ── Launch preflight (#36) ─────────────────────────────────────────────────────
+
+har_harness_uses_pm2() {
+  [ -f "${SCRIPT_DIR}/ecosystem.agent.template.cjs" ]
+}
+
+har_port_docker_occupant() {
+  local port="$1"
+  docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true
+}
+
+har_check_control_port_conflict() {
+  local port="$1"
+  local name
+  name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -i control | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true)"
+  if [ -n "$name" ]; then
+    echo "ERROR: Mission Control container \"${name}\" occupies port ${port}." >&2
+    echo "  Run: har control down — or use a different agent slot." >&2
+    return 1
+  fi
+  return 0
+}
+
+har_check_foreign_pm2() {
+  local agent_id="$1"
+  local pm2_raw
+  har_harness_uses_pm2 || return 0
+  pm2_raw="$(npx --yes pm2 jlist 2>/dev/null || true)"
+  [ -n "$pm2_raw" ] || return 0
+  set +e
+  echo "$pm2_raw" | node -e "
+const agentId = process.argv[1];
+const project = process.argv[2];
+const slotPrefix = 'har-' + project + '-agent-' + agentId + '-';
+const legacyPrefix = 'agent-' + agentId + '-';
+let raw = '';
+process.stdin.on('data', c => raw += c);
+process.stdin.on('end', () => {
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) process.exit(0);
+    const foreign = arr.filter(x =>
+      x.name && (
+        (x.name.startsWith('har-') && x.name.includes('-agent-' + agentId + '-') && !x.name.startsWith(slotPrefix)) ||
+        (x.name.startsWith(legacyPrefix) && !x.name.startsWith('har-'))
+      ));
+    if (foreign.length === 0) process.exit(0);
+    console.error('ERROR: foreign PM2 processes match agent ' + agentId + ':');
+    foreign.forEach(p => {
+      const cwd = p.pm2_env?.pm_cwd || p.pm2_env?.cwd || 'unknown';
+      console.error('  ' + p.name + '  cwd=' + cwd);
+    });
+    console.error('  Stop the other harness session or use a different slot.');
+    process.exit(1);
+  } catch {
+    process.exit(0);
+  }
+});
+" "$agent_id" "$HARNESS_PROJECT_NAME"
+  local rc=$?
+  set -e
+  return "$rc"
+}
+
+har_launch_preflight() {
+  local agent_id="$1"
+  local force="${2:-false}"
+  local replace="${3:-false}"
+
+  if slot_is_occupied "$agent_id"; then
+    if [ "$replace" != true ] && [ "${HAR_CONFIRM_REPLACE:-}" != "1" ]; then
+      print_slot_replace_warning "$agent_id"
+      echo "ERROR: slot ${agent_id} is occupied — pass --replace to proceed." >&2
+      return 2
+    fi
+    local wt
+    wt="$(existing_slot_worktree "$agent_id")"
+    if [ -n "$wt" ] && slot_worktree_dirty "$wt" && [ "$force" != true ]; then
+      echo "ERROR: dirty worktree requires --force after explicit user approval." >&2
+      return 2
+    fi
+  fi
+
+  if har_harness_uses_pm2; then
+    har_check_foreign_pm2 "$agent_id" || return 1
+    har_allocate_slot_app_ports "$agent_id" || return 1
+    local port occupant
+    for port in $(printf '%s\n' "$FE_PORT" "$API_PORT" | sort -u); do
+      har_check_control_port_conflict "$port" || return 1
+      occupant="$(har_port_docker_occupant "$port")"
+      if [ -n "$occupant" ] && [[ "$occupant" != har-${HARNESS_PROJECT_NAME}-* ]]; then
+        echo "ERROR: Docker container \"${occupant}\" binds port ${port}." >&2
+        echo "  Stop it with: docker stop ${occupant}" >&2
+        return 1
+      fi
+    done
+  fi
+  return 0
+}
+
 # Load persisted app/infra ports from .env.agent.<id> or the slot registry.
 load_agent_ports() {
   local agent_id="$1"

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -40,6 +40,9 @@ validate_agent_id "$AGENT_ID"
 
 log() { echo "==> [agent-$AGENT_ID] $*" >&2; }
 
+# Preflight before worktree/install — occupied slot gate for CLI harnesses.
+har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE" || exit $?
+
 # Replace any previous session for this slot — requires explicit confirmation.
 if slot_is_occupied "$AGENT_ID"; then
   require_slot_replace_confirm "$AGENT_ID" "$FORCE" "$REPLACE"

--- a/src/templates/har-boilerplate-cli/preflight.sh
+++ b/src/templates/har-boilerplate-cli/preflight.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Launch readiness gate for CLI/library harnesses (occupied slot only).
+# Usage: ./.har/preflight.sh <agent-id> [--replace] [--force]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/harness.env"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/agent-slot.sh"
+
+AGENT_ID="${1:-}"
+FORCE=false
+REPLACE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --replace) REPLACE=true ;;
+    --force)   FORCE=true ;;
+  esac
+done
+
+if [[ -z "$AGENT_ID" ]]; then
+  echo "Usage: $0 <agent-id> [--replace] [--force]" >&2
+  exit 1
+fi
+
+validate_agent_id "$AGENT_ID"
+
+if har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE"; then
+  echo "Slot ${AGENT_ID}: ready to launch."
+  exit 0
+fi
+
+exit $?

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -92,6 +92,112 @@ har_allocate_slot_app_ports() {
   export FE_PORT API_PORT DEBUG_PORT
 }
 
+# ── Launch preflight (#36) ─────────────────────────────────────────────────────
+# Readiness gate before worktree/install — ports, foreign PM2, Docker conflicts.
+
+har_harness_uses_pm2() {
+  [ -f "${SCRIPT_DIR}/ecosystem.agent.template.cjs" ]
+}
+
+har_port_docker_occupant() {
+  local port="$1"
+  docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true
+}
+
+har_check_control_port_conflict() {
+  local port="$1"
+  local name
+  name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -i control | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true)"
+  if [ -n "$name" ]; then
+    echo "ERROR: Mission Control container \"${name}\" occupies port ${port}." >&2
+    echo "  Run: har control down — or use a different agent slot." >&2
+    return 1
+  fi
+  return 0
+}
+
+har_check_foreign_pm2() {
+  local agent_id="$1"
+  local pm2_raw
+  har_harness_uses_pm2 || return 0
+  pm2_raw="$(npx --yes pm2 jlist 2>/dev/null || true)"
+  [ -n "$pm2_raw" ] || return 0
+  set +e
+  echo "$pm2_raw" | node -e "
+const agentId = process.argv[1];
+const project = process.argv[2];
+const slotPrefix = 'har-' + project + '-agent-' + agentId + '-';
+const legacyPrefix = 'agent-' + agentId + '-';
+let raw = '';
+process.stdin.on('data', c => raw += c);
+process.stdin.on('end', () => {
+  try {
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) process.exit(0);
+    const foreign = arr.filter(x =>
+      x.name && (
+        (x.name.startsWith('har-') && x.name.includes('-agent-' + agentId + '-') && !x.name.startsWith(slotPrefix)) ||
+        (x.name.startsWith(legacyPrefix) && !x.name.startsWith('har-'))
+      ));
+    if (foreign.length === 0) process.exit(0);
+    console.error('ERROR: foreign PM2 processes match agent ' + agentId + ':');
+    foreign.forEach(p => {
+      const cwd = p.pm2_env?.pm_cwd || p.pm2_env?.cwd || 'unknown';
+      console.error('  ' + p.name + '  cwd=' + cwd);
+    });
+    console.error('  Stop the other harness session or use a different slot.');
+    process.exit(1);
+  } catch {
+    process.exit(0);
+  }
+});
+" "$agent_id" "$HARNESS_PROJECT_NAME"
+  local rc=$?
+  set -e
+  return "$rc"
+}
+
+# har_launch_preflight <agent_id> <force> <replace>
+# Exit 0 when ready; 2 when occupied/replace required; 1 on machine blockers.
+# Sets FE_PORT/API_PORT/DEBUG_PORT when this harness uses PM2.
+har_launch_preflight() {
+  local agent_id="$1"
+  local force="${2:-false}"
+  local replace="${3:-false}"
+
+  if slot_is_occupied "$agent_id"; then
+    if [ "$replace" != true ] && [ "${HAR_CONFIRM_REPLACE:-}" != "1" ]; then
+      print_slot_replace_warning "$agent_id"
+      echo "ERROR: slot ${agent_id} is occupied — pass --replace to proceed." >&2
+      return 2
+    fi
+    local wt
+    wt="$(existing_slot_worktree "$agent_id")"
+    if [ -n "$wt" ] && slot_worktree_dirty "$wt" && [ "$force" != true ]; then
+      echo "ERROR: dirty worktree requires --force after explicit user approval." >&2
+      return 2
+    fi
+  fi
+
+  if har_harness_uses_pm2; then
+    har_check_foreign_pm2 "$agent_id" || return 1
+    har_allocate_slot_app_ports "$agent_id" || return 1
+    local port occupant
+    for port in $(printf '%s\n' "$FE_PORT" "$API_PORT" | sort -u); do
+      har_check_control_port_conflict "$port" || return 1
+      occupant="$(har_port_docker_occupant "$port")"
+      if [ -n "$occupant" ] && [[ "$occupant" != har-${HARNESS_PROJECT_NAME}-* ]]; then
+        echo "ERROR: Docker container \"${occupant}\" binds port ${port}." >&2
+        echo "  Stop it with: docker stop ${occupant}" >&2
+        return 1
+      fi
+    done
+  fi
+  return 0
+}
+
 # Load persisted app/infra ports from .env.agent.<id> or the slot registry.
 load_agent_ports() {
   local agent_id="$1"

--- a/src/templates/har-boilerplate/launch.sh
+++ b/src/templates/har-boilerplate/launch.sh
@@ -42,6 +42,9 @@ validate_agent_id "$AGENT_ID"
 
 log() { echo "==> [agent-$AGENT_ID] $*" >&2; }
 
+# Preflight before worktree/install — ports, foreign PM2, Docker, occupied slot.
+har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE" || exit $?
+
 # Replace any previous session for this slot — requires explicit confirmation.
 if slot_is_occupied "$AGENT_ID"; then
   require_slot_replace_confirm "$AGENT_ID" "$FORCE" "$REPLACE"
@@ -49,9 +52,9 @@ if slot_is_occupied "$AGENT_ID"; then
   "$SCRIPT_DIR/teardown.sh" "$AGENT_ID" >&2
 fi
 
-# Preflight port allocation before worktree/install — scan when defaults are busy.
-har_allocate_slot_app_ports "$AGENT_ID"
-log "Ports: frontend=$FE_PORT api=$API_PORT debug=$DEBUG_PORT"
+if har_harness_uses_pm2; then
+  log "Ports: frontend=$FE_PORT api=$API_PORT debug=$DEBUG_PORT"
+fi
 
 # Ensure shared infra is running (persists host ports in .har/state/infra.env).
 "$SCRIPT_DIR/setup-infra.sh"

--- a/src/templates/har-boilerplate/preflight.sh
+++ b/src/templates/har-boilerplate/preflight.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Launch readiness gate — run before launch.sh or standalone.
+# Usage: ./.har/preflight.sh <agent-id> [--replace] [--force]
+# JSON:  har env preflight <id> --json
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/harness.env"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/agent-slot.sh"
+
+AGENT_ID="${1:-}"
+FORCE=false
+REPLACE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --replace) REPLACE=true ;;
+    --force)   FORCE=true ;;
+  esac
+done
+
+if [[ -z "$AGENT_ID" ]]; then
+  echo "Usage: $0 <agent-id> [--replace] [--force]" >&2
+  exit 1
+fi
+
+validate_agent_id "$AGENT_ID"
+
+if har_launch_preflight "$AGENT_ID" "$FORCE" "$REPLACE"; then
+  echo "Slot ${AGENT_ID}: ready to launch."
+  if har_harness_uses_pm2; then
+    echo "  Ports: frontend=${FE_PORT} api=${API_PORT} debug=${DEBUG_PORT}"
+  fi
+  exit 0
+fi
+
+exit $?

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -9,6 +9,7 @@ describe('HAR MCP tool schemas', () => {
       'har_describe_project',
       'har_init_harness',
       'har_launch_environment',
+      'har_preflight_environment',
       'har_run_stage',
       'har_run_verification',
       'har_get_status',

--- a/tests/slot-preflight.test.ts
+++ b/tests/slot-preflight.test.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { inspectSlotReadiness } from '../src/core/slot-preflight';
+import { allocateAppPorts, isPortInUse } from '../src/core/slot-ports';
+
+const tmpDirs: string[] = [];
+
+function makeHarness(options: { pm2?: boolean; infraDb?: boolean } = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-preflight-'));
+  tmpDirs.push(dir);
+  const harDir = path.join(dir, '.har');
+  fs.mkdirSync(harDir, { recursive: true });
+  const lines = [
+    'export HARNESS_PROJECT_NAME=test-project',
+    'export HARNESS_FE_BASE_PORT=3000',
+    'export HARNESS_API_BASE_PORT=8000',
+    'export HARNESS_PORT_STEP=10',
+    'export HARNESS_AGENT_SLOT_MIN=1',
+    'export HARNESS_AGENT_SLOT_MAX=3',
+  ];
+  if (options.infraDb) {
+    lines.push('export HARNESS_INFRA_SERVICES="db"');
+    lines.push('export HARNESS_DB_PORT_DEFAULT=15432');
+  }
+  fs.writeFileSync(path.join(harDir, 'harness.env'), lines.join('\n') + '\n');
+  if (options.pm2) {
+    fs.writeFileSync(
+      path.join(harDir, 'ecosystem.agent.template.cjs'),
+      'module.exports = { apps: [] };',
+    );
+  }
+  return dir;
+}
+
+function writeOccupiedSlot(repo: string, agentId: number, dirty = false): void {
+  const worktree = path.join(repo, 'worktree');
+  fs.mkdirSync(worktree, { recursive: true });
+  fs.writeFileSync(path.join(worktree, '.env.agent.' + agentId), 'AGENT_ID=' + agentId + '\n');
+  if (dirty) {
+    fs.writeFileSync(path.join(worktree, 'dirty.txt'), 'x\n');
+  }
+  fs.mkdirSync(path.join(repo, '.har', 'slots'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repo, '.har', 'slots', `agent-${agentId}.json`),
+    JSON.stringify({
+      version: 1,
+      agentId,
+      projectName: 'test-project',
+      mode: 'worktree',
+      workDir: worktree,
+      worktreePath: worktree,
+      createdAt: new Date().toISOString(),
+      status: 'active',
+    }),
+  );
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('inspectSlotReadiness', () => {
+  it('returns ready for an empty cli harness slot', () => {
+    const repo = makeHarness();
+    const readiness = inspectSlotReadiness(repo, 1);
+    expect(readiness.canLaunch).toBe(true);
+    expect(readiness.verdict).toBe('ready');
+    expect(readiness.blockers).toHaveLength(0);
+  });
+
+  it('blocks when slot is occupied without confirmReplace', () => {
+    const repo = makeHarness();
+    writeOccupiedSlot(repo, 1);
+    const readiness = inspectSlotReadiness(repo, 1);
+    expect(readiness.canLaunch).toBe(false);
+    expect(readiness.blockers.some((b) => b.code === 'slot_occupied')).toBe(true);
+  });
+
+  it('allows occupied slot when confirmReplace is set', () => {
+    const repo = makeHarness();
+    writeOccupiedSlot(repo, 1);
+    const readiness = inspectSlotReadiness(repo, 1, { confirmReplace: true });
+    expect(readiness.canLaunch).toBe(true);
+  });
+
+  it('allocates app ports for PM2 harnesses', () => {
+    const repo = makeHarness({ pm2: true });
+    const readiness = inspectSlotReadiness(repo, 2);
+    expect(readiness.canLaunch).toBe(true);
+    expect(readiness.ports?.frontend).toBe(3020);
+    expect(readiness.ports?.api).toBe(8020);
+  });
+});
+
+describe('allocateAppPorts', () => {
+  it('returns defaults when ports are free', () => {
+    const repo = makeHarness({ pm2: true });
+    const ports = allocateAppPorts(repo, 1);
+    expect('error' in ports).toBe(false);
+    if (!('error' in ports)) {
+      expect(ports.frontend).toBe(3010);
+      expect(ports.api).toBe(8010);
+      expect(ports.allocated).toBe(false);
+    }
+  });
+});
+
+describe('isPortInUse', () => {
+  it('returns false for a high ephemeral port unlikely to be bound', () => {
+    expect(isPortInUse(59999)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **#33 / #34** — Scope PM2 process names by `HARNESS_PROJECT_NAME` (`har-<project>-agent-<id>-*`), detect foreign/legacy PM2 in status, and allocate free app/infra ports at launch with persisted values in the slot registry and `.har/state/infra.env`.
- **#36** — Add a launch preflight gate (`inspectSlotReadiness()`) that runs **before** worktree/install: checks occupied slot, foreign PM2, port bindability, Mission Control Docker conflicts, and foreign containers. Exposed as `har env preflight`, `har_preflight_environment` (MCP), `readiness` in `har env status --json`, and `./.har/preflight.sh` / `har_launch_preflight()` at the top of `launch.sh`.

## Test plan

- [x] `npm test` — 154 tests pass
- [x] `./.har/verify.sh 1 --full` — typecheck, lint, build, unit tests
- [ ] `har env preflight 1 --json` on a clean slot → `canLaunch: true` with port allocation
- [ ] Launch with a busy default port → preflight picks alternate port in slot lane; launch succeeds without worktree-on-failure
- [ ] Foreign PM2 for same agent id from another harness → preflight blocks with process names and cwd
- [ ] Mission Control running on harness port → preflight suggests `har control down`
- [ ] Occupied slot without `--replace` → preflight blocks; with `--replace` → proceeds

Fixes #33, #34, #36


Made with [Cursor](https://cursor.com)