### PR TITLE
fix(control): clear ghost worktrees after slot teardown

### DIFF
--- a/control/src/app/page.tsx
+++ b/control/src/app/page.tsx
@@ -82,7 +82,8 @@ export default async function HomePage() {
         <CardHeader>
           <CardTitle>Active sessions</CardTitle>
           <CardDescription>
-            Worktree, branch and drift per agent slot — status reflects the last `har` sync
+            Live worktrees only (active + path). Idle slots keep a last-session branch after
+            teardown — status reflects the last `har` sync
           </CardDescription>
         </CardHeader>
         <CardContent className="min-w-0">

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -98,6 +98,9 @@ export default async function SlotDetailPage({
             </p>
             {slot.branch && (
               <p className="mt-2 font-mono text-xs" title={slot.baseCommit ?? undefined}>
+                {!slot.active || !slot.worktreePath ? (
+                  <span className="text-muted-foreground">last session · </span>
+                ) : null}
                 {slot.branch}
               </p>
             )}

--- a/control/src/components/columns/slot-columns.tsx
+++ b/control/src/components/columns/slot-columns.tsx
@@ -225,21 +225,26 @@ export const slotColumns: ColumnDef<SlotRow>[] = [
     id: 'branch',
     accessorFn: (row) => row.branch ?? '',
     header: 'Branch',
-    cell: ({ row }) =>
-      row.original.branch ? (
+    cell: ({ row }) => {
+      const { branch, baseBranch, baseCommit, active, worktreePath } = row.original;
+      if (!branch) return '—';
+      const lastSession = !active || !worktreePath;
+      const baseHint = baseBranch
+        ? `based on ${baseBranch} @ ${baseCommit?.slice(0, 7) ?? '?'}`
+        : undefined;
+      const title = lastSession
+        ? ['last session branch', baseHint].filter(Boolean).join(' · ')
+        : baseHint;
+      return (
         <span
           className="block max-w-56 truncate font-mono text-xs text-muted-foreground"
-          title={
-            row.original.baseBranch
-              ? `based on ${row.original.baseBranch} @ ${row.original.baseCommit?.slice(0, 7) ?? '?'}`
-              : undefined
-          }
+          title={title}
         >
-          {row.original.branch}
+          {lastSession ? <span className="text-muted-foreground/80">last </span> : null}
+          {branch}
         </span>
-      ) : (
-        '—'
-      ),
+      );
+    },
   },
   {
     accessorKey: 'harnessUsage',

--- a/control/src/server/repositories.ts
+++ b/control/src/server/repositories.ts
@@ -5,7 +5,9 @@ import {
   SyncRunsInputSchema,
   SyncSlotsInputSchema,
 } from '@har/schemas';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db';
+import { buildAgentSlotSyncFields } from '@/server/slot-sync-fields';
 
 function toJson(value: unknown) {
   return JSON.parse(JSON.stringify(value)) as object;
@@ -52,8 +54,10 @@ export async function getRepository(id: string) {
 }
 
 export async function listActiveWorktrees() {
+  // Require a path so stale `active: true` rows without a worktree (missed sync
+  // after teardown) do not appear under Active sessions.
   return prisma.agentSlot.findMany({
-    where: { active: true },
+    where: { active: true, worktreePath: { not: null } },
     include: {
       repository: { select: { id: true, path: true, gitRemote: true } },
     },
@@ -105,37 +109,21 @@ export async function syncSlots(repositoryId: string, input: unknown) {
 
   for (const slot of slots) {
     const parsed = AgentSlotStatusSchema.parse(slot);
-    const fields = {
-      active: parsed.active,
-      workDir: parsed.workDir,
-      worktreePath: parsed.worktreePath,
-      branch: parsed.branch,
-      previewUrls: parsed.previewUrls ?? undefined,
-      harnessUsage: parsed.harnessUsage,
-      lastRunId: parsed.lastRunId,
-      lastRunAt: parsed.lastRunAt ? new Date(parsed.lastRunAt) : null,
-      lastVerifyStatus: parsed.lastVerifyStatus,
-      lastBuildPass: parsed.lastBuildPass,
-      mode: parsed.mode,
-      suffix: parsed.suffix,
-      baseBranch: parsed.baseBranch,
-      baseCommit: parsed.baseCommit,
-      sessionCreatedAt: parsed.sessionCreatedAt ? new Date(parsed.sessionCreatedAt) : null,
-      purpose: parsed.purpose,
-      detachedHead: parsed.detachedHead,
-      dirty: parsed.dirty,
-      ahead: parsed.ahead,
-      behind: parsed.behind,
-      stale: parsed.stale,
+    const fields = buildAgentSlotSyncFields(parsed);
+    // Prisma JSON columns need DbNull for SQL NULL (plain `null` is rejected).
+    const data = {
+      ...fields,
+      previewUrls:
+        fields.previewUrls === null ? Prisma.DbNull : fields.previewUrls,
     };
     await prisma.agentSlot.upsert({
       where: { repositoryId_slotId: { repositoryId, slotId: parsed.agentId } },
       create: {
         repositoryId,
         slotId: parsed.agentId,
-        ...fields,
+        ...data,
       },
-      update: fields,
+      update: data,
     });
   }
 

--- a/control/src/server/slot-sync-fields.test.ts
+++ b/control/src/server/slot-sync-fields.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentSlotStatus } from '@har/schemas';
+import { buildAgentSlotSyncFields } from './slot-sync-fields';
+
+function activeSlot(overrides: Partial<AgentSlotStatus> = {}): AgentSlotStatus {
+  return {
+    agentId: 1,
+    active: true,
+    harnessUsage: 'cli',
+    workDir: '/tmp/wt',
+    worktreePath: '/tmp/wt',
+    branch: 'feat-demo-har-agent-1-abcd',
+    previewUrls: { frontend: 'http://localhost:3000' },
+    dirty: true,
+    ahead: 2,
+    behind: 0,
+    stale: false,
+    detachedHead: false,
+    purpose: 'demo',
+    ...overrides,
+  };
+}
+
+describe('buildAgentSlotSyncFields', () => {
+  it('keeps live session fields when the slot is active', () => {
+    const fields = buildAgentSlotSyncFields(activeSlot());
+    expect(fields.active).toBe(true);
+    expect(fields.worktreePath).toBe('/tmp/wt');
+    expect(fields.workDir).toBe('/tmp/wt');
+    expect(fields.branch).toBe('feat-demo-har-agent-1-abcd');
+    expect(fields.previewUrls).toEqual({ frontend: 'http://localhost:3000' });
+    expect(fields.dirty).toBe(true);
+    expect(fields.ahead).toBe(2);
+  });
+
+  it('nulls worktree path, preview, and drift when idle (teardown sync)', () => {
+    const fields = buildAgentSlotSyncFields(
+      activeSlot({
+        active: false,
+        workDir: undefined,
+        worktreePath: undefined,
+        previewUrls: undefined,
+        dirty: undefined,
+        ahead: undefined,
+        behind: undefined,
+        stale: undefined,
+        detachedHead: undefined,
+        branch: undefined,
+      }),
+    );
+
+    expect(fields.active).toBe(false);
+    expect(fields.workDir).toBeNull();
+    expect(fields.worktreePath).toBeNull();
+    expect(fields.previewUrls).toBeNull();
+    expect(fields.dirty).toBeNull();
+    expect(fields.ahead).toBeNull();
+    expect(fields.behind).toBeNull();
+    expect(fields.stale).toBeNull();
+    expect(fields.detachedHead).toBeNull();
+    // Omitted branch on idle → leave previous DB value (field absent).
+    expect(fields).not.toHaveProperty('branch');
+  });
+
+  it('still records an explicit last branch when idle sync includes it', () => {
+    const fields = buildAgentSlotSyncFields(
+      activeSlot({
+        active: false,
+        worktreePath: undefined,
+        workDir: undefined,
+        branch: 'feat-demo-har-agent-1-abcd',
+      }),
+    );
+    expect(fields.worktreePath).toBeNull();
+    expect(fields.branch).toBe('feat-demo-har-agent-1-abcd');
+  });
+
+  it('clears branch when an active sync omits it', () => {
+    const fields = buildAgentSlotSyncFields(
+      activeSlot({
+        branch: undefined,
+      }),
+    );
+    expect(fields.branch).toBeNull();
+  });
+});

--- a/control/src/server/slot-sync-fields.ts
+++ b/control/src/server/slot-sync-fields.ts
@@ -1,0 +1,70 @@
+import type { AgentSlotStatus } from '@har/schemas';
+
+/**
+ * Prisma update payload for one agent slot sync.
+ *
+ * Optional JSON fields omitted from the harness status payload arrive as
+ * `undefined`. Prisma treats `undefined` as "leave the column unchanged", which
+ * left ghost worktree paths / drift after teardown (#68). Idle slots must
+ * explicitly null live-session columns; last `branch` is kept for history when
+ * the payload omits it.
+ */
+export type AgentSlotSyncFields = {
+  active: boolean;
+  workDir: string | null;
+  worktreePath: string | null;
+  branch?: string | null;
+  previewUrls: Record<string, string> | null;
+  harnessUsage: AgentSlotStatus['harnessUsage'];
+  lastRunId: string | null;
+  lastRunAt: Date | null;
+  lastVerifyStatus: string | null;
+  lastBuildPass: boolean | null;
+  mode: string | null;
+  suffix: string | null;
+  baseBranch: string | null;
+  baseCommit: string | null;
+  sessionCreatedAt: Date | null;
+  purpose: string | null;
+  detachedHead: boolean | null;
+  dirty: boolean | null;
+  ahead: number | null;
+  behind: number | null;
+  stale: boolean | null;
+};
+
+export function buildAgentSlotSyncFields(parsed: AgentSlotStatus): AgentSlotSyncFields {
+  const active = parsed.active;
+
+  const fields: AgentSlotSyncFields = {
+    active,
+    workDir: active ? parsed.workDir ?? null : null,
+    worktreePath: active ? parsed.worktreePath ?? null : null,
+    previewUrls: active ? parsed.previewUrls ?? null : null,
+    harnessUsage: parsed.harnessUsage,
+    lastRunId: parsed.lastRunId ?? null,
+    lastRunAt: parsed.lastRunAt ? new Date(parsed.lastRunAt) : null,
+    lastVerifyStatus: parsed.lastVerifyStatus ?? null,
+    lastBuildPass: parsed.lastBuildPass ?? null,
+    mode: parsed.mode ?? null,
+    suffix: parsed.suffix ?? null,
+    baseBranch: parsed.baseBranch ?? null,
+    baseCommit: parsed.baseCommit ?? null,
+    sessionCreatedAt: parsed.sessionCreatedAt ? new Date(parsed.sessionCreatedAt) : null,
+    purpose: parsed.purpose ?? null,
+    detachedHead: active ? parsed.detachedHead ?? null : null,
+    dirty: active ? parsed.dirty ?? null : null,
+    ahead: active ? parsed.ahead ?? null : null,
+    behind: active ? parsed.behind ?? null : null,
+    stale: active ? parsed.stale ?? null : null,
+  };
+
+  if (parsed.branch !== undefined) {
+    fields.branch = parsed.branch;
+  } else if (active) {
+    fields.branch = null;
+  }
+  // Idle + omitted branch: leave previous value (last session branch).
+
+  return fields;
+}


### PR DESCRIPTION
## Summary
- Fixes #68: idle slot sync now explicitly nulls live-session columns (`worktreePath`, `workDir`, `previewUrls`, drift) so Prisma does not keep ghost paths after teardown
- Active sessions list requires `active` **and** a non-null `worktreePath`
- Idle UI labels leftover branch as **last session** (git branch keep-on-teardown is unchanged)

## Test plan
- [x] `control/.har/verify.sh 3 --full` (pass)
- [x] Unit tests for `buildAgentSlotSyncFields` (idle clears path/drift; preserves omitted branch)
- [ ] Sync a torn-down repo (`har control sync` / post-teardown CLI sync) and confirm home Active sessions no longer shows the ghost row
- [ ] Repo slots tab still shows Idle + last-session branch when useful


Made with [Cursor](https://cursor.com)