### PR TITLE
fix(control): restore Prisma CLI boot in Docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
         working-directory: control
         run: ./.har/launch.sh 1 --no-worktree
 
+      # Full verify includes docker-build: image build + smoke-boot (prisma db push
+      # and /api/health). Build-only checks miss first-boot CLI/runtime regressions.
       - name: Verify Mission Control (full)
         working-directory: control
         env:

--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -66,7 +66,7 @@ Read **`stages.json`** for registered stages and **`verificationStages`** for th
 | Full | `har env verify <id> --full` or `verify.sh <id> --full` | + lint + optional readiness smoke + **`browser-e2e`** + **`docker-build`** (when those stage scripts exist) |
 
 Install Playwright stage: `har env add-stage playwright` (optional). UI changes should add or update specs under `tests/`.
-The `docker-build` stage builds `control/Dockerfile` against the session worktree (no push; native platform) so Dockerfile / `next build` regressions fail verification before release.
+The `docker-build` stage builds `control/Dockerfile` against the session worktree (no push; native platform), then smoke-boots the image and waits for `/api/health`. That catches first-boot failures (for example a broken Prisma CLI / missing wasm) that a build-only check would miss. PR CI runs this via `control` job `./.har/verify.sh 1 --full`.
 
 ## Run history
 

--- a/control/.har/stages.json
+++ b/control/.har/stages.json
@@ -97,13 +97,13 @@
     {
       "id": "docker-build",
       "kind": "test",
-      "description": "Build Mission Control Docker image (no push; native platform)",
+      "description": "Build Mission Control Docker image and smoke-boot it (prisma db push + /api/health; no push; native platform)",
       "script": "stages/docker-build.sh",
       "artifacts": [
         {
           "path": ".har/artifacts/docker-build",
           "kind": "directory",
-          "description": "Docker build logs"
+          "description": "Docker build logs and smoke-boot logs"
         }
       ],
       "requiresAgentId": true

--- a/control/.har/stages/docker-build.sh
+++ b/control/.har/stages/docker-build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Build the Mission Control Docker image (no push) for the agent worktree.
-# Catches Dockerfile / next build regressions before release publish.
+# Build the Mission Control Docker image (no push) and smoke-boot it.
+# Catches Dockerfile / next build / first-boot (prisma db push) regressions
+# before release publish.
 # Outputs JSON to stdout, human-readable progress to stderr.
 #
 # Usage: ./.har/stages/docker-build.sh <agent-id>
@@ -42,6 +43,9 @@ WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
 MONOREPO_ROOT="$(cd "$WORK_DIR/.." && pwd)"
 DOCKERFILE="$MONOREPO_ROOT/control/Dockerfile"
 IMAGE_TAG="har-control:verify-agent-${AGENT_ID}"
+CONTAINER_NAME="har-control-verify-agent-${AGENT_ID}"
+# High port unique per agent — avoid colliding with har control up (3847) / slots.
+SMOKE_PORT=$(( 18000 + AGENT_ID ))
 ARTIFACT_DIR="$REPO_ROOT/.har/artifacts/docker-build"
 mkdir -p "$ARTIFACT_DIR"
 
@@ -49,6 +53,11 @@ if [ ! -f "$DOCKERFILE" ]; then
   echo "Missing Dockerfile at $DOCKERFILE" >&2
   exit 1
 fi
+
+cleanup_smoke() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup_smoke EXIT
 
 log "Building $IMAGE_TAG from $MONOREPO_ROOT (file: control/Dockerfile)"
 log "Native platform only — release CI still builds linux/amd64 + linux/arm64"
@@ -64,20 +73,130 @@ BUILD_OUTPUT=$(docker build \
 BUILD_EXIT=$?
 set -e
 
-END_TOTAL=$(now_ms)
-TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
-
 echo "$BUILD_OUTPUT" >&2
 printf '%s\n' "$BUILD_OUTPUT" >"$ARTIFACT_DIR/build-agent-${AGENT_ID}.log"
 
-node -e "
+if [ "$BUILD_EXIT" -ne 0 ]; then
+  END_TOTAL=$(now_ms)
+  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+  node -e "
 const out = {
-  status: ${BUILD_EXIT} === 0 ? 'pass' : 'fail',
+  status: 'fail',
   stageId: 'docker-build',
   kind: 'test',
   agent_id: ${AGENT_ID},
   total_ms: ${TOTAL_MS},
   image: '${IMAGE_TAG}',
+  smoke: 'skipped',
+  artifacts: [
+    { path: '.har/artifacts/docker-build', kind: 'directory' },
+  ],
+};
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+"
+  exit "$BUILD_EXIT"
+fi
+
+log "Smoke-booting $IMAGE_TAG as $CONTAINER_NAME on localhost:${SMOKE_PORT}"
+cleanup_smoke
+
+set +e
+SMOKE_RUN_OUTPUT=$(docker run -d \
+  --name "$CONTAINER_NAME" \
+  -p "${SMOKE_PORT}:3847" \
+  -e DATABASE_URL="file:/data/har_control.db" \
+  "$IMAGE_TAG" 2>&1)
+SMOKE_RUN_EXIT=$?
+set -e
+
+printf '%s\n' "$SMOKE_RUN_OUTPUT" >"$ARTIFACT_DIR/smoke-run-agent-${AGENT_ID}.log"
+if [ "$SMOKE_RUN_EXIT" -ne 0 ]; then
+  echo "$SMOKE_RUN_OUTPUT" >&2
+  echo "Failed to start smoke container" >&2
+  END_TOTAL=$(now_ms)
+  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+  node -e "
+const out = {
+  status: 'fail',
+  stageId: 'docker-build',
+  kind: 'test',
+  agent_id: ${AGENT_ID},
+  total_ms: ${TOTAL_MS},
+  image: '${IMAGE_TAG}',
+  smoke: 'start-failed',
+  artifacts: [
+    { path: '.har/artifacts/docker-build', kind: 'directory' },
+  ],
+};
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+"
+  exit 1
+fi
+
+HEALTH_URL="http://127.0.0.1:${SMOKE_PORT}/api/health"
+SMOKE_OK=0
+SMOKE_LOG=""
+for i in $(seq 1 60); do
+  if curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
+    SMOKE_OK=1
+    log "Smoke health check passed (${HEALTH_URL})"
+    break
+  fi
+  if ! docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null | grep -qx true; then
+    SMOKE_LOG="$(docker logs "$CONTAINER_NAME" 2>&1 || true)"
+    echo "$SMOKE_LOG" >&2
+    printf '%s\n' "$SMOKE_LOG" >"$ARTIFACT_DIR/smoke-logs-agent-${AGENT_ID}.log"
+    echo "Smoke container exited before becoming healthy" >&2
+    break
+  fi
+  sleep 2
+done
+
+if [ "$SMOKE_OK" -ne 1 ]; then
+  if [ -z "$SMOKE_LOG" ]; then
+    SMOKE_LOG="$(docker logs "$CONTAINER_NAME" 2>&1 || true)"
+    echo "$SMOKE_LOG" >&2
+    printf '%s\n' "$SMOKE_LOG" >"$ARTIFACT_DIR/smoke-logs-agent-${AGENT_ID}.log"
+  fi
+  echo "Smoke health check failed for ${HEALTH_URL}" >&2
+  END_TOTAL=$(now_ms)
+  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+  node -e "
+const out = {
+  status: 'fail',
+  stageId: 'docker-build',
+  kind: 'test',
+  agent_id: ${AGENT_ID},
+  total_ms: ${TOTAL_MS},
+  image: '${IMAGE_TAG}',
+  smoke: 'health-failed',
+  healthUrl: '${HEALTH_URL}',
+  artifacts: [
+    { path: '.har/artifacts/docker-build', kind: 'directory' },
+  ],
+};
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+"
+  exit 1
+fi
+
+docker logs "$CONTAINER_NAME" >"$ARTIFACT_DIR/smoke-logs-agent-${AGENT_ID}.log" 2>&1 || true
+cleanup_smoke
+trap - EXIT
+
+END_TOTAL=$(now_ms)
+TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+
+node -e "
+const out = {
+  status: 'pass',
+  stageId: 'docker-build',
+  kind: 'test',
+  agent_id: ${AGENT_ID},
+  total_ms: ${TOTAL_MS},
+  image: '${IMAGE_TAG}',
+  smoke: 'pass',
+  healthUrl: '${HEALTH_URL}',
   artifacts: [
     { path: '.har/artifacts/docker-build', kind: 'directory' },
   ],
@@ -85,4 +204,4 @@ const out = {
 process.stdout.write(JSON.stringify(out, null, 2) + '\n');
 "
 
-exit "$BUILD_EXIT"
+exit 0

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -23,6 +23,18 @@ COPY --from=deps /app/control/node_modules ./node_modules
 RUN npx prisma generate
 RUN npm run build
 
+# Full Prisma CLI install (package + transitive deps like `effect`). Kept as its own
+# stage so the runner can merge it without a registry fetch, and so we can recreate
+# `.bin/prisma` as a symlink (Docker COPY dereferences symlinks).
+FROM node:20-alpine AS prisma-cli
+ENV npm_config_audit=false \
+    npm_config_fund=false \
+    npm_config_update_notifier=false
+WORKDIR /prisma
+# Pin to the version locked in control/package-lock.json.
+RUN --mount=type=cache,target=/root/.npm \
+  npm install prisma@6.19.3 --omit=dev
+
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
@@ -34,10 +46,46 @@ COPY --from=builder /app/control/public ./public
 COPY --from=builder /app/control/.next/standalone ./
 COPY --from=builder /app/control/.next/static ./.next/static
 COPY --from=builder /app/control/prisma ./prisma
-# Reuse Prisma CLI from the builder (avoids a registry fetch in the runner stage).
-COPY --from=builder /app/control/node_modules/prisma ./node_modules/prisma
-COPY --from=builder /app/control/node_modules/@prisma ./node_modules/@prisma
-COPY --from=builder /app/control/node_modules/.bin/prisma ./node_modules/.bin/prisma
+# Merge Prisma CLI + transitive deps into the Next standalone tree.
+# - Skip `.bin` from COPY (Docker materializes the prisma symlink as a file, so the
+#   CLI resolves wasm next to itself under `.bin/` → ENOENT on boot).
+# - Keep the generated client under `node_modules/.prisma` and `@prisma/client`.
+COPY --from=prisma-cli /prisma/node_modules /tmp/prisma-cli-modules
+RUN set -eux; \
+  mkdir -p node_modules/.bin; \
+  if [ -d node_modules/.prisma ]; then cp -a node_modules/.prisma /tmp/keep-prisma-generated; fi; \
+  if [ -d node_modules/@prisma/client ]; then cp -a node_modules/@prisma/client /tmp/keep-prisma-client; fi; \
+  for entry in /tmp/prisma-cli-modules/*; do \
+    name="$(basename "$entry")"; \
+    [ "$name" != ".bin" ] || continue; \
+    if [ "$name" = "@prisma" ]; then \
+      mkdir -p node_modules/@prisma; \
+      for pkg in "$entry"/*; do \
+        pkgname="$(basename "$pkg")"; \
+        [ "$pkgname" != "client" ] || continue; \
+        rm -rf "node_modules/@prisma/$pkgname"; \
+        cp -a "$pkg" "node_modules/@prisma/$pkgname"; \
+      done; \
+      continue; \
+    fi; \
+    rm -rf "node_modules/$name"; \
+    cp -a "$entry" "node_modules/$name"; \
+  done; \
+  if [ -d /tmp/keep-prisma-generated ]; then \
+    rm -rf node_modules/.prisma; \
+    cp -a /tmp/keep-prisma-generated node_modules/.prisma; \
+  fi; \
+  if [ -d /tmp/keep-prisma-client ]; then \
+    rm -rf node_modules/@prisma/client; \
+    mkdir -p node_modules/@prisma; \
+    cp -a /tmp/keep-prisma-client node_modules/@prisma/client; \
+  fi; \
+  ln -sfn ../prisma/build/index.js node_modules/.bin/prisma; \
+  rm -rf /tmp/prisma-cli-modules /tmp/keep-prisma-generated /tmp/keep-prisma-client; \
+  test -L node_modules/.bin/prisma; \
+  test -f node_modules/prisma/build/prisma_schema_build_bg.wasm; \
+  test -d node_modules/effect; \
+  test -f node_modules/.prisma/client/index.js
 RUN mkdir -p /data
 VOLUME ["/data"]
 EXPOSE 3847


### PR DESCRIPTION
## Summary
- Fixes `har control up` crash-loop on Hub image 0.14.2: Docker `COPY` of `.bin/prisma` dereferenced the npm symlink, so first-boot `prisma db push` looked for `prisma_schema_build_bg.wasm` under `.bin/` (and dropped transitive deps like `effect`).
- Installs Prisma in a dedicated image stage, merges CLI + deps into the Next standalone tree with a real `.bin/prisma` symlink, and keeps the generated client.
- Extends the `docker-build` harness stage to smoke-boot the image and wait for `/api/health`, so PR CI (`control` job → `./.har/verify.sh 1 --full`) catches first-boot regressions that build-only checks miss.

## Test plan
- [x] `cd control && ./.har/verify.sh 2 --full` (includes docker-build smoke) — pass
- [x] Smoke-boot fixed image; `/api/health` returns ok after `prisma db push`
- [ ] Confirm PR `Test` / `control` job runs docker-build smoke
- [ ] After merge/release, republish `theosfactory/har-control` so `har control up` pulls a fixed tag (0.14.2 remains broken on Hub until then)


Made with [Cursor](https://cursor.com)