### PR TITLE
feat(templates): document port allocation and shared services for harness setup

### DIFF
--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -88,14 +88,52 @@ Always use `./.har/agent-cli.sh <id> ...` — never hardcoded ports.
 
 ## Architecture
 
-Each agent slot gets isolated ports: `BASE + (AGENT_ID × 10)`.
+Each agent slot gets isolated app ports. Defaults follow `BASE + (AGENT_ID × HARNESS_PORT_STEP)`; when a default is busy, `launch.sh` scans the slot lane and writes resolved ports to `.env.agent.<id>` and `.har/slots/agent-<id>.json`.
 
 Configure how many slots your machine can run in parallel in `stages.json` (`agentSlots`) and `harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`). Keep both in sync.
 
-| Service | Agent 1 | Agent 2 | Agent 3 |
-|---------|---------|---------|---------|
+| Service | Agent 1 (default) | Agent 2 (default) | Agent 3 (default) |
+|---------|-------------------|-------------------|-------------------|
 | Web (UI + API) | 3847 | 3857 | 3867 |
-| Database | `agent_1` | `agent_2` | `agent_3` (all on `localhost:15432`) |
+| Database | `agent_1` | `agent_2` | `agent_3` (all on shared Postgres host port) |
+
+`HARNESS_FE_BASE_PORT=3837` and `HARNESS_API_BASE_PORT=3837` — slot 1 therefore defaults to **3847** (`3837 + 1 × 10`).
+
+## Port & shared services
+
+### Port allocation
+
+| Layer | Scope | Rule | On conflict |
+|-------|-------|------|-------------|
+| Web (UI + API) | Per slot | `HARNESS_FE_BASE_PORT + (AGENT_ID × HARNESS_PORT_STEP)` | Scan `STEP` increments within the slot lane |
+| Shared Postgres | Per machine | `HARNESS_DB_PORT_DEFAULT` (15432) | Scan `HARNESS_DB_PORT_SCAN_START..END` |
+
+Always use `./.har/agent-cli.sh <id>` or read `.har/slots/agent-<id>.json` — never hardcode `3847` or `15432` in app code or tests.
+
+### `har control up` vs harness slot 1
+
+These are **different ways to run Mission Control** and they **conflict on port 3847**:
+
+| Entry point | What it runs | Default port |
+|-------------|--------------|--------------|
+| `har control up` | Docker image `theosfactory/har-control` + bundled Postgres | **3847** (UI/API) |
+| `cd control && har env launch 1` | Harness slot with PM2 + shared Postgres from `setup-infra.sh` | **3847** for slot 1 |
+
+Do not run both at once. Before launching harness slot 1, run `har control down` if the control container is up. `launch.sh` preflight also detects a Mission Control container bound to the slot port and fails with a clear message.
+
+For day-to-day agent work on Mission Control itself, use the **harness** (`cd control && har env launch 1`). Use `har control up` when you want the published Docker image without a worktree slot.
+
+### Shared vs per-slot
+
+| Resource | Model | Configuration |
+|----------|-------|---------------|
+| Postgres | One shared container; per-slot database `agent_<id>` cloned from `template_control` | `HARNESS_INFRA_SERVICES="db"` |
+| Next.js app | One PM2 process per slot on isolated ports | `HARNESS_PRIMARY_APP=web`, `ecosystem.agent.template.cjs` |
+
+### Do not
+
+- Hardcode `3847` / `15432` in app code, Playwright specs, or docs — read from agent env / slot registry
+- Run raw `docker compose` for harness infrastructure — use `setup-infra.sh` / `launch.sh`
 
 ### Primary app vs shared services
 

--- a/control/.har/harness.env
+++ b/control/.har/harness.env
@@ -9,12 +9,15 @@ export HARNESS_USE_WORKTREE=true
 export HARNESS_PRIMARY_APP=web
 
 export HARNESS_TEMPLATE_DB=template_control
+
+# Per-slot app ports — slot 1 defaults to 3847 (3837 + 1 × 10). Conflicts with
+# `har control up` on the same port; run `har control down` before launch 1.
 export HARNESS_FE_BASE_PORT=3837
 export HARNESS_API_BASE_PORT=3837
 export HARNESS_PORT_STEP=10
 export HARNESS_HEALTH_CHECK_PATH=/api/health
 
-# Shared infra host ports — try the default first; scan the range when busy.
+# Shared infra host ports — setup-infra.sh tries DEFAULT first, scans when busy.
 export HARNESS_DB_PORT_DEFAULT=15432
 export HARNESS_DB_PORT_SCAN_START=15432
 export HARNESS_DB_PORT_SCAN_END=15499

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -722,11 +722,18 @@ function printDrift(drift: HarnessDriftResult): void {
   if (drift.extra.length > 0) {
     warn(`  Extra/stale files: ${drift.extra.join(', ')}`);
   }
+  if (drift.missingPortVars.length > 0) {
+    warn(
+      `  Missing port documentation vars in harness.env: ${drift.missingPortVars.join(', ')}`,
+    );
+    warn('  Copy the port-allocation block from the bundled template harness.env and adapt values.');
+  }
   if (
     !drift.generatorVersion.outdated &&
     drift.checksumMismatch.length === 0 &&
     drift.missing.length === 0 &&
-    drift.extra.length === 0
+    drift.extra.length === 0 &&
+    drift.missingPortVars.length === 0
   ) {
     success('  Harness matches bundled templates');
   }

--- a/src/harness/drift.ts
+++ b/src/harness/drift.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { HarnessProfile } from './generator';
+import { readHarnessEnv } from './env';
 import {
   computeFileChecksum,
   GENERATOR_VERSION,
@@ -31,6 +32,72 @@ export interface HarnessDriftResult {
   checksumMismatch: string[];
   extra: string[];
   unchanged: string[];
+  /** Port-allocation knobs from harness.env that the bundled template expects. */
+  missingPortVars: string[];
+}
+
+const APP_PORT_VARS = [
+  'HARNESS_FE_BASE_PORT',
+  'HARNESS_API_BASE_PORT',
+  'HARNESS_PORT_STEP',
+] as const;
+
+const INFRA_PORT_VARS_BY_SERVICE: Record<string, readonly string[]> = {
+  db: [
+    'HARNESS_DB_PORT_DEFAULT',
+    'HARNESS_DB_PORT_SCAN_START',
+    'HARNESS_DB_PORT_SCAN_END',
+  ],
+  minio: [
+    'HARNESS_MINIO_PORT_DEFAULT',
+    'HARNESS_MINIO_PORT_SCAN_START',
+    'HARNESS_MINIO_PORT_SCAN_END',
+    'HARNESS_MINIO_CONSOLE_PORT_DEFAULT',
+    'HARNESS_MINIO_CONSOLE_PORT_SCAN_START',
+    'HARNESS_MINIO_CONSOLE_PORT_SCAN_END',
+  ],
+  mailpit: [
+    'HARNESS_MAILPIT_WEB_PORT_DEFAULT',
+    'HARNESS_MAILPIT_WEB_PORT_SCAN_START',
+    'HARNESS_MAILPIT_WEB_PORT_SCAN_END',
+    'HARNESS_MAILPIT_SMTP_PORT_DEFAULT',
+    'HARNESS_MAILPIT_SMTP_PORT_SCAN_START',
+    'HARNESS_MAILPIT_SMTP_PORT_SCAN_END',
+  ],
+  'headless-browser': [
+    'HARNESS_BROWSER_PORT_DEFAULT',
+    'HARNESS_BROWSER_PORT_SCAN_START',
+    'HARNESS_BROWSER_PORT_SCAN_END',
+  ],
+};
+
+/** Returns harness.env export names missing for the profile and enabled infra services. */
+export function missingPortDocumentationVars(
+  profile: HarnessProfile,
+  env: Record<string, string>,
+): string[] {
+  const missing: string[] = [];
+
+  if (profile === 'default') {
+    for (const key of APP_PORT_VARS) {
+      if (!(key in env)) missing.push(key);
+    }
+  }
+
+  if (profile === 'cli' && !('HARNESS_PORT_STEP' in env)) {
+    missing.push('HARNESS_PORT_STEP');
+  }
+
+  const services = (env.HARNESS_INFRA_SERVICES ?? '').trim().split(/\s+/).filter(Boolean);
+  for (const service of services) {
+    const vars = INFRA_PORT_VARS_BY_SERVICE[service];
+    if (!vars) continue;
+    for (const key of vars) {
+      if (!(key in env)) missing.push(key);
+    }
+  }
+
+  return [...new Set(missing)];
 }
 
 function substituteProjectName(content: string, projectName: string): string {
@@ -99,6 +166,9 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
   }
 
   const installed = manifest?.generatorVersion;
+  const harnessEnv = readHarnessEnv(resolved);
+  const missingPortVars = missingPortDocumentationVars(profile, harnessEnv);
+
   return {
     generatorVersion: {
       installed,
@@ -109,5 +179,6 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
     checksumMismatch,
     extra,
     unchanged,
+    missingPortVars,
   };
 }

--- a/src/llm/prompts/system-authoring.md
+++ b/src/llm/prompts/system-authoring.md
@@ -104,11 +104,35 @@ If the repository contains more than one project or `.har` harness (check for `.
 - Keep a small `AGENT.md` / `CLAUDE.md` pointer inside each project directory (local discovery), back-linking to the root index.
 - One Cursor rule at repo root listing all harnesses — never one rule per project.
 
-## Port allocation
+## Port allocation & shared services
 
-Agents run in parallel on configurable slot ids. Ports: `BASE + (AGENT_ID × 10)`.
+Document ports in `.har/README.md` and configure them in `.har/harness.env`. Resolved values land in `.env.agent.<id>` and `.har/slots/agent-<id>.json` at launch — never hardcode defaults in app code or tests.
+
+### Per-slot app ports (default / PM2 profile)
+
+| Layer | Scope | Rule | On conflict |
+|-------|-------|------|-------------|
+| Frontend | Per slot | `HARNESS_FE_BASE_PORT + (AGENT_ID × HARNESS_PORT_STEP)` | Scan `STEP` increments within the slot lane |
+| API | Per slot | `HARNESS_API_BASE_PORT + (AGENT_ID × STEP)` | Same scan policy |
+| Node debug | Per slot | `9200 + (AGENT_ID × STEP)` | Same scan policy |
+
+### Shared infra ports (when listed in `HARNESS_INFRA_SERVICES`)
+
+| Service | Default var | On conflict |
+|---------|-------------|-------------|
+| Postgres | `HARNESS_DB_PORT_DEFAULT` | Scan `HARNESS_DB_PORT_SCAN_START..END` |
+| MinIO | `HARNESS_MINIO_PORT_DEFAULT` (+ console) | Scan configured ranges in `harness.env` |
+| Mailpit | `HARNESS_MAILPIT_*_PORT_DEFAULT` | Scan configured ranges |
+| Headless browser | `HARNESS_BROWSER_PORT_DEFAULT` | Scan configured ranges |
+
+CLI and iOS profiles typically have no per-slot app ports; optional backends still use the shared-infra model.
 
 Set slot limits in `.har/stages.json` (`agentSlots`) and `.har/harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`) based on machine capacity.
+
+### Do not
+
+- Hardcode `3000`, `15432`, `3847`, or other defaults in application code, tests, or agent docs
+- Run raw `docker compose` for harness infrastructure — use `setup-infra.sh` / `launch.sh`
 
 ## Rules
 
@@ -120,6 +144,7 @@ Set slot limits in `.har/stages.json` (`agentSlots`) and `.har/harness.env` (`HA
 6. **Do not edit manifest.json** — managed by har CLI
 7. **Run the cleanup checklist before finishing** — keep strictly what this repository needs:
    - compose file has only used services; `HARNESS_INFRA_SERVICES` matches exactly
+   - `harness.env` has port documentation vars for every enabled infra service; `.har/README.md` explains allocation and shared vs per-slot
    - `env.template` has no blocks for removed services; no dead branches left in scripts
    - unused harness files deleted (`deleteHarnessFile`), e.g. `attach.sh` when unused
    - `.har/README.md` file table matches the files that actually exist

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -132,9 +132,37 @@ Detailed agent instructions: commands, credentials, architecture, definition of 
 ### `.har/env.template`, `setup-infra.sh`, `docker-compose.agent.yml`
 Adapt as needed for the project's infra.
 
-### Port allocation
-Agents run in parallel on configurable slot ids. Ports: `BASE + (AGENT_ID × 10)`.
+### Port allocation & shared services
+
+Document and configure ports in `.har/harness.env` and `.har/README.md`. Use the bundled template's port-allocation block as the contract — do not hardcode ports in app code or tests.
+
+**Per-slot app ports** (default / PM2 profile only):
+
+| Layer | Scope | Rule | On conflict |
+|-------|-------|------|-------------|
+| Frontend | Per slot | `HARNESS_FE_BASE_PORT + (AGENT_ID × HARNESS_PORT_STEP)` | Scan `STEP` increments within the slot lane |
+| API | Per slot | `HARNESS_API_BASE_PORT + (AGENT_ID × STEP)` | Same scan policy |
+| Node debug | Per slot | `9200 + (AGENT_ID × STEP)` | Same scan policy |
+
+**Shared infra ports** (one per machine, all profiles when the service is in `HARNESS_INFRA_SERVICES`):
+
+| Service | Default var | On conflict |
+|---------|-------------|-------------|
+| Postgres | `HARNESS_DB_PORT_DEFAULT` | Scan `HARNESS_DB_PORT_SCAN_START..END` |
+| MinIO | `HARNESS_MINIO_PORT_DEFAULT` (+ console) | Scan configured ranges |
+| Mailpit | `HARNESS_MAILPIT_*_PORT_DEFAULT` | Scan configured ranges |
+| Headless browser | `HARNESS_BROWSER_PORT_DEFAULT` | Scan configured ranges |
+
 Set slot limits in `.har/stages.json` (`agentSlots`) and `.har/harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`) based on machine capacity.
+
+**Port / infra checklist:**
+
+- [ ] `.har/harness.env` has `HARNESS_FE_BASE_PORT`, `HARNESS_API_BASE_PORT`, `HARNESS_PORT_STEP` (default profile) or explains why they are absent (CLI/iOS)
+- [ ] For each service in `HARNESS_INFRA_SERVICES`, matching `HARNESS_*_PORT_DEFAULT` and `SCAN_*` vars exist in `harness.env`
+- [ ] `.har/README.md` has a **Port & shared services** section (allocation table, shared vs per-slot, do-not rules)
+- [ ] App code and tests read ports from `.env.agent.<id>` / `agent-cli.sh` / slot registry — no hardcoded `3000`, `15432`, `3847`, etc.
+- [ ] `env.template` and `CLAUDE.agent.md` show resolved ports via variables, not literals
+- [ ] Monorepos with `har control up`: document slot-1 conflict if the app port overlaps (e.g. Mission Control on 3847)
 
 ### Git worktree
 `launch.sh` creates an isolated session worktree at `~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>` by default (`HARNESS_USE_WORKTREE=true`) and records it in `.har/slots/agent-<id>.json`. Agents should commit from that worktree, not the main checkout.
@@ -187,6 +215,8 @@ The boilerplate ships more than any single repository needs. Strip it down to st
 - [ ] If full seed/setup is skipped, `.har/` provides a minimal bootstrap or clearly documents why none is needed
 - [ ] All per-slot data stores are provisioned, not just the primary database
 - [ ] `.har/CLAUDE.agent.md` defines what "agent usable" means for this repo: login/API smoke, credentials, required default data, and known skipped dev-setup steps
+- [ ] `.har/README.md` documents port allocation and shared-service model; `harness.env` has the port knobs for every enabled infra service
+- [ ] No hardcoded default ports (`3000`, `15432`, `3847`, …) in app code, tests, or harness docs — use agent env / slot registry
 
 ## Rules
 

--- a/src/templates/adaptation-prompt-maintain.md
+++ b/src/templates/adaptation-prompt-maintain.md
@@ -13,7 +13,7 @@ Compare the current repo against the existing harness:
 - Root manifests, CI, Docker, README
 - New or changed test, lint, build, migrate, or seed commands
 - New services, ports, or environment variables
-- Run `har env maintain` drift report (generator version, template checksum mismatches)
+- Run `har env maintain` drift report (generator version, template checksum mismatches, **missing port documentation vars** in `harness.env`)
 
 ## Step 2 — Update `.har/` files
 
@@ -67,6 +67,7 @@ When upgrading `@osfactory/har` or adopting new harness standards:
 - Migrate `harness.env` from boolean `HARNESS_INFRA_*` flags to the `HARNESS_INFRA_SERVICES` list (space-separated compose service names, e.g. `"db mailpit"`) and add the `har_infra_enabled()` helper — copy both from the bundled template. Update every script that still tests `HARNESS_INFRA_POSTGRES`-style flags (`setup-infra.sh`, `launch.sh`, `teardown.sh`, `agent-cli.sh`) to use `har_infra_enabled <service>`.
 - Set `HARNESS_PRIMARY_APP` in `harness.env` to the ONE app agents modify. Ensure `ecosystem.agent.template.cjs` starts only that app's processes. Move any other in-repo services agents depend on but don't change to shared infra: compose services in `docker-compose.agent.yml` or an optional `.har/ecosystem.shared.config.cjs` (processes `har-shared-<name>`; `setup-infra.sh` starts it when present — resync `setup-infra.sh` from the template to get this hook).
 - Prune `docker-compose.agent.yml` to only the services this project uses; delete unused menu services and volumes.
+- **Port & shared services:** ensure `.har/README.md` documents the allocation table and shared vs per-slot model; `harness.env` has every `HARNESS_*_PORT_*` var required for services in `HARNESS_INFRA_SERVICES` (copy missing vars from the bundled template when drift reports them). Remove hardcoded ports from app code, tests, and `CLAUDE.agent.md`.
 - Run the **cleanup checklist**: no TODO placeholders, no env blocks for removed services in `env.template`, no dead script branches, `.har/README.md` file table matches the actual files, `CLAUDE.agent.md` shows only real URLs/ports and commands, unused files deleted.
 
 **Earlier standards:**

--- a/src/templates/har-boilerplate-cli/README.md
+++ b/src/templates/har-boilerplate-cli/README.md
@@ -97,6 +97,32 @@ Work in the isolated git worktree created by launch. Use `./.har/agent-cli.sh <i
 
 When the project needs Postgres, Redis, or similar, add the service to `docker-compose.agent.yml` (or keep one from the menu), list it in `HARNESS_INFRA_SERVICES` in `harness.env`, and use `setup-infra.sh` — never run raw `docker compose` for shared infra. Shared services run once on fixed ports and serve every agent slot.
 
+## Port & shared services (CLI profile)
+
+This profile has **no PM2 app ports** — agents run project commands directly in their worktree. Port variables in `harness.env` exist for optional test servers and for shared Docker infra.
+
+### Port allocation
+
+| Layer | Scope | Rule | On conflict |
+|-------|-------|------|-------------|
+| Shared Postgres | Per machine | `HARNESS_DB_PORT_DEFAULT` | Scan `HARNESS_DB_PORT_SCAN_START..END` |
+| Other compose services | Per machine | `HARNESS_*_PORT_DEFAULT` for that service | Scan configured ranges in `harness.env` |
+
+When a repo adds a local HTTP server for integration tests, prefer reading ports from `.env.agent.<id>` or `./.har/agent-cli.sh <id>` rather than hardcoding values.
+
+### Shared vs per-slot
+
+| Resource | Model | Configuration |
+|----------|-------|---------------|
+| Postgres / Redis / mail / … | One shared container on a scanned host port | `HARNESS_INFRA_SERVICES` + matching vars in `harness.env` |
+| Per-slot databases | Cloned from template DB when `db` is enabled | `launch.sh` |
+| Application code | Isolated git worktree per slot | `HARNESS_USE_WORKTREE=true` |
+
+### Do not
+
+- Hardcode `15432` or other default infra ports in tests — read `AGENT_DB_PORT` from `.env.agent.<id>` or `har_pg`
+- Run raw `docker compose` for harness infrastructure — use `setup-infra.sh`
+
 ## Maintaining this harness
 
 When the project stack changes (new test commands, database needs, env vars):

--- a/src/templates/har-boilerplate-cli/harness.env
+++ b/src/templates/har-boilerplate-cli/harness.env
@@ -4,12 +4,13 @@
 export HARNESS_PROJECT_NAME=__PROJECT_NAME__
 export HARNESS_USE_WORKTREE=true
 
+# Optional per-slot HTTP ports for integration tests (unused when no local server).
 export HARNESS_FE_BASE_PORT=3000
 export HARNESS_API_BASE_PORT=8000
 export HARNESS_PORT_STEP=10
 export HARNESS_HEALTH_CHECK_PATH=
 
-# Shared infra host ports — try the default first; scan the range when busy.
+# Shared infra host ports — setup-infra.sh tries DEFAULT first, scans when busy.
 export HARNESS_DB_PORT_DEFAULT=15432
 export HARNESS_DB_PORT_SCAN_START=15432
 export HARNESS_DB_PORT_SCAN_END=15499

--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -85,6 +85,32 @@ Edit **`harness.env`** to set:
 - `HARNESS_SIMULATOR_NAME` — target simulator (must be listed in `xcrun simctl list devices`)
 - `HARNESS_BUNDLE_ID` — app bundle identifier
 
+## Port & shared services (iOS profile)
+
+Pure iOS apps have **no per-slot TCP ports** — agents build and run on a shared iOS Simulator. Optional backend containers (mock API, etc.) use the same shared-infra model as other profiles.
+
+### Port allocation
+
+| Layer | Scope | Rule | On conflict |
+|-------|-------|------|-------------|
+| Optional backend (compose) | Per machine | `HARNESS_*_PORT_DEFAULT` for that service | Scan configured ranges in `harness.env` |
+| iOS Simulator | Shared | No harness port — one booted simulator for all slots | N/A |
+
+When your app talks to a local backend, read the resolved host port from `.env.agent.<id>` (set by `setup-infra.sh`) — never hardcode `15432` or similar in tests or flow scripts.
+
+### Shared vs per-slot
+
+| Resource | Model | Configuration |
+|----------|-------|---------------|
+| iOS Simulator | One booted simulator shared by all slots | `HARNESS_SIMULATOR_NAME`, `setup-infra.sh` |
+| Optional backend | One shared compose service | `HARNESS_INFRA_SERVICES` (e.g. `"mock-server"`) |
+| Application code | Isolated git worktree per slot | `HARNESS_USE_WORKTREE=true` |
+
+### Do not
+
+- Hardcode backend ports in RocketSim flows or unit tests — read from agent env
+- Run raw `docker compose` for harness infrastructure — use `setup-infra.sh`
+
 ## Session lifecycle
 
 Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at

--- a/src/templates/har-boilerplate-ios/harness.env
+++ b/src/templates/har-boilerplate-ios/harness.env
@@ -33,8 +33,9 @@ export HARNESS_IOS_DESTINATION="platform=iOS Simulator,name=${HARNESS_SIMULATOR_
 export HARNESS_SWIFTLINT_CMD="${HARNESS_SWIFTLINT_CMD:-swiftlint}"
 
 # ── Infrastructure ────────────────────────────────────────────────────────────
-# No Docker infra for pure iOS apps. Set a service name here (space-separated)
+# No Docker infra for pure iOS apps. Set service names here (space-separated)
 # only if your app needs a local backend container (e.g. a mock server).
+# When enabled, add matching HARNESS_*_PORT_DEFAULT / SCAN_* vars for each service.
 export HARNESS_INFRA_SERVICES=""
 
 # Returns 0 when a shared infra service is enabled: har_infra_enabled mock-server

--- a/src/templates/har-boilerplate/README.md
+++ b/src/templates/har-boilerplate/README.md
@@ -113,14 +113,48 @@ Always use `./.har/agent-cli.sh <id> ...` — never hardcoded ports.
 
 ## Architecture
 
-Each agent slot gets isolated ports: `BASE + (AGENT_ID × 10)`.
+Each agent slot gets isolated app ports. Defaults follow `BASE + (AGENT_ID × HARNESS_PORT_STEP)`; when a default is busy, `launch.sh` scans the slot lane (`STEP` increments) and writes the resolved ports to `.env.agent.<id>` and `.har/slots/agent-<id>.json`.
 
 Configure how many slots your machine can run in parallel in `stages.json` (`agentSlots`) and `harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`). Keep both in sync.
 
-| Service | Agent 1 | Agent 2 |
-|---------|---------|---------|
+| Service | Agent 1 (default) | Agent 2 (default) |
+|---------|-------------------|-------------------|
 | Frontend | 3010 | 3020 |
 | API | 8010 | 8020 |
+| Node debug | 9210 | 9220 |
+
+## Port & shared services
+
+### Port allocation
+
+| Layer | Scope | Rule | On conflict |
+|-------|-------|------|-------------|
+| App — frontend | Per slot | `HARNESS_FE_BASE_PORT + (AGENT_ID × HARNESS_PORT_STEP)` | Scan `STEP` increments within the slot lane |
+| App — API | Per slot | `HARNESS_API_BASE_PORT + (AGENT_ID × STEP)` | Same scan policy |
+| Node debug | Per slot | `9200 + (AGENT_ID × STEP)` | Same scan policy |
+| Shared Postgres | Per machine | `HARNESS_DB_PORT_DEFAULT` | Scan `HARNESS_DB_PORT_SCAN_START..END` |
+| MinIO / S3 | Per machine | `HARNESS_MINIO_PORT_DEFAULT` (+ console port) | Scan configured ranges in `harness.env` |
+| Mailpit | Per machine | `HARNESS_MAILPIT_*_PORT_DEFAULT` | Scan configured ranges |
+| Headless browser | Per machine | `HARNESS_BROWSER_PORT_DEFAULT` | Scan configured ranges |
+
+Resolved ports may differ from the formula when something else is already bound. Always use `./.har/agent-cli.sh <id>` or read `.har/slots/agent-<id>.json` — never hardcode `3010`, `15432`, etc. in app code or tests.
+
+### Shared vs per-slot
+
+| Resource | Model | Configuration |
+|----------|-------|---------------|
+| Postgres | One shared container; per-slot database `agent_<id>` cloned from template | `HARNESS_INFRA_SERVICES="db"` |
+| MinIO / S3 | One shared container; per-slot bucket `agent-<id>` | `HARNESS_INFRA_SERVICES="... minio"` |
+| Mailpit, Redis, etc. | One shared container on a scanned host port | Listed in `HARNESS_INFRA_SERVICES` |
+| Primary application | One PM2 ecosystem per slot (isolated ports) | `HARNESS_PRIMARY_APP`, `ecosystem.agent.template.cjs` |
+| Internal supporting services | Shared across all slots | `docker-compose.agent.yml` or `ecosystem.shared.config.cjs` |
+
+Shared infra starts once via `./.har/setup-infra.sh` (also run automatically by `launch.sh`). Per-slot databases are cloned in `launch.sh`.
+
+### Do not
+
+- Hardcode default ports (`3000`, `15432`, `3847`, …) in application code, tests, or agent docs — read from `.env.agent.<id>`, `agent-cli.sh`, or the slot registry
+- Run raw `docker compose` for harness infrastructure — use `setup-infra.sh` / `launch.sh` so ports are scanned and persisted in `.har/state/infra.env`
 
 ### Primary app vs shared services
 

--- a/src/templates/har-boilerplate/harness.env
+++ b/src/templates/har-boilerplate/harness.env
@@ -11,24 +11,36 @@ export HARNESS_USE_WORKTREE=true
 export HARNESS_PRIMARY_APP=app
 
 export HARNESS_TEMPLATE_DB=template___PROJECT_NAME__
+
+# ── Per-slot app ports (PM2 / primary app) ────────────────────────────────────
+# Defaults: BASE + (AGENT_ID × HARNESS_PORT_STEP). launch.sh scans the slot lane
+# when busy and writes resolved FE_PORT / API_PORT / DEBUG_PORT to .env.agent.<id>.
 export HARNESS_FE_BASE_PORT=3000
 export HARNESS_API_BASE_PORT=8000
 export HARNESS_PORT_STEP=10
 export HARNESS_HEALTH_CHECK_PATH=/health
 
-# Shared infra host ports — try the default first; scan the range when busy.
+# ── Shared infra host ports (one per machine) ─────────────────────────────────
+# setup-infra.sh tries DEFAULT first, then scans SCAN_START..SCAN_END when busy.
+# Persisted in .har/state/infra.env — do not hardcode these ports in app code.
 export HARNESS_DB_PORT_DEFAULT=15432
 export HARNESS_DB_PORT_SCAN_START=15432
 export HARNESS_DB_PORT_SCAN_END=15499
 export HARNESS_MINIO_PORT_DEFAULT=19000
 export HARNESS_MINIO_PORT_SCAN_START=19000
 export HARNESS_MINIO_PORT_SCAN_END=19099
+export HARNESS_MINIO_CONSOLE_PORT_DEFAULT=19001
+export HARNESS_MINIO_CONSOLE_PORT_SCAN_START=19001
+export HARNESS_MINIO_CONSOLE_PORT_SCAN_END=19099
 export HARNESS_BROWSER_PORT_DEFAULT=13001
 export HARNESS_BROWSER_PORT_SCAN_START=13001
 export HARNESS_BROWSER_PORT_SCAN_END=13099
 export HARNESS_MAILPIT_WEB_PORT_DEFAULT=18025
 export HARNESS_MAILPIT_WEB_PORT_SCAN_START=18025
 export HARNESS_MAILPIT_WEB_PORT_SCAN_END=18099
+export HARNESS_MAILPIT_SMTP_PORT_DEFAULT=11025
+export HARNESS_MAILPIT_SMTP_PORT_SCAN_START=11025
+export HARNESS_MAILPIT_SMTP_PORT_SCAN_END=11099
 
 # Agent slot limits — set based on what your machine can run in parallel
 export HARNESS_AGENT_SLOT_MIN=1

--- a/tests/adaptation-prompt.test.ts
+++ b/tests/adaptation-prompt.test.ts
@@ -17,6 +17,8 @@ describe('adaptation prompts', () => {
     expect(defaultPrompt).toContain('Docker');
     expect(defaultPrompt).toContain('HAR profiles');
     expect(defaultPrompt).toContain('provision-toolchain.sh');
+    expect(defaultPrompt).toContain('Port & shared services');
+    expect(defaultPrompt).toContain('HARNESS_FE_BASE_PORT');
 
     const cliPrompt = buildInitAdaptationPrompt('/tmp/app', 'cli');
     expect(cliPrompt).toContain('Profile: cli');
@@ -31,6 +33,7 @@ describe('adaptation prompts', () => {
     expect(maintainPrompt).not.toEqual(initPrompt);
     expect(maintainPrompt).toContain('already exists');
     expect(maintainPrompt).toContain('targeted edits');
+    expect(maintainPrompt).toContain('missing port documentation vars');
   });
 
   it('writeAdaptationPrompt creates .har/ADAPT-PROMPT.md', () => {

--- a/tests/harness-contract.test.ts
+++ b/tests/harness-contract.test.ts
@@ -80,6 +80,10 @@ describe('harness stage contract', () => {
       expect.arrayContaining(['setup-infra', 'launch', 'verify', 'status', 'teardown']),
     );
     expect(registry.agentSlots).toEqual({ min: 1, max: 5 });
+
+    const readme = fs.readFileSync(path.join(repoPath, '.har', 'README.md'), 'utf8');
+    expect(readme).toContain('Port & shared services');
+    expect(readme).toContain('HARNESS_DB_PORT_DEFAULT');
   });
 
   it('scaffolds CLI profile without TODO verify placeholders', () => {
@@ -99,6 +103,9 @@ describe('harness stage contract', () => {
     expect(harnessEnv).toContain('HARNESS_INFRA_SERVICES=""');
     expect(harnessEnv).toContain('HARNESS_USE_WORKTREE=true');
     expect(harnessEnv).toContain('HARNESS_ECOSYSTEM');
+
+    const readme = fs.readFileSync(path.join(repoPath, '.har', 'README.md'), 'utf8');
+    expect(readme).toContain('Port & shared services');
 
     expect(fs.existsSync(path.join(repoPath, '.har', 'provision-toolchain.sh'))).toBe(true);
 

--- a/tests/runs.test.ts
+++ b/tests/runs.test.ts
@@ -9,7 +9,7 @@ import {
   listRuns,
   resolveAgentWorkDir,
 } from '../src/core/runs';
-import { compareHarnessToTemplate } from '../src/harness/drift';
+import { compareHarnessToTemplate, missingPortDocumentationVars } from '../src/harness/drift';
 import { scaffoldHarnessBoilerplate } from '../src/harness/generator';
 import { GENERATOR_VERSION } from '../src/harness/manifest';
 
@@ -102,5 +102,32 @@ describe('harness drift detection', () => {
     expect(drift.generatorVersion.bundled).toBe(GENERATOR_VERSION);
     expect(drift.missing).toEqual([]);
     expect(drift.extra).toEqual([]);
+    expect(drift.missingPortVars).toEqual([]);
+  });
+
+  it('flags missing port documentation vars when harness.env lacks infra scan knobs', () => {
+    const missing = missingPortDocumentationVars('default', {
+      HARNESS_FE_BASE_PORT: '3000',
+      HARNESS_API_BASE_PORT: '8000',
+      HARNESS_PORT_STEP: '10',
+      HARNESS_INFRA_SERVICES: 'db',
+      HARNESS_DB_PORT_DEFAULT: '15432',
+    });
+    expect(missing).toEqual([
+      'HARNESS_DB_PORT_SCAN_START',
+      'HARNESS_DB_PORT_SCAN_END',
+    ]);
+  });
+
+  it('requires infra port vars only for enabled compose services', () => {
+    const missing = missingPortDocumentationVars('cli', {
+      HARNESS_PORT_STEP: '10',
+      HARNESS_INFRA_SERVICES: 'db minio',
+      HARNESS_DB_PORT_DEFAULT: '15432',
+      HARNESS_DB_PORT_SCAN_START: '15432',
+      HARNESS_DB_PORT_SCAN_END: '15499',
+    });
+    expect(missing).toContain('HARNESS_MINIO_PORT_DEFAULT');
+    expect(missing).not.toContain('HARNESS_DB_PORT_DEFAULT');
   });
 });


### PR DESCRIPTION
## Summary

- Add **Port & shared services** sections to all boilerplate READMEs (`default`, `cli`, `ios`) and `control/.har/README.md`, including allocation tables, shared vs per-slot model, and do-not rules (no hardcoded ports, no raw `docker compose`).
- Expand `harness.env` template comments and add missing MinIO console / Mailpit SMTP port vars so dynamic allocation knobs are explicit.
- Update adaptation prompts (`init`, `maintain`) and `system-authoring.md` with port/infra checklists for coding agents.
- Extend `har env maintain` drift report with `missingPortVars` — warns when `harness.env` lacks `HARNESS_*_PORT_*` exports required by enabled `HARNESS_INFRA_SERVICES`.
- Document Mission Control `har control up` vs harness slot 1 conflict on port **3847**.

Closes #35.

## Test plan

- [x] `./.har/verify.sh 1 --full` (typecheck, build, unit tests, lint)
- [x] Drift unit tests for `missingPortDocumentationVars`
- [x] Contract tests assert scaffolded READMEs include **Port & shared services**
- [ ] `har env maintain` on an older harness missing scan vars — confirm drift warning prints


Made with [Cursor](https://cursor.com)