### PR TITLE
feat(env): wire --purpose through CLI and MCP launch

### DIFF
--- a/.cursor/rules/har-workflow.mdc
+++ b/.cursor/rules/har-workflow.mdc
@@ -30,7 +30,7 @@ Relaunching a slot **replaces** its previous session (the old branch is kept). R
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
-- Optional: set `HAR_SESSION_PURPOSE=label` or `--purpose=label` on launch so occupied-slot warnings show what you were doing.
+- Optional: set `har env launch <id> --purpose=label`, `HAR_SESSION_PURPOSE=label`, or `./.har/launch.sh <id> --purpose=label` so occupied-slot warnings show what you were doing.
 - If launch failed partway (registry `status: failed`), **resume** instead of replacing:
   `har env launch <id> --resume`, `har env recover <id>`, or `./.har/launch.sh <id> --resume`.
   Do not hand-roll PM2 or skip the harness.

--- a/.har/README.md
+++ b/.har/README.md
@@ -118,7 +118,7 @@ work dir printed by launch, never in the main checkout.
 - The session **branch is kept** on teardown if you committed; gitignored paths (`state/`,
   `runs/`, local clones) are **not** preserved when the worktree is removed.
 - Use **separate slots** for parallel unrelated tasks (`agentSlots.max` in `stages.json`).
-- Optional: `HAR_SESSION_PURPOSE=label` or `--purpose=label` tags the session in warnings.
+- Optional: `har env launch 1 --purpose=label`, `HAR_SESSION_PURPOSE=label`, or `./.har/launch.sh 1 --purpose=label` tags the session in status and occupied-slot warnings.
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, the slot registry records

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -14,10 +14,11 @@ description: The safe lifecycle for parallel coding tasks.
 ```bash
 har env status
 har env preflight 2
-har env launch 2
+har env launch 2 --purpose="my task label"
 ```
 
 Use one slot per task. Separate parallel tasks use separate slots.
+`--purpose` (or `HAR_SESSION_PURPOSE`) labels the session in status and occupied-slot warnings.
 
 ## Occupied and failed slots
 

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -61,12 +61,14 @@ har env add-stage <id> --custom --kind <kind>
 
 ```bash
 har env preflight 1 [--json] [--replace] [--force]
-har env launch 1 [--no-worktree] [--claude] [--replace] [--force] [--resume]
+har env launch 1 [--no-worktree] [--claude] [--replace] [--force] [--resume] [--purpose=label]
 har env recover 1
 ```
 
 `--replace` confirms replacement of an occupied slot. `--force` additionally
 permits discarding dirty uncommitted work and must only follow explicit approval.
+`--purpose` stores an optional session label (also via `HAR_SESSION_PURPOSE`) shown
+in `har env status` and occupied-slot warnings.
 
 ### Verify and finish
 

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -18,7 +18,7 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 | Tool | Inputs | Result |
 | --- | --- | --- |
 | `har_preflight_environment` | `agentId`, `confirmReplace`, `force` | Readiness, blockers, and whether launch is safe |
-| `har_launch_environment` | `agentId`, `worktree`, `claude`, `confirmReplace`, `force`, `resume` | Work directory, branch, URLs, and normalized stage result |
+| `har_launch_environment` | `agentId`, `worktree`, `claude`, `confirmReplace`, `force`, `resume`, `purpose` | Work directory, branch, URLs, and normalized stage result |
 | `har_recover_environment` | `agentId` | Resumed failed or partial launch |
 | `har_get_status` | optional `agentId` | Slot, process, worktree, branch, and dirty state |
 | `har_get_logs` | `agentId`, optional `service` | Recent service output |

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -201,6 +201,11 @@ export const envCommand = {
               type: 'boolean',
               default: false,
               describe: 'Resume a failed or partial launch without creating a new worktree',
+            })
+            .option('purpose', {
+              type: 'string',
+              describe:
+                'Optional session label stored in the slot registry (shown in status and occupied-slot warnings)',
             }),
         handleLaunch,
       )
@@ -684,6 +689,7 @@ export async function handleLaunch(argv: {
   replace: boolean;
   force: boolean;
   resume: boolean;
+  purpose?: string;
 }): Promise<void> {
   const repo = path.resolve(argv.repo);
   const agentId = validateAgentId(argv.id, repo);
@@ -741,6 +747,7 @@ export async function handleLaunch(argv: {
     confirmReplace,
     force,
     resume: argv.resume,
+    purpose: argv.purpose,
     capture: false,
   });
   if (result.blocked) {

--- a/src/core/local-executor.ts
+++ b/src/core/local-executor.ts
@@ -14,10 +14,29 @@ import { buildStageResult, parseVerificationResult } from './results';
 import {
   ArtifactEntry,
   ExecutionContext,
+  LaunchFlags,
   StageExecutor,
   StageRunOptions,
 } from './types';
 import { readSlotRegistry } from './slot-registry';
+
+/** Quote a single argv token for `bash -lc` when it needs shell metacharacters. */
+export function quoteShellArg(arg: string): string {
+  if (/^[A-Za-z0-9_./:=+-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Argv fragments forwarded to launch.sh for a launch stage. */
+export function buildLaunchFlagArgs(flags: LaunchFlags): string[] {
+  const args: string[] = [];
+  if (flags.worktree === false) args.push('--no-worktree');
+  if (flags.claude) args.push('--claude');
+  if (flags.confirmReplace) args.push('--replace');
+  if (flags.force) args.push('--force');
+  if (flags.resume) args.push('--resume');
+  if (flags.purpose) args.push(`--purpose=${flags.purpose}`);
+  return args;
+}
 
 function resolveRepoPath(repoPath: string): string {
   return path.resolve(repoPath);
@@ -132,19 +151,18 @@ function buildExecutionPlan(
   const cwd = stage.cwd ? path.resolve(resolvedRepo, stage.cwd) : resolvedRepo;
   const extraArgs = options.args ?? [];
 
-  const launchFlagArgs: string[] = [];
-  if (stage.kind === 'launch' && options.launchFlags) {
-    if (options.launchFlags.worktree === false) launchFlagArgs.push('--no-worktree');
-    if (options.launchFlags.claude) launchFlagArgs.push('--claude');
-    if (options.launchFlags.confirmReplace) launchFlagArgs.push('--replace');
-    if (options.launchFlags.force) launchFlagArgs.push('--force');
-    if (options.launchFlags.resume) launchFlagArgs.push('--resume');
+  const launchFlagArgs =
+    stage.kind === 'launch' && options.launchFlags
+      ? buildLaunchFlagArgs(options.launchFlags)
+      : [];
+  if (stage.kind === 'launch' && options.launchFlags?.purpose) {
+    mergedEnv.HAR_SESSION_PURPOSE = options.launchFlags.purpose;
   }
 
   if (stage.command) {
     let shellCommand = substituteAgentId(stage.command, options.agentId);
     for (const extra of [...extraArgs, ...launchFlagArgs]) {
-      shellCommand = `${shellCommand} ${extra}`;
+      shellCommand = `${shellCommand} ${quoteShellArg(extra)}`;
     }
     return { mode: 'shell', shellCommand, args: [], cwd, env: mergedEnv };
   }

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -177,6 +177,7 @@ export class RunService {
               branch: slot.branch,
               dirty: slot.dirty,
               sessionCreatedAt: slot.sessionCreatedAt,
+              purpose: slot.purpose,
             }
           : undefined,
       };
@@ -206,6 +207,7 @@ export class RunService {
         confirmReplace: options.confirmReplace,
         force: options.force,
         resume: options.resume,
+        purpose: options.purpose,
       },
       trigger: 'cli',
     });

--- a/src/core/slot-launch-guard-occupied.ts
+++ b/src/core/slot-launch-guard-occupied.ts
@@ -100,6 +100,7 @@ function collectOccupiedSlot(repoPath: string, agentId: number): AgentSlotStatus
     sessionStatus: session?.status,
     lastError: session?.lastError,
     sessionCreatedAt: session?.createdAt,
+    purpose: session?.purpose,
     dirty,
     harnessUsage: 'none',
   };
@@ -111,6 +112,7 @@ function formatOccupiedSlot(slot: AgentSlotStatus, resume?: boolean): string {
     slot.worktreePath ? `  Worktree: ${slot.worktreePath}` : undefined,
     slot.branch ? `  Branch:   ${slot.branch}` : undefined,
     slot.workDir ? `  Work dir: ${slot.workDir}` : undefined,
+    slot.purpose ? `  Purpose:  ${slot.purpose}` : undefined,
     slot.sessionStatus ? `  Status:   ${slot.sessionStatus}` : undefined,
     slot.lastError ? `  Error:    ${slot.lastError}` : undefined,
     slot.sessionCreatedAt ? `  Since:    ${slot.sessionCreatedAt}` : undefined,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -29,6 +29,8 @@ export interface LaunchFlags {
   force?: boolean;
   /** Resume a failed or partial launch without creating a new worktree. */
   resume?: boolean;
+  /** Optional label stored on the session (shown in status / occupied-slot warnings). */
+  purpose?: string;
 }
 
 export interface StageRunOptions {
@@ -49,6 +51,8 @@ export interface LaunchOptions {
   confirmReplace?: boolean;
   force?: boolean;
   resume?: boolean;
+  /** Optional label stored on the session (shown in status / occupied-slot warnings). */
+  purpose?: string;
   capture?: boolean;
 }
 
@@ -85,6 +89,7 @@ export interface EnvironmentRunResult {
     branch?: string;
     dirty?: boolean;
     sessionCreatedAt?: string;
+    purpose?: string;
   };
 }
 

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -84,6 +84,12 @@ export const LaunchEnvironmentInputSchema = z.object({
     .boolean()
     .default(false)
     .describe('Resume a failed or partial launch without creating a new worktree.'),
+  purpose: z
+    .string()
+    .optional()
+    .describe(
+      'Optional session label stored in the slot registry (shown in status and occupied-slot warnings).',
+    ),
 });
 
 export const LaunchEnvironmentOutputSchema = ShellRunOutputSchema.extend({
@@ -103,6 +109,7 @@ export const LaunchEnvironmentOutputSchema = ShellRunOutputSchema.extend({
       branch: z.string().optional(),
       dirty: z.boolean().optional(),
       sessionCreatedAt: z.string().optional(),
+      purpose: z.string().optional(),
     })
     .optional(),
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -97,6 +97,11 @@ export const HAR_MCP_TOOLS: Tool[] = [
           description:
             'Resume a failed or partial launch (status failed/starting) without --replace. Preserves worktree and env.',
         },
+        purpose: {
+          type: 'string',
+          description:
+            'Optional session label stored in the slot registry (shown in status and occupied-slot warnings).',
+        },
       },
       ['agentId'],
     ),
@@ -293,6 +298,7 @@ export async function handleMcpToolCall(
         confirmReplace: input.confirmReplace,
         force: input.force,
         resume: input.resume,
+        purpose: input.purpose,
         capture: true,
       });
       const parsed = LaunchEnvironmentOutputSchema.parse(result);

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -30,7 +30,7 @@ Relaunching a slot **replaces** its previous session (the old branch is kept). R
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
-- Optional: set `HAR_SESSION_PURPOSE=label` or `--purpose=label` on launch so occupied-slot warnings show what you were doing.
+- Optional: set `har env launch <id> --purpose=label`, `HAR_SESSION_PURPOSE=label`, or `./.har/launch.sh <id> --purpose=label` so occupied-slot warnings show what you were doing.
 
 <!-- Monorepo: if this repository contains multiple .har harnesses, list them here
      and pick by the files you are changing. Example:

--- a/tests/launch-flags.test.ts
+++ b/tests/launch-flags.test.ts
@@ -1,0 +1,41 @@
+import { buildLaunchFlagArgs, quoteShellArg } from '../src/core/local-executor';
+import { LaunchEnvironmentInputSchema } from '../src/mcp/schemas';
+
+describe('launch purpose plumbing', () => {
+  it('forwards --purpose to launch.sh argv', () => {
+    expect(
+      buildLaunchFlagArgs({
+        worktree: true,
+        purpose: 'fix sqlite backend',
+      }),
+    ).toEqual(['--purpose=fix sqlite backend']);
+  });
+
+  it('includes purpose alongside other launch flags', () => {
+    expect(
+      buildLaunchFlagArgs({
+        worktree: false,
+        confirmReplace: true,
+        force: true,
+        resume: true,
+        claude: true,
+        purpose: 'label',
+      }),
+    ).toEqual(['--no-worktree', '--claude', '--replace', '--force', '--resume', '--purpose=label']);
+  });
+
+  it('shell-quotes purpose values that contain spaces', () => {
+    expect(quoteShellArg('--purpose=fix sqlite backend')).toBe(
+      "'--purpose=fix sqlite backend'",
+    );
+    expect(quoteShellArg('--replace')).toBe('--replace');
+  });
+
+  it('accepts purpose on MCP launch input', () => {
+    const parsed = LaunchEnvironmentInputSchema.parse({
+      agentId: 1,
+      purpose: 'wire launch purpose',
+    });
+    expect(parsed.purpose).toBe('wire launch purpose');
+  });
+});

--- a/tests/slot-launch-guard.test.ts
+++ b/tests/slot-launch-guard.test.ts
@@ -11,7 +11,12 @@ function initGitRepo(repoPath: string): void {
   execSync('git commit --allow-empty -q -m init', { cwd: repoPath });
 }
 
-function writeSlotRegistry(harDir: string, agentId: number, worktreePath: string): void {
+function writeSlotRegistry(
+  harDir: string,
+  agentId: number,
+  worktreePath: string,
+  extras: { purpose?: string } = {},
+): void {
   const slotsDir = path.join(harDir, 'slots');
   fs.mkdirSync(slotsDir, { recursive: true });
   fs.writeFileSync(
@@ -27,6 +32,7 @@ function writeSlotRegistry(harDir: string, agentId: number, worktreePath: string
         branch: 'session-branch',
         createdAt: '2026-01-01T00:00:00Z',
         status: 'active',
+        ...(extras.purpose ? { purpose: extras.purpose } : {}),
       },
       null,
       2,
@@ -69,13 +75,15 @@ describe('slot launch guard', () => {
     initGitRepo(repoPath);
     const worktreePath = path.join(os.tmpdir(), `har-guard-wt-${Date.now()}`);
     execSync(`git worktree add -b session-branch ${worktreePath}`, { cwd: repoPath });
-    writeSlotRegistry(harDir, 1, worktreePath);
+    writeSlotRegistry(harDir, 1, worktreePath, { purpose: 'fix sqlite backend' });
 
     const result = checkLaunchGuard(repoPath, 1, {});
     expect(result.allowed).toBe(false);
     expect(result.blocked).toBe(true);
     expect(result.slot?.worktreePath).toBe(worktreePath);
+    expect(result.slot?.purpose).toBe('fix sqlite backend');
     expect(result.reason).toContain('already in use');
+    expect(result.reason).toContain('Purpose:  fix sqlite backend');
   });
 
   it('requires force when replacing a dirty occupied slot', () => {


### PR DESCRIPTION
## Summary
- Accept `--purpose` on `har env launch` and `purpose` on MCP `har_launch_environment`, forwarding it to `launch.sh` (and `HAR_SESSION_PURPOSE`)
- Show session purpose in CLI/MCP occupied-slot warnings (parity with `./.har/launch.sh`)
- Document the flag in CLI/MCP/docs and cover forwarding + guard messaging with tests

## Test plan
- [x] `./.har/verify.sh 1 --full` passes
- [x] Built CLI accepts `har env launch --purpose=…` (no unknown-argument error)
- [x] Live launch writes `purpose` into `.har/slots/agent-<id>.json`
- [x] Re-launch occupied warning includes `Purpose:`
- [ ] Smoke after install: `har env launch 1 --purpose="label"` then `har env status 1`


Made with [Cursor](https://cursor.com)