### PR TITLE
fix: har env init --no-agents no longer crashes

### DIFF
--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -69,22 +69,17 @@ export const envCommand = {
             })
             .option('cursor-rule', {
               type: 'boolean',
-              default: false,
-              describe: 'Create .cursor/rules/har-workflow.mdc without prompting',
-            })
-            .option('no-cursor-rule', {
-              type: 'boolean',
-              default: false,
-              describe: 'Skip Cursor rule scaffolding',
+              // No default: unset → prompt/auto-detect; --cursor-rule → true; --no-cursor-rule → false
+              // (do not declare a separate --no-cursor-rule option — yargs negation owns that.)
+              describe:
+                'Create .cursor/rules/har-workflow.mdc without prompting (use --no-cursor-rule to skip)',
             })
             .option('agents', {
               type: 'string',
-              describe: 'Scaffold agent skills for these targets (comma-separated: claude,cursor,codex); auto-detected when omitted',
-            })
-            .option('no-agents', {
-              type: 'boolean',
-              default: false,
-              describe: 'Skip agent skills scaffolding',
+              // --no-agents is yargs negation of this string option (sets agents=false). Do not
+              // declare a separate --no-agents boolean — it collides and crashes parseAgentTargets.
+              describe:
+                'Scaffold agent skills for these targets (comma-separated: claude,cursor,codex); auto-detected when omitted; --no-agents to skip',
             }),
         handleInit,
       )
@@ -113,22 +108,14 @@ export const envCommand = {
             })
             .option('cursor-rule', {
               type: 'boolean',
-              default: false,
-              describe: 'Create .cursor/rules/har-workflow.mdc without prompting',
-            })
-            .option('no-cursor-rule', {
-              type: 'boolean',
-              default: false,
-              describe: 'Skip Cursor rule scaffolding',
+              // No default: unset → prompt/auto-detect; --cursor-rule → true; --no-cursor-rule → false
+              describe:
+                'Create .cursor/rules/har-workflow.mdc without prompting (use --no-cursor-rule to skip)',
             })
             .option('agents', {
               type: 'string',
-              describe: 'Scaffold agent skills for these targets (comma-separated: claude,cursor,codex); auto-detected when omitted',
-            })
-            .option('no-agents', {
-              type: 'boolean',
-              default: false,
-              describe: 'Skip agent skills scaffolding',
+              describe:
+                'Scaffold agent skills for these targets (comma-separated: claude,cursor,codex); auto-detected when omitted; --no-agents to skip',
             }),
         handleMaintain,
       )
@@ -340,10 +327,10 @@ export async function handleInit(argv: {
   auto: boolean;
   yes: boolean;
   profile: 'default' | 'cli' | 'ios';
-  cursorRule: boolean;
-  noCursorRule: boolean;
-  agents?: string;
-  noAgents: boolean;
+  /** Tri-state from yargs: unset | --cursor-rule | --no-cursor-rule */
+  cursorRule?: boolean;
+  /** String from --agents=…, or `false` when --no-agents (yargs negation). */
+  agents?: string | false;
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
 
@@ -393,14 +380,13 @@ export async function handleInit(argv: {
     recordRepoForControlSync(repoPath);
     await handleCursorRule({
       repoPath,
-      cursorRule: resolveCursorRuleFlag(argv.cursorRule, argv.noCursorRule),
+      cursorRule: resolveCursorRuleFlag(argv.cursorRule),
       autoYes: argv.yes,
       mode: 'init',
     });
     await handleAgentSkills({
       repoPath,
-      agents: argv.agents,
-      enabled: argv.noAgents ? false : undefined,
+      ...resolveAgentsScaffoldOptions(argv.agents),
       autoYes: argv.yes,
       force: argv.force,
       mode: 'init',
@@ -420,10 +406,10 @@ export async function handleMaintain(argv: {
   yes: boolean;
   finalize: boolean;
   summary?: string;
-  cursorRule: boolean;
-  noCursorRule: boolean;
-  agents?: string;
-  noAgents: boolean;
+  /** Tri-state from yargs: unset | --cursor-rule | --no-cursor-rule */
+  cursorRule?: boolean;
+  /** String from --agents=…, or `false` when --no-agents (yargs negation). */
+  agents?: string | false;
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
 
@@ -486,14 +472,13 @@ export async function handleMaintain(argv: {
     }
     await handleCursorRule({
       repoPath,
-      cursorRule: resolveCursorRuleFlag(argv.cursorRule, argv.noCursorRule),
+      cursorRule: resolveCursorRuleFlag(argv.cursorRule),
       autoYes: argv.yes,
       mode: 'maintain',
     });
     await handleAgentSkills({
       repoPath,
-      agents: argv.agents,
-      enabled: argv.noAgents ? false : undefined,
+      ...resolveAgentsScaffoldOptions(argv.agents),
       autoYes: argv.yes,
       mode: 'maintain',
     });
@@ -503,10 +488,25 @@ export async function handleMaintain(argv: {
   }
 }
 
-function resolveCursorRuleFlag(cursorRule: boolean, noCursorRule: boolean): boolean | undefined {
-  if (noCursorRule) return false;
-  if (cursorRule) return true;
-  return undefined;
+/**
+ * Map yargs `--cursor-rule` / `--no-cursor-rule` onto the tri-state handleCursorRule expects.
+ * Do not declare a separate `--no-cursor-rule` option — yargs negation sets this to false.
+ */
+export function resolveCursorRuleFlag(cursorRule: boolean | undefined): boolean | undefined {
+  return cursorRule;
+}
+
+/**
+ * Map yargs `--agents` / `--no-agents` onto handleAgentSkills options.
+ * `--no-agents` is yargs negation of the string `--agents` option and yields `false`.
+ */
+export function resolveAgentsScaffoldOptions(agents: string | false | undefined): {
+  agents?: string;
+  enabled?: boolean;
+} {
+  if (agents === false) return { enabled: false };
+  if (typeof agents === 'string') return { agents };
+  return {};
 }
 
 function emitManualAdaptationPrompt(

--- a/src/harness/agent-skills.ts
+++ b/src/harness/agent-skills.ts
@@ -244,7 +244,7 @@ export async function handleAgentSkills(options: AgentSkillsScaffoldOptions): Pr
   if (options.enabled === false) return false;
 
   let targets: AgentSkillTarget[];
-  if (options.agents !== undefined) {
+  if (typeof options.agents === 'string') {
     targets = parseAgentTargets(options.agents);
   } else {
     targets = detectAgentTargets(repoPath);

--- a/tests/env-init-flags.test.ts
+++ b/tests/env-init-flags.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import {
+  resolveAgentsScaffoldOptions,
+  resolveCursorRuleFlag,
+} from '../src/cli/commands/env';
+
+function sh(cwd: string, command: string): string {
+  return execFileSync('bash', ['-lc', command], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function initFixtureRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-init-flags-'));
+  sh(dir, 'git init -q -b main');
+  sh(dir, 'git config user.email har@test.local');
+  sh(dir, 'git config user.name har');
+  fs.writeFileSync(path.join(dir, 'README.md'), '# fixture\n');
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'fixture', scripts: { typecheck: 'true', test: 'true' } }),
+  );
+  sh(dir, 'git add -A');
+  sh(dir, 'git commit -q -m init');
+  return dir;
+}
+
+function runInit(dir: string, extraArgs: string[]): { status: number | null; combined: string } {
+  const cli = path.resolve(__dirname, '..', 'dist', 'index.js');
+  const result = spawnSync(
+    process.execPath,
+    [cli, 'env', 'init', '--repo', dir, '--yes', '--profile', 'cli', ...extraArgs],
+    { encoding: 'utf8' },
+  );
+  return {
+    status: result.status,
+    combined: `${result.stdout ?? ''}\n${result.stderr ?? ''}`,
+  };
+}
+
+describe('env init / maintain flag resolution', () => {
+  it('maps --no-agents (yargs false) to enabled: false', () => {
+    expect(resolveAgentsScaffoldOptions(false)).toEqual({ enabled: false });
+    expect(resolveAgentsScaffoldOptions('claude,cursor')).toEqual({ agents: 'claude,cursor' });
+    expect(resolveAgentsScaffoldOptions(undefined)).toEqual({});
+  });
+
+  it('maps --no-cursor-rule (yargs false) to skip', () => {
+    expect(resolveCursorRuleFlag(false)).toBe(false);
+    expect(resolveCursorRuleFlag(true)).toBe(true);
+    expect(resolveCursorRuleFlag(undefined)).toBeUndefined();
+  });
+});
+
+describe('har env init --no-agents / --no-cursor-rule (CLI)', () => {
+  const cli = path.resolve(__dirname, '..', 'dist', 'index.js');
+  const hasBuild = fs.existsSync(cli);
+  const maybeIt = hasBuild ? it : it.skip;
+
+  maybeIt('exits 0 and skips skills + cursor rule when both --no-* flags are set', () => {
+    const dir = initFixtureRepo();
+    // Seed dirs so auto-detect would otherwise want to scaffold
+    fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+
+    const { status, combined } = runInit(dir, ['--no-agents', '--no-cursor-rule']);
+
+    expect(status).toBe(0);
+    expect(combined).toMatch(/Harness initialized/);
+    expect(combined).not.toMatch(/raw\.split is not a function/);
+    expect(fs.existsSync(path.join(dir, '.har', 'manifest.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, '.cursor', 'rules', 'har-workflow.mdc'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, '.claude', 'skills', 'setup-har', 'SKILL.md'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, '.cursor', 'commands', 'setup-har.md'))).toBe(false);
+  });
+
+  maybeIt('still writes the cursor rule when --yes without --no-cursor-rule', () => {
+    const dir = initFixtureRepo();
+    fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
+
+    const { status, combined } = runInit(dir, ['--no-agents']);
+
+    expect(status).toBe(0);
+    expect(combined).not.toMatch(/raw\.split is not a function/);
+    expect(fs.existsSync(path.join(dir, '.cursor', 'rules', 'har-workflow.mdc'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes `#55`: `har env init --yes --no-agents` crashed with `raw.split is not a function` because a separately declared `--no-agents` boolean collided with yargs auto-negation of the string `--agents` option (`agents` became `false`, then `parseAgentTargets` called `.split`).
- Same clash broke `--no-cursor-rule` with `--yes` (rule was still written). Drop the duplicate boolean options and rely on yargs negation; keep `--cursor-rule` without a default so unset stays tri-state.
- Adds CLI regression coverage in `tests/env-init-flags.test.ts`.

## Test plan
- [x] `har env verify 1 --full` on the session worktree
- [x] `jest tests/env-init-flags.test.ts`
- [x] Manual: `har env init --yes --no-agents --no-cursor-rule` on a fixture exits 0 and skips skills/rule
- [ ] Reviewer: spot-check `har env init --help` still documents `--no-agents` / `--no-cursor-rule` via the option describe strings


Made with [Cursor](https://cursor.com)