### PR TITLE
fix: unify agent slot limits on stages.json and prefer MCP/CLI hints

### DIFF
--- a/.har/agent-cli.sh
+++ b/.har/agent-cli.sh
@@ -116,7 +116,7 @@ process.stdin.on('end', () => {
       echo "  API:       http://localhost:${API_PORT}"
     else
       echo "No active environment for agent ${AGENT_ID}"
-      echo "  Run: ./.har/launch.sh ${AGENT_ID}"
+      har_suggest_launch "$AGENT_ID"
     fi
     ;;
 

--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -5,13 +5,50 @@
 #   source "$SCRIPT_DIR/agent-slot.sh"
 #   validate_agent_id "$AGENT_ID"
 
+# Canonical slot limits live in stages.json (agentSlots); harness.env is legacy fallback.
+har_load_agent_slot_limits() {
+  local registry="${SCRIPT_DIR}/stages.json"
+  if [[ -f "$registry" ]]; then
+    local parsed
+    parsed="$(node -e '
+try {
+  const slots = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).agentSlots;
+  if (slots && Number.isInteger(slots.min) && Number.isInteger(slots.max)) {
+    process.stdout.write(String(slots.min) + " " + String(slots.max));
+  }
+} catch {}
+' "$registry" 2>/dev/null || true)"
+    if [[ -n "$parsed" ]]; then
+      HARNESS_AGENT_SLOT_MIN="${parsed%% *}"
+      HARNESS_AGENT_SLOT_MAX="${parsed#* }"
+      export HARNESS_AGENT_SLOT_MIN HARNESS_AGENT_SLOT_MAX
+      return 0
+    fi
+  fi
+}
+
+har_suggest_launch() {
+  local id="$1"
+  echo "  Launch: har env launch ${id}     # or har_launch_environment (MCP)" >&2
+  echo "  Fallback: ./.har/launch.sh ${id}  # when har CLI/MCP unavailable" >&2
+}
+
+har_suggest_status() {
+  local id="${1:-}"
+  echo "  Status: har env status           # or har_get_status (MCP)" >&2
+  if [[ -n "$id" ]]; then
+    echo "  Fallback: ./.har/agent-cli.sh ${id} status" >&2
+  fi
+}
+
 validate_agent_id() {
   local id="${1:-}"
+  har_load_agent_slot_limits
   local min="${HARNESS_AGENT_SLOT_MIN:-1}"
   local max="${HARNESS_AGENT_SLOT_MAX:-}"
 
   if [[ -z "$max" ]]; then
-    echo "Error: HARNESS_AGENT_SLOT_MAX is not set in harness.env" >&2
+    echo "Error: configure agentSlots in .har/stages.json or HARNESS_AGENT_SLOT_MAX in harness.env" >&2
     exit 1
   fi
 

--- a/.har/launch.sh
+++ b/.har/launch.sh
@@ -33,6 +33,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$AGENT_ID" ]]; then
+  har_load_agent_slot_limits
   echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--resume] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
@@ -74,7 +75,7 @@ if [ "$RESUME" = true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT
@@ -145,7 +146,7 @@ if [ "$RESUME" != true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -28,7 +28,8 @@ done
 validate_agent_id "$AGENT_ID"
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -91,7 +91,7 @@ Always use `./.har/agent-cli.sh <id> ...` — never hardcoded ports.
 
 Each agent slot gets isolated app ports. Defaults follow `BASE + (AGENT_ID × HARNESS_PORT_STEP)`; when a default is busy, `launch.sh` scans the slot lane and writes resolved ports to `.env.agent.<id>` and `.har/slots/agent-<id>.json`.
 
-Configure how many slots your machine can run in parallel in `stages.json` (`agentSlots`) and `harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`). Keep both in sync.
+Configure how many slots your machine can run in parallel in `.har/stages.json` (`agentSlots`). Bash scripts and the CLI read that first; `harness.env` keeps legacy `HARNESS_AGENT_SLOT_*` exports in sync via `har env maintain --finalize`.
 
 | Service | Agent 1 (default) | Agent 2 (default) | Agent 3 (default) |
 |---------|-------------------|-------------------|-------------------|

--- a/control/.har/agent-cli.sh
+++ b/control/.har/agent-cli.sh
@@ -119,7 +119,7 @@ process.stdin.on('end', () => {
       echo "  API:       http://localhost:${API_PORT}"
     else
       echo "No active environment for agent ${AGENT_ID}"
-      echo "  Run: ./.har/launch.sh ${AGENT_ID}"
+      har_suggest_launch "$AGENT_ID"
     fi
     ;;
 

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -5,13 +5,50 @@
 #   source "$SCRIPT_DIR/agent-slot.sh"
 #   validate_agent_id "$AGENT_ID"
 
+# Canonical slot limits live in stages.json (agentSlots); harness.env is legacy fallback.
+har_load_agent_slot_limits() {
+  local registry="${SCRIPT_DIR}/stages.json"
+  if [[ -f "$registry" ]]; then
+    local parsed
+    parsed="$(node -e '
+try {
+  const slots = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).agentSlots;
+  if (slots && Number.isInteger(slots.min) && Number.isInteger(slots.max)) {
+    process.stdout.write(String(slots.min) + " " + String(slots.max));
+  }
+} catch {}
+' "$registry" 2>/dev/null || true)"
+    if [[ -n "$parsed" ]]; then
+      HARNESS_AGENT_SLOT_MIN="${parsed%% *}"
+      HARNESS_AGENT_SLOT_MAX="${parsed#* }"
+      export HARNESS_AGENT_SLOT_MIN HARNESS_AGENT_SLOT_MAX
+      return 0
+    fi
+  fi
+}
+
+har_suggest_launch() {
+  local id="$1"
+  echo "  Launch: har env launch ${id}     # or har_launch_environment (MCP)" >&2
+  echo "  Fallback: ./.har/launch.sh ${id}  # when har CLI/MCP unavailable" >&2
+}
+
+har_suggest_status() {
+  local id="${1:-}"
+  echo "  Status: har env status           # or har_get_status (MCP)" >&2
+  if [[ -n "$id" ]]; then
+    echo "  Fallback: ./.har/agent-cli.sh ${id} status" >&2
+  fi
+}
+
 validate_agent_id() {
   local id="${1:-}"
+  har_load_agent_slot_limits
   local min="${HARNESS_AGENT_SLOT_MIN:-1}"
   local max="${HARNESS_AGENT_SLOT_MAX:-}"
 
   if [[ -z "$max" ]]; then
-    echo "Error: HARNESS_AGENT_SLOT_MAX is not set in harness.env" >&2
+    echo "Error: configure agentSlots in .har/stages.json or HARNESS_AGENT_SLOT_MAX in harness.env" >&2
     exit 1
   fi
 

--- a/control/.har/launch.sh
+++ b/control/.har/launch.sh
@@ -35,6 +35,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$AGENT_ID" ]]; then
+  har_load_agent_slot_limits
   echo "Usage: $0 <agent-id> [--no-worktree] [--claude] [--replace] [--force] [--resume] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
@@ -78,7 +79,7 @@ if [ "$RESUME" = true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT
@@ -197,7 +198,7 @@ if [ "$RESUME" != true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT

--- a/control/.har/stages/browser-e2e.sh
+++ b/control/.har/stages/browser-e2e.sh
@@ -21,7 +21,8 @@ validate_agent_id "$AGENT_ID"
 log() { echo "==> [browser-e2e agent-$AGENT_ID] $*" >&2; }
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/control/.har/stages/docker-build.sh
+++ b/control/.har/stages/docker-build.sh
@@ -27,7 +27,8 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -25,7 +25,8 @@ validate_agent_id "$AGENT_ID"
 API_PORT=$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -13,7 +13,7 @@ Edit shared configuration in `.har/harness.env`. Launch expands resolved values 
 | `HARNESS_PROJECT_NAME` | Stable project identifier used for processes and infrastructure |
 | `HARNESS_USE_WORKTREE` | Whether launch uses isolated worktrees by default |
 | `HARNESS_PRIMARY_APP` | Primary per-slot application in the web profile |
-| `HARNESS_AGENT_SLOT_MIN` / `MAX` | Allowed slot id range |
+| `HARNESS_AGENT_SLOT_MIN` / `MAX` | Legacy fallback for slot id range — canonical limits are in `.har/stages.json` (`agentSlots`) |
 | `HAR_SESSION_PURPOSE` | Optional label stored with a launched session |
 
 ## Toolchain

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -924,12 +924,19 @@ function printDrift(drift: HarnessDriftResult): void {
     );
     warn('  See maintain/templates/harness.env in the maintenance bundle.');
   }
+  if (drift.agentSlotMismatch) {
+    warn(
+      `  Agent slot limits disagree: stages.json ${drift.agentSlotMismatch.stages.min}–${drift.agentSlotMismatch.stages.max}, harness.env ${drift.agentSlotMismatch.env.min}–${drift.agentSlotMismatch.env.max}`,
+    );
+    warn('  Canonical source is .har/stages.json — har env maintain --finalize syncs harness.env.');
+  }
   if (
     !drift.generatorVersion.outdated &&
     drift.checksumMismatch.length === 0 &&
     drift.missing.length === 0 &&
     drift.extra.length === 0 &&
-    drift.missingPortVars.length === 0
+    drift.missingPortVars.length === 0 &&
+    !drift.agentSlotMismatch
   ) {
     success('  Harness matches bundled templates');
   }

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -10,7 +10,7 @@ import {
   removeMaintainBundle,
 } from '../harness/maintain-bundle';
 import { readManifest, getHarnessDir } from '../harness/manifest';
-import { getVerificationStageIds, getAgentSlotRange, listStages } from '../harness/stages';
+import { getVerificationStageIds, getAgentSlotRange, listStages, syncAgentSlotsToHarnessEnv } from '../harness/stages';
 import {
   applyStageTemplate,
   ApplyStageTemplateOptions,
@@ -111,6 +111,7 @@ export async function initHarness(options: InitHarnessOptions): Promise<InitHarn
     force: options.force,
     profile: options.profile,
   });
+  syncAgentSlotsToHarnessEnv(repoPath);
   let adaptationSummary: string | undefined;
 
   if (options.auto) {
@@ -172,6 +173,7 @@ export async function maintainHarness(options: MaintainHarnessOptions): Promise<
     if (!validation.pass) {
       throw new Error('Cannot finalize: harness validation has errors. Fix them first.');
     }
+    syncAgentSlotsToHarnessEnv(repoPath);
     const existing = readManifest(repoPath);
     finalizeHarness(
       repoPath,

--- a/src/harness/drift.ts
+++ b/src/harness/drift.ts
@@ -13,6 +13,7 @@ import {
   getHarnessDir,
   readManifest,
 } from './manifest';
+import { detectAgentSlotEnvMismatch } from './stages';
 import { resolveTemplatesDir } from '../utils/paths';
 
 const PROFILE_DIRS: Record<HarnessProfile, string> = {
@@ -39,6 +40,11 @@ export interface HarnessDriftResult {
   unchanged: string[];
   /** Port-allocation knobs from harness.env that the bundled template expects. */
   missingPortVars: string[];
+  /** stages.json agentSlots disagree with HARNESS_AGENT_SLOT_* in harness.env. */
+  agentSlotMismatch: {
+    stages: { min: number; max: number };
+    env: { min: number; max: number };
+  } | null;
 }
 
 const APP_PORT_VARS = [
@@ -178,6 +184,7 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
   const installed = manifest?.generatorVersion;
   const harnessEnv = readHarnessEnv(resolved);
   const missingPortVars = missingPortDocumentationVars(profile, harnessEnv);
+  const agentSlotMismatch = detectAgentSlotEnvMismatch(resolved);
 
   return {
     generatorVersion: {
@@ -190,5 +197,6 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
     extra,
     unchanged,
     missingPortVars,
+    agentSlotMismatch,
   };
 }

--- a/src/harness/generator.ts
+++ b/src/harness/generator.ts
@@ -6,6 +6,7 @@ import { resolveTemplatesDir, resolveTemplateFile } from '../utils/paths';
 import { ensureRootGitignorePatterns } from '../core/gitignore';
 import { writeHarnessGitignore } from './gitignore-template';
 import { createManifest, writeManifest, DEFAULT_HAR_DIR, readManifest } from './manifest';
+import { syncAgentSlotsToHarnessEnv } from './stages';
 
 export type HarnessProfile = 'default' | 'cli' | 'ios';
 
@@ -86,6 +87,8 @@ export function scaffoldHarnessBoilerplate(
   if (profile === 'cli') {
     pruneCliProfile(harnessDir);
   }
+
+  syncAgentSlotsToHarnessEnv(repoPath);
 
   const harnessEnvPath = path.join(harnessDir, 'harness.env');
   if (fs.existsSync(harnessEnvPath)) {

--- a/src/harness/maintain-bundle.ts
+++ b/src/harness/maintain-bundle.ts
@@ -41,6 +41,7 @@ export interface MaintainBundleReport {
   actions: MaintainAction[];
   stale: MaintainStaleFile[];
   missingPortVars: string[];
+  agentSlotMismatch: HarnessDriftResult['agentSlotMismatch'];
   validation: {
     pass: boolean;
     errors: ValidationIssue[];
@@ -216,6 +217,19 @@ function buildReadme(report: MaintainBundleReport): string {
     }
   }
 
+  if (report.agentSlotMismatch) {
+    lines.push(
+      '',
+      '## Agent slot limit mismatch',
+      '',
+      `- \`stages.json\` agentSlots: ${report.agentSlotMismatch.stages.min}–${report.agentSlotMismatch.stages.max}`,
+      `- \`harness.env\` HARNESS_AGENT_SLOT_*: ${report.agentSlotMismatch.env.min}–${report.agentSlotMismatch.env.max}`,
+      '',
+      'Canonical source is `.har/stages.json`. Run `har env maintain` to sync legacy exports in `harness.env`, or edit `agentSlots` there.',
+      '',
+    );
+  }
+
   lines.push('', '## Stale files (review)', '');
 
   if (report.stale.length === 0) {
@@ -324,6 +338,7 @@ export function buildMaintainBundle(
     actions: buildActions(repoPath, profile, drift),
     stale: buildStale(drift),
     missingPortVars: drift.missingPortVars,
+    agentSlotMismatch: drift.agentSlotMismatch,
     validation: {
       pass: validation.pass,
       errors,
@@ -388,10 +403,23 @@ export function formatMaintainBundlePromptSection(report: MaintainBundleReport):
     lines.push('');
   }
 
+  if (report.agentSlotMismatch) {
+    lines.push(
+      '### Agent slot limit mismatch',
+      '',
+      `- \`stages.json\` agentSlots: ${report.agentSlotMismatch.stages.min}–${report.agentSlotMismatch.stages.max}`,
+      `- \`harness.env\` HARNESS_AGENT_SLOT_*: ${report.agentSlotMismatch.env.min}–${report.agentSlotMismatch.env.max}`,
+      '',
+      'Canonical source is `.har/stages.json`. `har env maintain --finalize` syncs legacy exports in `harness.env`.',
+      '',
+    );
+  }
+
   if (
     report.actions.length === 0 &&
     report.stale.length === 0 &&
     report.missingPortVars.length === 0 &&
+    !report.agentSlotMismatch &&
     report.validation.errors.length === 0
   ) {
     lines.push('No template drift detected. Review repo stack changes manually if needed.', '');

--- a/src/harness/stages.ts
+++ b/src/harness/stages.ts
@@ -185,6 +185,63 @@ export function getAgentSlotIds(repoPath: string): number[] {
   return ids;
 }
 
+/** When both stages.json and harness.env define limits, returns a mismatch or null. */
+export function detectAgentSlotEnvMismatch(
+  repoPath: string,
+): { stages: { min: number; max: number }; env: { min: number; max: number } } | null {
+  const registryPath = getStageRegistryPath(repoPath);
+  if (!fs.existsSync(registryPath)) return null;
+
+  let stagesSlots: { min: number; max: number } | null = null;
+  try {
+    const raw = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+    if (
+      raw.agentSlots &&
+      Number.isInteger(raw.agentSlots.min) &&
+      Number.isInteger(raw.agentSlots.max)
+    ) {
+      stagesSlots = { min: raw.agentSlots.min, max: raw.agentSlots.max };
+    }
+  } catch {
+    return null;
+  }
+  if (!stagesSlots) return null;
+
+  const env = readHarnessEnv(repoPath);
+  const envMax = parseHarnessEnvInt(env, 'HARNESS_AGENT_SLOT_MAX');
+  if (envMax === undefined) return null;
+  const envMin = parseHarnessEnvInt(env, 'HARNESS_AGENT_SLOT_MIN') ?? HAR_AGENT_SLOT_MIN;
+  if (envMin === stagesSlots.min && envMax === stagesSlots.max) return null;
+  return { stages: stagesSlots, env: { min: envMin, max: envMax } };
+}
+
+/** Sync legacy HARNESS_AGENT_SLOT_* exports in harness.env from stages.json agentSlots. */
+export function syncAgentSlotsToHarnessEnv(repoPath: string): boolean {
+  const mismatch = detectAgentSlotEnvMismatch(repoPath);
+  if (!mismatch) return false;
+
+  const envPath = path.join(getHarnessDir(repoPath), 'harness.env');
+  if (!fs.existsSync(envPath)) return false;
+
+  let content = fs.readFileSync(envPath, 'utf8');
+  const minLine = `export HARNESS_AGENT_SLOT_MIN=${mismatch.stages.min}`;
+  const maxLine = `export HARNESS_AGENT_SLOT_MAX=${mismatch.stages.max}`;
+
+  if (/^export HARNESS_AGENT_SLOT_MIN=/m.test(content)) {
+    content = content.replace(/^export HARNESS_AGENT_SLOT_MIN=.*$/m, minLine);
+  } else {
+    content = `${content.replace(/\s*$/, '')}\n${minLine}\n`;
+  }
+  if (/^export HARNESS_AGENT_SLOT_MAX=/m.test(content)) {
+    content = content.replace(/^export HARNESS_AGENT_SLOT_MAX=.*$/m, maxLine);
+  } else {
+    content = `${content.replace(/\s*$/, '')}\n${maxLine}\n`;
+  }
+
+  fs.writeFileSync(envPath, content);
+  return true;
+}
+
 export function stageRequiresAgentId(stage: HarnessStage): boolean {
   if (typeof stage.requiresAgentId === 'boolean') return stage.requiresAgentId;
   return AGENT_REQUIRED_KINDS.has(stage.kind);

--- a/src/llm/prompts/system-authoring.md
+++ b/src/llm/prompts/system-authoring.md
@@ -127,7 +127,7 @@ Document ports in `.har/README.md` and configure them in `.har/harness.env`. Res
 
 CLI and iOS profiles typically have no per-slot app ports; optional backends still use the shared-infra model.
 
-Set slot limits in `.har/stages.json` (`agentSlots`) and `.har/harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`) based on machine capacity.
+Set slot limits in `.har/stages.json` (`agentSlots`) based on machine capacity. `har env maintain --finalize` syncs legacy `HARNESS_AGENT_SLOT_*` exports in `harness.env`.
 
 ### Do not
 

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -153,7 +153,7 @@ Document and configure ports in `.har/harness.env` and `.har/README.md`. Use the
 | Mailpit | `HARNESS_MAILPIT_*_PORT_DEFAULT` | Scan configured ranges |
 | Headless browser | `HARNESS_BROWSER_PORT_DEFAULT` | Scan configured ranges |
 
-Set slot limits in `.har/stages.json` (`agentSlots`) and `.har/harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`) based on machine capacity.
+Set slot limits in `.har/stages.json` (`agentSlots`) based on machine capacity. `har env maintain --finalize` syncs legacy `HARNESS_AGENT_SLOT_*` exports in `harness.env`.
 
 **Port / infra checklist:**
 

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -15,8 +15,8 @@ work around it with ad-hoc commands.
 
 ## Before making changes
 
-1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP), `har env launch 1`, or `./.har/launch.sh 1`. Launch always creates a **fresh session worktree** from the current HEAD and returns its **work dir**.
-2. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `./.har/agent-cli.sh <id> restart` if a change doesn't take.
+1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP) or `har env launch 1`. Launch always creates a **fresh session worktree** from the current HEAD and returns its **work dir**.
+2. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `har env restart <id>` or `./.har/agent-cli.sh <id> restart` if a change doesn't take.
 3. Read [AGENT.md](./AGENT.md) at the repo root
 4. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)
 5. After launch, read [.har/CLAUDE.agent.md](./.har/CLAUDE.agent.md) for slot URLs and definition of done
@@ -26,7 +26,7 @@ Relaunching a slot **replaces** its previous session (the old branch is kept). R
 ### Slot safety (read before launch)
 
 - **One slot ≈ one task** — do not share slot 1 across unrelated chats; use slot 2+ for parallel work.
-- **Call `har_get_status` / `./.har/agent-cli.sh <id> status`** before launch when a slot may be occupied.
+- **Call `har_get_status` / `har env status`** before launch when a slot may be occupied.
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.

--- a/src/templates/har-boilerplate-cli/agent-cli.sh
+++ b/src/templates/har-boilerplate-cli/agent-cli.sh
@@ -25,7 +25,7 @@ resolve_work_dir() {
   local env_file
   env_file="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
     echo "No active environment for agent ${AGENT_ID}" >&2
-    echo "  Run: ./.har/launch.sh ${AGENT_ID}" >&2
+    har_suggest_launch "$AGENT_ID"
     exit 1
   }
   # shellcheck source=/dev/null
@@ -54,7 +54,7 @@ case "$COMMAND" in
       [ -n "$WT" ] && echo "  Git:       $(slot_dirty_summary "$WT")"
     else
       echo "No active environment for agent ${AGENT_ID}"
-      echo "  Run: ./.har/launch.sh ${AGENT_ID}"
+      har_suggest_launch "$AGENT_ID"
     fi
     ;;
 

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -5,13 +5,50 @@
 #   source "$SCRIPT_DIR/agent-slot.sh"
 #   validate_agent_id "$AGENT_ID"
 
+# Canonical slot limits live in stages.json (agentSlots); harness.env is legacy fallback.
+har_load_agent_slot_limits() {
+  local registry="${SCRIPT_DIR}/stages.json"
+  if [[ -f "$registry" ]]; then
+    local parsed
+    parsed="$(node -e '
+try {
+  const slots = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).agentSlots;
+  if (slots && Number.isInteger(slots.min) && Number.isInteger(slots.max)) {
+    process.stdout.write(String(slots.min) + " " + String(slots.max));
+  }
+} catch {}
+' "$registry" 2>/dev/null || true)"
+    if [[ -n "$parsed" ]]; then
+      HARNESS_AGENT_SLOT_MIN="${parsed%% *}"
+      HARNESS_AGENT_SLOT_MAX="${parsed#* }"
+      export HARNESS_AGENT_SLOT_MIN HARNESS_AGENT_SLOT_MAX
+      return 0
+    fi
+  fi
+}
+
+har_suggest_launch() {
+  local id="$1"
+  echo "  Launch: har env launch ${id}     # or har_launch_environment (MCP)" >&2
+  echo "  Fallback: ./.har/launch.sh ${id}  # when har CLI/MCP unavailable" >&2
+}
+
+har_suggest_status() {
+  local id="${1:-}"
+  echo "  Status: har env status           # or har_get_status (MCP)" >&2
+  if [[ -n "$id" ]]; then
+    echo "  Fallback: ./.har/agent-cli.sh ${id} status" >&2
+  fi
+}
+
 validate_agent_id() {
   local id="${1:-}"
+  har_load_agent_slot_limits
   local min="${HARNESS_AGENT_SLOT_MIN:-1}"
   local max="${HARNESS_AGENT_SLOT_MAX:-}"
 
   if [[ -z "$max" ]]; then
-    echo "Error: HARNESS_AGENT_SLOT_MAX is not set in harness.env" >&2
+    echo "Error: configure agentSlots in .har/stages.json or HARNESS_AGENT_SLOT_MAX in harness.env" >&2
     exit 1
   fi
 

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -33,6 +33,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$AGENT_ID" ]]; then
+  har_load_agent_slot_limits
   echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--resume] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
@@ -74,7 +75,7 @@ if [ "$RESUME" = true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT
@@ -145,7 +146,7 @@ if [ "$RESUME" != true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -28,7 +28,8 @@ done
 validate_agent_id "$AGENT_ID"
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/src/templates/har-boilerplate-ios/agent-cli.sh
+++ b/src/templates/har-boilerplate-ios/agent-cli.sh
@@ -23,7 +23,7 @@ resolve_work_dir() {
   local env_file
   env_file="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
     echo "No active environment for agent ${AGENT_ID}" >&2
-    echo "  Run: ./.har/launch.sh ${AGENT_ID}" >&2
+    har_suggest_launch "$AGENT_ID"
     exit 1
   }
   # shellcheck source=/dev/null
@@ -46,7 +46,7 @@ case "$COMMAND" in
       echo "  Bundle ID: ${HARNESS_BUNDLE_ID:-not set}"
     else
       echo "No active environment for agent ${AGENT_ID}"
-      echo "  Run: ./.har/launch.sh ${AGENT_ID}"
+      har_suggest_launch "$AGENT_ID"
     fi
     ;;
 

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -5,13 +5,50 @@
 #   source "$SCRIPT_DIR/agent-slot.sh"
 #   validate_agent_id "$AGENT_ID"
 
+# Canonical slot limits live in stages.json (agentSlots); harness.env is legacy fallback.
+har_load_agent_slot_limits() {
+  local registry="${SCRIPT_DIR}/stages.json"
+  if [[ -f "$registry" ]]; then
+    local parsed
+    parsed="$(node -e '
+try {
+  const slots = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).agentSlots;
+  if (slots && Number.isInteger(slots.min) && Number.isInteger(slots.max)) {
+    process.stdout.write(String(slots.min) + " " + String(slots.max));
+  }
+} catch {}
+' "$registry" 2>/dev/null || true)"
+    if [[ -n "$parsed" ]]; then
+      HARNESS_AGENT_SLOT_MIN="${parsed%% *}"
+      HARNESS_AGENT_SLOT_MAX="${parsed#* }"
+      export HARNESS_AGENT_SLOT_MIN HARNESS_AGENT_SLOT_MAX
+      return 0
+    fi
+  fi
+}
+
+har_suggest_launch() {
+  local id="$1"
+  echo "  Launch: har env launch ${id}     # or har_launch_environment (MCP)" >&2
+  echo "  Fallback: ./.har/launch.sh ${id}  # when har CLI/MCP unavailable" >&2
+}
+
+har_suggest_status() {
+  local id="${1:-}"
+  echo "  Status: har env status           # or har_get_status (MCP)" >&2
+  if [[ -n "$id" ]]; then
+    echo "  Fallback: ./.har/agent-cli.sh ${id} status" >&2
+  fi
+}
+
 validate_agent_id() {
   local id="${1:-}"
+  har_load_agent_slot_limits
   local min="${HARNESS_AGENT_SLOT_MIN:-1}"
   local max="${HARNESS_AGENT_SLOT_MAX:-}"
 
   if [[ -z "$max" ]]; then
-    echo "Error: HARNESS_AGENT_SLOT_MAX is not set in harness.env" >&2
+    echo "Error: configure agentSlots in .har/stages.json or HARNESS_AGENT_SLOT_MAX in harness.env" >&2
     exit 1
   fi
 

--- a/src/templates/har-boilerplate-ios/launch.sh
+++ b/src/templates/har-boilerplate-ios/launch.sh
@@ -31,6 +31,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$AGENT_ID" ]]; then
+  har_load_agent_slot_limits
   echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -28,7 +28,8 @@ done
 validate_agent_id "$AGENT_ID"
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/src/templates/har-boilerplate/README.md
+++ b/src/templates/har-boilerplate/README.md
@@ -115,7 +115,7 @@ Always use `./.har/agent-cli.sh <id> ...` — never hardcoded ports.
 
 Each agent slot gets isolated app ports. Defaults follow `BASE + (AGENT_ID × HARNESS_PORT_STEP)`; when a default is busy, `launch.sh` scans the slot lane (`STEP` increments) and writes the resolved ports to `.env.agent.<id>` and `.har/slots/agent-<id>.json`.
 
-Configure how many slots your machine can run in parallel in `stages.json` (`agentSlots`) and `harness.env` (`HARNESS_AGENT_SLOT_MIN` / `HARNESS_AGENT_SLOT_MAX`). Keep both in sync.
+Configure how many slots your machine can run in parallel in `.har/stages.json` (`agentSlots`). Bash scripts and the CLI read that first; `harness.env` keeps legacy `HARNESS_AGENT_SLOT_*` exports in sync via `har env maintain --finalize`.
 
 | Service | Agent 1 (default) | Agent 2 (default) |
 |---------|-------------------|-------------------|

--- a/src/templates/har-boilerplate/agent-cli.sh
+++ b/src/templates/har-boilerplate/agent-cli.sh
@@ -116,7 +116,7 @@ process.stdin.on('end', () => {
       echo "  API:       http://localhost:${API_PORT}"
     else
       echo "No active environment for agent ${AGENT_ID}"
-      echo "  Run: ./.har/launch.sh ${AGENT_ID}"
+      har_suggest_launch "$AGENT_ID"
     fi
     ;;
 

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -5,13 +5,50 @@
 #   source "$SCRIPT_DIR/agent-slot.sh"
 #   validate_agent_id "$AGENT_ID"
 
+# Canonical slot limits live in stages.json (agentSlots); harness.env is legacy fallback.
+har_load_agent_slot_limits() {
+  local registry="${SCRIPT_DIR}/stages.json"
+  if [[ -f "$registry" ]]; then
+    local parsed
+    parsed="$(node -e '
+try {
+  const slots = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).agentSlots;
+  if (slots && Number.isInteger(slots.min) && Number.isInteger(slots.max)) {
+    process.stdout.write(String(slots.min) + " " + String(slots.max));
+  }
+} catch {}
+' "$registry" 2>/dev/null || true)"
+    if [[ -n "$parsed" ]]; then
+      HARNESS_AGENT_SLOT_MIN="${parsed%% *}"
+      HARNESS_AGENT_SLOT_MAX="${parsed#* }"
+      export HARNESS_AGENT_SLOT_MIN HARNESS_AGENT_SLOT_MAX
+      return 0
+    fi
+  fi
+}
+
+har_suggest_launch() {
+  local id="$1"
+  echo "  Launch: har env launch ${id}     # or har_launch_environment (MCP)" >&2
+  echo "  Fallback: ./.har/launch.sh ${id}  # when har CLI/MCP unavailable" >&2
+}
+
+har_suggest_status() {
+  local id="${1:-}"
+  echo "  Status: har env status           # or har_get_status (MCP)" >&2
+  if [[ -n "$id" ]]; then
+    echo "  Fallback: ./.har/agent-cli.sh ${id} status" >&2
+  fi
+}
+
 validate_agent_id() {
   local id="${1:-}"
+  har_load_agent_slot_limits
   local min="${HARNESS_AGENT_SLOT_MIN:-1}"
   local max="${HARNESS_AGENT_SLOT_MAX:-}"
 
   if [[ -z "$max" ]]; then
-    echo "Error: HARNESS_AGENT_SLOT_MAX is not set in harness.env" >&2
+    echo "Error: configure agentSlots in .har/stages.json or HARNESS_AGENT_SLOT_MAX in harness.env" >&2
     exit 1
   fi
 

--- a/src/templates/har-boilerplate/harness.env
+++ b/src/templates/har-boilerplate/harness.env
@@ -42,7 +42,8 @@ export HARNESS_MAILPIT_SMTP_PORT_DEFAULT=11025
 export HARNESS_MAILPIT_SMTP_PORT_SCAN_START=11025
 export HARNESS_MAILPIT_SMTP_PORT_SCAN_END=11099
 
-# Agent slot limits — set based on what your machine can run in parallel
+# Agent slot limits — canonical source: .har/stages.json (agentSlots).
+# Legacy fallback below; har env maintain --finalize syncs these from stages.json.
 export HARNESS_AGENT_SLOT_MIN=1
 export HARNESS_AGENT_SLOT_MAX=5
 

--- a/src/templates/har-boilerplate/launch.sh
+++ b/src/templates/har-boilerplate/launch.sh
@@ -35,6 +35,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$AGENT_ID" ]]; then
+  har_load_agent_slot_limits
   echo "Usage: $0 <agent-id> [--no-worktree] [--claude] [--replace] [--force] [--resume] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
@@ -78,7 +79,7 @@ if [ "$RESUME" = true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT
@@ -186,7 +187,7 @@ if [ "$RESUME" != true ]; then
         write_slot_registry
       log "  Work dir:  ${WORK_DIR}"
       log "  Env file:  ${ENV_FILE}"
-      log "  Recovery:  ./.har/launch.sh ${AGENT_ID} --resume"
+      log "  Recovery:  har env launch ${AGENT_ID} --resume  # or ./.har/launch.sh ${AGENT_ID} --resume"
     fi
   }
   trap mark_slot_failed EXIT

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -30,7 +30,8 @@ validate_agent_id "$AGENT_ID"
 API_PORT=$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/src/templates/stage-templates/custom-stage-skeleton.sh
+++ b/src/templates/stage-templates/custom-stage-skeleton.sh
@@ -25,7 +25,8 @@ AGENT_ID="${1:?Usage: __STAGE_ID__.sh <agent-id> [extra args...]}"
 validate_agent_id "$AGENT_ID"
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 set -a

--- a/src/templates/stage-templates/playwright/.har/stages/browser-e2e.sh
+++ b/src/templates/stage-templates/playwright/.har/stages/browser-e2e.sh
@@ -21,7 +21,8 @@ validate_agent_id "$AGENT_ID"
 log() { echo "==> [browser-e2e agent-$AGENT_ID] $*" >&2; }
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/src/templates/stage-templates/rocketsim/.har/stages/rocketsim-flows.sh
+++ b/src/templates/stage-templates/rocketsim/.har/stages/rocketsim-flows.sh
@@ -42,7 +42,8 @@ fi
 
 # ── Resolve agent env ─────────────────────────────────────────────────────────
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found. Run: ./.har/launch.sh ${AGENT_ID}" >&2
+  echo "No .env.agent.${AGENT_ID} found." >&2
+  har_suggest_launch "$AGENT_ID" >&2
   exit 1
 }
 

--- a/tests/agent-slots-bash.test.ts
+++ b/tests/agent-slots-bash.test.ts
@@ -1,0 +1,50 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const AGENT_SLOT = path.join(process.cwd(), 'src/templates/har-boilerplate/agent-slot.sh');
+
+describe('bash agent slot limits', () => {
+  it('reads agentSlots from stages.json before harness.env', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-bash-slots-'));
+    const harDir = path.join(dir, '.har');
+    fs.mkdirSync(harDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(harDir, 'stages.json'),
+      JSON.stringify({ version: '1', agentSlots: { min: 1, max: 10 }, stages: [] }),
+    );
+    fs.writeFileSync(
+      path.join(harDir, 'harness.env'),
+      ['export HARNESS_AGENT_SLOT_MIN=1', 'export HARNESS_AGENT_SLOT_MAX=3', ''].join('\n'),
+    );
+
+    const ok = execSync(
+      `bash -c 'SCRIPT_DIR="${harDir}"; source "${harDir}/harness.env"; source "${AGENT_SLOT}"; validate_agent_id 10'`,
+      { encoding: 'utf8' },
+    );
+    expect(ok).toBe('');
+
+    let failed = false;
+    try {
+      execSync(
+        `bash -c 'SCRIPT_DIR="${harDir}"; source "${harDir}/harness.env"; source "${AGENT_SLOT}"; validate_agent_id 11'`,
+        { encoding: 'utf8', stdio: 'pipe' },
+      );
+    } catch {
+      failed = true;
+    }
+    expect(failed).toBe(true);
+  });
+
+  it('har_suggest_launch prefers MCP/CLI over shell scripts', () => {
+    const out = execSync(
+      `bash -c 'SCRIPT_DIR="/tmp"; source "${AGENT_SLOT}"; har_suggest_launch 2' 2>&1`,
+      { encoding: 'utf8' },
+    );
+    expect(out).toContain('har env launch 2');
+    expect(out).toContain('har_launch_environment');
+    expect(out).toContain('./.har/launch.sh 2');
+    expect(out.indexOf('har env launch')).toBeLessThan(out.indexOf('./.har/launch.sh'));
+  });
+});

--- a/tests/agent-slots.test.ts
+++ b/tests/agent-slots.test.ts
@@ -1,8 +1,13 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { getAgentSlotRange } from '../src/harness/stages';
+import {
+  detectAgentSlotEnvMismatch,
+  getAgentSlotRange,
+  syncAgentSlotsToHarnessEnv,
+} from '../src/harness/stages';
 import { validateAgentId } from '../src/utils/validation';
+import { compareHarnessToTemplate } from '../src/harness/drift';
 
 describe('agent slot limits', () => {
   it('uses agentSlots from stages.json', () => {
@@ -30,5 +35,45 @@ describe('agent slot limits', () => {
     expect(getAgentSlotRange(repoPath)).toEqual({ min: 2, max: 8 });
     expect(validateAgentId(2, repoPath)).toBe(2);
     expect(() => validateAgentId(1, repoPath)).toThrow('agent-id must be a number between 2 and 8');
+  });
+
+  it('detects mismatch between stages.json and harness.env', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slots-mismatch-'));
+    fs.mkdirSync(path.join(repoPath, '.har'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoPath, '.har', 'stages.json'),
+      JSON.stringify({ version: '1', agentSlots: { min: 1, max: 10 }, stages: [] }),
+    );
+    fs.writeFileSync(
+      path.join(repoPath, '.har', 'harness.env'),
+      ['export HARNESS_AGENT_SLOT_MIN=1', 'export HARNESS_AGENT_SLOT_MAX=3', ''].join('\n'),
+    );
+
+    expect(detectAgentSlotEnvMismatch(repoPath)).toEqual({
+      stages: { min: 1, max: 10 },
+      env: { min: 1, max: 3 },
+    });
+    expect(compareHarnessToTemplate(repoPath).agentSlotMismatch).toEqual({
+      stages: { min: 1, max: 10 },
+      env: { min: 1, max: 3 },
+    });
+  });
+
+  it('syncs harness.env slot limits from stages.json', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slots-sync-'));
+    fs.mkdirSync(path.join(repoPath, '.har'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoPath, '.har', 'stages.json'),
+      JSON.stringify({ version: '1', agentSlots: { min: 1, max: 10 }, stages: [] }),
+    );
+    fs.writeFileSync(
+      path.join(repoPath, '.har', 'harness.env'),
+      ['export HARNESS_AGENT_SLOT_MIN=1', 'export HARNESS_AGENT_SLOT_MAX=3', ''].join('\n'),
+    );
+
+    expect(syncAgentSlotsToHarnessEnv(repoPath)).toBe(true);
+    expect(detectAgentSlotEnvMismatch(repoPath)).toBeNull();
+    const env = fs.readFileSync(path.join(repoPath, '.har', 'harness.env'), 'utf8');
+    expect(env).toContain('export HARNESS_AGENT_SLOT_MAX=10');
   });
 });

--- a/tests/fixtures/minimal-harness/.har/agent-slot.sh
+++ b/tests/fixtures/minimal-harness/.har/agent-slot.sh
@@ -1,13 +1,35 @@
 #!/usr/bin/env bash
-# Validates agent-id against HARNESS_AGENT_SLOT_MIN/MAX from harness.env.
+# Validates agent-id — stages.json agentSlots is canonical; harness.env is fallback.
+
+har_load_agent_slot_limits() {
+  local registry="${SCRIPT_DIR}/stages.json"
+  if [[ -f "$registry" ]]; then
+    local parsed
+    parsed="$(node -e '
+try {
+  const slots = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).agentSlots;
+  if (slots && Number.isInteger(slots.min) && Number.isInteger(slots.max)) {
+    process.stdout.write(String(slots.min) + " " + String(slots.max));
+  }
+} catch {}
+' "$registry" 2>/dev/null || true)"
+    if [[ -n "$parsed" ]]; then
+      HARNESS_AGENT_SLOT_MIN="${parsed%% *}"
+      HARNESS_AGENT_SLOT_MAX="${parsed#* }"
+      export HARNESS_AGENT_SLOT_MIN HARNESS_AGENT_SLOT_MAX
+      return 0
+    fi
+  fi
+}
 
 validate_agent_id() {
   local id="${1:-}"
+  har_load_agent_slot_limits
   local min="${HARNESS_AGENT_SLOT_MIN:-1}"
   local max="${HARNESS_AGENT_SLOT_MAX:-}"
 
   if [[ -z "$max" ]]; then
-    echo "Error: HARNESS_AGENT_SLOT_MAX is not set in harness.env" >&2
+    echo "Error: configure agentSlots in .har/stages.json or HARNESS_AGENT_SLOT_MAX in harness.env" >&2
     exit 1
   fi
 

--- a/tests/maintain-bundle.test.ts
+++ b/tests/maintain-bundle.test.ts
@@ -132,6 +132,7 @@ describe('adaptation prompts with maintain bundle', () => {
       ],
       stale: [{ file: 'legacy.sh', hint: 'Delete after merge.' }],
       missingPortVars: ['HARNESS_DB_PORT_DEFAULT'],
+      agentSlotMismatch: null,
       validation: {
         pass: false,
         errors: [{ file: 'provision-toolchain.sh', message: 'Required file missing', severity: 'error' }],


### PR DESCRIPTION
## Summary

- Bash harness scripts (`agent-slot.sh`, `launch.sh`, `verify.sh`, `agent-cli.sh`) now read `agentSlots` from `.har/stages.json` first, with `harness.env` as legacy fallback — fixing the bug where slots 4+ were rejected despite a higher `stages.json` max.
- Added `har_suggest_launch()` / `har_suggest_status()` helpers so empty-slot messages recommend `har env launch` / MCP before `./.har/launch.sh`.
- Drift detection warns when `stages.json` and `harness.env` disagree; `har env maintain --finalize` syncs legacy env exports from `stages.json`.
- Updated agent docs/templates (cursor rule, README, authoring prompts) to treat MCP/CLI as the primary interface.

## Test plan

- [x] `./.har/verify.sh 1 --full` (typecheck, build, unit tests, lint, docs-drift)
- [x] New unit tests: `tests/agent-slots.test.ts` (mismatch detection + sync)
- [x] New bash tests: `tests/agent-slots-bash.test.ts` (stages.json overrides harness.env; hint ordering)
- [ ] After merge: on a repo with `agentSlots.max=10` but `HARNESS_AGENT_SLOT_MAX=3`, confirm `./.har/agent-cli.sh 4 status` no longer errors on slot range


Made with [Cursor](https://cursor.com)