### PR TITLE
feat(control): add change batch diff viewer in Mission Control

### DIFF
--- a/control/.har/launch.sh
+++ b/control/.har/launch.sh
@@ -98,6 +98,20 @@ fi
 
 # Ensure shared infra is running (persists host ports in .har/state/infra.env).
 "$SCRIPT_DIR/setup-infra.sh"
+# A worktree has its own .har directory, while shared infrastructure is launched
+# from the harness checkout that created the session. Reuse that persisted port
+# assignment so the agent env does not fall back to an occupied default port.
+INFRA_STATE="$SCRIPT_DIR/state/infra.env"
+if [ ! -f "$INFRA_STATE" ]; then
+  COMMON_GIT_DIR="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -n "$COMMON_GIT_DIR" ]; then
+    INFRA_STATE="$(cd "$(dirname "$COMMON_GIT_DIR")" && pwd)/.har/state/infra.env"
+  fi
+fi
+if [ -f "$INFRA_STATE" ]; then
+  # shellcheck source=/dev/null
+  source "$INFRA_STATE"
+fi
 DB_PORT="${AGENT_DB_PORT:-${HARNESS_DB_PORT_DEFAULT:-15432}}"
 MINIO_PORT="${AGENT_MINIO_PORT:-${HARNESS_MINIO_PORT_DEFAULT:-19000}}"
 BROWSER_PORT="${AGENT_BROWSER_PORT:-${HARNESS_BROWSER_PORT_DEFAULT:-13001}}"

--- a/control/components.json
+++ b/control/components.json
@@ -10,6 +10,7 @@
     "cssVariables": true,
     "prefix": ""
   },
+  "iconLibrary": "lucide",
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
@@ -17,5 +18,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "registries": {
+    "@reui": "https://reui.io/r/{style}/{name}.json"
+  }
 }

--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,18 +1,22 @@
 {
   "name": "@har/control",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "0.1.0",
+      "version": "0.7.0",
+      "hasInstallScript": true,
       "dependencies": {
+        "@base-ui/react": "^1.6.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@har/schemas": "file:../packages/schemas",
+        "@headless-tree/core": "^1.7.0",
+        "@headless-tree/react": "^1.7.0",
         "@prisma/client": "^6.0.0",
         "@radix-ui/react-avatar": "^1.2.1",
         "@radix-ui/react-checkbox": "^1.3.6",
@@ -61,8 +65,8 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "0.1.0",
-      "license": "MIT",
+      "version": "0.7.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.23.8"
       }
@@ -86,6 +90,66 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-ui/react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -683,6 +747,29 @@
     "node_modules/@har/schemas": {
       "resolved": "../packages/schemas",
       "link": true
+    },
+    "node_modules/@headless-tree/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@headless-tree/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-LxcX7LNepwfOPrZcs4PNfDwCzbi326uCAX5jYBfw94jI+pZQA7ANaE/No3LW0XFgcBcQtK/G2bInbVEhLF1C/Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/lukasbach"
+      }
+    },
+    "node_modules/@headless-tree/react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@headless-tree/react/-/react-1.7.0.tgz",
+      "integrity": "sha512-hcnG4mpTP98KVWZYqKsXNOoiv7ZQqZVM2jWwzEWtF+VDSz+1O/juMI+/Q0G4lZM+ez07/tmBBWjvZub/mLAUXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/lukasbach"
+      },
+      "peerDependencies": {
+        "@headless-tree/core": "*",
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -8257,6 +8344,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",

--- a/control/package.json
+++ b/control/package.json
@@ -20,11 +20,14 @@
     "test:e2e:ci": "playwright test --reporter=html --workers=2 --retries=2"
   },
   "dependencies": {
+    "@base-ui/react": "^1.6.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@har/schemas": "file:../packages/schemas",
+    "@headless-tree/core": "^1.7.0",
+    "@headless-tree/react": "^1.7.0",
     "@prisma/client": "^6.0.0",
     "@radix-ui/react-avatar": "^1.2.1",
     "@radix-ui/react-checkbox": "^1.3.6",

--- a/control/src/app/api/repos/[id]/changes/[batchId]/route.ts
+++ b/control/src/app/api/repos/[id]/changes/[batchId]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getChangeBatchDiff } from '@/server/change-batch-diff';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; batchId: string }> },
+) {
+  const { id, batchId } = await params;
+
+  try {
+    const result = await getChangeBatchDiff(id, batchId);
+    if (!result) return NextResponse.json({ error: 'Change batch not found' }, { status: 404 });
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unable to load change batch diff';
+    return NextResponse.json({ error: message }, { status: 422 });
+  }
+}

--- a/control/src/app/repos/[id]/page.tsx
+++ b/control/src/app/repos/[id]/page.tsx
@@ -185,6 +185,7 @@ export default async function RepoDetailPage({
             </CardHeader>
             <CardContent>
               <ChangeBatchList
+                repoId={id}
                 batches={changeBatches.map((b) => ({
                   id: b.id,
                   treeHash: b.treeHash,

--- a/control/src/components/change-batch-diff.tsx
+++ b/control/src/components/change-batch-diff.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FileDiff, GripVertical, LoaderCircle } from 'lucide-react';
+import type { ChangeBatchRow } from '@/components/columns/change-batch-columns';
+import { DiffFileTree } from '@/components/diff-file-tree';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+import { parseUnifiedDiff, type DiffFile, type DiffLine } from '@/lib/unified-diff';
+
+interface ChangeBatchDiffProps {
+  repoId: string;
+  batch: ChangeBatchRow | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function lineClass(kind: DiffLine['kind']) {
+  switch (kind) {
+    case 'add':
+      return 'bg-emerald-500/10 text-emerald-950 dark:text-emerald-100';
+    case 'delete':
+      return 'bg-rose-500/10 text-rose-950 dark:text-rose-100';
+    case 'meta':
+      return 'bg-muted/60 text-muted-foreground';
+    default:
+      return 'text-foreground';
+  }
+}
+
+function linePrefix(kind: DiffLine['kind']) {
+  if (kind === 'add') return '+';
+  if (kind === 'delete') return '−';
+  return ' ';
+}
+
+function DiffLineRow({ line }: { line: DiffLine }) {
+  if (line.kind === 'meta') {
+    return (
+      <div className={cn('px-4 py-1 font-mono text-xs', lineClass(line.kind))}>{line.content}</div>
+    );
+  }
+
+  return (
+    <div className={cn('grid grid-cols-[3rem_3rem_1.5rem_minmax(0,1fr)] font-mono text-xs leading-5', lineClass(line.kind))}>
+      <span className="select-none border-r border-current/10 px-2 text-right text-muted-foreground">
+        {line.oldLine ?? ''}
+      </span>
+      <span className="select-none border-r border-current/10 px-2 text-right text-muted-foreground">
+        {line.newLine ?? ''}
+      </span>
+      <span className="select-none text-center">{linePrefix(line.kind)}</span>
+      <code className="min-w-0 whitespace-pre px-2">{line.content}</code>
+    </div>
+  );
+}
+
+function FileDiffView({ file }: { file: DiffFile }) {
+  return (
+    <div className="min-w-0 overflow-x-auto rounded-md border bg-background">
+      <div className="sticky top-0 z-10 border-b bg-muted/80 px-4 py-2 font-mono text-xs font-medium backdrop-blur">
+        {file.path}
+        {file.oldPath && file.oldPath !== file.path && (
+          <span className="ml-2 text-muted-foreground">renamed from {file.oldPath}</span>
+        )}
+      </div>
+      <div className="min-w-max">
+        {file.lines.map((line, index) => (
+          <DiffLineRow key={`${line.kind}-${index}`} line={line} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ChangeBatchDiff({ repoId, batch, open, onOpenChange }: ChangeBatchDiffProps) {
+  const [diff, setDiff] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [selectedPath, setSelectedPath] = useState<string>();
+  const [sheetWidth, setSheetWidth] = useState(1100);
+  const [treeWidth, setTreeWidth] = useState(208);
+  const [resizing, setResizing] = useState<'sheet' | 'tree' | null>(null);
+  const diffScrollRef = useRef<HTMLDivElement>(null);
+  const splitPaneRef = useRef<HTMLDivElement>(null);
+  const fileSectionRefs = useRef(new Map<string, HTMLDivElement>());
+  const files = useMemo(() => parseUnifiedDiff(diff), [diff]);
+  const selectedFile = files.find((file) => file.path === selectedPath) ?? files[0];
+  const selectFile = (path: string) => {
+    setSelectedPath(path);
+    fileSectionRefs.current.get(path)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+  const updateActiveFileOnScroll = (event: React.UIEvent<HTMLDivElement>) => {
+    const scrollPosition = event.currentTarget.scrollTop + 16;
+    let activeFile = files[0];
+
+    for (const file of files) {
+      const section = fileSectionRefs.current.get(file.path);
+      if (section && section.offsetTop <= scrollPosition) activeFile = file;
+      else break;
+    }
+
+    if (activeFile && activeFile.path !== selectedFile?.path) {
+      setSelectedPath(activeFile.path);
+    }
+  };
+
+  useEffect(() => {
+    if (!open || !batch) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setDiff('');
+    setTruncated(false);
+    setSelectedPath(undefined);
+
+    fetch(`/api/repos/${encodeURIComponent(repoId)}/changes/${encodeURIComponent(batch.id)}`)
+      .then(async (response) => {
+        const payload = (await response.json()) as { diff?: string; error?: string; truncated?: boolean };
+        if (!response.ok) throw new Error(payload.error ?? 'Unable to load diff');
+        return payload;
+      })
+      .then((payload) => {
+        if (cancelled) return;
+        setDiff(payload.diff ?? '');
+        setTruncated(payload.truncated ?? false);
+      })
+      .catch((fetchError: unknown) => {
+        if (!cancelled) setError(fetchError instanceof Error ? fetchError.message : 'Unable to load diff');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [batch, open, repoId]);
+
+  useEffect(() => {
+    if (!resizing) return;
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (resizing === 'sheet') {
+        const maxWidth = Math.min(window.innerWidth * 0.96, 1600);
+        setSheetWidth(Math.max(720, Math.min(maxWidth, window.innerWidth - event.clientX)));
+        return;
+      }
+
+      const bounds = splitPaneRef.current?.getBoundingClientRect();
+      if (!bounds) return;
+      const maxTreeWidth = Math.max(180, Math.min(480, bounds.width - 360));
+      setTreeWidth(Math.max(180, Math.min(maxTreeWidth, event.clientX - bounds.left)));
+    };
+    const stopResizing = () => setResizing(null);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', stopResizing);
+    return () => {
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', stopResizing);
+    };
+  }, [resizing]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex min-h-0 w-full flex-col gap-4 p-6 sm:max-w-[min(96vw,1200px)]"
+        style={{ width: `${sheetWidth}px`, maxWidth: '96vw' }}
+      >
+        <button
+          type="button"
+          aria-label="Resize diff drawer"
+          onPointerDown={() => setResizing('sheet')}
+          className="absolute inset-y-0 left-0 z-20 w-2 cursor-col-resize touch-none bg-transparent transition-colors hover:bg-primary/20 focus-visible:bg-primary/20 focus-visible:outline-none"
+        />
+        {batch && (
+          <>
+            <SheetHeader>
+              <SheetTitle className="flex items-center gap-2 pr-8">
+                <FileDiff className="h-5 w-5 text-primary" />
+                Change batch <span className="font-mono text-base">{batch.treeHash.slice(0, 8)}</span>
+              </SheetTitle>
+              <SheetDescription>
+                {batch.branch ?? 'Detached HEAD'} · {batch.changedFiles.length} changed file
+                {batch.changedFiles.length === 1 ? '' : 's'} · {batch.createdAt.toLocaleString()}
+              </SheetDescription>
+            </SheetHeader>
+
+            {loading && (
+              <div className="flex flex-1 items-center justify-center gap-2 text-sm text-muted-foreground">
+                <LoaderCircle className="h-4 w-4 animate-spin" />
+                Loading diff…
+              </div>
+            )}
+            {error && <p className="rounded-md border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">{error}</p>}
+            {truncated && (
+              <p className="rounded-md border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-950 dark:text-amber-100">
+                This diff exceeds the 1 MB viewer limit. Use Git locally to inspect the full patch.
+              </p>
+            )}
+            {!loading && !error && !truncated && files.length === 0 && (
+              <p className="rounded-md border bg-muted/30 p-4 text-sm text-muted-foreground">
+                No textual patch was produced. This batch may only contain binary or mode changes.
+              </p>
+            )}
+            {!loading && !error && !truncated && files.length > 0 && (
+              <div
+                ref={splitPaneRef}
+                className="grid min-h-0 flex-1 overflow-hidden rounded-md border"
+                style={{ gridTemplateColumns: `${treeWidth}px 9px minmax(0, 1fr)` }}
+              >
+                <nav
+                  className="h-full min-h-0 overflow-auto overscroll-contain border-r bg-muted/30 p-2"
+                  aria-label="Changed files"
+                >
+                  <DiffFileTree
+                    files={files}
+                    selectedPath={selectedFile?.path}
+                    onSelect={selectFile}
+                  />
+                </nav>
+                <button
+                  type="button"
+                  aria-label="Resize file tree"
+                  onPointerDown={() => setResizing('tree')}
+                  className="group relative z-10 flex cursor-col-resize touch-none items-center justify-center bg-muted/30 hover:bg-primary/10 focus-visible:bg-primary/10 focus-visible:outline-none"
+                >
+                  <GripVertical className="h-3.5 w-3.5 text-muted-foreground transition-colors group-hover:text-primary" />
+                </button>
+                <div
+                  ref={diffScrollRef}
+                  onScroll={updateActiveFileOnScroll}
+                  className="h-full min-h-0 min-w-0 overflow-auto overscroll-contain bg-muted/10 p-3"
+                >
+                  <div className="space-y-3">
+                    {files.map((file) => (
+                      <div
+                        key={file.path}
+                        ref={(element) => {
+                          if (element) fileSectionRefs.current.set(file.path, element);
+                          else fileSectionRefs.current.delete(file.path);
+                        }}
+                      >
+                        <FileDiffView file={file} />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/control/src/components/change-batch-list.tsx
+++ b/control/src/components/change-batch-list.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+import { ChangeBatchDiff } from '@/components/change-batch-diff';
 import { DataTable } from '@/components/data-table/data-table';
 import {
   changeBatchColumns,
@@ -8,7 +10,9 @@ import {
 
 export type { ChangeBatchRow };
 
-export function ChangeBatchList({ batches }: { batches: ChangeBatchRow[] }) {
+export function ChangeBatchList({ repoId, batches }: { repoId: string; batches: ChangeBatchRow[] }) {
+  const [selectedBatch, setSelectedBatch] = useState<ChangeBatchRow | null>(null);
+
   if (batches.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
@@ -31,13 +35,21 @@ export function ChangeBatchList({ batches }: { batches: ChangeBatchRow[] }) {
         <div key={branch}>
           <h3 className="mb-2 font-mono text-sm font-semibold text-muted-foreground">{branch}</h3>
           <DataTable
-            columns={changeBatchColumns}
+            columns={changeBatchColumns(setSelectedBatch)}
             data={group}
             getRowId={(batch) => batch.id}
             showPagination={group.length > 10}
           />
         </div>
       ))}
+      <ChangeBatchDiff
+        repoId={repoId}
+        batch={selectedBatch}
+        open={selectedBatch !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedBatch(null);
+        }}
+      />
     </div>
   );
 }

--- a/control/src/components/columns/change-batch-columns.tsx
+++ b/control/src/components/columns/change-batch-columns.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { FileDiff } from 'lucide-react';
 import { type ColumnDef } from '@tanstack/react-table';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 
 interface ChangedFileEntry {
   path: string;
@@ -40,7 +42,10 @@ function filesSummary(files: ChangedFileEntry[]): string {
     .join('\n');
 }
 
-export const changeBatchColumns: ColumnDef<ChangeBatchRow>[] = [
+export function changeBatchColumns(
+  onOpenDiff: (batch: ChangeBatchRow) => void,
+): ColumnDef<ChangeBatchRow>[] {
+  return [
   {
     accessorKey: 'createdAt',
     header: 'Created',
@@ -92,4 +97,21 @@ export const changeBatchColumns: ColumnDef<ChangeBatchRow>[] = [
     header: 'Agent',
     cell: ({ row }) => row.original.agentId ?? '—',
   },
+  {
+    id: 'diff',
+    header: '',
+    cell: ({ row }) => (
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className="h-8 gap-1.5 px-2 text-xs"
+        onClick={() => onOpenDiff(row.original)}
+      >
+        <FileDiff className="h-3.5 w-3.5" />
+        Diff
+      </Button>
+    ),
+  },
 ];
+}

--- a/control/src/components/diff-file-tree.tsx
+++ b/control/src/components/diff-file-tree.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useMemo } from 'react';
+import { hotkeysCoreFeature, syncDataLoaderFeature } from '@headless-tree/core';
+import { useTree } from '@headless-tree/react';
+import { FileCode2, FileText, Folder, FolderOpen } from 'lucide-react';
+import { Tree, TreeItem, TreeItemLabel } from '@/components/reui/tree';
+import { cn } from '@/lib/utils';
+import type { DiffFile } from '@/lib/unified-diff';
+
+interface FileTreeItem {
+  name: string;
+  path?: string;
+  children?: string[];
+}
+
+interface DiffFileTreeProps {
+  files: DiffFile[];
+  selectedPath?: string;
+  onSelect: (path: string) => void;
+}
+
+function fileIcon(path: string, expanded: boolean, folder: boolean) {
+  if (folder) {
+    return expanded ? (
+      <FolderOpen className="size-3.5 text-amber-500" />
+    ) : (
+      <Folder className="size-3.5 text-amber-500" />
+    );
+  }
+  if (/\.[cm]?[jt]sx?$/.test(path)) return <FileCode2 className="size-3.5 text-sky-500" />;
+  return <FileText className="size-3.5 text-muted-foreground" />;
+}
+
+function createTree(files: DiffFile[]) {
+  const items: Record<string, FileTreeItem> = {
+    root: { name: 'Changed files', children: [] },
+  };
+
+  for (const file of files) {
+    const parts = file.path.split('/').filter(Boolean);
+    let parentId = 'root';
+    let accumulatedPath = '';
+
+    for (const [index, part] of parts.entries()) {
+      accumulatedPath = accumulatedPath ? `${accumulatedPath}/${part}` : part;
+      const isFile = index === parts.length - 1;
+      const itemId = isFile ? `file:${file.path}` : `folder:${accumulatedPath}`;
+      const parent = items[parentId];
+      if (!parent.children?.includes(itemId)) parent.children?.push(itemId);
+
+      if (!items[itemId]) {
+        items[itemId] = isFile
+          ? { name: part, path: file.path }
+          : { name: part, children: [] };
+      }
+      parentId = itemId;
+    }
+  }
+
+  return items;
+}
+
+export function DiffFileTree({ files, selectedPath, onSelect }: DiffFileTreeProps) {
+  const items = useMemo(() => createTree(files), [files]);
+  const expandedItems = useMemo(
+    () => Object.keys(items).filter((id) => id === 'root' || id.startsWith('folder:')),
+    [items],
+  );
+  const tree = useTree<FileTreeItem>({
+    initialState: { expandedItems },
+    rootItemId: 'root',
+    getItemName: (item) => item.getItemData().name,
+    isItemFolder: (item) => (item.getItemData().children?.length ?? 0) > 0,
+    dataLoader: {
+      getItem: (itemId) => items[itemId],
+      getChildren: (itemId) => items[itemId].children ?? [],
+    },
+    features: [syncDataLoaderFeature, hotkeysCoreFeature],
+  });
+
+  return (
+    <Tree indent={14} tree={tree} className="w-max min-w-full gap-0.5">
+      {tree.getItems().map((item) => {
+        const data = item.getItemData();
+        const folder = item.isFolder();
+        const selected = data.path === selectedPath;
+        return (
+          <TreeItem
+            key={item.getId()}
+            item={item}
+            onClick={() => {
+              if (data.path) onSelect(data.path);
+            }}
+          >
+            <TreeItemLabel
+              className={cn(
+                'w-max min-w-full whitespace-nowrap py-1 text-xs [&_svg]:size-3.5',
+                selected && 'bg-accent text-accent-foreground',
+              )}
+            >
+              <span className="flex min-w-0 items-center gap-1.5">
+                {fileIcon(data.path ?? data.name, item.isExpanded(), folder)}
+                <span className="truncate">{data.name}</span>
+              </span>
+            </TreeItemLabel>
+          </TreeItem>
+        );
+      })}
+    </Tree>
+  );
+}

--- a/control/src/components/reui/tree.tsx
+++ b/control/src/components/reui/tree.tsx
@@ -1,0 +1,229 @@
+"use client"
+
+import { createContext, useContext } from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { ItemInstance } from "@headless-tree/core"
+
+import { cn } from "@/lib/utils"
+import { MinusIcon, PlusIcon, ChevronDownIcon } from "lucide-react"
+
+type ToggleIconType = "chevron" | "plus-minus"
+
+interface TreeApi {
+  getContainerProps?: () => React.HTMLAttributes<HTMLDivElement>
+  getDragLineStyle?: () => React.CSSProperties
+}
+
+interface TreeItemContextItem {
+  isExpanded: () => boolean
+  isFolder: () => boolean
+  getItemName?: () => string
+}
+
+interface TreeContextValue {
+  indent: number
+  currentItem?: TreeItemContextItem
+  tree?: TreeApi
+  toggleIconType?: ToggleIconType
+}
+
+const TreeContext = createContext<TreeContextValue>({
+  indent: 20,
+  currentItem: undefined,
+  tree: undefined,
+  toggleIconType: "plus-minus",
+})
+
+function useTreeContext() {
+  return useContext(TreeContext)
+}
+
+interface TreeProps extends React.HTMLAttributes<HTMLDivElement> {
+  indent?: number
+  tree?: TreeApi
+  toggleIconType?: ToggleIconType
+}
+
+function Tree({
+  indent = 20,
+  tree,
+  className,
+  toggleIconType = "chevron",
+  ...props
+}: TreeProps) {
+  const containerProps =
+    tree && typeof tree.getContainerProps === "function"
+      ? tree.getContainerProps()
+      : {}
+  const mergedProps = { ...props, ...containerProps }
+
+  // Extract style from mergedProps to merge with our custom styles
+  const { style: propStyle, ...otherProps } = mergedProps
+
+  // Merge styles
+  const mergedStyle = {
+    ...propStyle,
+    "--tree-indent": `${indent}px`,
+  } as React.CSSProperties
+
+  return (
+    <TreeContext.Provider value={{ indent, tree, toggleIconType }}>
+      <div
+        data-slot="tree"
+        style={mergedStyle}
+        className={cn("flex flex-col", className)}
+        {...otherProps}
+      />
+    </TreeContext.Provider>
+  )
+}
+
+interface TreeItemProps<T = unknown> extends Omit<
+  useRender.ComponentProps<"button">,
+  "indent"
+> {
+  item: ItemInstance<T>
+  indent?: number
+}
+
+function TreeItem<T = unknown>({
+  item,
+  className,
+  render,
+  children,
+  ...props
+}: TreeItemProps<T>) {
+  const parentContext = useTreeContext()
+  const { indent } = parentContext
+
+  const itemProps = typeof item.getProps === "function" ? item.getProps() : {}
+  const mergedProps = { ...props, children, ...itemProps }
+
+  // Extract style from mergedProps to merge with our custom styles
+  const { style: propStyle, ...otherProps } = mergedProps
+
+  // Merge styles
+  const mergedStyle = {
+    ...propStyle,
+    paddingInlineStart: `${item.getItemMeta().level * indent}px`,
+  } as React.CSSProperties
+
+  const defaultProps = {
+    "data-slot": "tree-item",
+    style: mergedStyle,
+    className: cn(
+      "z-10 outline-hidden select-none not-last:pb-0.5 focus:z-20 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    ),
+    "data-focus":
+      typeof item.isFocused === "function"
+        ? item.isFocused() || false
+        : undefined,
+    "data-folder":
+      typeof item.isFolder === "function"
+        ? item.isFolder() || false
+        : undefined,
+    "data-selected":
+      typeof item.isSelected === "function"
+        ? item.isSelected() || false
+        : undefined,
+    "data-drag-target":
+      typeof item.isDragTarget === "function"
+        ? item.isDragTarget() || false
+        : undefined,
+    "data-search-match":
+      typeof item.isMatchingSearch === "function"
+        ? item.isMatchingSearch() || false
+        : undefined,
+    "aria-expanded": item.isExpanded(),
+  }
+
+  return (
+    <TreeContext.Provider value={{ ...parentContext, currentItem: item }}>
+      {useRender({
+        defaultTagName: "button",
+        render,
+        props: mergeProps<"button">(defaultProps, otherProps),
+      })}
+    </TreeContext.Provider>
+  )
+}
+
+interface TreeItemLabelProps<
+  T = unknown,
+> extends React.HTMLAttributes<HTMLSpanElement> {
+  item?: ItemInstance<T>
+}
+
+function TreeItemLabel<T = unknown>({
+  item: propItem,
+  children,
+  className,
+  ...props
+}: TreeItemLabelProps<T>) {
+  const { currentItem, toggleIconType } = useTreeContext()
+  const item = propItem || currentItem
+
+  if (!item) {
+    console.warn("TreeItemLabel: No item provided via props or context")
+    return null
+  }
+
+  return (
+    <span
+      data-slot="tree-item-label"
+      className={cn(
+        "in-focus-visible:ring-ring/50 bg-background hover:bg-accent in-data-[selected=true]:bg-accent in-data-[selected=true]:text-accent-foreground in-data-[drag-target=true]:bg-accent flex items-center gap-1 transition-colors not-in-data-[folder=true]:ps-7 in-focus-visible:ring-[3px] in-data-[search-match=true]:bg-blue-50! [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "rounded-md",
+        "py-1.5",
+        "px-2",
+        "text-sm",
+        className
+      )}
+      {...props}
+    >
+      {item.isFolder() &&
+        (toggleIconType === "plus-minus" ? (
+          item.isExpanded() ? (
+            <MinusIcon className="text-muted-foreground size-3.5" stroke="currentColor" strokeWidth="1" />
+          ) : (
+            <PlusIcon className="text-muted-foreground size-3.5" stroke="currentColor" strokeWidth="1" />
+          )
+        ) : (
+          <ChevronDownIcon className="text-muted-foreground size-4 in-aria-[expanded=false]:-rotate-90" />
+        ))}
+      {children ||
+        (typeof item.getItemName === "function" ? item.getItemName() : null)}
+    </span>
+  )
+}
+
+function TreeDragLine({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const { tree } = useTreeContext()
+
+  if (!tree || typeof tree.getDragLineStyle !== "function") {
+    console.warn(
+      "TreeDragLine: No tree provided via context or tree does not have getDragLineStyle method"
+    )
+    return null
+  }
+
+  const dragLine = tree.getDragLineStyle()
+  return (
+    <div
+      style={dragLine}
+      className={cn(
+        "bg-primary before:bg-background before:border-primary absolute z-30 -mt-px h-0.5 w-[unset] before:absolute before:-top-[3px] before:left-0 before:size-2 before:border-2",
+        "before:rounded-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Tree, TreeItem, TreeItemLabel, TreeDragLine }

--- a/control/src/lib/unified-diff.test.ts
+++ b/control/src/lib/unified-diff.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { parseUnifiedDiff } from './unified-diff';
+
+describe('parseUnifiedDiff', () => {
+  it('groups hunks by file and assigns paired line numbers', () => {
+    const files = parseUnifiedDiff(`diff --git a/src/example.ts b/src/example.ts
+index 1111111..2222222 100644
+--- a/src/example.ts
++++ b/src/example.ts
+@@ -2,3 +2,4 @@
+ const stable = true;
+-const removed = false;
++const added = true;
++const another = true;
+ export { stable };`);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      path: 'src/example.ts',
+      oldPath: 'src/example.ts',
+      lines: [
+        { kind: 'meta', content: 'index 1111111..2222222 100644' },
+        { kind: 'meta', content: '@@ -2,3 +2,4 @@' },
+        { kind: 'context', content: 'const stable = true;', oldLine: 2, newLine: 2 },
+        { kind: 'delete', content: 'const removed = false;', oldLine: 3 },
+        { kind: 'add', content: 'const added = true;', newLine: 3 },
+        { kind: 'add', content: 'const another = true;', newLine: 4 },
+        { kind: 'context', content: 'export { stable };', oldLine: 4, newLine: 5 },
+      ],
+    });
+  });
+
+  it('preserves /dev/null changes and metadata-only files', () => {
+    const files = parseUnifiedDiff(`diff --git a/new.ts b/new.ts
+new file mode 100644
+--- /dev/null
++++ b/new.ts
+@@ -0,0 +1 @@
++export const created = true;
+diff --git a/script.sh b/script.sh
+old mode 100644
+new mode 100755`);
+
+    expect(files[0]).toMatchObject({
+      path: 'new.ts',
+      lines: [{ kind: 'meta' }, { kind: 'meta' }, { kind: 'add', newLine: 1 }],
+    });
+    expect(files[1]).toMatchObject({
+      path: 'Unknown file',
+      lines: [
+        { kind: 'meta', content: 'old mode 100644' },
+        { kind: 'meta', content: 'new mode 100755' },
+      ],
+    });
+  });
+});

--- a/control/src/lib/unified-diff.ts
+++ b/control/src/lib/unified-diff.ts
@@ -1,0 +1,88 @@
+export type DiffLineKind = 'add' | 'delete' | 'context' | 'meta';
+
+export interface DiffLine {
+  kind: DiffLineKind;
+  content: string;
+  oldLine?: number;
+  newLine?: number;
+}
+
+export interface DiffFile {
+  path: string;
+  oldPath?: string;
+  lines: DiffLine[];
+}
+
+function filePath(line: string): string | undefined {
+  const value = line.slice(4).split('\t')[0];
+  if (!value || value === '/dev/null') return undefined;
+  return value.replace(/^[ab]\//, '');
+}
+
+function hunkStart(line: string): { oldLine: number; newLine: number } | undefined {
+  const match = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+  if (!match) return undefined;
+  return { oldLine: Number(match[1]), newLine: Number(match[2]) };
+}
+
+/**
+ * Converts a unified diff into display-ready files and line numbers. Git metadata
+ * remains available so binary and mode-only changes do not silently disappear.
+ */
+export function parseUnifiedDiff(diff: string): DiffFile[] {
+  const files: DiffFile[] = [];
+  let current: DiffFile | undefined;
+  let oldLine = 0;
+  let newLine = 0;
+
+  for (const content of diff.split('\n')) {
+    if (content.startsWith('diff --git ')) {
+      if (current) files.push(current);
+      current = { path: 'Unknown file', lines: [] };
+      oldLine = 0;
+      newLine = 0;
+      continue;
+    }
+
+    if (!current) continue;
+
+    if (content.startsWith('--- ')) {
+      current.oldPath = filePath(content);
+      continue;
+    }
+    if (content.startsWith('+++ ')) {
+      current.path = filePath(content) ?? current.oldPath ?? 'Unknown file';
+      continue;
+    }
+
+    const start = hunkStart(content);
+    if (start) {
+      oldLine = start.oldLine;
+      newLine = start.newLine;
+      current.lines.push({ kind: 'meta', content });
+      continue;
+    }
+
+    if (content.startsWith('+') && !content.startsWith('+++')) {
+      current.lines.push({ kind: 'add', content: content.slice(1), newLine });
+      newLine += 1;
+      continue;
+    }
+    if (content.startsWith('-') && !content.startsWith('---')) {
+      current.lines.push({ kind: 'delete', content: content.slice(1), oldLine });
+      oldLine += 1;
+      continue;
+    }
+    if (content.startsWith(' ')) {
+      current.lines.push({ kind: 'context', content: content.slice(1), oldLine, newLine });
+      oldLine += 1;
+      newLine += 1;
+      continue;
+    }
+
+    if (content) current.lines.push({ kind: 'meta', content });
+  }
+
+  if (current) files.push(current);
+  return files;
+}

--- a/control/src/server/change-batch-diff.ts
+++ b/control/src/server/change-batch-diff.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { prisma } from '@/lib/db';
+
+const execFileAsync = promisify(execFile);
+const GIT_OBJECT_ID = /^[0-9a-f]{40,64}$/i;
+const MAX_DIFF_BYTES = 1_000_000;
+
+function diffDirectory(repoPath: string, workDir: string | null): string {
+  if (workDir && fs.existsSync(workDir)) return workDir;
+  return repoPath;
+}
+
+export async function getChangeBatchDiff(repositoryId: string, batchId: string) {
+  const batch = await prisma.changeBatch.findFirst({
+    where: { id: batchId, repositoryId },
+    include: { repository: { select: { path: true } } },
+  });
+  if (!batch) return undefined;
+
+  if (!batch.headSha || !GIT_OBJECT_ID.test(batch.headSha) || !GIT_OBJECT_ID.test(batch.treeHash)) {
+    throw new Error('This change batch does not have a diffable Git snapshot.');
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      [
+        'diff',
+        '--no-ext-diff',
+        '--find-renames',
+        '--find-copies',
+        '--unified=3',
+        batch.headSha,
+        batch.treeHash,
+        '--',
+      ],
+      {
+        cwd: diffDirectory(batch.repository.path, batch.workDir),
+        maxBuffer: MAX_DIFF_BYTES,
+        encoding: 'utf8',
+      },
+    );
+    return { diff: stdout, truncated: false };
+  } catch (error: unknown) {
+    const code = (error as { code?: string }).code;
+    if (code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+      return {
+        diff: '',
+        truncated: true,
+      };
+    }
+    throw new Error('The Git objects for this change batch are no longer available.');
+  }
+}


### PR DESCRIPTION

<img width="1860" height="928" alt="image" src="https://github.com/user-attachments/assets/c4469be7-9c4d-4b42-b160-5d5100101eac" />

## Summary

- Add a Mission Control diff viewer for recorded change batches: open from the repo Changes table via a new **Diff** action
- Fetch unified diffs server-side (`git diff headSha treeHash`) and render a continuous multi-file scroll pane with syntax-colored hunks
- File/folder tree (`@reui/c-tree-5`) with scroll sync, resizable drawer width, and resizable tree/diff split
- Reuse shared infra ports from the main harness checkout when launching control from a worktree (`.har/launch.sh`)

## Test plan

- [ ] Open a repo in Mission Control with at least one change batch
- [ ] Click **Diff** on a batch — sheet opens with file tree and full-batch diff
- [ ] Scroll the diff pane — tree selection follows the visible file
- [ ] Click a file in the tree — diff scrolls to that file
- [ ] Resize drawer (left edge) and tree/diff split (grip handle)
- [ ] `har env verify 1 --full` in `control/` (typecheck, unit tests, lint, API health)


Made with [Cursor](https://cursor.com)