### PR TITLE
feat(cli): clarify launch lifecycle and new session base

### DIFF
--- a/.cursor/rules/har-workflow.mdc
+++ b/.cursor/rules/har-workflow.mdc
@@ -15,13 +15,14 @@ work around it with ad-hoc commands.
 
 ## Before making changes
 
-1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP), `har env launch 1`, or `./.har/launch.sh 1`. Launch always creates a **fresh session worktree** from the current HEAD and returns its **work dir**.
-2. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `./.har/agent-cli.sh <id> restart` if a change doesn't take.
-3. Read [AGENT.md](./AGENT.md) at the repo root
-4. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)
-5. After launch, read [.har/CLAUDE.agent.md](./.har/CLAUDE.agent.md) for slot URLs and definition of done
+1. **On the main checkout, switch to the intended base** (usually `main`) — every launch creates a worktree from that HEAD. `--replace` does not select the base.
+2. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP), `har env launch 1`, or `./.har/launch.sh 1`. Launch always creates a **fresh session worktree** and returns its **work dir**.
+3. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `./.har/agent-cli.sh <id> restart` if a change doesn't take.
+4. Read [AGENT.md](./AGENT.md) at the repo root
+5. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)
+6. After launch, read [.har/CLAUDE.agent.md](./.har/CLAUDE.agent.md) for slot URLs and definition of done
 
-Relaunching a slot **replaces** its previous session (the old branch is kept). Replacement requires explicit confirmation (`--replace`, `confirmReplace=true`, or an interactive prompt). If the previous session has uncommitted changes, you must also pass `force`/`--force` after **explicit user approval** — never autonomously.
+When a slot is occupied: prefer `complete` / `teardown` if the previous task is finished, then launch. Use `--replace` / `confirmReplace=true` only to reuse the same slot id immediately (destroys the old worktree; the old branch is kept if committed). If the previous session has uncommitted changes, you must also pass `force`/`--force` after **explicit user approval** — never autonomously. Failed launches: `--resume` / `recover`, not `--replace`.
 
 ### Slot safety (read before launch)
 
@@ -30,6 +31,7 @@ Relaunching a slot **replaces** its previous session (the old branch is kept). R
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
+- With telemetry prompts enabled, Mission Control derives session purpose from the first captured user prompt.
 - If launch failed partway (registry `status: failed`), **resume** instead of replacing:
   `har env launch <id> --resume`, `har env recover <id>`, or `./.har/launch.sh <id> --resume`.
   Do not hand-roll PM2 or skip the harness.

--- a/.har/README.md
+++ b/.har/README.md
@@ -104,19 +104,25 @@ har env maintain --no-cursor-rule  # skip Cursor rule scaffolding
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **fresh session**: a new git worktree from the **main
+checkout's current HEAD** at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
-The session is recorded in `.har/slots/agent-<id>.json` (the slot registry) — status,
-verify, and teardown resolve the work dir through it. Make ALL file edits under the
-work dir printed by launch, never in the main checkout.
+Switch that checkout to `main` (or your intended base) before launch for a new
+unrelated task. The session is recorded in `.har/slots/agent-<id>.json` (the slot
+registry) — status, verify, and teardown resolve the work dir through it. Make ALL
+file edits under the work dir printed by launch, never in the main checkout.
 
-- Relaunching a slot **replaces** its previous session and **requires explicit confirmation**
-  (`--replace`, `HAR_CONFIRM_REPLACE=1`, `har env launch --replace`, or MCP `confirmReplace=true`).
-  Launch prints a warning showing the occupied worktree, branch, and dirty state.
-- If the old worktree has uncommitted changes, you must also pass `--force` — **only after
-  explicit user approval** (agents must never set force autonomously).
-- The session **branch is kept** on teardown if you committed; gitignored paths (`state/`,
-  `runs/`, local clones) are **not** preserved when the worktree is removed.
+- Prefer `har env complete <id>` (or `teardown`) when a task is finished, then
+  launch — that frees the slot without mixing bases.
+- Relaunching with `--replace` **destroys** the previous worktree and **requires
+  explicit confirmation** (`--replace`, `HAR_CONFIRM_REPLACE=1`, or MCP
+  `confirmReplace=true`). It does **not** choose `main`; the new session still
+  uses current HEAD. Occupied warnings show both the old session and the
+  upcoming base.
+- If the old worktree has uncommitted changes, you must also pass `--force` —
+  **only after explicit user approval** (agents must never set force autonomously).
+- The session **branch is kept** on teardown if you committed; gitignored paths
+  (`state/`, `runs/`, local clones) are **not** preserved when the worktree is removed.
 - Use **separate slots** for parallel unrelated tasks (`agentSlots.max` in `stages.json`).
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).

--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -516,6 +516,17 @@ print_slot_replace_warning() {
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
+  local base_root="${HARNESS_ROOT:-${REPO_ROOT:-}}"
+  if [ -n "$base_root" ] && [ -d "$base_root" ]; then
+    local base_branch base_sha
+    base_branch="$(git -C "$base_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+    base_sha="$(git -C "$base_root" rev-parse --short HEAD 2>/dev/null || true)"
+    echo "  New session will be based on: ${base_branch}${base_sha:+ @ ${base_sha}}" >&2
+    echo "  (HEAD of ${base_root})" >&2
+    echo "  --replace does not choose this base — switch that checkout first for a new unrelated task." >&2
+    echo "" >&2
+  fi
+  echo "  Prefer complete/teardown when the previous task is finished, then launch." >&2
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2

--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -182,15 +182,17 @@ The authoring agent updates scripts and this README. Review changes before commi
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **fresh session**: a new git worktree from the **main
+checkout's current HEAD** at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
-The session is recorded in `.har/slots/agent-<id>.json` (the slot registry) — status,
-verify, and teardown resolve the work dir through it. Make ALL file edits under the
-work dir printed by launch, never in the main checkout.
+Switch that checkout to your intended base before launch. The session is recorded in
+`.har/slots/agent-<id>.json` (the slot registry) — status, verify, and teardown resolve
+the work dir through it. Make ALL file edits under the work dir printed by launch,
+never in the main checkout.
 
-- Relaunching a slot **replaces** its previous session; replacement requires `--replace` /
-  `confirmReplace=true` (or an interactive prompt). Uncommitted changes also need `--force`
-  after explicit user approval.
+- Prefer `complete` / `teardown` when a task is finished, then launch.
+- `--replace` destroys the previous worktree (requires confirmation); it does **not**
+  choose `main`. Uncommitted changes also need `--force` after explicit user approval.
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).
 - `har env complete <id>` finishes a session: full verify (recorded as a validation),

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -535,6 +535,17 @@ print_slot_replace_warning() {
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
+  local base_root="${HARNESS_ROOT:-${REPO_ROOT:-}}"
+  if [ -n "$base_root" ] && [ -d "$base_root" ]; then
+    local base_branch base_sha
+    base_branch="$(git -C "$base_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+    base_sha="$(git -C "$base_root" rev-parse --short HEAD 2>/dev/null || true)"
+    echo "  New session will be based on: ${base_branch}${base_sha:+ @ ${base_sha}}" >&2
+    echo "  (HEAD of ${base_root})" >&2
+    echo "  --replace does not choose this base — switch that checkout first for a new unrelated task." >&2
+    echo "" >&2
+  fi
+  echo "  Prefer complete/teardown when the previous task is finished, then launch." >&2
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -7,8 +7,10 @@ description: The safe lifecycle for parallel coding tasks.
 
 1. Read the repository's `AGENT.md`, `.har/README.md`, and `.har/stages.json`.
 2. Check status before choosing a slot.
-3. Launch once and record the returned work directory.
-4. Read `.har/CLAUDE.agent.md` in that worktree for resolved URLs and the
+3. On the **main checkout**, switch to the branch you want as the session base
+   (usually `main`) — every launch creates a worktree from that HEAD.
+4. Launch once and record the returned work directory.
+5. Read `.har/CLAUDE.agent.md` in that worktree for resolved URLs and the
    repository-specific definition of done.
 
 ```bash
@@ -23,15 +25,25 @@ fills the session purpose from the first captured user prompt.
 
 ## Occupied and failed slots
 
-A normal launch never silently replaces an active session.
+A normal launch never silently replaces an active session. Prefer finishing the
+previous task first:
+
+```bash
+har env complete 2   # or: har env teardown 2
+har env launch 2
+```
+
+To reuse the same slot id immediately, pass `--replace` after reviewing the
+occupied warning (it shows the **new** session base — HEAD of `--repo` — not
+only the old worktree). `--replace` destroys the previous worktree; it does
+**not** select `main`.
 
 ```bash
 har env launch 2 --replace
 ```
 
-Only use `--replace` after reviewing the current branch and worktree. If that
-worktree has uncommitted changes, replacement remains blocked until the owner
-explicitly approves `--force`.
+If that worktree has uncommitted changes, replacement remains blocked until the
+owner explicitly approves `--force`.
 
 A launch that failed partway is different. Preserve and resume its existing state:
 

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -13,11 +13,11 @@ All repository commands accept `--repo <path>`; the default is the current direc
 | `maintain` | Validate, compare templates, and prepare or finalize an upgrade |
 | `add-stage [template]` | List/install shipped templates or register a custom stage |
 | `preflight <id>` | Check ports, processes, Docker, and slot occupation |
-| `launch <id>` | Create and start a fresh slot session |
+| `launch <id>` | Start a fresh session (new worktree from `--repo` HEAD) |
 | `recover <id>` | Resume a failed or partial launch |
 | `verify <id>` | Run quick or full verification |
 | `complete <id>` | Full verify, record validation, teardown, keep branch |
-| `teardown <id>` | Stop a slot and keep its branch |
+| `teardown <id>` | Free a slot without a completion validation; keep branch |
 | `status` | Inspect all slots |
 | `runs list` | List persisted run records |
 | `runs get <runId>` | Return one run record |
@@ -65,8 +65,15 @@ har env launch 1 [--no-worktree] [--claude] [--replace] [--force] [--resume]
 har env recover 1
 ```
 
-`--replace` confirms replacement of an occupied slot. `--force` additionally
-permits discarding dirty uncommitted work and must only follow explicit approval.
+Every `launch` creates a **new** session from the current HEAD of `--repo` (the
+main checkout). Occupied-slot warnings print that upcoming base so you can
+confirm it before replacing.
+
+`--replace` only confirms destroying the previous session on that slot id — it
+does not choose `main`. Prefer `complete` / `teardown` when the prior task is
+finished, then launch. `--force` additionally permits discarding dirty
+uncommitted work and must only follow explicit approval. Use `--resume` /
+`recover` for failed launches, not `--replace`.
 
 ### Verify and finish
 

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -25,9 +25,13 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 | `har_complete_environment` | `agentId`, `skipVerify` | Validation, teardown, and retained branch |
 | `har_teardown_environment` | `agentId`, `deleteBranch` | Teardown result |
 
-Launch is blocked when a slot is occupied until `confirmReplace` is true. Dirty
-replacement additionally requires `force`; agents should never set either without
-review and explicit approval. Use recovery, not replacement, for a failed launch.
+Every launch creates a new session from the main checkout's current HEAD.
+`confirmReplace` only confirms destroying the previous worktree on that slot —
+it does not choose `main`. Prefer `har_complete_environment` /
+`har_teardown_environment` when the prior task is finished, then launch.
+Occupied-slot errors include the upcoming base. Dirty replacement additionally
+requires `force`; agents should never set either without review and explicit
+approval. Use recovery, not replacement, for a failed launch.
 
 ## Execution
 

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -35,10 +35,18 @@ import { recordRepoForControlSync } from '../../core/control-registry';
 import { writeFileSafe } from '../../utils/file-ops';
 import { requireApiKey, validateAgentId } from '../../utils/validation';
 import { info, success, error, header, divider, warn } from '../../utils/logging';
+import {
+  HAR_ENV_EPILOG,
+  LAUNCH_COMMAND_DESCRIBE,
+  LAUNCH_EPILOG,
+  LAUNCH_FORCE_DESCRIBE,
+  LAUNCH_REPLACE_DESCRIBE,
+  LAUNCH_RESUME_DESCRIBE,
+} from '../help-text';
 
 export const envCommand = {
   command: 'env <subcommand>',
-  describe: 'Manage agent environments',
+  describe: 'Manage agent environments (launch → verify → complete)',
   builder: (yargs: Argv) =>
     yargs
       .command(
@@ -175,11 +183,15 @@ export const envCommand = {
       )
       .command(
         'launch <id>',
-        'Launch a fresh agent session (replaces any previous session for the slot)',
+        LAUNCH_COMMAND_DESCRIBE,
         (y: Argv) =>
           y
             .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
-            .option('repo', { type: 'string', default: '.' })
+            .option('repo', {
+              type: 'string',
+              default: '.',
+              describe: 'Main checkout whose HEAD becomes the new session base',
+            })
             .option('worktree', {
               type: 'boolean',
               default: true,
@@ -189,19 +201,19 @@ export const envCommand = {
             .option('replace', {
               type: 'boolean',
               default: false,
-              describe: 'Replace an occupied slot (prompts on TTY when omitted)',
+              describe: LAUNCH_REPLACE_DESCRIBE,
             })
             .option('force', {
               type: 'boolean',
               default: false,
-              describe:
-                'Discard uncommitted changes when replacing a dirty worktree (only after explicit approval)',
+              describe: LAUNCH_FORCE_DESCRIBE,
             })
             .option('resume', {
               type: 'boolean',
               default: false,
-              describe: 'Resume a failed or partial launch without creating a new worktree',
-            }),
+              describe: LAUNCH_RESUME_DESCRIBE,
+            })
+            .epilog(LAUNCH_EPILOG),
         handleLaunch,
       )
       .command(
@@ -314,7 +326,11 @@ export const envCommand = {
             .demandCommand(1, 'Use: runs list | runs get <runId>'),
         () => {},
       )
-      .demandCommand(1, 'Please specify a subcommand: init, maintain, add-stage, launch, recover, verify, complete, teardown, status, runs'),
+      .demandCommand(
+        1,
+        'Please specify a subcommand: init, maintain, add-stage, launch, recover, verify, complete, teardown, status, runs',
+      )
+      .epilog(HAR_ENV_EPILOG),
   handler: () => {},
 };
 

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -1,0 +1,59 @@
+/** Shared CLI epilog / launch copy for `har --help` and `har env` help. */
+
+export const HAR_ROOT_EPILOG = `Typical agent workflow:
+  har env status                 # see which slots are free / occupied
+  har env launch <id>            # new session from the main checkout's HEAD
+  # …edit only under the printed work dir…
+  har env verify <id> --full
+  har env complete <id>          # done: verify + free the slot (branch kept for PR)
+
+Slot lifecycle (do not confuse these):
+  launch     start a NEW session (worktree from $REPO_ROOT HEAD)
+  recover    resume a failed/partial launch (keeps the existing worktree)
+  complete   finish successfully: full verify, then teardown (frees the slot)
+  teardown   abandon / free the slot without a completion validation
+
+  --replace  only confirms destroying a previous session on that slot id
+             it does NOT choose main — new session still uses current HEAD
+  --force    additionally discard dirty uncommitted work (user approval only)
+  --resume   recover failed/starting; never use --replace for that
+
+For a new unrelated task: checkout main (or your intended base) on the main
+repo checkout, free the slot (complete/teardown), then launch.`;
+
+export const HAR_ENV_EPILOG = `Environment lifecycle:
+  preflight <id>   dry-run: ports, PM2, Docker, occupied-slot gates
+  launch <id>      fresh session worktree from the main checkout's current HEAD
+  recover <id>     alias for launch --resume (failed/starting only)
+  verify <id>      run checks (--full before declaring done)
+  complete <id>    full verify + teardown; keeps branch for push/PR (frees slot)
+  teardown <id>    free the slot without recording a completion validation
+
+Occupied slots:
+  Prefer complete/teardown when the previous task is finished, then launch.
+  Use --replace only to reuse the same slot id immediately (destroys old worktree).
+  --replace does not select the base branch — HEAD of --repo does.
+  Dirty previous worktree also needs --force after explicit user approval.`;
+
+export const LAUNCH_COMMAND_DESCRIBE =
+  'Start a fresh agent session (new worktree from the main checkout HEAD)';
+
+export const LAUNCH_REPLACE_DESCRIBE =
+  'Destroy the previous session on this slot and start another (does not choose main; still uses --repo HEAD)';
+
+export const LAUNCH_FORCE_DESCRIBE =
+  'With --replace: discard uncommitted changes in the old worktree (only after explicit user approval)';
+
+export const LAUNCH_RESUME_DESCRIBE =
+  'Continue a failed or starting launch without creating a new worktree (prefer over --replace)';
+
+export const LAUNCH_EPILOG = `Every launch creates a NEW session from the current HEAD of --repo (the main
+checkout). The worktree path encodes that base branch — switch --repo to main
+before launch for a new unrelated task unless you intentionally stack on a
+feature branch.
+
+  Free slot:     har env launch 1
+  Occupied:      har env complete 1   # or teardown — then launch
+                 har env launch 1 --replace          # reuse slot id now
+                 har env launch 1 --replace --force  # + discard dirty work
+  Failed launch: har env recover 1    # or: har env launch 1 --resume`;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { controlCommand } from './commands/control';
 import { hooksCommand } from './commands/hooks';
 import { mcpCommand } from './commands/mcp';
 import { telemetryCommand } from './commands/telemetry';
+import { HAR_ROOT_EPILOG } from './help-text';
 
 export async function runCli(): Promise<void> {
   await yargs(hideBin(process.argv))
@@ -18,7 +19,8 @@ export async function runCli(): Promise<void> {
     .command(hooksCommand)
     .command(mcpCommand)
     .command(telemetryCommand)
-    .demandCommand(1, 'Please specify a command. Try: har env init')
+    .demandCommand(1, 'Please specify a command. Try: har env --help')
+    .epilog(HAR_ROOT_EPILOG)
     .strict()
     .help()
     .version(getHarPackageVersion())

--- a/src/core/slot-launch-guard-occupied.ts
+++ b/src/core/slot-launch-guard-occupied.ts
@@ -105,7 +105,23 @@ function collectOccupiedSlot(repoPath: string, agentId: number): AgentSlotStatus
   };
 }
 
-function formatOccupiedSlot(slot: AgentSlotStatus, resume?: boolean): string {
+/** Describe the HEAD that a new launch would use (main checkout / --repo). */
+export function describeLaunchBase(repoPath: string): string[] {
+  const harnessRoot = resolveHarnessRoot(repoPath);
+  const branch = runGit(harnessRoot, 'rev-parse --abbrev-ref HEAD') ?? 'detached';
+  const sha = runGit(harnessRoot, 'rev-parse --short HEAD');
+  return [
+    `New session will be based on: ${branch}${sha ? ` @ ${sha}` : ''}`,
+    `  (HEAD of ${harnessRoot})`,
+    '  --replace does not choose this base — switch the main checkout first for a new unrelated task.',
+  ];
+}
+
+function formatOccupiedSlot(
+  slot: AgentSlotStatus,
+  repoPath: string,
+  resume?: boolean,
+): string {
   const lines = [
     `Slot ${slot.agentId} is already in use.`,
     slot.worktreePath ? `  Worktree: ${slot.worktreePath}` : undefined,
@@ -117,6 +133,8 @@ function formatOccupiedSlot(slot: AgentSlotStatus, resume?: boolean): string {
     slot.dirty
       ? '  Git:      dirty (uncommitted changes — commit or use force to discard)'
       : '  Git:      clean',
+    '',
+    ...describeLaunchBase(repoPath),
     '',
   ];
 
@@ -135,6 +153,7 @@ function formatOccupiedSlot(slot: AgentSlotStatus, resume?: boolean): string {
   }
 
   lines.push(
+    'Prefer complete/teardown when the previous task is finished, then launch.',
     'Replacing removes the worktree. The session branch is kept only if you committed.',
     'Gitignored paths (state/, runs/, local clones) are NOT preserved.',
     '',
@@ -178,7 +197,7 @@ export function checkLaunchGuard(
       allowed: false,
       blocked: true,
       slot,
-      reason: formatOccupiedSlot(slot),
+      reason: formatOccupiedSlot(slot, repoPath),
     };
   }
 
@@ -187,7 +206,7 @@ export function checkLaunchGuard(
       allowed: false,
       blocked: true,
       slot,
-      reason: formatOccupiedSlot(slot),
+      reason: formatOccupiedSlot(slot, repoPath),
     };
   }
 
@@ -197,7 +216,7 @@ export function checkLaunchGuard(
       blocked: true,
       slot,
       reason: [
-        formatOccupiedSlot(slot),
+        formatOccupiedSlot(slot, repoPath),
         '',
         'The occupied worktree has uncommitted changes.',
         'Pass force=true / --force to discard them (only after explicit user approval).',

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -72,7 +72,7 @@ export const LaunchEnvironmentInputSchema = z.object({
     .boolean()
     .default(false)
     .describe(
-      'Replace an occupied slot. Required when a session is already active. Call har_get_status first; get explicit user approval before setting this.',
+      'Destroy the previous session on this slot and start another from main-checkout HEAD. Does not choose main. Prefer complete/teardown when the prior task is finished. Call har_get_status first; get explicit user approval.',
     ),
   force: z
     .boolean()

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -75,7 +75,7 @@ export const HAR_MCP_TOOLS: Tool[] = [
   {
     name: 'har_launch_environment',
     description:
-      'Start a FRESH agent session. Run this BEFORE editing any file: it returns workDir — ALL file edits must go under that path, never the main checkout. If the slot is already occupied, launch is BLOCKED until confirmReplace=true (call har_get_status first; get explicit user approval). force=true discards dirty uncommitted work — never set without user approval. Edits under workDir hot-reload in the running slot.',
+      'Start a FRESH agent session from the main checkout HEAD (switch that checkout to main first for a new unrelated task). Run BEFORE editing any file: returns workDir — ALL edits go there, never the main checkout. Prefer har_complete_environment / har_teardown_environment when a prior task is done. Occupied slots block until confirmReplace=true (does NOT choose main). force=true discards dirty work — never set without user approval. Failed launches: resume=true / har_recover_environment.',
     inputSchema: objectJsonSchema(
       {
         repo: repoJsonProperty,
@@ -85,7 +85,7 @@ export const HAR_MCP_TOOLS: Tool[] = [
         confirmReplace: {
           type: 'boolean',
           description:
-            'Replace an occupied slot. Required when a session is active. Call har_get_status first; get explicit user approval before setting true.',
+            'Destroy the previous session on this slot and start another from main-checkout HEAD. Does not choose main. Prefer complete/teardown when the prior task is finished. Call har_get_status first; get explicit user approval.',
         },
         force: {
           type: 'boolean',
@@ -95,7 +95,7 @@ export const HAR_MCP_TOOLS: Tool[] = [
         resume: {
           type: 'boolean',
           description:
-            'Resume a failed or partial launch (status failed/starting) without --replace. Preserves worktree and env.',
+            'Resume a failed or partial launch (status failed/starting) without confirmReplace. Preserves worktree and env.',
         },
       },
       ['agentId'],

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -15,13 +15,14 @@ work around it with ad-hoc commands.
 
 ## Before making changes
 
-1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP) or `har env launch 1`. Launch always creates a **fresh session worktree** from the current HEAD and returns its **work dir**.
-2. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `har env restart <id>` or `./.har/agent-cli.sh <id> restart` if a change doesn't take.
-3. Read [AGENT.md](./AGENT.md) at the repo root
-4. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)
-5. After launch, read [.har/CLAUDE.agent.md](./.har/CLAUDE.agent.md) for slot URLs and definition of done
+1. **On the main checkout, switch to the intended base** (usually `main`) — every launch creates a worktree from that HEAD. `--replace` does not select the base.
+2. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP) or `har env launch 1`. Launch always creates a **fresh session worktree** and returns its **work dir**.
+3. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `har env restart <id>` or `./.har/agent-cli.sh <id> restart` if a change doesn't take.
+4. Read [AGENT.md](./AGENT.md) at the repo root
+5. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)
+6. After launch, read [.har/CLAUDE.agent.md](./.har/CLAUDE.agent.md) for slot URLs and definition of done
 
-Relaunching a slot **replaces** its previous session (the old branch is kept). Replacement requires explicit confirmation (`--replace`, `confirmReplace=true`, or an interactive prompt). If the previous session has uncommitted changes, you must also pass `force`/`--force` after **explicit user approval** — never autonomously.
+When a slot is occupied: prefer `complete` / `teardown` if the previous task is finished, then launch. Use `--replace` / `confirmReplace=true` only to reuse the same slot id immediately (destroys the old worktree; the old branch is kept if committed). If the previous session has uncommitted changes, you must also pass `force`/`--force` after **explicit user approval** — never autonomously. Failed launches: `--resume` / `recover`, not `--replace`.
 
 ### Slot safety (read before launch)
 
@@ -30,7 +31,7 @@ Relaunching a slot **replaces** its previous session (the old branch is kept). R
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
-- Optional: set `har env launch <id> --purpose=label`, `HAR_SESSION_PURPOSE=label`, or `./.har/launch.sh <id> --purpose=label` so occupied-slot warnings show what you were doing.
+- With telemetry prompts enabled, Mission Control derives session purpose from the first captured user prompt.
 
 <!-- Monorepo: if this repository contains multiple .har harnesses, list them here
      and pick by the files you are changing. Example:

--- a/src/templates/har-boilerplate-cli/README.md
+++ b/src/templates/har-boilerplate-cli/README.md
@@ -137,15 +137,17 @@ The authoring agent updates scripts and this README. Review changes before commi
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **fresh session**: a new git worktree from the **main
+checkout's current HEAD** at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
-The session is recorded in `.har/slots/agent-<id>.json` (the slot registry) — status,
-verify, and teardown resolve the work dir through it. Make ALL file edits under the
-work dir printed by launch, never in the main checkout.
+Switch that checkout to your intended base before launch. The session is recorded in
+`.har/slots/agent-<id>.json` (the slot registry) — status, verify, and teardown resolve
+the work dir through it. Make ALL file edits under the work dir printed by launch,
+never in the main checkout.
 
-- Relaunching a slot **replaces** its previous session; replacement requires `--replace` /
-  `confirmReplace=true` (or an interactive prompt). Uncommitted changes also need `--force`
-  after explicit user approval.
+- Prefer `complete` / `teardown` when a task is finished, then launch.
+- `--replace` destroys the previous worktree (requires confirmation); it does **not**
+  choose `main`. Uncommitted changes also need `--force` after explicit user approval.
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, resume with

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -515,6 +515,17 @@ print_slot_replace_warning() {
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
+  local base_root="${HARNESS_ROOT:-${REPO_ROOT:-}}"
+  if [ -n "$base_root" ] && [ -d "$base_root" ]; then
+    local base_branch base_sha
+    base_branch="$(git -C "$base_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+    base_sha="$(git -C "$base_root" rev-parse --short HEAD 2>/dev/null || true)"
+    echo "  New session will be based on: ${base_branch}${base_sha:+ @ ${base_sha}}" >&2
+    echo "  (HEAD of ${base_root})" >&2
+    echo "  --replace does not choose this base — switch that checkout first for a new unrelated task." >&2
+    echo "" >&2
+  fi
+  echo "  Prefer complete/teardown when the previous task is finished, then launch." >&2
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2

--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -113,10 +113,14 @@ When your app talks to a local backend, read the resolved host port from `.env.a
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **fresh session**: a new git worktree from the **main
+checkout's current HEAD** at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
-The session is recorded in `.har/slots/agent-<id>.json`.
+Switch that checkout to your intended base before launch. The session is recorded in
+`.har/slots/agent-<id>.json`.
 
-- Relaunching a slot **replaces** its previous session; uncommitted changes require `--force`.
+- Prefer `complete` / `teardown` when a task is finished, then launch.
+- `--replace` destroys the previous worktree; it does **not** choose `main`.
+  Uncommitted changes also require `--force` after explicit approval.
 - `teardown` removes the worktree but **keeps the session branch** for push / PR.
 - `har env complete <id>` finishes a session: full verify + teardown, branch kept.

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -176,6 +176,17 @@ print_slot_replace_warning() {
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
+  local base_root="${HARNESS_ROOT:-${REPO_ROOT:-}}"
+  if [ -n "$base_root" ] && [ -d "$base_root" ]; then
+    local base_branch base_sha
+    base_branch="$(git -C "$base_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+    base_sha="$(git -C "$base_root" rev-parse --short HEAD 2>/dev/null || true)"
+    echo "  New session will be based on: ${base_branch}${base_sha:+ @ ${base_sha}}" >&2
+    echo "  (HEAD of ${base_root})" >&2
+    echo "  --replace does not choose this base — switch that checkout first for a new unrelated task." >&2
+    echo "" >&2
+  fi
+  echo "  Prefer complete/teardown when the previous task is finished, then launch." >&2
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2

--- a/src/templates/har-boilerplate/README.md
+++ b/src/templates/har-boilerplate/README.md
@@ -179,15 +179,17 @@ The authoring agent updates scripts and this README. Review changes before commi
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **fresh session**: a new git worktree from the **main
+checkout's current HEAD** at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
-The session is recorded in `.har/slots/agent-<id>.json` (the slot registry) — status,
-verify, and teardown resolve the work dir through it. Make ALL file edits under the
-work dir printed by launch, never in the main checkout.
+Switch that checkout to your intended base before launch. The session is recorded in
+`.har/slots/agent-<id>.json` (the slot registry) — status, verify, and teardown resolve
+the work dir through it. Make ALL file edits under the work dir printed by launch,
+never in the main checkout.
 
-- Relaunching a slot **replaces** its previous session; replacement requires `--replace` /
-  `confirmReplace=true` (or an interactive prompt). Uncommitted changes also need `--force`
-  after explicit user approval.
+- Prefer `complete` / `teardown` when a task is finished, then launch.
+- `--replace` destroys the previous worktree (requires confirmation); it does **not**
+  choose `main`. Uncommitted changes also need `--force` after explicit user approval.
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, the registry records `status: failed`.

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -535,6 +535,17 @@ print_slot_replace_warning() {
   [ -n "$created" ] && echo "  Since:     ${created}" >&2
   echo "  Git:       ${dirty_summary}" >&2
   echo "" >&2
+  local base_root="${HARNESS_ROOT:-${REPO_ROOT:-}}"
+  if [ -n "$base_root" ] && [ -d "$base_root" ]; then
+    local base_branch base_sha
+    base_branch="$(git -C "$base_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+    base_sha="$(git -C "$base_root" rev-parse --short HEAD 2>/dev/null || true)"
+    echo "  New session will be based on: ${base_branch}${base_sha:+ @ ${base_sha}}" >&2
+    echo "  (HEAD of ${base_root})" >&2
+    echo "  --replace does not choose this base — switch that checkout first for a new unrelated task." >&2
+    echo "" >&2
+  fi
+  echo "  Prefer complete/teardown when the previous task is finished, then launch." >&2
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2

--- a/tests/cli-help-text.test.ts
+++ b/tests/cli-help-text.test.ts
@@ -1,0 +1,19 @@
+import {
+  HAR_ENV_EPILOG,
+  HAR_ROOT_EPILOG,
+  LAUNCH_COMMAND_DESCRIBE,
+  LAUNCH_EPILOG,
+  LAUNCH_REPLACE_DESCRIBE,
+} from '../src/cli/help-text';
+
+describe('cli help text', () => {
+  it('explains launch base and replace vs complete', () => {
+    expect(HAR_ROOT_EPILOG).toContain('main checkout');
+    expect(HAR_ROOT_EPILOG).toContain('--replace');
+    expect(HAR_ROOT_EPILOG).toContain('complete');
+    expect(HAR_ENV_EPILOG).toContain('HEAD of --repo');
+    expect(LAUNCH_COMMAND_DESCRIBE).toContain('HEAD');
+    expect(LAUNCH_REPLACE_DESCRIBE).toContain('does not choose main');
+    expect(LAUNCH_EPILOG).toContain('recover');
+  });
+});

--- a/tests/slot-launch-guard.test.ts
+++ b/tests/slot-launch-guard.test.ts
@@ -81,6 +81,16 @@ describe('slot launch guard', () => {
     expect(result.slot?.worktreePath).toBe(worktreePath);
     expect(result.reason).toContain('already in use');
     expect(result.reason).not.toContain('Purpose:');
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: repoPath,
+      encoding: 'utf8',
+    }).trim();
+    const sha = execSync('git rev-parse --short HEAD', {
+      cwd: repoPath,
+      encoding: 'utf8',
+    }).trim();
+    expect(result.reason).toContain(`New session will be based on: ${branch} @ ${sha}`);
+    expect(result.reason).toContain('--replace does not choose this base');
   });
 
   it('requires force when replacing a dirty occupied slot', () => {


### PR DESCRIPTION
## Summary
- Expand `har` / `har env` / `har env launch` help so agents see the real lifecycle: launch from main-checkout HEAD → verify → complete/teardown, with `--replace` clearly not choosing `main`.
- Occupied-slot warnings (CLI + shell) now print the **upcoming** session base (`branch @ sha`).
- Align agent workflow docs, MCP tool copy, Cursor rule, and boilerplate READMEs (purpose stays OTEL-derived).

Closes #73

## Test plan
- [x] `har env verify 1 --full` on the session worktree
- [ ] `har --help` / `har env --help` / `har env launch --help` show the new epilog copy
- [ ] Occupied launch without `--replace` prints “New session will be based on: …”
- [ ] Confirm docs pages (agent workflow, CLI, MCP) read correctly in a docs preview if needed


Made with [Cursor](https://cursor.com)