### PR TITLE
fix: Docker build stage + publish Docker before npm

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,8 @@
 name: Publish Docker (manual)
 
-# Normal releases publish Docker in the Release workflow (publish-docker job).
-# Use this workflow only to republish an existing tag.
+# Normal releases cut the version first, then publish Docker, then npm
+# (see .github/workflows/release.yml). Use this workflow only to republish
+# an existing tag to Docker Hub.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,29 @@ jobs:
           node dist/index.js env launch 1
           node dist/index.js env verify 1 --full
 
-      - name: Verify Mission Control
+      - name: Install Mission Control dependencies
         run: |
           npm ci --prefix packages/schemas
           npm ci --prefix control
-          npm run typecheck --prefix control
-          npm test --prefix control
+
+      - name: Install Playwright Chromium
+        working-directory: control
+        run: npx playwright install --with-deps chromium
+
+      - name: Launch Mission Control harness
+        working-directory: control
+        run: ./.har/launch.sh 1 --no-worktree
+
+      - name: Verify Mission Control (full)
+        working-directory: control
+        env:
+          CI: true
+        run: ./.har/verify.sh 1 --full
+
+      - name: Teardown Mission Control harness
+        if: always()
+        working-directory: control
+        run: ./.har/teardown.sh 1
 
   release:
     needs: verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
 
       - run: npm ci
 
-      - name: Semantic release (npm + GitHub tag/release)
+      - name: Semantic release (version cut + GitHub; npm deferred until Docker)
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -129,10 +129,10 @@ jobs:
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "tag=$TAG" >> "$GITHUB_OUTPUT"
             echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-            echo "Published $TAG (npm, GitHub Release, Docker follow in publish-docker job)"
+            echo "Published $TAG (version cut + GitHub Release; Docker then npm follow)"
           else
             echo "released=false" >> "$GITHUB_OUTPUT"
-            echo "No new release — skipped npm publish and downstream jobs"
+            echo "No new release — skipped version cut and downstream publish jobs"
           fi
 
   publish-docker:
@@ -194,3 +194,38 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Publish to npm only after Docker Hub has the matching version (avoids CLI
+  # pointing users at har control up for a tag that does not exist on Docker Hub).
+  publish-npm:
+    needs: [release, publish-docker]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install and publish @osfactory/har
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          EXPECTED="${{ needs.release.outputs.version }}"
+          ACTUAL="$(node -p "require('./package.json').version")"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "package.json version ($ACTUAL) does not match tag v${EXPECTED}" >&2
+            exit 1
+          fi
+          npm ci
+          npm publish --access public
+          echo "Published @osfactory/har@${EXPECTED} to npm after Docker Hub push"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: 
+on:
   pull_request:
     branches:
       - main
@@ -19,15 +19,39 @@ jobs:
 
   control:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: control/package-lock.json
+
       # @har/schemas path alias typechecks source files — zod must exist under packages/schemas/
-      - run: npm ci --prefix packages/schemas
-      - run: npm ci --prefix control
-      - run: npm run typecheck --prefix control
-      - run: npm test --prefix control
+      - name: Install dependencies
+        run: |
+          npm ci --prefix packages/schemas
+          npm ci --prefix control
+
+      - name: Install Playwright Chromium
+        working-directory: control
+        run: npx playwright install --with-deps chromium
+
+      # Dogfood control/.har (same path agents use locally). --no-worktree: the
+      # Actions checkout is already the code under test.
+      - name: Launch Mission Control harness
+        working-directory: control
+        run: ./.har/launch.sh 1 --no-worktree
+
+      - name: Verify Mission Control (full)
+        working-directory: control
+        env:
+          CI: true
+        run: ./.har/verify.sh 1 --full
+
+      - name: Teardown Mission Control harness
+        if: always()
+        working-directory: control
+        run: ./.har/teardown.sh 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,12 +381,12 @@ The tarball should contain `dist/` (bundled CLI + templates + prompts), `control
 Maintainers do **not** hand-cut version tags after the baseline. Merge conventional commits to `main`; the [Release workflow](.github/workflows/release.yml) runs on every push to `main` and, when semantic-release finds releasable commits:
 
 1. Runs full CLI + Mission Control verification
-2. Bumps `@osfactory/har`, `@har/control`, and `@har/schemas` to the same version
-3. Publishes `@osfactory/har` to **npm**
-4. Creates git tag `vX.Y.Z` and a **GitHub Release** (with CLI tarball + compose assets)
-5. Pushes **`theosfactory/har-control`** to Docker Hub (`X.Y.Z`, `X.Y`, `X`, and `latest`) in the same workflow
+2. Bumps `@osfactory/har`, `@har/control`, and `@har/schemas` to the same version (npm package prepared, **not** published yet)
+3. Creates git tag `vX.Y.Z` and a **GitHub Release** (with CLI tarball + compose assets)
+4. Pushes **`theosfactory/har-control`** to Docker Hub (`X.Y.Z`, `X.Y`, `X`, and `latest`)
+5. Publishes `@osfactory/har` to **npm** only after the Docker push succeeds
 
-If there is nothing to release, verify still runs and publish steps are skipped.
+If there is nothing to release, verify still runs and publish steps are skipped. If Docker publish fails, npm is **not** published for that tag (fix the image, then use [Publish Docker (manual)](.github/workflows/publish-docker.yml) and publish npm from the tag, or re-run the failed jobs).
 
 ### Maintainer setup
 
@@ -416,11 +416,12 @@ GITHUB_TOKEN=... NPM_TOKEN=... npx semantic-release --dry-run
 
 `@osfactory/har`, Mission Control (`control/`), and `@har/schemas` share one semver. [semantic-release](release.config.cjs) keeps them aligned:
 
-1. `@semantic-release/npm` bumps root `package.json` and publishes to npm
+1. `@semantic-release/npm` bumps root `package.json` with `npmPublish: false` (prepare only)
 2. [`release/sync-package-versions.js`](release/sync-package-versions.js) syncs `control/` and `packages/schemas/`
 3. `@semantic-release/github` creates git tag `vX.Y.Z` and the GitHub Release
 4. The Release workflow `publish-docker` job pushes `theosfactory/har-control:X.Y.Z` (plus `X.Y`, `X`, and **`latest`**)
-5. Installed CLI reads its own `package.json` version and pulls `theosfactory/har-control:<same-version>` on `har control up`
+5. The `publish-npm` job publishes `@osfactory/har@X.Y.Z` to npmjs **after** Docker succeeds
+6. Installed CLI reads its own `package.json` version and pulls `theosfactory/har-control:<same-version>` on `har control up`
 
 Override with `HAR_CONTROL_IMAGE` / `HAR_CONTROL_IMAGE_TAG`, or use `har control up --build` / `HAR_CONTROL_BUILD=true` to build locally from a git checkout.
 

--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -63,9 +63,10 @@ Read **`stages.json`** for registered stages and **`verificationStages`** for th
 | Mode | Command | Typical steps |
 |------|---------|---------------|
 | Quick | `har env verify <id>` or `verify.sh <id>` | typecheck, unit tests, api-health |
-| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint + optional readiness smoke + **`browser-e2e`** when `.har/stages/browser-e2e.sh` exists |
+| Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint + optional readiness smoke + **`browser-e2e`** + **`docker-build`** (when those stage scripts exist) |
 
 Install Playwright stage: `har env add-stage playwright` (optional). UI changes should add or update specs under `tests/`.
+The `docker-build` stage builds `control/Dockerfile` against the session worktree (no push; native platform) so Dockerfile / `next build` regressions fail verification before release.
 
 ## Run history
 

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -683,6 +683,16 @@ run_browser_e2e_if_present() {
   fi
 }
 
+# Build Mission Control Docker image on verify --full when the stage is installed.
+run_docker_build_if_present() {
+  local script_dir="$1"
+  local agent_id="$2"
+  local script="$script_dir/stages/docker-build.sh"
+  if [ -x "$script" ]; then
+    "$script" "$agent_id"
+  fi
+}
+
 # Optional project-owned "agent usable" smoke beyond health.
 run_readiness_if_configured() {
   local agent_id="$1"

--- a/control/.har/stages.json
+++ b/control/.har/stages.json
@@ -11,7 +11,8 @@
     "unit-tests",
     "api-health",
     "lint",
-    "browser-e2e"
+    "browser-e2e",
+    "docker-build"
   ],
   "stages": [
     {
@@ -89,6 +90,20 @@
         {
           "path": ".har/artifacts/browser-e2e/playwright-report",
           "kind": "report"
+        }
+      ],
+      "requiresAgentId": true
+    },
+    {
+      "id": "docker-build",
+      "kind": "test",
+      "description": "Build Mission Control Docker image (no push; native platform)",
+      "script": "stages/docker-build.sh",
+      "artifacts": [
+        {
+          "path": ".har/artifacts/docker-build",
+          "kind": "directory",
+          "description": "Docker build logs"
         }
       ],
       "requiresAgentId": true

--- a/control/.har/stages/docker-build.sh
+++ b/control/.har/stages/docker-build.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Build the Mission Control Docker image (no push) for the agent worktree.
+# Catches Dockerfile / next build regressions before release publish.
+# Outputs JSON to stdout, human-readable progress to stderr.
+#
+# Usage: ./.har/stages/docker-build.sh <agent-id>
+# Prerequisite: ./.har/launch.sh <agent-id> (uses the session worktree as context)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$HARNESS_DIR/harness.env"
+# shellcheck source=/dev/null
+source "$HARNESS_DIR/agent-slot.sh"
+
+AGENT_ID="${1:?Usage: docker-build.sh <agent-id>}"
+validate_agent_id "$AGENT_ID"
+
+log() { echo "==> [docker-build agent-$AGENT_ID] $*" >&2; }
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required for the docker-build stage" >&2
+  exit 1
+fi
+
+ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
+  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  exit 1
+}
+
+set -a
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +a
+
+WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+# control/ is the app root; Dockerfile context is the monorepo root above it.
+MONOREPO_ROOT="$(cd "$WORK_DIR/.." && pwd)"
+DOCKERFILE="$MONOREPO_ROOT/control/Dockerfile"
+IMAGE_TAG="har-control:verify-agent-${AGENT_ID}"
+ARTIFACT_DIR="$REPO_ROOT/.har/artifacts/docker-build"
+mkdir -p "$ARTIFACT_DIR"
+
+if [ ! -f "$DOCKERFILE" ]; then
+  echo "Missing Dockerfile at $DOCKERFILE" >&2
+  exit 1
+fi
+
+log "Building $IMAGE_TAG from $MONOREPO_ROOT (file: control/Dockerfile)"
+log "Native platform only — release CI still builds linux/amd64 + linux/arm64"
+
+START_TOTAL=$(now_ms)
+
+set +e
+BUILD_OUTPUT=$(docker build \
+  --file "$DOCKERFILE" \
+  --tag "$IMAGE_TAG" \
+  --progress=plain \
+  "$MONOREPO_ROOT" 2>&1)
+BUILD_EXIT=$?
+set -e
+
+END_TOTAL=$(now_ms)
+TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+
+echo "$BUILD_OUTPUT" >&2
+printf '%s\n' "$BUILD_OUTPUT" >"$ARTIFACT_DIR/build-agent-${AGENT_ID}.log"
+
+node -e "
+const out = {
+  status: ${BUILD_EXIT} === 0 ? 'pass' : 'fail',
+  stageId: 'docker-build',
+  kind: 'test',
+  agent_id: ${AGENT_ID},
+  total_ms: ${TOTAL_MS},
+  image: '${IMAGE_TAG}',
+  artifacts: [
+    { path: '.har/artifacts/docker-build', kind: 'directory' },
+  ],
+};
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+"
+
+exit "$BUILD_EXIT"

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -143,6 +143,7 @@ if [ -n "$FULL" ]; then
   run_step "lint" "npm run lint" || true
   run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   run_step "browser-e2e" "run_browser_e2e_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
+  run_step "docker-build" "run_docker_build_if_present \"$SCRIPT_DIR\" \"$AGENT_ID\"" || true
 fi
 
 # ── Output results ────────────────────────────────────────────────────────────

--- a/control/src/app/globals.css
+++ b/control/src/app/globals.css
@@ -16,7 +16,7 @@
     --secondary: 120 12% 88%;
     --secondary-foreground: 124 11% 30%;
     --muted: 120 10% 90%;
-    --muted-foreground: 90 8% 45%;
+    --muted-foreground: 124 10% 36%;
     --accent: 120 5% 69%;
     --accent-foreground: 124 11% 30%;
     --destructive: 0 84.2% 60.2%;

--- a/control/src/components/repo-table.tsx
+++ b/control/src/components/repo-table.tsx
@@ -50,7 +50,8 @@ export function RepoTable({ repos }: { repos: RepoRow[] }) {
 
   if (repos.length === 0) {
     return (
-      <div className="px-4 lg:px-6">
+      <div className="flex w-full flex-col gap-4 px-4 lg:px-6">
+        <h1 className="text-base font-medium">Repositories</h1>
         <p className="text-sm text-muted-foreground">
           No repositories registered. Run <code className="rounded bg-muted px-1">har env init</code>{' '}
           or <code className="rounded bg-muted px-1">har control register</code>.

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module';
 import type { AgentSessionUsage, AgentTool } from '@har/schemas';
 import { prisma } from '@/lib/db';
 import { upsertSessionUsage } from '@/server/usage';
+
+const nodeRequire = createRequire(__filename);
 
 interface AttrMap {
   [key: string]: string | number | boolean;
@@ -283,8 +286,7 @@ export async function ingestOtelMetricsBody(
 
   // Protobuf: try optional transformer; otherwise acknowledge without failing the exporter.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { ProtobufMetricsSerializer } = require('@opentelemetry/otlp-transformer') as {
+    const { ProtobufMetricsSerializer } = nodeRequire('@opentelemetry/otlp-transformer') as {
       ProtobufMetricsSerializer?: {
         deserializeRequest: (data: Uint8Array) => unknown;
       };

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -27,7 +27,13 @@ module.exports = {
       },
     ],
     './release/sync-package-versions.js',
-    '@semantic-release/npm',
+    [
+      '@semantic-release/npm',
+      {
+        // Defer registry publish until Docker Hub succeeds (see release.yml publish-npm).
+        npmPublish: false,
+      },
+    ],
     [
       '@semantic-release/git',
       {


### PR DESCRIPTION
## Summary
- Fix Mission Control Docker CI: optional OTLP protobuf loading now uses `createRequire` instead of an `eslint-disable` for a rule that is missing during `next build` in the image.
- Add a `docker-build` stage to `control/.har` and run it on `verify --full` so Dockerfile / production build regressions fail locally before release.
- Reorder the Release workflow: cut the version and GitHub release first (`npmPublish: false`), push `theosfactory/har-control` to Docker Hub, then publish `@osfactory/har` to npm only after Docker succeeds.

## Test plan
- [x] `control` fast verify (typecheck, unit tests, api-health)
- [x] `./.har/stages/docker-build.sh` / full-verify `docker-build` step passes
- [x] Local `next build` and Docker builder image build succeed after the otel-ingest change
- [ ] Confirm Release workflow dry-run still analyzes the next version
- [ ] After merge: next release pushes Docker Hub tags before npm publish


Made with [Cursor](https://cursor.com)