### PR TITLE
feat: coordinate har control up with harness launch (shared port 3847)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ control/.env
 .har/runs/
 .har/validations/
 .har/slots/
+.har/state/
+control/.har/state/
 .env.agent.*
 ecosystem.agent.*.config.cjs

--- a/.har/.gitignore
+++ b/.har/.gitignore
@@ -3,6 +3,7 @@ logs/
 runs/
 validations/
 artifacts/
+state/
 AGENT.md.proposed
 AGENT.md.proposed.meta.json
 slots/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,11 @@ har control up --build  # build locally from source (monorepo contributors)
 cd control && npm run dev   # dashboard development without Docker app image
 ```
 
+**Port 3847** is shared by `har control up` (Docker) and Mission Control harness slot 1 (`cd control && har env launch 1`). Do not run both at once on the default port:
+
+- **Agent dev** (hot reload, worktrees): `cd control && har env launch 1` — preflight auto-picks an alternate port when 3847 is busy and names `har control up` as the cause.
+- **Packaged dashboard** (Docker image): `har control up` / `har control down` — warns if harness slot 1 is already active.
+
 See [`control/AGENT.md`](./control/AGENT.md).
 
 ### Sample fixtures

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ har env init            # remembers the repo for sync when Control starts
 har control sync        # push runs + slot status
 ```
 
+**Do not run `har control up` and `cd control && har env launch 1` on port 3847 at the same time.** Use the harness for agent dev (hot reload); use `har control up` for the packaged Docker dashboard. Preflight on each side detects the conflict and suggests `har control down` or an alternate harness slot/port.
+
 See [`control/AGENT.md`](./control/AGENT.md) for dashboard development. Hosted team features are **HAR Cloud** (paid).
 
 Agents can still use GitHub, Linear, observability, and other MCP servers directly. HAR focuses on the repository harness and run state.

--- a/control/.har/.gitignore
+++ b/control/.har/.gitignore
@@ -3,6 +3,7 @@ logs/
 runs/
 validations/
 artifacts/
+state/
 AGENT.md.proposed
 AGENT.md.proposed.meta.json
 slots/

--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -156,10 +156,16 @@ from a fresh worktree (monorepo `file:` link).
 
 ### Port safety
 
-`launch.sh` refuses to start if a slot's ports are already held by a foreign process
-(e.g. the app container from `docker compose up -d`, which binds slot 1's port 3847), and
-fails if its own PM2 processes are not online after launch — a passing health check alone
-is not trusted, since it could be answered by whatever else is bound to the port.
+`launch.sh` and `har env preflight` refuse to start when a slot's allocated ports are held by a
+foreign process. **`har control up`** (Docker `control-app-1` on port 3847) is detected explicitly:
+
+- If the default port is busy but another port in the slot lane is free, launch proceeds on the
+  alternate port and warns that `har control up` holds the default.
+- If no port in the lane is free, preflight blocks with `control_port_conflict` and suggests
+  `har control down` or a different slot id.
+
+`har control up` warns when `control/.har` slot 1 is already active. Recommended workflow: harness
+for agent dev, `har control up` for the packaged dashboard — not both on 3847 without an explicit choice.
 
 ## Maintaining this harness
 

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -104,17 +104,35 @@ har_port_docker_occupant() {
     | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true
 }
 
+# Detect port conflicts with `har control up` (Docker dashboard).
 har_check_control_port_conflict() {
   local port="$1"
   local name
   name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
     | grep -i control | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true)"
   if [ -n "$name" ]; then
-    echo "ERROR: Mission Control container \"${name}\" occupies port ${port}." >&2
+    echo "ERROR: har control up (container \"${name}\") occupies port ${port}." >&2
     echo "  Run: har control down — or use a different agent slot." >&2
     return 1
   fi
   return 0
+}
+
+har_warn_control_on_default_port() {
+  local agent_id="$1"
+  har_harness_uses_pm2 || return 0
+  local default_port
+  default_port="$(har_default_app_port "${HARNESS_FE_BASE_PORT:-3000}" "$agent_id")"
+  if [ "$FE_PORT" = "$default_port" ]; then
+    return 0
+  fi
+  local name
+  name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -i control | grep -E ":${default_port}->|:${default_port}/" | head -1 | cut -f1 || true)"
+  if [ -n "$name" ]; then
+    echo "WARN: har control up holds port ${default_port} (container \"${name}\")." >&2
+    echo "  Harness will use port ${FE_PORT} instead. Run: har control down — to reclaim the default port." >&2
+  fi
 }
 
 har_check_foreign_pm2() {
@@ -180,6 +198,7 @@ har_launch_preflight() {
   if har_harness_uses_pm2; then
     har_check_foreign_pm2 "$agent_id" || return 1
     har_allocate_slot_app_ports "$agent_id" || return 1
+    har_warn_control_on_default_port "$agent_id"
     local port occupant
     for port in $(printf '%s\n' "$FE_PORT" "$API_PORT" | sort -u); do
       har_check_control_port_conflict "$port" || return 1

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -289,6 +289,8 @@ export const SlotReadinessSchema = z.object({
   remediations: z.array(z.string()),
   ports: z.record(z.number()).optional(),
   allocatedPorts: z.boolean().optional(),
+  /** Non-blocking notices (e.g. har control up holds the default port but an alternate was picked). */
+  warnings: z.array(z.string()).optional(),
 });
 
 export type SlotReadiness = z.infer<typeof SlotReadinessSchema>;

--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -4,6 +4,7 @@ import {
   getControlApiUrl,
   isControlEnabled,
 } from '../../core/control-config';
+import { inspectControlUpReadiness } from '../../core/control-port';
 import {
   syncRepoWithControl,
 } from '../../core/control-sync';
@@ -83,6 +84,27 @@ export const controlCommand = {
 
 async function handleUp(argv: { detach: boolean; build: boolean }): Promise<void> {
   header('har control up');
+  const readiness = inspectControlUpReadiness(process.cwd());
+  for (const message of readiness.warnings) {
+    warn(message);
+  }
+  if (readiness.controlAlreadyRunning) {
+    success(`Mission Control is already running at ${getControlApiUrl()}`);
+    if (!isControlEnabled()) return;
+    info('Syncing repositories with Mission Control...');
+    const { synced, failed, apiReady } = await syncReposAfterControlStart(process.cwd());
+    if (!apiReady) {
+      warn('Mission Control API did not become ready — run har control sync later');
+      return;
+    }
+    if (synced > 0) {
+      success(`Synced ${synced} ${synced === 1 ? 'repository' : 'repositories'} with Mission Control`);
+    }
+    if (failed > 0) {
+      warn(`${failed} ${failed === 1 ? 'repository' : 'repositories'} could not be synced`);
+    }
+    return;
+  }
   const { code, apiUrl, imageRef } = await startMissionControl({
     detach: argv.detach,
     build: argv.build,

--- a/src/core/control-port.ts
+++ b/src/core/control-port.ts
@@ -1,0 +1,147 @@
+/**
+ * Port coordination with `har control up` — the customer-facing Docker CLI command.
+ * Not tied to this monorepo's internal control/.har; any PM2 harness can hit the same
+ * host port if they run `har control up` alongside `har env launch`.
+ */
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getControlApiUrl } from './control-config';
+import { readSlotRegistry } from './slot-registry';
+import { isPortInUse } from './slot-ports';
+
+export interface DockerRow {
+  name: string;
+  ports: string;
+}
+
+/** Host port Mission Control binds (from HAR_CONTROL_API_URL or default 3847). */
+export function parseControlHostPort(apiUrl = getControlApiUrl()): number {
+  try {
+    const url = new URL(apiUrl);
+    if (url.port) return Number(url.port);
+    return url.protocol === 'https:' ? 443 : 80;
+  } catch {
+    return 3847;
+  }
+}
+
+export function portPublishedInDocker(ports: string, port: number): boolean {
+  const re = new RegExp(`:${port}->|:${port}/`);
+  return re.test(ports) || ports.includes(`0.0.0.0:${port}`);
+}
+
+export function dockerOnPort(containers: DockerRow[], port: number): DockerRow | undefined {
+  return containers.find((c) => portPublishedInDocker(c.ports, port));
+}
+
+/** Docker container from `har control up` publishing the given host port. */
+export function controlContainerOnPort(containers: DockerRow[], port: number): DockerRow | undefined {
+  return containers.find(
+    (c) => /control/i.test(c.name) && portPublishedInDocker(c.ports, port),
+  );
+}
+
+export function listDockerContainers(): DockerRow[] {
+  try {
+    const raw = execSync('docker ps --format {{.Names}}\\t{{.Ports}}', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 3000,
+    });
+    return raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const tab = line.indexOf('\t');
+        if (tab === -1) return { name: line, ports: '' };
+        return { name: line.slice(0, tab), ports: line.slice(tab + 1) };
+      });
+  } catch {
+    return [];
+  }
+}
+
+export function formatControlPortBlocker(containerName: string, port: number, label?: string): string {
+  const suffix = label ? ` (${label})` : '';
+  return `har control up (container "${containerName}") occupies port ${port}${suffix}.`;
+}
+
+export function formatControlDefaultPortWarning(
+  containerName: string,
+  defaultPort: number,
+  allocatedPort: number,
+): string {
+  return (
+    `har control up holds port ${defaultPort} (container "${containerName}"). ` +
+    `Harness will use port ${allocatedPort} instead. Run har control down to reclaim the default port.`
+  );
+}
+
+/** Warn when har control up holds the slot default but launch proceeds on an alternate port. */
+export function controlDefaultPortWarnings(
+  containers: DockerRow[],
+  defaultFrontendPort: number,
+  allocatedFrontend: number,
+): string[] {
+  if (allocatedFrontend === defaultFrontendPort) return [];
+  const control = controlContainerOnPort(containers, defaultFrontendPort);
+  if (!control) return [];
+  return [formatControlDefaultPortWarning(control.name, defaultFrontendPort, allocatedFrontend)];
+}
+
+export interface ControlUpReadiness {
+  warnings: string[];
+  portInUse: boolean;
+  controlAlreadyRunning: boolean;
+  harnessSlot1Active: boolean;
+}
+
+/**
+ * Preflight for `har control up` — surfaces port 3847 conflicts with the control harness.
+ */
+export function inspectControlUpReadiness(repoPath: string): ControlUpReadiness {
+  const resolved = path.resolve(repoPath);
+  const port = parseControlHostPort();
+  const containers = listDockerContainers();
+  const control = controlContainerOnPort(containers, port);
+  const warnings: string[] = [];
+
+  const controlHarnessDir = path.join(resolved, 'control', '.har');
+  const harnessSlot1Active =
+    fs.existsSync(controlHarnessDir) &&
+    readSlotRegistry(path.join(resolved, 'control'), 1)?.status === 'active';
+
+  if (control) {
+    return {
+      warnings,
+      portInUse: true,
+      controlAlreadyRunning: true,
+      harnessSlot1Active,
+    };
+  }
+
+  if (harnessSlot1Active) {
+    warnings.push(
+      `Mission Control harness slot 1 is active under control/.har (port ${port}). ` +
+        'Stop it with: cd control && har env teardown 1 — or use har control up only when the harness is down.',
+    );
+  }
+
+  const portBusy = isPortInUse(port);
+  if (portBusy) {
+    const occupant = dockerOnPort(containers, port);
+    const who = occupant ? `container "${occupant.name}"` : 'another process';
+    warnings.push(
+      `Port ${port} is already in use by ${who}. har control up needs this port — free it first.`,
+    );
+  }
+
+  return {
+    warnings,
+    portInUse: portBusy,
+    controlAlreadyRunning: false,
+    harnessSlot1Active,
+  };
+}

--- a/src/core/slot-preflight.ts
+++ b/src/core/slot-preflight.ts
@@ -1,8 +1,15 @@
-import { execSync } from 'child_process';
 import * as path from 'path';
 import { readHarnessEnv } from '../harness/env';
 import { resolveHarnessRoot } from '../harness/manifest';
 import type { SlotReadiness } from '../harness/schema';
+import {
+  controlContainerOnPort,
+  controlDefaultPortWarnings,
+  formatControlPortBlocker,
+  listDockerContainers,
+  dockerOnPort,
+  type DockerRow,
+} from './control-port';
 import { checkLaunchGuard as checkOccupiedSlotGuard } from './slot-launch-guard-occupied';
 import type { LaunchGuardOptions } from './slot-launch-guard-occupied';
 import {
@@ -15,6 +22,7 @@ import {
   slotPortLaneEnd,
 } from './slot-ports';
 import { readSlotRegistry } from './slot-registry';
+import { execSync } from 'child_process';
 
 export interface PreflightOptions extends LaunchGuardOptions {
   /** When true, include port allocation in the result (default true for PM2 harnesses). */
@@ -24,16 +32,15 @@ export interface PreflightOptions extends LaunchGuardOptions {
    * through collectEnvironmentStatus.
    */
   occupied?: { active: boolean; dirty?: boolean };
+  /** Test hook: override docker ps results. */
+  dockerContainers?: DockerRow[];
+  /** Test hook: override PM2 process list (pass [] to skip live pm2 jlist). */
+  pm2Processes?: Pm2Process[];
 }
 
 interface Pm2Process {
   name?: string;
   pm2_env?: { pm_cwd?: string; cwd?: string; status?: string };
-}
-
-interface DockerRow {
-  name: string;
-  ports: string;
 }
 
 function listPm2Processes(): Pm2Process[] | undefined {
@@ -48,40 +55,6 @@ function listPm2Processes(): Pm2Process[] | undefined {
   } catch {
     return undefined;
   }
-}
-
-function listDockerContainers(): DockerRow[] {
-  try {
-    const raw = execSync('docker ps --format {{.Names}}\\t{{.Ports}}', {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-      timeout: 3000,
-    });
-    return raw
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => {
-        const tab = line.indexOf('\t');
-        if (tab === -1) return { name: line, ports: '' };
-        return { name: line.slice(0, tab), ports: line.slice(tab + 1) };
-      });
-  } catch {
-    return [];
-  }
-}
-
-function dockerOnPort(containers: DockerRow[], port: number): DockerRow | undefined {
-  const re = new RegExp(`:${port}->|:${port}/`);
-  return containers.find((c) => re.test(c.ports));
-}
-
-function controlContainerOnPort(containers: DockerRow[], port: number): DockerRow | undefined {
-  return containers.find(
-    (c) =>
-      /control/i.test(c.name) &&
-      (new RegExp(`:${port}->|:${port}/`).test(c.ports) || c.ports.includes(`0.0.0.0:${port}`)),
-  );
 }
 
 function detectForeignPm2(
@@ -153,6 +126,7 @@ export function inspectSlotReadiness(
   const usesPm2 = harnessUsesPm2(repoPath);
   const blockers: SlotReadiness['blockers'] = [];
   const remediations: string[] = [];
+  const warnings: string[] = [];
   const ports: Record<string, number> = {};
 
   const guard =
@@ -188,7 +162,11 @@ export function inspectSlotReadiness(
     );
   }
 
-  const pm2Procs = usesPm2 ? listPm2Processes() : undefined;
+  const pm2Procs = usesPm2
+    ? options.pm2Processes !== undefined
+      ? options.pm2Processes
+      : listPm2Processes()
+    : undefined;
   const foreign = usesPm2 ? detectForeignPm2(projectName, agentId, pm2Procs) : undefined;
   if (foreign) {
     const names = foreign.processes.map((p) => p.name).join(', ');
@@ -237,13 +215,20 @@ export function inspectSlotReadiness(
       ports.debug = alloc.debug;
       allocatedPorts = alloc.allocated;
 
-      const containers = listDockerContainers();
+      const containers = options.dockerContainers ?? listDockerContainers();
+      const feDefault = defaultAppPort(
+        Number(env.HARNESS_FE_BASE_PORT ?? 3000),
+        agentId,
+        portStep(env),
+      );
+      warnings.push(...controlDefaultPortWarnings(containers, feDefault, alloc.frontend));
+
       for (const [label, port] of Object.entries({ frontend: alloc.frontend, api: alloc.api })) {
         const control = controlContainerOnPort(containers, port);
         if (control) {
           blockers.push({
             code: 'control_port_conflict',
-            message: `Mission Control container "${control.name}" occupies port ${port} (${label}).`,
+            message: formatControlPortBlocker(control.name, port, label),
             remediation: 'Run: har control down — or launch a different slot id.',
             details: { container: control.name, port, label },
           });
@@ -276,7 +261,10 @@ export function inspectSlotReadiness(
       });
     } else if (dbCheck.port !== undefined) {
       ports.db = dbCheck.port;
-      const occupant = dockerOnPort(listDockerContainers(), dbCheck.port);
+      const occupant = dockerOnPort(
+        options.dockerContainers ?? listDockerContainers(),
+        dbCheck.port,
+      );
       if (
         occupant &&
         !occupant.name.startsWith(`har-${projectName}-`) &&
@@ -300,6 +288,7 @@ export function inspectSlotReadiness(
     remediations: [...new Set(remediations)],
     ports: Object.keys(ports).length > 0 ? ports : undefined,
     allocatedPorts: allocatedPorts || undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
   };
 }
 
@@ -316,8 +305,13 @@ export function formatPreflightReport(agentId: number, readiness: SlotReadiness)
         p.db !== undefined ? `db=${p.db}` : undefined,
       ].filter(Boolean);
       if (parts.length) lines.push(`  Ports: ${parts.join(' ')}`);
-      if (readiness.allocatedPorts) {
+      if (readiness.allocatedPorts && !readiness.warnings?.length) {
         lines.push('  (alternate ports selected — defaults were busy)');
+      }
+    }
+    if (readiness.warnings?.length) {
+      for (const w of readiness.warnings) {
+        lines.push(`  WARN: ${w}`);
       }
     }
     return lines.join('\n');

--- a/src/templates/har-boilerplate-cli/.gitignore
+++ b/src/templates/har-boilerplate-cli/.gitignore
@@ -3,6 +3,7 @@ logs/
 runs/
 validations/
 artifacts/
+state/
 AGENT.md.proposed
 AGENT.md.proposed.meta.json
 slots/

--- a/src/templates/har-boilerplate/.gitignore
+++ b/src/templates/har-boilerplate/.gitignore
@@ -3,6 +3,7 @@ logs/
 runs/
 validations/
 artifacts/
+state/
 AGENT.md.proposed
 AGENT.md.proposed.meta.json
 slots/

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -105,17 +105,36 @@ har_port_docker_occupant() {
     | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true
 }
 
+# Detect port conflicts with `har control up` (Docker dashboard) — not project-specific;
+# warns when the customer's packaged Mission Control container shares a slot app port.
 har_check_control_port_conflict() {
   local port="$1"
   local name
   name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
     | grep -i control | grep -E ":${port}->|:${port}/" | head -1 | cut -f1 || true)"
   if [ -n "$name" ]; then
-    echo "ERROR: Mission Control container \"${name}\" occupies port ${port}." >&2
+    echo "ERROR: har control up (container \"${name}\") occupies port ${port}." >&2
     echo "  Run: har control down — or use a different agent slot." >&2
     return 1
   fi
   return 0
+}
+
+har_warn_control_on_default_port() {
+  local agent_id="$1"
+  har_harness_uses_pm2 || return 0
+  local default_port
+  default_port="$(har_default_app_port "${HARNESS_FE_BASE_PORT:-3000}" "$agent_id")"
+  if [ "$FE_PORT" = "$default_port" ]; then
+    return 0
+  fi
+  local name
+  name="$(docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
+    | grep -i control | grep -E ":${default_port}->|:${default_port}/" | head -1 | cut -f1 || true)"
+  if [ -n "$name" ]; then
+    echo "WARN: har control up holds port ${default_port} (container \"${name}\")." >&2
+    echo "  Harness will use port ${FE_PORT} instead. Run: har control down — to reclaim the default port." >&2
+  fi
 }
 
 har_check_foreign_pm2() {
@@ -184,6 +203,7 @@ har_launch_preflight() {
   if har_harness_uses_pm2; then
     har_check_foreign_pm2 "$agent_id" || return 1
     har_allocate_slot_app_ports "$agent_id" || return 1
+    har_warn_control_on_default_port "$agent_id"
     local port occupant
     for port in $(printf '%s\n' "$FE_PORT" "$API_PORT" | sort -u); do
       har_check_control_port_conflict "$port" || return 1

--- a/tests/control-port.test.ts
+++ b/tests/control-port.test.ts
@@ -1,0 +1,153 @@
+import * as fs from 'fs';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  controlContainerOnPort,
+  controlDefaultPortWarnings,
+  dockerOnPort,
+  formatControlPortBlocker,
+  inspectControlUpReadiness,
+  parseControlHostPort,
+  portPublishedInDocker,
+} from '../src/core/control-port';
+import { inspectSlotReadiness } from '../src/core/slot-preflight';
+
+describe('control-port helpers', () => {
+  it('parseControlHostPort reads port from URL', () => {
+    expect(parseControlHostPort('http://localhost:3847')).toBe(3847);
+    expect(parseControlHostPort('http://localhost:3857/api')).toBe(3857);
+  });
+
+  it('detects published docker ports', () => {
+    expect(portPublishedInDocker('0.0.0.0:3847->3847/tcp', 3847)).toBe(true);
+    expect(portPublishedInDocker('0.0.0.0:3857->3847/tcp', 3847)).toBe(false);
+  });
+
+  it('finds control container on port', () => {
+    const containers = [
+      { name: 'control-app-1', ports: '0.0.0.0:3847->3847/tcp' },
+      { name: 'har-other-db-1', ports: '0.0.0.0:15432->5432/tcp' },
+    ];
+    expect(controlContainerOnPort(containers, 3847)?.name).toBe('control-app-1');
+    expect(dockerOnPort(containers, 15432)?.name).toBe('har-other-db-1');
+  });
+
+  it('builds control default port warning when alternate allocated', () => {
+    const containers = [{ name: 'control-app-1', ports: '0.0.0.0:3847->3847/tcp' }];
+    const warnings = controlDefaultPortWarnings(containers, 3847, 3848);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('har control up');
+    expect(warnings[0]).toContain('3847');
+    expect(warnings[0]).toContain('3848');
+  });
+
+  it('formats blocker message with har control up', () => {
+    expect(formatControlPortBlocker('control-app-1', 3847, 'frontend')).toContain(
+      'har control up (container "control-app-1")',
+    );
+  });
+});
+
+describe('inspectControlUpReadiness', () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns when control harness slot 1 is active', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-control-up-'));
+    tmpDirs.push(repo);
+    const slotsDir = path.join(repo, 'control', '.har', 'slots');
+    fs.mkdirSync(slotsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(slotsDir, 'agent-1.json'),
+      JSON.stringify({
+        version: 1,
+        agentId: 1,
+        projectName: 'control',
+        mode: 'worktree',
+        workDir: '/tmp/wt',
+        createdAt: new Date().toISOString(),
+        status: 'active',
+      }),
+    );
+
+    const readiness = inspectControlUpReadiness(repo);
+    expect(readiness.harnessSlot1Active).toBe(true);
+    expect(readiness.warnings.some((w) => w.includes('harness slot 1'))).toBe(true);
+  });
+});
+
+describe('inspectSlotReadiness control conflicts', () => {
+  const tmpDirs: string[] = [];
+
+  function makePm2Harness(feBase = 59700): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-preflight-pm2-'));
+    tmpDirs.push(dir);
+    const harDir = path.join(dir, '.har');
+    fs.mkdirSync(harDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(harDir, 'harness.env'),
+      [
+        'export HARNESS_PROJECT_NAME=control',
+        `export HARNESS_FE_BASE_PORT=${feBase}`,
+        `export HARNESS_API_BASE_PORT=${feBase}`,
+        'export HARNESS_PORT_STEP=10',
+        'export HARNESS_AGENT_SLOT_MIN=1',
+        'export HARNESS_AGENT_SLOT_MAX=3',
+      ].join('\n') + '\n',
+    );
+    fs.writeFileSync(
+      path.join(harDir, 'ecosystem.agent.template.cjs'),
+      'module.exports = { apps: [] };',
+    );
+    return dir;
+  }
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks when har control up occupies the allocated port', () => {
+    const repo = makePm2Harness();
+    const defaultPort = 59710;
+    const readiness = inspectSlotReadiness(repo, 1, {
+      pm2Processes: [],
+      dockerContainers: [{ name: 'control-app-1', ports: `0.0.0.0:${defaultPort}->${defaultPort}/tcp` }],
+    });
+    expect(readiness.canLaunch).toBe(false);
+    const conflict = readiness.blockers.find((b) => b.code === 'control_port_conflict');
+    expect(conflict).toBeDefined();
+    expect(conflict?.message).toContain('har control up');
+    expect(readiness.remediations).toContain('har control down');
+  });
+
+  it('warns when har control up holds default but alternate port is allocated', async () => {
+    const repo = makePm2Harness();
+    const defaultPort = 59710;
+    const server = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(defaultPort, '127.0.0.1', () => resolve());
+    });
+    try {
+      const readiness = inspectSlotReadiness(repo, 1, {
+        pm2Processes: [],
+        dockerContainers: [
+          { name: 'control-app-1', ports: `0.0.0.0:${defaultPort}->${defaultPort}/tcp` },
+        ],
+      });
+      expect(readiness.canLaunch).toBe(true);
+      expect(readiness.ports?.frontend).toBe(defaultPort + 1);
+      expect(readiness.warnings?.some((w) => w.includes('har control up'))).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Detect `har control up` Docker containers during harness preflight/launch and surface `control_port_conflict` blockers or non-blocking warnings when an alternate slot port is used
- Add `har control up` preflight warnings when port 3847 is busy or `control/.har` slot 1 is already active
- Gitignore ephemeral `.har/state/` (including `infra.env`) in templates and this repo

Closes #37.

## Test plan

- [x] `har env verify 1 --full` (typecheck, unit tests, lint)
- [x] `tests/control-port.test.ts` — control container detection, preflight blockers/warnings
- [ ] Manual: run `har control up`, then `cd control && har env preflight 1` — expect warning or alternate port
- [ ] Manual: run `cd control && har env launch 1`, then `har control up` — expect harness slot warning


Made with [Cursor](https://cursor.com)