### PR TITLE
fix(control): stop counting session worktrees as repositories

### DIFF
--- a/control/src/server/git-repo-path.test.ts
+++ b/control/src/server/git-repo-path.test.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { canonicalizeControlRepoPath } from './git-repo-path';
+
+const temps: string[] = [];
+
+function sh(cwd: string, command: string): void {
+  execFileSync('bash', ['-lc', command], { cwd, stdio: 'pipe' });
+}
+
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-mc-repo-'));
+  temps.push(dir);
+  sh(dir, 'git init -q -b main');
+  sh(dir, 'git config user.email har@test.local');
+  sh(dir, 'git config user.name har');
+  fs.writeFileSync(path.join(dir, 'README.md'), 'hello\n');
+  sh(dir, 'git add -A && git commit -q -m init');
+  return dir;
+}
+
+afterEach(() => {
+  while (temps.length > 0) {
+    const dir = temps.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('canonicalizeControlRepoPath (Mission Control)', () => {
+  it('maps linked worktrees to the main checkout', () => {
+    const main = initRepo();
+    const wtParent = fs.mkdtempSync(path.join(os.tmpdir(), 'har-mc-wt-'));
+    temps.push(wtParent);
+    const worktree = path.join(wtParent, 'wt');
+    sh(main, `git worktree add -q "${worktree}" -b feature-wt`);
+
+    expect(canonicalizeControlRepoPath(worktree)).toBe(path.resolve(main));
+    expect(canonicalizeControlRepoPath(main)).toBe(path.resolve(main));
+  });
+});

--- a/control/src/server/git-repo-path.ts
+++ b/control/src/server/git-repo-path.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function tryGit(cwd: string, args: string[]): string | undefined {
+  if (!fs.existsSync(cwd)) return undefined;
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Main working tree for a git checkout (linked worktree → primary checkout). */
+export function resolveMainWorkingTree(cwd: string): string | undefined {
+  const toplevel = tryGit(cwd, ['rev-parse', '--show-toplevel']);
+  if (!toplevel) return undefined;
+
+  const commonDirRaw = tryGit(cwd, ['rev-parse', '--git-common-dir']);
+  const commonDir = commonDirRaw ? path.resolve(cwd, commonDirRaw) : undefined;
+  if (!commonDir) return path.resolve(toplevel);
+
+  if (path.basename(commonDir) === '.git') {
+    return path.dirname(commonDir);
+  }
+
+  const porcelain = tryGit(cwd, ['worktree', 'list', '--porcelain']);
+  if (porcelain) {
+    for (const line of porcelain.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        return path.resolve(line.slice('worktree '.length));
+      }
+    }
+  }
+
+  return path.resolve(toplevel);
+}
+
+/**
+ * Map a repository path onto the main git working tree so linked HAR session
+ * worktrees are not stored as distinct Mission Control repositories.
+ */
+export function canonicalizeControlRepoPath(repoPath: string): string {
+  const resolved = path.resolve(repoPath);
+  const toplevel = tryGit(resolved, ['rev-parse', '--show-toplevel']);
+  if (!toplevel) return resolved;
+
+  const mainRoot = resolveMainWorkingTree(resolved);
+  if (!mainRoot) return resolved;
+
+  const top = path.resolve(toplevel);
+  const main = path.resolve(mainRoot);
+  if (top === main) return resolved;
+
+  const rel = path.relative(top, resolved);
+  if (!rel || rel === '.') return main;
+  if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
+    return resolved;
+  }
+  return path.resolve(main, rel);
+}

--- a/control/src/server/repositories.ts
+++ b/control/src/server/repositories.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   AgentSlotStatusSchema,
   RegisterRepoInputSchema,
@@ -7,6 +8,7 @@ import {
 } from '@har/schemas';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db';
+import { canonicalizeControlRepoPath } from '@/server/git-repo-path';
 import { buildAgentSlotSyncFields } from '@/server/slot-sync-fields';
 
 function toJson(value: unknown) {
@@ -15,11 +17,13 @@ function toJson(value: unknown) {
 
 export async function registerRepository(input: unknown) {
   const data = RegisterRepoInputSchema.parse(input);
+  const requested = path.resolve(data.path);
+  const repoPath = canonicalizeControlRepoPath(requested);
 
-  return prisma.repository.upsert({
-    where: { path: data.path },
+  const repo = await prisma.repository.upsert({
+    where: { path: repoPath },
     create: {
-      path: data.path,
+      path: repoPath,
       gitRemote: data.gitRemote,
       manifest: data.manifest ? toJson(data.manifest) : undefined,
       stagesRegistry: data.stagesRegistry ? toJson(data.stagesRegistry) : undefined,
@@ -32,15 +36,43 @@ export async function registerRepository(input: unknown) {
       lastSyncAt: new Date(),
     },
   });
+
+  // Drop a prior row that registered the linked worktree path as its own repo.
+  if (requested !== repoPath) {
+    await prisma.repository.deleteMany({ where: { path: requested } });
+  }
+
+  return repo;
+}
+
+/** Remove linked-worktree rows when the main checkout is already registered. */
+async function pruneWorktreeRepositoryDuplicates<
+  T extends { id: string; path: string },
+>(repos: T[]): Promise<T[]> {
+  const paths = new Set(repos.map((repo) => repo.path));
+  const duplicateIds: string[] = [];
+
+  for (const repo of repos) {
+    const canonical = canonicalizeControlRepoPath(repo.path);
+    if (canonical !== repo.path && paths.has(canonical)) {
+      duplicateIds.push(repo.id);
+    }
+  }
+
+  if (duplicateIds.length === 0) return repos;
+
+  await prisma.repository.deleteMany({ where: { id: { in: duplicateIds } } });
+  return repos.filter((repo) => !duplicateIds.includes(repo.id));
 }
 
 export async function listRepositories() {
-  return prisma.repository.findMany({
+  const repos = await prisma.repository.findMany({
     orderBy: { updatedAt: 'desc' },
     include: {
       _count: { select: { runs: true, slots: true } },
     },
   });
+  return pruneWorktreeRepositoryDuplicates(repos);
 }
 
 export async function getRepository(id: string) {

--- a/src/core/control-registry.ts
+++ b/src/core/control-registry.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { readManifest } from '../harness/manifest';
+import { canonicalizeControlRepoPath } from './control-repo-path';
 
 interface ControlRegistry {
   repos: string[];
@@ -30,11 +31,16 @@ function writeRegistry(registry: ControlRegistry): void {
   fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2) + '\n');
 }
 
+function registryChanged(before: string[], after: string[]): boolean {
+  if (before.length !== after.length) return true;
+  return before.some((repoPath, index) => repoPath !== after[index]);
+}
+
 /** Remember a repo so Mission Control can sync it when the dashboard starts. */
 export function recordRepoForControlSync(repoPath: string): void {
   if (process.env.HAR_CONTROL_DISABLED === 'true') return;
 
-  const resolved = path.resolve(repoPath);
+  const resolved = canonicalizeControlRepoPath(repoPath);
   if (!readManifest(resolved)) return;
 
   const registry = readRegistry();
@@ -47,9 +53,19 @@ export function recordRepoForControlSync(repoPath: string): void {
 /** Registered repos that still exist and have a harness manifest. */
 export function listRegisteredRepos(): string[] {
   const registry = readRegistry();
-  const kept = registry.repos.filter((repoPath) => fs.existsSync(repoPath) && readManifest(repoPath));
+  const kept: string[] = [];
+  const seen = new Set<string>();
 
-  if (kept.length !== registry.repos.length) {
+  for (const repoPath of registry.repos) {
+    if (!fs.existsSync(repoPath)) continue;
+    const canonical = canonicalizeControlRepoPath(repoPath);
+    if (!fs.existsSync(canonical) || !readManifest(canonical)) continue;
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    kept.push(canonical);
+  }
+
+  if (registryChanged(registry.repos, kept)) {
     writeRegistry({ repos: kept });
   }
 

--- a/src/core/control-repo-path.ts
+++ b/src/core/control-repo-path.ts
@@ -1,0 +1,68 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { run } from '../utils/shell';
+
+function tryGit(cwd: string, args: string): string | undefined {
+  if (!fs.existsSync(cwd)) return undefined;
+  const result = run(`git ${args}`, { cwd });
+  return result.code === 0 ? result.stdout.trim() : undefined;
+}
+
+/**
+ * Main working tree for a git checkout (linked worktree → primary checkout).
+ * Returns undefined when `cwd` is not inside a git work tree.
+ */
+export function resolveMainWorkingTree(cwd: string): string | undefined {
+  const toplevel = tryGit(cwd, 'rev-parse --show-toplevel');
+  if (!toplevel) return undefined;
+
+  const commonDirRaw = tryGit(cwd, 'rev-parse --git-common-dir');
+  const commonDir = commonDirRaw ? path.resolve(cwd, commonDirRaw) : undefined;
+  if (!commonDir) return path.resolve(toplevel);
+
+  // Normal repos: common dir is `<main>/.git` (or a `.git` file is not used here —
+  // `git-common-dir` already resolves to the real common directory).
+  if (path.basename(commonDir) === '.git') {
+    return path.dirname(commonDir);
+  }
+
+  // Unusual gitdir layouts — first porcelain worktree entry is the primary.
+  const porcelain = tryGit(cwd, 'worktree list --porcelain');
+  if (porcelain) {
+    for (const line of porcelain.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        return path.resolve(line.slice('worktree '.length));
+      }
+    }
+  }
+
+  return path.resolve(toplevel);
+}
+
+/**
+ * Map a harness/repo path onto the main git working tree.
+ *
+ * Mission Control identities repositories by absolute path. Session worktrees
+ * contain a full `.har/` tree, so sync/register from a worktree would otherwise
+ * create a duplicate repository row. Rewrite linked-worktree paths to the same
+ * relative location under the main checkout.
+ */
+export function canonicalizeControlRepoPath(repoPath: string): string {
+  const resolved = path.resolve(repoPath);
+  const toplevel = tryGit(resolved, 'rev-parse --show-toplevel');
+  if (!toplevel) return resolved;
+
+  const mainRoot = resolveMainWorkingTree(resolved);
+  if (!mainRoot) return resolved;
+
+  const top = path.resolve(toplevel);
+  const main = path.resolve(mainRoot);
+  if (top === main) return resolved;
+
+  const rel = path.relative(top, resolved);
+  if (!rel || rel === '.') return main;
+  if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
+    return resolved;
+  }
+  return path.resolve(main, rel);
+}

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -13,6 +13,7 @@ import {
 } from '../harness/schema';
 import { getControlApiUrl, isControlEnabled } from './control-config';
 import { listRegisteredRepos } from './control-registry';
+import { canonicalizeControlRepoPath } from './control-repo-path';
 import { collectEnvironmentStatus } from './slot-status';
 import { listRuns } from './runs';
 import { listValidations } from './validations';
@@ -88,7 +89,7 @@ export async function syncAllKnownReposWithControl(options?: {
   const repoPaths = new Set<string>(listRegisteredRepos());
 
   if (options?.cwd) {
-    const cwd = path.resolve(options.cwd);
+    const cwd = canonicalizeControlRepoPath(options.cwd);
     if (readManifest(cwd)) repoPaths.add(cwd);
   }
 
@@ -97,7 +98,7 @@ export async function syncAllKnownReposWithControl(options?: {
     if (listResponse.ok) {
       const repos = (await listResponse.json()) as { path: string }[];
       for (const repo of repos) {
-        const resolved = path.resolve(repo.path);
+        const resolved = canonicalizeControlRepoPath(repo.path);
         if (readManifest(resolved)) repoPaths.add(resolved);
       }
     }
@@ -122,7 +123,7 @@ export async function syncAllKnownReposWithControl(options?: {
 export async function registerRepoWithControl(
   options: ControlRegisterOptions,
 ): Promise<{ id: string } | null> {
-  const repoPath = path.resolve(options.repoPath);
+  const repoPath = canonicalizeControlRepoPath(options.repoPath);
   const apiUrl = options.apiUrl ?? getControlApiUrl();
   const manifest = readManifest(repoPath);
   const stagesRegistry = readStageRegistry(repoPath);
@@ -138,7 +139,7 @@ export async function registerRepoWithControl(
 }
 
 export async function syncRepoWithControl(options: ControlSyncOptions): Promise<void> {
-  const repoPath = path.resolve(options.repoPath);
+  const repoPath = canonicalizeControlRepoPath(options.repoPath);
   const apiUrl = options.apiUrl ?? getControlApiUrl();
 
   if (options.cloud) {
@@ -282,7 +283,12 @@ export async function syncRepoWithControlAsync(repoPath: string): Promise<void> 
       }
       return;
     }
-    await withTimeout(syncRepoWithControl({ repoPath, apiUrl }), SYNC_TIMEOUT_MS, 'control sync');
+    const canonical = canonicalizeControlRepoPath(repoPath);
+    await withTimeout(
+      syncRepoWithControl({ repoPath: canonical, apiUrl }),
+      SYNC_TIMEOUT_MS,
+      'control sync',
+    );
   } catch (err: unknown) {
     if (verbose) {
       const message = err instanceof Error ? err.message : String(err);
@@ -299,14 +305,15 @@ export async function syncRunWithControlAsync(repoPath: string, run: RunRecord):
     const reachable = await isControlApiReachable(apiUrl);
     if (!reachable) return;
 
-    const registerResult = await registerRepoWithControl({ repoPath, apiUrl });
+    const canonical = canonicalizeControlRepoPath(repoPath);
+    const registerResult = await registerRepoWithControl({ repoPath: canonical, apiUrl });
     let repoId = registerResult?.id;
 
     if (!repoId) {
       const listResponse = await fetch(`${apiUrl}/api/repos`);
       if (!listResponse.ok) return;
       const repos = (await listResponse.json()) as { id: string; path: string }[];
-      repoId = repos.find((r) => path.resolve(r.path) === path.resolve(repoPath))?.id;
+      repoId = repos.find((r) => path.resolve(r.path) === canonical)?.id;
     }
 
     if (!repoId) return;

--- a/tests/control-registry.test.ts
+++ b/tests/control-registry.test.ts
@@ -6,8 +6,11 @@ import {
   listRegisteredRepos,
   recordRepoForControlSync,
 } from '../src/core/control-registry';
+import { canonicalizeControlRepoPath } from '../src/core/control-repo-path';
 
 const FIXTURE = path.join(__dirname, 'fixtures/minimal-harness');
+/** Mission Control identity is the main checkout path, even from a session worktree. */
+const FIXTURE_CANONICAL = canonicalizeControlRepoPath(FIXTURE);
 
 describe('control registry', () => {
   let tempHome: string;
@@ -26,7 +29,7 @@ describe('control registry', () => {
 
   it('records a repo with a harness manifest', () => {
     recordRepoForControlSync(FIXTURE);
-    expect(listRegisteredRepos()).toEqual([path.resolve(FIXTURE)]);
+    expect(listRegisteredRepos()).toEqual([FIXTURE_CANONICAL]);
     expect(fs.existsSync(getControlRegistryPath())).toBe(true);
   });
 
@@ -55,9 +58,7 @@ describe('control registry', () => {
       JSON.stringify({ repos: [path.resolve(FIXTURE), '/tmp/missing-har-repo'] }, null, 2),
     );
 
-    expect(listRegisteredRepos()).toEqual([path.resolve(FIXTURE)]);
-    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).repos).toEqual([
-      path.resolve(FIXTURE),
-    ]);
+    expect(listRegisteredRepos()).toEqual([FIXTURE_CANONICAL]);
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).repos).toEqual([FIXTURE_CANONICAL]);
   });
 });

--- a/tests/control-repo-path.test.ts
+++ b/tests/control-repo-path.test.ts
@@ -1,0 +1,121 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import {
+  canonicalizeControlRepoPath,
+  resolveMainWorkingTree,
+} from '../src/core/control-repo-path';
+import { recordRepoForControlSync, listRegisteredRepos } from '../src/core/control-registry';
+
+function sh(cwd: string, command: string): string {
+  return execSync(command, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-control-repo-'));
+  sh(dir, 'git init -q -b main');
+  sh(dir, 'git config user.email har@test.local');
+  sh(dir, 'git config user.name har');
+  fs.mkdirSync(path.join(dir, '.har'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.har', 'manifest.json'),
+    JSON.stringify({
+      version: '1',
+      generatorVersion: '0.2.0',
+      outputDir: '.har',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      stack: { language: 'node', packageManager: 'npm', database: 'none' },
+    }),
+  );
+  fs.writeFileSync(path.join(dir, 'README.md'), 'hello\n');
+  sh(dir, 'git add -A');
+  sh(dir, 'git commit -q -m init');
+  return dir;
+}
+
+function addWorktree(main: string): string {
+  const worktree = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'har-control-wt-')), 'wt');
+  sh(main, `git worktree add -q "${worktree}" -b feature-har-agent-1-abcd`);
+  return worktree;
+}
+
+describe('canonicalizeControlRepoPath', () => {
+  afterEach(() => {
+    delete process.env.HAR_CONTROL_REGISTRY_PATH;
+    delete process.env.HAR_CONTROL_DISABLED;
+  });
+
+  it('leaves a main checkout path unchanged', () => {
+    const main = initRepo();
+    expect(canonicalizeControlRepoPath(main)).toBe(path.resolve(main));
+    expect(resolveMainWorkingTree(main)).toBe(path.resolve(main));
+  });
+
+  it('maps a linked worktree root to the main checkout', () => {
+    const main = initRepo();
+    const worktree = addWorktree(main);
+    expect(canonicalizeControlRepoPath(worktree)).toBe(path.resolve(main));
+    expect(resolveMainWorkingTree(worktree)).toBe(path.resolve(main));
+  });
+
+  it('maps a path under a linked worktree to the same relative path on main', () => {
+    const main = initRepo();
+    fs.mkdirSync(path.join(main, 'control', '.har'), { recursive: true });
+    fs.writeFileSync(
+      path.join(main, 'control', '.har', 'manifest.json'),
+      JSON.stringify({
+        version: '1',
+        generatorVersion: '0.2.0',
+        outputDir: '.har',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        stack: { language: 'node', packageManager: 'npm', database: 'none' },
+      }),
+    );
+    sh(main, 'git add -A');
+    sh(main, 'git commit -q -m nested');
+
+    const worktree = addWorktree(main);
+    const nested = path.join(worktree, 'control');
+    expect(canonicalizeControlRepoPath(nested)).toBe(path.resolve(main, 'control'));
+  });
+
+  it('returns the resolved path for non-git directories', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-nongit-'));
+    expect(canonicalizeControlRepoPath(dir)).toBe(path.resolve(dir));
+  });
+
+  it('records the main checkout when given a worktree path', () => {
+    const main = initRepo();
+    const worktree = addWorktree(main);
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'har-control-registry-'));
+    process.env.HAR_CONTROL_REGISTRY_PATH = path.join(tempHome, 'repos.json');
+
+    recordRepoForControlSync(worktree);
+    expect(listRegisteredRepos()).toEqual([path.resolve(main)]);
+  });
+
+  it('dedupes a worktree entry already stored in the registry', () => {
+    const main = initRepo();
+    const worktree = addWorktree(main);
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'har-control-registry-'));
+    const registryPath = path.join(tempHome, 'repos.json');
+    process.env.HAR_CONTROL_REGISTRY_PATH = registryPath;
+
+    fs.writeFileSync(
+      registryPath,
+      JSON.stringify({ repos: [path.resolve(worktree), path.resolve(main)] }, null, 2),
+    );
+
+    expect(listRegisteredRepos()).toEqual([path.resolve(main)]);
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).repos).toEqual([
+      path.resolve(main),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Mission Control identified repositories by absolute path only, so sync/register from a HAR session worktree created a duplicate repo row next to the main checkout.
- Canonicalize linked worktrees to the main working tree before CLI register/sync and local registry writes.
- On the Mission Control API, apply the same canonicalization on register and prune stale worktree duplicate rows when listing repositories.

## Test plan
- [x] CLI harness `har env verify 1 --full` (typecheck, unit tests, lint, build, docs)
- [x] Control harness `har env verify 2 --full` (typecheck, unit tests, api-health, browser-e2e, docker-build)
- [ ] Open Mission Control → Repositories after syncing from a session worktree; confirm only the main checkout path appears
- [ ] Confirm an existing worktree duplicate row disappears after the next `/api/repos` list or register/sync


Made with [Cursor](https://cursor.com)