### PR TITLE
ci: speed up Docker publish with native multi-arch builds

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,27 +1,52 @@
-name: Publish Docker (manual)
+name: Publish Docker
 
-# Normal releases cut the version first, then publish Docker, then npm
-# (see .github/workflows/release.yml). Use this workflow only to republish
-# an existing tag to Docker Hub.
+# Builds and pushes theosfactory/har-control for linux/amd64 + linux/arm64.
+# Used by Release after a version cut, or manually to republish an existing tag.
+#
+# Speed notes:
+# - Platforms build in parallel on native runners (no QEMU arm64 emulation).
+# - Per-platform GitHub Actions cache (scope=har-control-<platform>).
+# - Skips the build when the exact version tag already exists on Docker Hub
+#   (re-runs / retries). Pass force=true to rebuild and retag anyway.
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Git tag to publish (e.g. v0.2.0)
+        required: true
+        type: string
+      force:
+        description: Rebuild even if the version tag already exists on Docker Hub
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       tag:
         description: Git tag to publish (e.g. v0.2.0)
         required: true
         type: string
+      force:
+        description: Rebuild even if the version tag already exists on Docker Hub
+        required: false
+        type: boolean
+        default: false
 
 env:
   DOCKERHUB_USERNAME: theosfactory
   IMAGE: theosfactory/har-control
 
 jobs:
-  publish:
+  prepare:
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:
       contents: read
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+      should_build: ${{ steps.exists.outputs.should_build }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,7 +81,57 @@ jobs:
             fi
           done
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Skip build if version already published
+        id: exists
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          FORCE="${{ inputs.force }}"
+          if [ "$FORCE" = "true" ]; then
+            echo "Force rebuild requested"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if docker buildx imagetools inspect "${{ env.IMAGE }}:${VERSION}" >/dev/null 2>&1; then
+            echo "Image ${{ env.IMAGE }}:${VERSION} already exists — skipping rebuild"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Image ${{ env.IMAGE }}:${VERSION} not found — will build"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    environment: npm-publish
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+
+      - name: Platform cache scope
+        run: |
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" >> "$GITHUB_ENV"
+        env:
+          PLATFORM: ${{ matrix.platform }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -70,18 +145,91 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.meta.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.meta.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ steps.meta.outputs.tag }}
+            type=semver,pattern={{version}},value=${{ needs.prepare.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ needs.prepare.outputs.tag }}
             type=raw,value=latest
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: control/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=har-control-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=har-control-${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: docker_meta
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.prepare.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.tag }}
+            type=semver,pattern={{major}},value=${{ needs.prepare.outputs.tag }}
+            type=raw,value=latest
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Create multi-arch manifest and push tags
+        working-directory: /tmp/digests
+        run: |
+          set -euo pipefail
+          mapfile -t DIGEST_FILES < <(printf '%s\n' *)
+          if [ "${#DIGEST_FILES[@]}" -eq 0 ]; then
+            echo "No digests downloaded" >&2
+            exit 1
+          fi
+
+          TAG_ARGS=()
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            TAG_ARGS+=(-t "$tag")
+          done <<< "${{ steps.docker_meta.outputs.tags }}"
+
+          DIGEST_REFS=()
+          for digest_file in "${DIGEST_FILES[@]}"; do
+            DIGEST_REFS+=("${{ env.IMAGE }}@sha256:${digest_file}")
+          done
+
+          docker buildx imagetools create \
+            "${TAG_ARGS[@]}" \
+            "${DIGEST_REFS[@]}"
+
+          echo "Published ${{ env.IMAGE }}:${{ needs.prepare.outputs.version }} (multi-arch)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  DOCKERHUB_USERNAME: theosfactory
-  CONTROL_IMAGE: theosfactory/har-control
-
 jobs:
   verify:
     if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]')
@@ -152,65 +148,15 @@ jobs:
             echo "No new release — skipped version cut and downstream publish jobs"
           fi
 
+  # Native amd64 + arm64 builds in parallel (see publish-docker.yml). Skips
+  # rebuild when the exact version tag already exists (e.g. re-run after npm failed).
   publish-docker:
     needs: release
     if: needs.release.outputs.released == 'true'
-    runs-on: ubuntu-latest
-    environment: npm-publish
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release.outputs.tag }}
-
-      - name: Validate tag matches package.json
-        run: |
-          ROOT_VERSION="$(node -p "require('./package.json').version")"
-          CONTROL_VERSION="$(node -p "require('./control/package.json').version")"
-          SCHEMAS_VERSION="$(node -p "require('./packages/schemas/package.json').version")"
-          EXPECTED="${{ needs.release.outputs.version }}"
-          for label_version in \
-            "package.json:${ROOT_VERSION}" \
-            "control/package.json:${CONTROL_VERSION}" \
-            "packages/schemas/package.json:${SCHEMAS_VERSION}"; do
-            FILE="${label_version%%:*}"
-            ACTUAL="${label_version#*:}"
-            if [ "$ACTUAL" != "$EXPECTED" ]; then
-              echo "$FILE version ($ACTUAL) does not match tag (${{ needs.release.outputs.tag }})" >&2
-              exit 1
-            fi
-          done
-
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - uses: docker/metadata-action@v5
-        id: docker_meta
-        with:
-          images: ${{ env.CONTROL_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ needs.release.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ needs.release.outputs.tag }}
-            type=raw,value=latest
-
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: control/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    uses: ./.github/workflows/publish-docker.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit
 
   # Publish to npm only after Docker Hub has the matching version (avoids CLI
   # pointing users at har control up for a tag that does not exist on Docker Hub).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -432,4 +432,6 @@ docker login
 ./release/publish-control-image.sh
 ```
 
-Releases also publish via the Release workflow automatically. To republish an existing tag manually, use [Publish Docker (manual)](.github/workflows/publish-docker.yml) or `./release/publish-control-image.sh`.
+Releases also publish via the Release workflow automatically. To republish an existing tag manually, use [Publish Docker](.github/workflows/publish-docker.yml) (workflow_dispatch; set **force** to rebuild if the version tag already exists) or `./release/publish-control-image.sh`.
+
+Docker publish builds `linux/amd64` and `linux/arm64` in parallel on native runners (not QEMU), with per-platform GitHub Actions cache. If the exact `theosfactory/har-control:X.Y.Z` tag already exists, the build is skipped unless **force** is set.

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -1,10 +1,17 @@
 FROM node:20-alpine AS deps
+ENV npm_config_audit=false \
+    npm_config_fund=false \
+    npm_config_update_notifier=false
 WORKDIR /app
-COPY packages/schemas ./packages/schemas
-RUN npm install --prefix packages/schemas --omit=dev
+# Copy package manifests only so source edits don't invalidate npm install layers.
+COPY packages/schemas/package.json packages/schemas/package-lock.json ./packages/schemas/
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci --prefix packages/schemas --omit=dev
 WORKDIR /app/control
-COPY control/package.json control/package-lock.json* ./
-RUN npm install
+COPY control/package.json control/package-lock.json ./
+# Schemas deps are installed above; skip control postinstall re-install.
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci --ignore-scripts
 
 FROM node:20-alpine AS builder
 WORKDIR /app
@@ -27,8 +34,10 @@ COPY --from=builder /app/control/public ./public
 COPY --from=builder /app/control/.next/standalone ./
 COPY --from=builder /app/control/.next/static ./.next/static
 COPY --from=builder /app/control/prisma ./prisma
-# Pin Prisma CLI (devDependency at build time; npx would fetch Prisma 7+).
-RUN npm install prisma@6.19.3 --omit=dev
+# Reuse Prisma CLI from the builder (avoids a registry fetch in the runner stage).
+COPY --from=builder /app/control/node_modules/prisma ./node_modules/prisma
+COPY --from=builder /app/control/node_modules/@prisma ./node_modules/@prisma
+COPY --from=builder /app/control/node_modules/.bin/prisma ./node_modules/.bin/prisma
 RUN mkdir -p /data
 VOLUME ["/data"]
 EXPOSE 3847


### PR DESCRIPTION
## Summary
- Replace QEMU-based multi-arch Docker builds with parallel native runners (`ubuntu-latest` + `ubuntu-24.04-arm`) and per-platform GHA cache scopes.
- Refactor `publish-docker.yml` into prepare/build/merge jobs, skip rebuild when `theosfactory/har-control:X.Y.Z` already exists (unless **force**), and wire Release to the reusable workflow.
- Optimize `control/Dockerfile` dependency layers (`npm ci`, BuildKit npm cache, skip redundant postinstall/prisma install).

## Context
Release run [#29839772451](https://github.com/os-factory/har/actions/runs/29839772451) was stuck for ~50+ minutes on `docker/build-push-action` because arm64 was built under QEMU emulation. Previous successful releases took ~22 minutes for the same job.

## Test plan
- [ ] Merge PR and monitor the next Release workflow `publish-docker` job timing
- [ ] Confirm both `linux/amd64` and `linux/arm64` digests are merged and tagged on Docker Hub
- [ ] Re-run Release after Docker succeeds but npm fails — verify prepare job skips rebuild when version tag exists
- [ ] Manual `Publish Docker` workflow_dispatch with **force=true** rebuilds when needed

Made with [Cursor](https://cursor.com)