### PR TITLE
feat: functional verify sandbox + diversified SWE-bench sampling

### DIFF
--- a/benchmarks/swebench-har/BENCHMARK-50-REPORT.md
+++ b/benchmarks/swebench-har/BENCHMARK-50-REPORT.md
@@ -1,0 +1,184 @@
+# SWE-bench HAR Benchmark Report — Diversified n=50
+
+**Batch:** `20260723-113828`  
+**Date:** 2026-07-23 → 2026-07-24  
+**Dataset:** SWE-bench Lite (`test`)  
+**Sample:** seed `42`, count `50`, max **5** instances/repo, max **10** repos/language  
+**Arms:** raw Codex vs HAR-assisted Codex  
+**Models:** fix=`gpt-5-mini`, HAR setup=`gpt-5.5`  
+**HAR stack:** functional-verify prompts + task-scoped stages + fail-closed `--full` (`fix_max_rounds: 3`)  
+**Host:** EC2 `sshbench`  
+**Orchestration:** 11:38 → 21:41 UTC (~10h) · **Eval finished:** 2026-07-24 ~00:06 UTC
+
+This is **Iteration 4** of the campaign (see `BENCHMARK-ITERATIONS.md`).
+
+---
+
+## Executive summary
+
+| Metric | Raw | HAR |
+|--------|-----|-----|
+| Patches produced | **50/50** | **50/50** |
+| Official resolve | **23/50 (46%)** | **24/50 (48%)** |
+| Unique resolves | 2 | **3** |
+| Both resolved | 21 | 21 |
+| Neither | 24 | 24 |
+
+HAR edges raw by **+1 resolve** on this diversified 50. Orchestration is solid (no failed instances). Post-fix `verify --full` remains a **weak proxy** for official SWE-bench resolve (many false greens and false reds).
+
+---
+
+## Sampling (diversity)
+
+SWE-bench Lite has 12 repos (all Python). Caps selected the 10 largest repos × 5 instances:
+
+| Repository | n | Raw resolve | HAR resolve | HAR `--full` pass |
+|------------|---|-------------|-------------|-------------------|
+| astropy/astropy | 5 | 2 | 2 | 0 |
+| django/django | 5 | 1 | 1 | 4 |
+| matplotlib/matplotlib | 5 | 3 | 2 | 4 |
+| psf/requests | 5 | 3 | **4** | 3 |
+| pydata/xarray | 5 | 1 | 1 | 2 |
+| pylint-dev/pylint | 5 | 1 | **2** | 4 |
+| pytest-dev/pytest | 5 | 3 | 3 | 3 |
+| scikit-learn/scikit-learn | 5 | **5** | 4 | 0 |
+| sphinx-doc/sphinx | 5 | 3 | 3 | 1 |
+| sympy/sympy | 5 | 1 | **2** | 1 |
+
+Without the per-repo cap, seed-42 draws historically over-weighted Django/SymPy; this sample is intentionally broader.
+
+---
+
+## Resolve agreement (raw vs HAR)
+
+| Outcome | Count | Instances |
+|---------|-------|-----------|
+| Both resolve | 21 | — |
+| HAR only | **3** | `psf__requests-1963`, `pylint-dev__pylint-7993`, `sympy__sympy-15609` |
+| Raw only | **2** | `matplotlib__matplotlib-23987`, `scikit-learn__scikit-learn-12471` |
+| Neither | 24 | — |
+
+Net unique advantage: **HAR +1**.
+
+---
+
+## HAR verification behavior
+
+| Signal | Count |
+|--------|-------|
+| Pre-fix ready | 50/50 |
+| Post-fix `--full` pass | **22/50** |
+| `post_fix_verify_failed` (fail-closed warning) | **28/50** |
+| Arm status `completed_with_warnings` | 28 |
+| Arm status `completed` | 22 |
+
+### Does `--full` predict official resolve?
+
+| | Official resolved | Official unresolved |
+|--|-------------------|---------------------|
+| `--full` pass | TP **10** | FP **12** |
+| `--full` fail | FN **14** | TN **14** |
+
+`--full` is roughly coin-flip vs gold tests on this sample: many agent-written stages pass while SWE-bench fails (FP), and many patches resolve officially while `--full` still fails (FN — often polluted/noisy or over-strict stages). Fail-closed correctly *marks* failures but still submits patches for grading (warnings path).
+
+Agents did add issue-specific stages (examples): `colorbar-norm`, `redirect-method-regression`, `pipeline-len`, `napoleon-trailing-underscore`, `p7080-ignore-paths`, `latex-indexed-matrix`, …
+
+---
+
+## Campaign context (same seed family)
+
+| Iter | Batch | n | Raw resolve | HAR resolve | Notes |
+|------|-------|---|-------------|-------------|-------|
+| 0 | `20260708-173731` | 10 | — | — | HAR patches 5/10 (gate) |
+| 1 | `20260718-185954` | 10 | 4/10 | 5/10 | Gate fixed |
+| 2 | `20260718-230801` | 10 | 6/10 | 5/10 | Functional prompts; cache pollution |
+| 3 | `20260720-195658` | 10 | 4/10 | 4/10 | Fail-closed + task-scoped stages |
+| **4** | **`20260723-113828`** | **50** | **23/50** | **24/50** | Diversified sample |
+
+Small-n swings (±1–2) are noise; the n=50 result is the first stable head-to-head under the improved HAR stack.
+
+---
+
+## What improved in HAR (methods relevant to this run)
+
+1. **Sandbox framing** — agents may add stages/tests on the fly; done = `verify --full`.
+2. **Task-scoped stages** — issue stages do not permanently pollute `.har-cache`.
+3. **Fail-closed instrumentation** — failed `--full` recorded (`post_fix_verify_failed`) with fix retries.
+4. **Diversity sampling** — fairer repo mix for paper claims.
+
+---
+
+## Limitations / next work
+
+1. **Align stages with FAIL_TO_PASS** (or run a subset of official tests) to cut FP/FN vs gold.
+2. **Decide patch policy** when `--full` fails: withhold patch vs warn-and-submit (today: warn-and-submit).
+3. **Cost/latency** — ~10h orchestration + overnight Docker eval for n=50 × 2 arms.
+4. **Language diversity** — Lite is Python-only; language cap matters more on full SWE-bench.
+5. **Multiple seeds** — single seed 42; replicate before strong claims.
+
+---
+
+## Artifacts
+
+- EC2 batch: `batches/20260723-113828/batch.json`
+- Eval: `results/batch-20260723-113828/batch-evaluation.{json,md}`
+- Comparison: `results/ec2-comparison.json`
+- Iteration log: `BENCHMARK-ITERATIONS.md`
+- PR: https://github.com/os-factory/har/pull/75
+
+---
+
+## Per-instance resolve table
+
+| # | Instance | Raw | HAR |
+|---|----------|-----|-----|
+| 1 | matplotlib-25498 | yes | yes |
+| 2 | xarray-3364 | no | no |
+| 3 | xarray-5131 | yes | yes |
+| 4 | sphinx-8627 | yes | yes |
+| 5 | astropy-14182 | no | no |
+| 6 | matplotlib-23987 | yes | no |
+| 7 | matplotlib-23913 | yes | yes |
+| 8 | sphinx-7738 | no | no |
+| 9 | xarray-4094 | no | no |
+| 10 | pytest-11143 | yes | yes |
+| 11 | requests-1963 | no | **yes** |
+| 12 | django-11797 | no | no |
+| 13 | sklearn-13439 | yes | yes |
+| 14 | matplotlib-18869 | no | no |
+| 15 | pytest-11148 | no | no |
+| 16 | django-10924 | yes | yes |
+| 17 | pylint-7114 | no | no |
+| 18 | requests-2674 | yes | yes |
+| 19 | sklearn-14894 | yes | yes |
+| 20 | sympy-14317 | no | no |
+| 21 | pylint-7228 | no | no |
+| 22 | requests-3362 | no | no |
+| 23 | sklearn-13496 | yes | yes |
+| 24 | pylint-7993 | no | **yes** |
+| 25 | astropy-12907 | yes | yes |
+| 26 | xarray-4493 | no | no |
+| 27 | pytest-5227 | yes | yes |
+| 28 | pytest-5413 | no | no |
+| 29 | sympy-15609 | no | **yes** |
+| 30 | sympy-20049 | no | no |
+| 31 | sphinx-8713 | yes | yes |
+| 32 | pytest-7373 | yes | yes |
+| 33 | sphinx-7975 | yes | yes |
+| 34 | requests-2148 | yes | yes |
+| 35 | django-11964 | no | no |
+| 36 | astropy-6938 | yes | yes |
+| 37 | astropy-14365 | no | no |
+| 38 | sympy-21171 | no | no |
+| 39 | sphinx-8474 | no | no |
+| 40 | matplotlib-22835 | no | no |
+| 41 | requests-863 | yes | yes |
+| 42 | astropy-7746 | no | no |
+| 43 | django-16229 | no | no |
+| 44 | sklearn-12471 | yes | no |
+| 45 | sympy-18532 | yes | yes |
+| 46 | xarray-4248 | no | no |
+| 47 | django-12284 | no | no |
+| 48 | sklearn-11281 | yes | yes |
+| 49 | pylint-7080 | yes | yes |
+| 50 | pylint-6506 | no | no |

--- a/benchmarks/swebench-har/BENCHMARK-ITERATIONS.md
+++ b/benchmarks/swebench-har/BENCHMARK-ITERATIONS.md
@@ -1,0 +1,136 @@
+# SWE-bench HAR — Iteration Log (paper track)
+
+Living log of benchmark/HAR iterations for the scientific write-up.
+Each iteration records **hypothesis → change → measured outcome**.
+
+Dataset unless noted: **SWE-bench Lite** `test` (300 instances).  
+Models: fix=`gpt-5-mini`, HAR setup=`gpt-5.5`. Arms: **raw** vs **HAR**.
+
+---
+
+## Iteration 0 — Baseline orchestration (2026-07-08)
+
+**Batch:** `20260708-173731` · seed `42` · n=`10`  
+**Hypothesis:** HAR-assisted Codex can produce patches on SWE-bench instances.  
+**Setup:** Pre-fix launch+verify gate; no official Docker eval.
+
+| Arm | Patches | Official resolve |
+|-----|---------|------------------|
+| Raw | 10/10 | not run |
+| HAR | **5/10** | not run |
+
+**Finding:** HAR failures were **infrastructure** (gate never passed); fix agent often never ran.  
+**Doc:** `BENCHMARK-RUN-REPORT.md`
+
+---
+
+## Iteration 1 — Make HAR finish (2026-07-18)
+
+**Batch:** `20260718-185954` · seed `42` · n=`10`  
+**Hypothesis:** Fixing init/CLI/gate/smoke contracts unblocks the HAR arm.  
+**Changes:**
+- HAR CLI invocation via Node; non-interactive `har env init`
+- Setup retries / smoke-level pre-fix gate (not full suite)
+- Per-repo `.har-cache`
+- First official SWE-bench Docker evaluation on this sample
+
+| Arm | Patches | Resolve |
+|-----|---------|---------|
+| Raw | 10/10 | **4/10** |
+| HAR | **10/10** | **5/10** |
+
+**Finding:** Orchestration gap closed (5→10 HAR patches). HAR uniquely resolved `matplotlib-25498`.  
+Post-fix verify was mostly **smoke** (compile/import).
+
+---
+
+## Iteration 2 — Functional verification prompts (2026-07-18/19)
+
+**Batch:** `20260718-230801` · seed `42` · n=`10`  
+**Hypothesis:** If prompts state that HAR is a **verification sandbox** and agents **may add stages/tests on the fly**, resolve rises.  
+**Changes (product + benchmark):**
+- Prompts: done = `verify --full`; allow `har env add-stage` + small regression tests
+- Boilerplate `CLAUDE.agent.md` / setup-har skill / adaptation prompt
+- Config: `har_verify_full: true`
+- Commit `b817956`
+
+| Arm | Patches | Resolve | HAR `--full` pass |
+|-----|---------|---------|-------------------|
+| Raw | 10/10 | **6/10** | — |
+| HAR | 10/10 | **5/10** | **2/10** |
+
+**Finding:** Agents *did* add issue-specific stages (`password-reset-token`, `colorbar-update-norm`, …).  
+Resolve did **not** improve for HAR. New failure modes:
+1. **Cache pollution** — issue stages persisted into `.har-cache` and poisoned later Django `--full` runs  
+2. **Not fail-closed** — patches submitted despite failed `--full`  
+3. **False greens** — agent stages ≠ official FAIL_TO_PASS (e.g. matplotlib-25498)
+
+**Paper lesson (locked in):** prompts must explicitly say stages/tests can be added on the fly; HAR’s purpose is verifying code changes in a sandbox — but runner semantics must match.
+
+---
+
+## Iteration 3 — Task-scoped stages + fail-closed retries (2026-07-20)
+
+**Batch:** `20260720-195658` · seed `42` · n=`10`  
+**Hypothesis:** Isolating task stages from cache + fail-closed `--full` with fix retries improves harness honesty and possibly resolve.  
+**Changes:**
+- Task stages snapshotted to per-run overlay; `.har-cache` keeps only baseline stage IDs
+- Post-fix `--full` failure → `post_fix_verify_failed` + up to `fix_max_rounds: 3`
+- Prompt wording: sandbox + fail-before/pass-after + do not pollute cache
+- Commit `a63b10b`
+
+| Arm | Patches | Resolve | HAR `--full` pass | `post_fix_verify_failed` |
+|-----|---------|---------|-------------------|---------------------------|
+| Raw | 10/10 | **4/10** | — | — |
+| HAR | 10/10 | **4/10** | **5/10** | **5/10** |
+
+**Per-instance resolve:** both arms resolved the same four: django-11099, matplotlib-25498, sympy-20442, django-12915.  
+**Finding:** Fail-closed instrumentation works (5 failures recorded). Stage lists no longer show cross-issue Django pollution in the same way as Iter 2. Resolve tied with raw at 4/10 on this draw (model variance vs Iter 1–2).  
+**Still open:** agent functional stages can disagree with gold tests; n=10 too small for uplift claims.
+
+---
+
+## Iteration 4 — Diversified n=50 (in progress)
+
+**Batch:** `20260723-113828` · seed `42` · n=`50`  
+**Host:** EC2 `sshbench` · tmux `swebench` · log `logs/ec2-batch-20260723-113826.log`  
+**Hypothesis:** With Iter 3 harness semantics, a larger **repo- and language-diverse** sample yields a stable raw-vs-HAR comparison for the paper.  
+**Sampling constraints (new):**
+- `max_per_repo = 5` — avoid Django/SymPy dominance  
+- `max_repos_per_language = 10` — cap language fan-out when multi-lang splits are used  
+- On SWE-bench Lite (12 Python repos): selects 10 repos × ≤5 instances → 50
+
+**Selected repos (5 each):** matplotlib, xarray, sphinx, astropy, pytest, requests, django, scikit-learn, pylint, sympy.
+
+**HAR stack under test:** Iter 3 semantics (`har_verify_full`, task-scoped cache, `fix_max_rounds=3`, sandbox prompts).
+
+| Arm | Patches | Resolve | Notes |
+|-----|---------|---------|-------|
+| Raw | _TBD_ | _TBD_ | |
+| HAR | _TBD_ | _TBD_ | |
+
+Fill this section when the EC2 batch + official eval complete.
+
+---
+
+## Cumulative HAR product changes (for paper “methods”)
+
+1. **Pre-fix gate = launch + smoke**, not full suite.  
+2. **Definition of done = `verify --full`**, with agents allowed to **add verification stages and small tests on the fly**.  
+3. **Task-scoped stages** must not enter the reusable per-repo harness cache.  
+4. **Fail-closed post-fix verify** with bounded fix retries.  
+5. **Repeatable EC2 campaign tooling** (`EC2.md`, bootstrap/run/evaluate scripts).
+
+Branch: `feat/functional-verify-agent-guidance` (`b817956`, `a63b10b`, + Iter 4 sampling).
+
+---
+
+## Scoreboard snapshot (seed 42, n=10 fixed sample)
+
+| Iter | Batch | Raw resolve | HAR resolve | HAR patches |
+|------|-------|-------------|-------------|-------------|
+| 0 | `20260708-173731` | — | — | 5/10 |
+| 1 | `20260718-185954` | 4/10 | 5/10 | 10/10 |
+| 2 | `20260718-230801` | 6/10 | 5/10 | 10/10 |
+| 3 | `20260720-195658` | 4/10 | 4/10 | 10/10 |
+| 4 | diversified n=50 | _TBD_ | _TBD_ | _TBD_ |

--- a/benchmarks/swebench-har/BENCHMARK-ITERATIONS.md
+++ b/benchmarks/swebench-har/BENCHMARK-ITERATIONS.md
@@ -90,26 +90,40 @@ Resolve did **not** improve for HAR. New failure modes:
 
 ---
 
-## Iteration 4 — Diversified n=50 (in progress)
+## Iteration 4 — Diversified n=50 (complete)
 
 **Batch:** `20260723-113828` · seed `42` · n=`50`  
-**Host:** EC2 `sshbench` · tmux `swebench` · log `logs/ec2-batch-20260723-113826.log`  
-**Hypothesis:** With Iter 3 harness semantics, a larger **repo- and language-diverse** sample yields a stable raw-vs-HAR comparison for the paper.  
-**Sampling constraints (new):**
-- `max_per_repo = 5` — avoid Django/SymPy dominance  
-- `max_repos_per_language = 10` — cap language fan-out when multi-lang splits are used  
-- On SWE-bench Lite (12 Python repos): selects 10 repos × ≤5 instances → 50
+**Host:** EC2 `sshbench` · orch ~10h · eval completed 2026-07-24  
+**Hypothesis:** With Iter 3 harness semantics, a larger **repo-diverse** sample yields a stable raw-vs-HAR comparison.  
+**Sampling:** `max_per_repo=5`, `max_repos_per_language=10` → 10 Python repos × 5.
 
-**Selected repos (5 each):** matplotlib, xarray, sphinx, astropy, pytest, requests, django, scikit-learn, pylint, sympy.
+| Arm | Patches | Resolve | Notes |
+|-----|---------|---------|-------|
+| Raw | 50/50 | **23/50 (46%)** | 2 unique wins |
+| HAR | 50/50 | **24/50 (48%)** | 3 unique wins; net **+1** |
 
-**HAR stack under test:** Iter 3 semantics (`har_verify_full`, task-scoped cache, `fix_max_rounds=3`, sandbox prompts).
+**HAR verify:** `--full` pass 22/50; `post_fix_verify_failed` 28/50. `--full` vs official resolve: TP10 / FP12 / FN14 / TN14 (weak predictor).
+
+**Full write-up:** `BENCHMARK-50-REPORT.md`
+
+---
+
+## Iteration 5 — Fail-before + behavioral oracles (in progress)
+
+**Batch:** _TBD_ · seed `42` · n=`50` (same diversity caps)  
+**Hypothesis:** Stronger product prompts + runner **fail-before / task-stage** gates make stages real oracles (from the problem statement only), improving independent verification quality and possibly resolve.
+
+**Product changes:**
+- `CLAUDE.agent.md` / `STAGES.md` / setup-har / adaptation: smoke ≠ done; require change-specific stage; fail-before/pass-after; runnable oracles
+
+**Benchmark changes:**
+- Readiness must register a task stage that **fails on the buggy tree** (not env ImportError)
+- Fix prompts require fail-before then pass-after without gold tests
 
 | Arm | Patches | Resolve | Notes |
 |-----|---------|---------|-------|
 | Raw | _TBD_ | _TBD_ | |
 | HAR | _TBD_ | _TBD_ | |
-
-Fill this section when the EC2 batch + official eval complete.
 
 ---
 
@@ -133,4 +147,4 @@ Branch: `feat/functional-verify-agent-guidance` (`b817956`, `a63b10b`, + Iter 4 
 | 1 | `20260718-185954` | 4/10 | 5/10 | 10/10 |
 | 2 | `20260718-230801` | 6/10 | 5/10 | 10/10 |
 | 3 | `20260720-195658` | 4/10 | 4/10 | 10/10 |
-| 4 | diversified n=50 | _TBD_ | _TBD_ | _TBD_ |
+| 4 | `20260723-113828` (n=50) | **23/50** | **24/50** | 50/50 |

--- a/benchmarks/swebench-har/EC2.md
+++ b/benchmarks/swebench-har/EC2.md
@@ -1,0 +1,250 @@
+# Re-run SWE-bench HAR on the benchmark EC2
+
+This is the runbook for the **already-running** Amazon Linux host used for SWE-bench HAR batches. The `sshbench` alias only SSHes in — it does not start or stop the instance.
+
+## Connect
+
+From a laptop that has the PEM key:
+
+```bash
+alias sshbench="ssh -i ${BENCHMARK_SSH_KEY} ec2-user@${BENCHMARK_HOST}"
+sshbench
+```
+
+| | |
+|--|--|
+| User | `ec2-user` |
+| Host | `${BENCHMARK_HOST}` |
+| Region | `eu-west-1` |
+| Repo on box | `~/har` |
+| Benchmark dir | `~/har/benchmarks/swebench-har` |
+
+## What a full re-run does
+
+1. Bootstrap host deps (idempotent): Node, Docker, `uv`, build HAR CLI, `uv sync`
+2. Clear `.har-cache/` (recommended when launch/verify contracts changed)
+3. `run_batch.py --count 10 --seed 42 --arm both` (same sample as baseline `20260708-173731`)
+4. Official SWE-bench Docker eval via `evaluate_batch.py`
+5. Write `results/ec2-comparison.json` vs that baseline
+
+Expect **multi-hour** wall time (setup budgets + Codex + Docker eval). Always use `tmux`.
+
+## Sync the code you want to measure
+
+On the EC2 box the checkout lives at `~/har`. Prefer one of:
+
+**A — git (when the branch is pushed)**
+
+```bash
+sshbench
+cd ~/har
+git fetch origin
+git checkout <branch-or-sha>
+git pull --ff-only
+```
+
+**B — rsync from your laptop worktree (unpushed local changes)**
+
+```bash
+rsync -az --delete \
+  --exclude node_modules \
+  --exclude .venv \
+  --exclude dist \
+  --exclude '.har/slots' \
+  --exclude '.har/runs' \
+  --exclude '.har/state' \
+  --exclude 'benchmarks/swebench-har/.venv' \
+  --exclude 'benchmarks/swebench-har/.har-cache' \
+  --exclude 'benchmarks/swebench-har/.repo-cache' \
+  --exclude 'benchmarks/swebench-har/runs' \
+  --exclude 'benchmarks/swebench-har/batches' \
+  --exclude 'benchmarks/swebench-har/results' \
+  --exclude 'benchmarks/swebench-har/logs' \
+  --exclude 'benchmarks/swebench-har/.env.local' \
+  -e "ssh -i ${BENCHMARK_SSH_KEY}" \
+  /path/to/har-checkout/ \
+  ec2-user@${BENCHMARK_HOST}:~/har/
+```
+
+Do **not** rsync over `.env.local` (API keys stay on the box).
+
+## One-time / idempotent bootstrap
+
+```bash
+sshbench
+cd ~/har
+bash benchmarks/swebench-har/scripts/ec2_bootstrap.sh
+```
+
+This will:
+
+- Install packages / ensure Docker + Node ≥ 20 + `uv`
+- `npm ci && npm run build` → `~/har/dist/index.js`
+- `uv sync` under `benchmarks/swebench-har`
+- Create `benchmarks/swebench-har/.env.local` if missing
+
+### API key
+
+`OPENAI_API_KEY` is required. Bootstrap will reuse it from:
+
+1. The environment (`export OPENAI_API_KEY=...`), or
+2. `~/aicore/benchmark/.env` on this host (if present)
+
+Optional in `.env.local`:
+
+```bash
+OPENAI_MODEL=gpt-5-mini
+OPENAI_SETUP_MODEL=gpt-5.5
+HF_TOKEN=...          # higher Hugging Face rate limits
+HAR_BIN=/home/ec2-user/har/dist/index.js
+```
+
+Never commit `.env.local`.
+
+### Disk
+
+```bash
+df -h /
+```
+
+Aim for **≥40 GB free** (100 GB+ is safer). SWE-bench Docker images and repo caches grow quickly. Prune if needed:
+
+```bash
+docker system df
+# careful — removes unused images/containers:
+# docker system prune -a
+```
+
+## Run the benchmark (headless)
+
+```bash
+sshbench
+cd ~/har/benchmarks/swebench-har
+
+# optional: kill a leftover session
+tmux kill-session -t swebench 2>/dev/null || true
+
+tmux new -s swebench
+# inside tmux:
+bash scripts/ec2_run.sh
+# defaults: COUNT=10 SEED=42 ARM=both, clears .har-cache, then eval
+```
+
+Detach: `Ctrl-b` then `d`. Reattach: `tmux attach -t swebench`.
+
+### Useful flags / env
+
+```bash
+# Bootstrap then run
+bash scripts/ec2_run.sh --bootstrap
+
+# Keep existing .har-cache (faster; only if harness contract unchanged)
+bash scripts/ec2_run.sh --keep-cache
+
+# Orchestration only (skip official Docker eval)
+bash scripts/ec2_run.sh --skip-eval
+
+# Different sample size (apples-to-apples comparison uses 10 / 42)
+COUNT=25 SEED=42 bash scripts/ec2_run.sh
+
+# Dry-run plumbing (no Codex / no real eval work)
+bash scripts/ec2_run.sh --dry-run
+```
+
+Stdin is redirected from `/dev/null` in the recommended tmux one-liner above if you wrap it:
+
+```bash
+tmux new -s swebench "bash -lc 'source ~/.nvm/nvm.sh; cd ~/har/benchmarks/swebench-har && bash scripts/ec2_run.sh </dev/null; exec bash'"
+```
+
+That avoids interactive `har env init` prompts on a TTY.
+
+## Monitor
+
+```bash
+sshbench
+tmux attach -t swebench
+# or:
+tail -f ~/har/benchmarks/swebench-har/logs/ec2-batch-*.log
+```
+
+When finished, `ec2_run.sh` prints `results/ec2-comparison.json` and exits `0`.
+
+## Artifacts
+
+Under `~/har/benchmarks/swebench-har/`:
+
+| Path | Meaning |
+|------|---------|
+| `batches/<batch_id>/batch.json` | Per-instance orchestration status |
+| `runs/<run-id>/run.json` | Raw/HAR arm metrics, gates, cache |
+| `runs/<run-id>/predictions/{raw,har}.jsonl` | SWE-bench submission patches |
+| `results/ec2-comparison.json` | Summary vs baseline `20260708-173731` |
+| `results/batch-<id>/batch-evaluation.md` | Per-instance resolve table |
+| `logs/ec2-batch-*.log` / `logs/ec2-eval-*.log` | Full stdout |
+| `logs/run_evaluation/` | Official harness Docker reports |
+
+Copy results home:
+
+```bash
+scp -i ${BENCHMARK_SSH_KEY} -r \
+  ec2-user@${BENCHMARK_HOST}:~/har/benchmarks/swebench-har/results \
+  ./swebench-results-$(date +%Y%m%d)/
+```
+
+## Apples-to-apples comparison
+
+Default sample matches the first report ([BENCHMARK-RUN-REPORT.md](./BENCHMARK-RUN-REPORT.md)):
+
+- Dataset: SWE-bench Lite `test`
+- `--count 10 --seed 42 --arm both`
+- Fix/raw model: `gpt-5-mini`
+- HAR setup model: `gpt-5.5`
+
+Baseline orchestration (2026-07-08): raw patches **10/10**, HAR patches **5/10** (gate failures). Official resolve was not measured then.
+
+Latest successful EC2 batch on this host: **`20260718-185954`** — HAR patches **10/10**, official resolve raw **4/10** / HAR **5/10**.
+
+## Eval-only re-run
+
+If orchestration finished but you need to re-score:
+
+```bash
+cd ~/har/benchmarks/swebench-har
+uv run scripts/evaluate_batch.py --batch-id 20260718-185954
+# or
+uv run scripts/evaluate_batch.py --latest-batch
+```
+
+## Clean re-run checklist
+
+1. Sync the commit under test to `~/har`
+2. `bash scripts/ec2_bootstrap.sh` (or `ec2_run.sh --bootstrap`)
+3. Confirm `df -h /` and Docker works (`docker info`)
+4. Confirm `.env.local` has `OPENAI_API_KEY`
+5. Archive or leave old `batches/` / `runs/` (new batch id is timestamped)
+6. Clear cache unless intentionally measuring cache reuse: default `ec2_run.sh` clears `.har-cache`
+7. Start under `tmux` → `bash scripts/ec2_run.sh`
+8. When done, read `results/ec2-comparison.json` and `results/batch-*/batch-evaluation.md`
+
+## Known pitfalls (this host)
+
+| Symptom | Fix |
+|---------|-----|
+| `Permission denied: .../dist/index.js` | HAR must be invoked via `node` (fixed in `resolve_har_base_cmd`); re-bootstrap / rebuild `dist/` |
+| `har env init` hangs in tmux | Non-interactive flags + stdin `/dev/null` (see above); init uses `--no-cursor-rule --no-agents` |
+| HF Hub rate-limit warnings | Set `HF_TOKEN` in `.env.local` |
+| Disk full during Docker eval | Free space / prune images; prefer ≥100 GB free before large batches |
+| Stale bad `.har-cache` | Re-run without `--keep-cache` (default clears cache) |
+
+## Scripts reference
+
+| Script | Role |
+|--------|------|
+| [`scripts/ec2_bootstrap.sh`](./scripts/ec2_bootstrap.sh) | Host + CLI + Python deps + `.env.local` |
+| [`scripts/ec2_run.sh`](./scripts/ec2_run.sh) | Preflight → batch → batch eval → comparison |
+| [`scripts/run_batch.py`](./scripts/run_batch.py) | Multi-instance orchestration |
+| [`scripts/evaluate_batch.py`](./scripts/evaluate_batch.py) | Official eval over a whole batch |
+| [`scripts/test_swebench_har.py`](./scripts/test_swebench_har.py) | Local smoke (no Codex / Docker grading) |
+
+For local (non-EC2) usage, see [README.md](./README.md).

--- a/benchmarks/swebench-har/README.md
+++ b/benchmarks/swebench-har/README.md
@@ -26,7 +26,12 @@ uv sync
 
 ```bash
 uv run scripts/run_batch.py --count 10 --seed 42 --arm both
+# Diversified sample (caps from config.yaml by default):
+uv run scripts/run_batch.py --count 50 --seed 42 --arm both \
+  --max-per-repo 5 --max-repos-per-language 10
 ```
+
+Paper iteration log: [`BENCHMARK-ITERATIONS.md`](./BENCHMARK-ITERATIONS.md). EC2 campaign: [`EC2.md`](./EC2.md).
 
 See [BENCHMARK-RUN-REPORT.md](./BENCHMARK-RUN-REPORT.md) for findings from the first 10-instance batch and recommended follow-up issues.
 

--- a/benchmarks/swebench-har/README.md
+++ b/benchmarks/swebench-har/README.md
@@ -170,6 +170,20 @@ If the gate fails after a cache hit, the cache is **invalidated** and repo boots
 uv run scripts/test_swebench_har.py
 ```
 
+## Running on EC2 (`sshbench`)
+
+Full re-run instructions for the shared benchmark host (connect, sync code, bootstrap, tmux, artifacts, pitfalls): see **[EC2.md](./EC2.md)**.
+
+Quick start:
+
+```bash
+alias sshbench="ssh -i ${BENCHMARK_SSH_KEY} ec2-user@${BENCHMARK_HOST}"
+sshbench
+cd ~/har && bash benchmarks/swebench-har/scripts/ec2_bootstrap.sh
+tmux new -s swebench
+cd ~/har/benchmarks/swebench-har && bash scripts/ec2_run.sh
+```
+
 ## Caveats
 
 - One random instance is a feasibility smoke test, not a statistically meaningful benchmark.

--- a/benchmarks/swebench-har/config.yaml
+++ b/benchmarks/swebench-har/config.yaml
@@ -12,6 +12,9 @@ setup_max_rounds: 6
 har_verify_full: true
 # Fix agent retries when post-fix verify --full fails
 fix_max_rounds: 3
+# Diversity sampling (null = uniform random.sample)
+sample_max_per_repo: 5
+sample_max_repos_per_language: 10
 har_cache_dir: .har-cache
 runs_dir: runs
 results_dir: results

--- a/benchmarks/swebench-har/config.yaml
+++ b/benchmarks/swebench-har/config.yaml
@@ -8,7 +8,8 @@ setup_budget_minutes: 120
 setup_timeout_minutes: 45
 readiness_timeout_minutes: 20
 setup_max_rounds: 6
-har_verify_full: false
+# Post-fix: run verify --full so registered functional verificationStages are enforced
+har_verify_full: true
 har_cache_dir: .har-cache
 runs_dir: runs
 results_dir: results

--- a/benchmarks/swebench-har/config.yaml
+++ b/benchmarks/swebench-har/config.yaml
@@ -10,6 +10,8 @@ readiness_timeout_minutes: 20
 setup_max_rounds: 6
 # Post-fix: run verify --full so registered functional verificationStages are enforced
 har_verify_full: true
+# Fix agent retries when post-fix verify --full fails
+fix_max_rounds: 3
 har_cache_dir: .har-cache
 runs_dir: runs
 results_dir: results

--- a/benchmarks/swebench-har/prompts/har-fix.md
+++ b/benchmarks/swebench-har/prompts/har-fix.md
@@ -11,10 +11,13 @@ Fix attempt: {{fix_round}} / {{fix_max_rounds}}
 
 ## What HAR is for
 
-HAR is a **sandbox for verifying code changes**. The harness exists so you can prove
-your fix works *before* you stop — launch a slot, run checks, add checks, iterate.
-Quick verify is only smoke (compile/import). Functional proof is `verify --full`
-and the stages registered in `.har/stages.json` `verificationStages`.
+HAR is a **sandbox for verifying code changes** so the fix is proven *before* you
+stop — the same habit that improves real PRs. Quick verify is only smoke
+(compile/import). Functional proof is `verify --full` with a **change-specific**
+behavioral stage (not smoke alone).
+
+Do **not** use evaluator-only gold tests (`FAIL_TO_PASS`, `PASS_TO_PASS`, official
+patches). Derive checks only from this problem statement and the repository.
 
 ## HAR workflow (required)
 
@@ -23,40 +26,39 @@ You are running inside the HAR session worktree. All file edits must stay in thi
 Read `.har/CLAUDE.agent.md` and `AGENT.md` (if present) for definition of done.
 
 1. Use `har env status 1` or `./.har/agent-cli.sh 1 status` if you need slot details.
-2. Fix the issue with the smallest correct production-quality change.
-3. **Prove the change is functional through HAR** — not only that it compiles:
-   - Run `har env verify 1` (quick smoke) while iterating if useful.
-   - Before you stop, run `har env verify 1 --full`. This **must** pass.
-   - **You may add stages on the fly** to validate this change:
+2. Ensure there is a **task-scoped behavioral stage** for *this* issue (add one if
+   missing). It must encode the bug from the problem statement.
+3. **Fail-before:** on the current (still broken) tree, that stage must **fail** for
+   the *behavioral* reason in the ticket — not merely `ModuleNotFoundError` because
+   deps/extensions were never built. If imports fail, fix the slot install/build
+   first so the oracle can run, then re-check fail-before.
+4. Implement the smallest correct production-quality fix.
+5. **Pass-after:** re-run until `har env verify 1 --full` is green with that stage
+   passing. Smoke-only green is **not** done.
 
-     ```bash
-     har env add-stage <short-id> --custom --kind test --command "<functional check>" --verification
-     # or: har env add-stage <short-id> --custom --script --verification
-     ```
+```bash
+har env add-stage <short-id> --custom --kind test --command "<behavioral check>" --verification
+# or: har env add-stage <short-id> --custom --script --verification
+```
 
-   - **You may add a small new test / regression script** when that is the clearest
-     way to prove the behavior (keep it focused; prefer wiring it as a stage so
-     `verify --full` runs it). Do not rewrite the entire suite. Do not use
-     evaluator-only gold tests.
-   - Prefer **fail-before / pass-after**: a good check fails on the broken tree and
-     passes after your fix.
-4. Do not hand-roll setup that HAR already provides.
+You may add a small focused regression script/test and wire it as that stage.
+Keep it narrow. Prefer fail-before / pass-after.
 
-You may use normal repository commands (`pytest`, etc.) to debug. Still finish only
-when `har env verify 1 --full` is green.
+Do not hand-roll setup that HAR already provides. You may use normal repository
+commands (`pytest`, etc.) to debug, but finish only when `verify --full` is green
+with a real behavioral oracle.
 
 {{fix_failure_context}}
 
 ## Instructions
 
-- Explore the repository and understand the issue.
+- Explore the repository and understand the issue from the problem statement.
+- Add/fix the task stage so it fails before and passes after.
 - Implement the fix.
-- Ensure functional validation is registered as a HAR stage (existing or newly added)
-  and green under `verify --full`.
-- Do not modify unrelated test files; adding a *small* focused check for this bug is allowed.
+- Do not modify unrelated test files; a *small* focused check for this bug is allowed.
 
 Report:
 - HAR commands you ran (`verify`, `verify --full`, `add-stage`) and whether they passed
-- which stage(s) / tests proved the fix
+- which stage(s) proved fail-before and pass-after
 - a brief summary of the fix
 - the final `git diff --stat`

--- a/benchmarks/swebench-har/prompts/har-fix.md
+++ b/benchmarks/swebench-har/prompts/har-fix.md
@@ -12,22 +12,35 @@ HAR work directory: {{work_dir}}
 
 You are running inside the HAR session worktree. All file edits must stay in this work directory.
 
+Read `.har/CLAUDE.agent.md` and `AGENT.md` (if present) for definition of done.
+
 1. Use `har env status 1` or `./.har/agent-cli.sh 1 status` if you need slot details.
 2. Fix the issue with the smallest correct production-quality change.
-3. Before finishing, run `har env verify 1` (quick verify). If it fails, fix harness or code issues and retry.
+3. **Prove the change is functional through HAR** — not only that it compiles:
+   - Run `har env verify 1` (quick smoke) while iterating if useful.
+   - Before you stop, run `har env verify 1 --full`. This must pass.
+   - `--full` runs registered `verificationStages` in `.har/stages.json`. Those stages should exercise real behavior for this kind of change.
+   - If no stage can confirm your fix works, **add one**, then re-run `--full`:
+
+     ```bash
+     har env add-stage <short-id> --custom --kind test --command "<functional check for this fix>" --verification
+     # or --script when you need a small shell check under .har/stages/
+     ```
+
+     Prefer a focused functional check (import+exercise the fixed API, a tiny regression script, a CLI dry-run) — not the entire repository test suite, and not evaluator-only gold tests.
 4. Do not hand-roll setup that HAR already provides.
 
-You may also use normal repository commands (`pytest`, etc.) to debug, but HAR verify must be attempted before you stop.
+You may use normal repository commands to debug, but **do not stop** until `har env verify 1 --full` passes. Quick verify alone is not enough.
 
 ## Instructions
 
 - Explore the repository and understand the issue.
 - Implement the fix.
-- Run `har env verify 1` before stopping.
+- Ensure functional validation is registered as a HAR stage and green under `verify --full`.
 - Do not modify test files unless the issue explicitly requires it.
 
 Report:
-- HAR commands you ran and whether they passed
-- other verification commands you ran
+- HAR commands you ran (especially `verify` / `verify --full` / `add-stage`) and whether they passed
+- which verification stage(s) proved the fix
 - a brief summary of the fix
 - the final `git diff --stat`

--- a/benchmarks/swebench-har/prompts/har-fix.md
+++ b/benchmarks/swebench-har/prompts/har-fix.md
@@ -3,10 +3,18 @@ You are fixing a real software engineering issue in {{repo}} using the HAR harne
 Instance: {{instance_id}}
 Base commit: {{base_commit}}
 HAR work directory: {{work_dir}}
+Fix attempt: {{fix_round}} / {{fix_max_rounds}}
 
 ## Problem statement
 
 {{problem_statement}}
+
+## What HAR is for
+
+HAR is a **sandbox for verifying code changes**. The harness exists so you can prove
+your fix works *before* you stop — launch a slot, run checks, add checks, iterate.
+Quick verify is only smoke (compile/import). Functional proof is `verify --full`
+and the stages registered in `.har/stages.json` `verificationStages`.
 
 ## HAR workflow (required)
 
@@ -18,29 +26,37 @@ Read `.har/CLAUDE.agent.md` and `AGENT.md` (if present) for definition of done.
 2. Fix the issue with the smallest correct production-quality change.
 3. **Prove the change is functional through HAR** — not only that it compiles:
    - Run `har env verify 1` (quick smoke) while iterating if useful.
-   - Before you stop, run `har env verify 1 --full`. This must pass.
-   - `--full` runs registered `verificationStages` in `.har/stages.json`. Those stages should exercise real behavior for this kind of change.
-   - If no stage can confirm your fix works, **add one**, then re-run `--full`:
+   - Before you stop, run `har env verify 1 --full`. This **must** pass.
+   - **You may add stages on the fly** to validate this change:
 
      ```bash
-     har env add-stage <short-id> --custom --kind test --command "<functional check for this fix>" --verification
-     # or --script when you need a small shell check under .har/stages/
+     har env add-stage <short-id> --custom --kind test --command "<functional check>" --verification
+     # or: har env add-stage <short-id> --custom --script --verification
      ```
 
-     Prefer a focused functional check (import+exercise the fixed API, a tiny regression script, a CLI dry-run) — not the entire repository test suite, and not evaluator-only gold tests.
+   - **You may add a small new test / regression script** when that is the clearest
+     way to prove the behavior (keep it focused; prefer wiring it as a stage so
+     `verify --full` runs it). Do not rewrite the entire suite. Do not use
+     evaluator-only gold tests.
+   - Prefer **fail-before / pass-after**: a good check fails on the broken tree and
+     passes after your fix.
 4. Do not hand-roll setup that HAR already provides.
 
-You may use normal repository commands to debug, but **do not stop** until `har env verify 1 --full` passes. Quick verify alone is not enough.
+You may use normal repository commands (`pytest`, etc.) to debug. Still finish only
+when `har env verify 1 --full` is green.
+
+{{fix_failure_context}}
 
 ## Instructions
 
 - Explore the repository and understand the issue.
 - Implement the fix.
-- Ensure functional validation is registered as a HAR stage and green under `verify --full`.
-- Do not modify test files unless the issue explicitly requires it.
+- Ensure functional validation is registered as a HAR stage (existing or newly added)
+  and green under `verify --full`.
+- Do not modify unrelated test files; adding a *small* focused check for this bug is allowed.
 
 Report:
-- HAR commands you ran (especially `verify` / `verify --full` / `add-stage`) and whether they passed
-- which verification stage(s) proved the fix
+- HAR commands you ran (`verify`, `verify --full`, `add-stage`) and whether they passed
+- which stage(s) / tests proved the fix
 - a brief summary of the fix
 - the final `git diff --stat`

--- a/benchmarks/swebench-har/prompts/har-setup.md
+++ b/benchmarks/swebench-har/prompts/har-setup.md
@@ -35,9 +35,10 @@ is smoke for the pre-fix gate. Functional proof is `verify --full` via
 
 Document in `.har/CLAUDE.agent.md` / `AGENT.md`:
 - quick verify = smoke
-- done = `verify --full`
+- done = `verify --full` with a **change-specific behavioral** stage (smoke alone ≠ done)
+- agents **must** use fail-before / pass-after when adding stages for a bug
 - agents **may add stages on the fly** and may add a small focused test/check when needed
-- HAR is the verification sandbox for changes
+- HAR is the verification sandbox for changes; keep issue stages out of the long-lived cache
 
 ## Generic HAR adaptation prompt (from `har env init`)
 

--- a/benchmarks/swebench-har/prompts/har-setup.md
+++ b/benchmarks/swebench-har/prompts/har-setup.md
@@ -14,52 +14,32 @@ Do **not** run `har env init --auto`. Edit harness files directly.
 The benchmark runner validates readiness **after** your edits — do not launch or
 verify slots yourself.
 
-**SWE-bench grading is external.** Harness quick verify is smoke-only (compile /
-import / build) for the pre-fix gate. Separately, you **must** register at least
-one **functional** verification stage for `har env verify 1 --full` so the fix
-agent can prove its change works through HAR (not via the official evaluator).
+**HAR purpose:** a sandbox where agents verify that code changes work. Quick verify
+is smoke for the pre-fix gate. Functional proof is `verify --full` via
+`verificationStages`. The fix agent may add stages and small tests on the fly.
+
+**SWE-bench grading is external** — do not replicate the official evaluator.
 
 ## Benchmark constraints (override the generic prompt where they conflict)
 
 | Topic | Benchmark rule |
 |-------|----------------|
 | `launch.sh` / `agent-slot.sh` | **Do not edit** — runner owns worktrees and slot registry |
-| Allowed edits | `harness.env`, `verify.sh` (especially quick-mode smoke steps), `CLAUDE.agent.md`, `README.md` |
+| Allowed edits | `harness.env`, `verify.sh` (quick smoke), `stages.json`, `.har/stages/*`, `CLAUDE.agent.md`, `README.md`, `AGENT.md` |
 | During setup | Do **not** run `har env launch`, `./.har/launch.sh`, `./.har/teardown.sh`, or `./.har/verify.sh` |
-| Quick verify | Language-agnostic smoke only — not full pytest/Django runtests/Sphinx graphs |
+| Quick verify | Smoke only — compile/import/build (smoke-only pre-fix gate) |
 | Full verify | Register functional `verificationStages` (CLI/API/module exercise, focused check). Not the whole suite unless that is truly the repo's lightweight check |
 | Profile | Stay on `{{har_profile}}` — do not re-init with a different profile |
 
-Pre-fix gate the runner enforces: `har env launch 1` + quick `har env verify 1`.
+`launch.sh` / `agent-slot.sh`: **Do not edit** — runner owns worktrees and slot replace/force.
 
-After the fix, the runner also runs `har env verify 1 --full` — your functional
-stages must be registered so that path is meaningful.
-
-Quick-mode examples (pick what fits this stack):
-
-- Python: `python -m compileall`, `pip install -e .`, import smoke
-- Node: `npm run build`, `npm run typecheck`
-- Java: `mvn -q compile`, `./gradlew compileJava`
-- Go: `go build ./...`
-- Rust: `cargo check`
-
-Functional stage examples (for `--full` / definition of done — keep them small):
-
-```bash
-har env add-stage module-smoke --custom --kind test \
-  --command '${PYTHON_BIN:-python3} -c "import <pkg>; …exercise fixed API…"' \
-  --verification
-```
-
-Or a short `.har/stages/<id>.sh` via `har env add-stage <id> --custom --script --verification`.
-
-Update `.har/CLAUDE.agent.md` / `AGENT.md` so definition of done says: quick verify
-is smoke; finishing requires `verify --full`; if no stage covers the change, add one.
+Document in `.har/CLAUDE.agent.md` / `AGENT.md`:
+- quick verify = smoke
+- done = `verify --full`
+- agents **may add stages on the fly** and may add a small focused test/check when needed
+- HAR is the verification sandbox for changes
 
 ## Generic HAR adaptation prompt (from `har env init`)
-
-The following is the same prompt saved to `.har/ADAPT-PROMPT.md` — follow it except
-where the benchmark constraints above take precedence.
 
 ---
 
@@ -69,6 +49,5 @@ where the benchmark constraints above take precedence.
 
 {{setup_failure_context}}
 
-When finished, summarize:
-1. which **smoke** commands quick verify will run
-2. which **functional** verification stage(s) you registered for `--full`
+When finished, summarize smoke commands for quick verify and any **repo-generic**
+`--full` stage (not issue-specific).

--- a/benchmarks/swebench-har/prompts/har-setup.md
+++ b/benchmarks/swebench-har/prompts/har-setup.md
@@ -15,7 +15,9 @@ The benchmark runner validates readiness **after** your edits — do not launch 
 verify slots yourself.
 
 **SWE-bench grading is external.** Harness quick verify is smoke-only (compile /
-import / build); it does not need to pass the repo's full test suite.
+import / build) for the pre-fix gate. Separately, you **must** register at least
+one **functional** verification stage for `har env verify 1 --full` so the fix
+agent can prove its change works through HAR (not via the official evaluator).
 
 ## Benchmark constraints (override the generic prompt where they conflict)
 
@@ -25,10 +27,13 @@ import / build); it does not need to pass the repo's full test suite.
 | Allowed edits | `harness.env`, `verify.sh` (especially quick-mode smoke steps), `CLAUDE.agent.md`, `README.md` |
 | During setup | Do **not** run `har env launch`, `./.har/launch.sh`, `./.har/teardown.sh`, or `./.har/verify.sh` |
 | Quick verify | Language-agnostic smoke only — not full pytest/Django runtests/Sphinx graphs |
-| Full verify | Optional stricter checks (`--full`); not required for the pre-fix gate |
+| Full verify | Register functional `verificationStages` (CLI/API/module exercise, focused check). Not the whole suite unless that is truly the repo's lightweight check |
 | Profile | Stay on `{{har_profile}}` — do not re-init with a different profile |
 
 Pre-fix gate the runner enforces: `har env launch 1` + quick `har env verify 1`.
+
+After the fix, the runner also runs `har env verify 1 --full` — your functional
+stages must be registered so that path is meaningful.
 
 Quick-mode examples (pick what fits this stack):
 
@@ -37,6 +42,19 @@ Quick-mode examples (pick what fits this stack):
 - Java: `mvn -q compile`, `./gradlew compileJava`
 - Go: `go build ./...`
 - Rust: `cargo check`
+
+Functional stage examples (for `--full` / definition of done — keep them small):
+
+```bash
+har env add-stage module-smoke --custom --kind test \
+  --command '${PYTHON_BIN:-python3} -c "import <pkg>; …exercise fixed API…"' \
+  --verification
+```
+
+Or a short `.har/stages/<id>.sh` via `har env add-stage <id> --custom --script --verification`.
+
+Update `.har/CLAUDE.agent.md` / `AGENT.md` so definition of done says: quick verify
+is smoke; finishing requires `verify --full`; if no stage covers the change, add one.
 
 ## Generic HAR adaptation prompt (from `har env init`)
 
@@ -51,4 +69,6 @@ where the benchmark constraints above take precedence.
 
 {{setup_failure_context}}
 
-When finished, summarize what you changed and which **smoke** commands quick verify will run.
+When finished, summarize:
+1. which **smoke** commands quick verify will run
+2. which **functional** verification stage(s) you registered for `--full`

--- a/benchmarks/swebench-har/prompts/har-task-readiness.md
+++ b/benchmarks/swebench-har/prompts/har-task-readiness.md
@@ -16,29 +16,34 @@ You run **after** repo bootstrap (or on a cache hit) — do **not** re-bootstrap
 
 The benchmark runner validates readiness **after** your edits — do not launch or verify slots yourself.
 
+Also ensure the fix agent will be able to **functionally** validate a solution through HAR
+(`verify --full` / `verificationStages`) — not only compile smoke.
+
 ## Allowed actions
 
 - Confirm generic quick verify will pass at this commit (adjust `harness.env` or quick-mode steps in `verify.sh` only if needed)
-- Add **one** lightweight task-scoped smoke check derived from the issue (e.g. import mentioned module, compile mentioned file)
-- Write ephemeral per-run overlay files under:
-
-  `{{task_overlay_dir}}`
-
-  Examples: `task-verify.sh`, `task.env` — the runner may source these before the pre-fix gate.
+- Confirm a repo-level functional verification stage exists for `--full`; if not, add a small one under `.har/` (stages) appropriate to this stack
+- Optionally add **one** task-scoped functional check derived from the issue (exercise the module/API named in the problem — not the full suite):
+  - prefer a verification stage, or
+  - write ephemeral overlay files under `{{task_overlay_dir}}` (`task-verify.sh`, `task.env`)
+- Update `.har/CLAUDE.agent.md` if needed so definition of done requires `verify --full` and adding a stage when none fits
 
 ## Forbidden
 
 - Do **not** edit `launch.sh` or `agent-slot.sh` (repo bootstrap only)
-- Do **not** run full test suites or replicate SWE-bench grading
+- Do **not** run the entire repository test suite or replicate SWE-bench grading
 - Do **not** use evaluator-only fields (`FAIL_TO_PASS`, `PASS_TO_PASS`, gold patch)
 - Do **not** run `har env init`, `har env launch`, `./.har/launch.sh`, `./.har/teardown.sh`, or `./.har/verify.sh`
-- Do **not** overwrite repo-generic defaults in `.har-cache/` — task overlays are per-run only
+- Do **not** overwrite repo-generic defaults in `.har-cache/` with task-only hacks — prefer overlays for per-run checks; keep reusable stages in `.har/` when they help every instance of this repo
 
 ## Task overlay
 
 If you add a task-scoped check, put it in `{{task_overlay_dir}}/task-verify.sh` (executable) or
-`{{task_overlay_dir}}/task.env` (key=value lines). Keep it minimal — one command or short script.
+`{{task_overlay_dir}}/task.env` (key=value lines). Keep it minimal — one command or short script
+that would fail before the fix and pass after a correct fix when possible.
 
 {{readiness_failure_context}}
 
-When finished, summarize whether quick verify should pass at this commit and any overlay you added.
+When finished, summarize:
+1. whether quick verify should pass at this commit
+2. how the fix agent should functionally prove a solution (`verify --full` stage id and/or overlay)

--- a/benchmarks/swebench-har/prompts/har-task-readiness.md
+++ b/benchmarks/swebench-har/prompts/har-task-readiness.md
@@ -11,39 +11,38 @@ HAR profile: {{har_profile}}
 
 ## Your role
 
-Confirm the cached repo harness works at **this** `base_commit` for fixing the issue above.
+Confirm the cached repo harness works at **this** `base_commit` for fixing the issue.
 You run **after** repo bootstrap (or on a cache hit) — do **not** re-bootstrap the whole repo.
 
-The benchmark runner validates readiness **after** your edits — do not launch or verify slots yourself.
+The runner validates readiness **after** your edits — do not launch/verify yourself.
 
-Also ensure the fix agent will be able to **functionally** validate a solution through HAR
-(`verify --full` / `verificationStages`) — not only compile smoke.
+HAR is a **sandbox for verifying code changes**. Prepare a **task-scoped** way for the
+fix agent to prove a solution works via `verify --full`.
 
 ## Allowed actions
 
-- Confirm generic quick verify will pass at this commit (adjust `harness.env` or quick-mode steps in `verify.sh` only if needed)
-- Confirm a repo-level functional verification stage exists for `--full`; if not, add a small one under `.har/` (stages) appropriate to this stack
-- Optionally add **one** task-scoped functional check derived from the issue (exercise the module/API named in the problem — not the full suite):
-  - prefer a verification stage, or
-  - write ephemeral overlay files under `{{task_overlay_dir}}` (`task-verify.sh`, `task.env`)
-- Update `.har/CLAUDE.agent.md` if needed so definition of done requires `verify --full` and adding a stage when none fits
+- Confirm quick verify will pass (adjust `harness.env` / quick-mode `verify.sh` only if needed)
+- Add **one** task-scoped functional verification stage for *this* issue, e.g.:
+
+  ```bash
+  har env add-stage <short-id> --custom --kind test --command "<focused check>" --verification
+  # or --script
+  ```
+
+  Prefer a check that would **fail before** a correct fix and **pass after**.
+  You may add a tiny focused regression script/test and wire it as that stage.
+  Keep it narrow — not the full suite, not gold evaluator tests.
+- Write overlay notes under `{{task_overlay_dir}}` (`task.env`, `task-verify.sh` optional)
+- Update `.har/CLAUDE.agent.md` so done = `verify --full`, and agents may add stages / small tests on the fly
 
 ## Forbidden
 
-- Do **not** edit `launch.sh` or `agent-slot.sh` (repo bootstrap only)
-- Do **not** run the entire repository test suite or replicate SWE-bench grading
+- Do **not** edit `launch.sh` or `agent-slot.sh`
+- Do **not** dump the entire test suite into verification
 - Do **not** use evaluator-only fields (`FAIL_TO_PASS`, `PASS_TO_PASS`, gold patch)
-- Do **not** run `har env init`, `har env launch`, `./.har/launch.sh`, `./.har/teardown.sh`, or `./.har/verify.sh`
-- Do **not** overwrite repo-generic defaults in `.har-cache/` with task-only hacks — prefer overlays for per-run checks; keep reusable stages in `.har/` when they help every instance of this repo
-
-## Task overlay
-
-If you add a task-scoped check, put it in `{{task_overlay_dir}}/task-verify.sh` (executable) or
-`{{task_overlay_dir}}/task.env` (key=value lines). Keep it minimal — one command or short script
-that would fail before the fix and pass after a correct fix when possible.
+- Do **not** run launch/teardown/verify yourself
+- Issue-specific stages are **per-run** — the runner strips them from the per-repo cache after the gate so they do not leak into other instances
 
 {{readiness_failure_context}}
 
-When finished, summarize:
-1. whether quick verify should pass at this commit
-2. how the fix agent should functionally prove a solution (`verify --full` stage id and/or overlay)
+When finished, summarize quick-verify readiness and the task-scoped stage (id + what it checks).

--- a/benchmarks/swebench-har/prompts/har-task-readiness.md
+++ b/benchmarks/swebench-har/prompts/har-task-readiness.md
@@ -14,35 +14,52 @@ HAR profile: {{har_profile}}
 Confirm the cached repo harness works at **this** `base_commit` for fixing the issue.
 You run **after** repo bootstrap (or on a cache hit) — do **not** re-bootstrap the whole repo.
 
-The runner validates readiness **after** your edits — do not launch/verify yourself.
+The runner validates readiness **after** your edits — do not launch/verify yourself
+unless a note below asks you to prepare scripts only.
 
-HAR is a **sandbox for verifying code changes**. Prepare a **task-scoped** way for the
-fix agent to prove a solution works via `verify --full`.
+HAR is a **sandbox for verifying code changes**. You must prepare a **task-scoped
+behavioral oracle** so the fix agent can prove a solution via `verify --full`
+**without** reading official evaluator gold tests.
 
-## Allowed actions
+## Required: task-scoped stage with fail-before
 
-- Confirm quick verify will pass (adjust `harness.env` / quick-mode `verify.sh` only if needed)
-- Add **one** task-scoped functional verification stage for *this* issue, e.g.:
+Add **exactly one** (unless one already exists for this issue) task-scoped
+verification stage derived from the problem statement:
 
-  ```bash
-  har env add-stage <short-id> --custom --kind test --command "<focused check>" --verification
-  # or --script
-  ```
+```bash
+har env add-stage <short-id> --custom --kind test --command "<focused behavioral check>" --verification
+# or --script
+```
 
-  Prefer a check that would **fail before** a correct fix and **pass after**.
-  You may add a tiny focused regression script/test and wire it as that stage.
-  Keep it narrow — not the full suite, not gold evaluator tests.
-- Write overlay notes under `{{task_overlay_dir}}` (`task.env`, `task-verify.sh` optional)
-- Update `.har/CLAUDE.agent.md` so done = `verify --full`, and agents may add stages / small tests on the fly
+Hard requirements:
+
+1. **Behavioral** — reproduces the bug/expected behavior from the problem statement
+   (not compile/import/smoke alone).
+2. **Fail-before** — on this unbroken buggy tree the stage must **fail** for the
+   ticket reason. If it already passes, tighten it until it fails.
+3. **Runnable** — if the check cannot import the package (missing editable install /
+   native extensions), fix harness install/`harness.env` so the oracle can run.
+   An import error is not a valid fail-before for the product bug.
+4. **Per-run only** — issue-specific stages must not pollute the per-repo `.har-cache`
+   (the runner strips them after the gate).
+
+You may add a tiny focused regression script under `{{task_overlay_dir}}` and wire
+it as that stage.
+
+Also allowed:
+
+- Adjust `harness.env` / quick-mode `verify.sh` so smoke stays green
+- Update `.har/CLAUDE.agent.md` so done = behavioral `--full` with fail-before/pass-after
 
 ## Forbidden
 
 - Do **not** edit `launch.sh` or `agent-slot.sh`
 - Do **not** dump the entire test suite into verification
 - Do **not** use evaluator-only fields (`FAIL_TO_PASS`, `PASS_TO_PASS`, gold patch)
-- Do **not** run launch/teardown/verify yourself
-- Issue-specific stages are **per-run** — the runner strips them from the per-repo cache after the gate so they do not leak into other instances
+- Do **not** run launch/teardown/verify yourself (runner owns the gate)
+- Do **not** leave only repo-generic smoke stages as the proof for this issue
 
 {{readiness_failure_context}}
 
-When finished, summarize quick-verify readiness and the task-scoped stage (id + what it checks).
+When finished, summarize: stage id, what behavior it asserts, and why it should
+fail on the current buggy tree.

--- a/benchmarks/swebench-har/scripts/ec2_bootstrap.sh
+++ b/benchmarks/swebench-har/scripts/ec2_bootstrap.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Idempotent host bootstrap for SWE-bench HAR on Amazon Linux / ec2-user.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCHMARK_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${BENCHMARK_ROOT}/../.." && pwd)"
+
+log() { printf '==> %s\n' "$*"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+ensure_packages() {
+  if have dnf; then
+    sudo dnf install -y git gcc gcc-c++ make tar gzip which tmux 2>/dev/null || true
+  elif have yum; then
+    sudo yum install -y git gcc gcc-c++ make tar gzip which tmux 2>/dev/null || true
+  fi
+}
+
+ensure_docker() {
+  if ! have docker; then
+    log "Installing Docker..."
+    if have dnf; then
+      sudo dnf install -y docker
+    else
+      sudo yum install -y docker
+    fi
+  fi
+  if ! sudo systemctl is-active --quiet docker 2>/dev/null; then
+    sudo systemctl enable --now docker || sudo service docker start || true
+  fi
+  if ! groups | tr ' ' '\n' | grep -qx docker; then
+    log "Adding ${USER} to docker group (may need re-login)"
+    sudo usermod -aG docker "$USER" || true
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    if sudo docker info >/dev/null 2>&1; then
+      log "WARNING: docker requires sudo for ${USER}; eval will use sudo docker via DOCKER_HOST if needed"
+    else
+      log "ERROR: Docker daemon not reachable"
+      exit 1
+    fi
+  fi
+}
+
+ensure_node() {
+  if have node; then
+    local major
+    major="$(node -p "process.versions.node.split('.')[0]")"
+    if [[ "${major}" -ge 20 ]]; then
+      log "Node $(node -v) OK"
+      return
+    fi
+  fi
+  log "Installing Node 20 via nvm..."
+  export NVM_DIR="${HOME}/.nvm"
+  if [[ ! -s "${NVM_DIR}/nvm.sh" ]]; then
+    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+  fi
+  # shellcheck disable=SC1091
+  . "${NVM_DIR}/nvm.sh"
+  nvm install 20
+  nvm use 20
+  nvm alias default 20
+}
+
+ensure_uv() {
+  if have uv; then
+    log "uv $(uv --version) OK"
+    return
+  fi
+  log "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="${HOME}/.local/bin:${PATH}"
+}
+
+ensure_har_cli() {
+  log "Building HAR CLI at ${REPO_ROOT}"
+  cd "${REPO_ROOT}"
+  # Ensure nvm node is on PATH for non-interactive shells
+  if [[ -s "${HOME}/.nvm/nvm.sh" ]]; then
+    # shellcheck disable=SC1091
+    . "${HOME}/.nvm/nvm.sh"
+  fi
+  if [[ -f package-lock.json ]]; then
+    npm ci
+  else
+    npm install
+  fi
+  npm run build
+  if [[ -f "${REPO_ROOT}/dist/index.js" ]]; then
+    chmod +x "${REPO_ROOT}/dist/index.js" || true
+    export HAR_BIN="${REPO_ROOT}/dist/index.js"
+    log "HAR_BIN=${HAR_BIN}"
+  fi
+}
+
+ensure_benchmark_deps() {
+  log "Syncing swebench-har Python deps"
+  cd "${BENCHMARK_ROOT}"
+  export PATH="${HOME}/.local/bin:${PATH}"
+  uv sync
+}
+
+ensure_env_local() {
+  local env_file="${BENCHMARK_ROOT}/.env.local"
+  if [[ -f "${env_file}" ]]; then
+    log ".env.local already present"
+    return
+  fi
+  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    # Common location on this benchmark host
+    if [[ -f "${HOME}/aicore/benchmark/.env" ]]; then
+      # shellcheck disable=SC1091
+      set -a
+      # Only pull keys we care about
+      OPENAI_API_KEY="$(grep -E '^OPENAI_API_KEY=' "${HOME}/aicore/benchmark/.env" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")"
+      set +a
+      export OPENAI_API_KEY
+    fi
+  fi
+  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    log "ERROR: OPENAI_API_KEY not set and could not load from ~/aicore/benchmark/.env"
+    log "Export OPENAI_API_KEY then re-run bootstrap."
+    exit 1
+  fi
+  {
+    echo "OPENAI_API_KEY=${OPENAI_API_KEY}"
+    [[ -n "${OPENAI_MODEL:-}" ]] && echo "OPENAI_MODEL=${OPENAI_MODEL}"
+    [[ -n "${OPENAI_SETUP_MODEL:-}" ]] && echo "OPENAI_SETUP_MODEL=${OPENAI_SETUP_MODEL}"
+    [[ -n "${HF_TOKEN:-}" ]] && echo "HF_TOKEN=${HF_TOKEN}"
+    echo "HAR_BIN=${REPO_ROOT}/dist/index.js"
+  } >"${env_file}"
+  chmod 600 "${env_file}"
+  log "Wrote ${env_file}"
+}
+
+disk_check() {
+  local avail_gb
+  avail_gb="$(df -BG --output=avail / | tail -1 | tr -dc '0-9')"
+  log "Disk free: ${avail_gb}G"
+  if [[ "${avail_gb}" -lt 40 ]]; then
+    log "WARNING: less than 40G free; SWE-bench Docker images may fill the disk"
+  fi
+}
+
+main() {
+  log "Bootstrap starting (repo=${REPO_ROOT})"
+  disk_check
+  ensure_packages
+  ensure_docker
+  ensure_node
+  ensure_uv
+  ensure_har_cli
+  ensure_benchmark_deps
+  ensure_env_local
+  log "Bootstrap complete"
+  log "Next: bash ${SCRIPT_DIR}/ec2_run.sh"
+}
+
+main "$@"

--- a/benchmarks/swebench-har/scripts/ec2_run.sh
+++ b/benchmarks/swebench-har/scripts/ec2_run.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Full SWE-bench HAR pipeline for EC2 (batch + official eval + comparison).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BENCHMARK_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${BENCHMARK_ROOT}/../.." && pwd)"
+
+COUNT="${COUNT:-10}"
+SEED="${SEED:-42}"
+ARM="${ARM:-both}"
+SKIP_BOOTSTRAP=0
+SKIP_EVAL=0
+DRY_RUN=0
+CLEAR_CACHE=1
+
+log() { printf '==> %s\n' "$*"; }
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --count N           Instances to sample (default: ${COUNT})
+  --seed N            Sample seed (default: ${SEED})
+  --arm raw|har|both  Arms to run (default: ${ARM})
+  --bootstrap         Run ec2_bootstrap.sh first
+  --skip-bootstrap    Do not bootstrap (default)
+  --skip-eval         Skip official Docker evaluation
+  --keep-cache        Do not clear .har-cache before batch
+  --dry-run           Orchestration dry-run (no Codex / no Docker eval work)
+  -h, --help          Show help
+
+Env:
+  COUNT SEED ARM OPENAI_API_KEY HF_TOKEN ARTIFACT_S3_URI
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --count) COUNT="$2"; shift 2 ;;
+    --seed) SEED="$2"; shift 2 ;;
+    --arm) ARM="$2"; shift 2 ;;
+    --bootstrap) SKIP_BOOTSTRAP=0; DO_BOOTSTRAP=1; shift ;;
+    --skip-bootstrap) SKIP_BOOTSTRAP=1; shift ;;
+    --skip-eval) SKIP_EVAL=1; shift ;;
+    --keep-cache) CLEAR_CACHE=0; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) log "Unknown arg: $1"; usage; exit 1 ;;
+  esac
+done
+DO_BOOTSTRAP="${DO_BOOTSTRAP:-0}"
+
+# Non-interactive PATH for nvm / uv
+export PATH="${HOME}/.local/bin:${PATH}"
+if [[ -s "${HOME}/.nvm/nvm.sh" ]]; then
+  # shellcheck disable=SC1091
+  . "${HOME}/.nvm/nvm.sh"
+fi
+
+if [[ "${DO_BOOTSTRAP}" -eq 1 ]]; then
+  bash "${SCRIPT_DIR}/ec2_bootstrap.sh"
+fi
+
+cd "${BENCHMARK_ROOT}"
+
+if [[ -f .env.local ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env.local
+  set +a
+fi
+
+export HAR_BIN="${HAR_BIN:-${REPO_ROOT}/dist/index.js}"
+export HAR_CONFIRM_REPLACE=1
+
+preflight() {
+  log "Preflight checks"
+  if [[ ! -f "${HAR_BIN}" ]] && ! command -v har >/dev/null 2>&1; then
+    log "ERROR: HAR CLI not found (HAR_BIN=${HAR_BIN})"
+    exit 1
+  fi
+  if [[ -f "${HAR_BIN}" ]]; then
+    node "${HAR_BIN}" --version >/dev/null || node "${HAR_BIN}" --help >/dev/null
+    log "HAR_BIN OK (${HAR_BIN})"
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    if sudo docker info >/dev/null 2>&1; then
+      log "WARNING: using sudo for docker"
+    else
+      log "ERROR: Docker not available"
+      exit 1
+    fi
+  else
+    log "Docker OK"
+  fi
+  if [[ -z "${OPENAI_API_KEY:-}" && "${DRY_RUN}" -eq 0 ]]; then
+    log "ERROR: OPENAI_API_KEY is required"
+    exit 1
+  fi
+  uv run scripts/test_swebench_har.py
+  log "Smoke tests passed"
+}
+
+preflight
+
+mkdir -p logs results
+TS="$(date -u +%Y%m%d-%H%M%S)"
+BATCH_LOG="logs/ec2-batch-${TS}.log"
+
+if [[ "${CLEAR_CACHE}" -eq 1 ]]; then
+  log "Clearing .har-cache (launch/verify contracts may have changed)"
+  rm -rf .har-cache
+fi
+
+BATCH_ARGS=(scripts/run_batch.py --count "${COUNT}" --seed "${SEED}" --arm "${ARM}")
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  BATCH_ARGS+=(--dry-run)
+fi
+
+log "Starting batch: count=${COUNT} seed=${SEED} arm=${ARM} (log=${BATCH_LOG})"
+set -o pipefail
+uv run "${BATCH_ARGS[@]}" 2>&1 | tee "${BATCH_LOG}"
+set +o pipefail
+
+BATCH_ID="$(python3 - <<'PY'
+import json, pathlib
+batches = sorted((pathlib.Path("batches")).glob("*/batch.json"), key=lambda p: p.stat().st_mtime)
+if not batches:
+    raise SystemExit("no batch.json written")
+print(json.loads(batches[-1].read_text())["batch_id"])
+PY
+)"
+log "Batch id: ${BATCH_ID}"
+
+if [[ "${SKIP_EVAL}" -eq 0 ]]; then
+  EVAL_ARGS=(scripts/evaluate_batch.py --batch-id "${BATCH_ID}")
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    EVAL_ARGS+=(--dry-run)
+  fi
+  log "Running official evaluation for batch ${BATCH_ID}"
+  uv run "${EVAL_ARGS[@]}" 2>&1 | tee "logs/ec2-eval-${TS}.log"
+else
+  log "Skipping evaluation (--skip-eval)"
+fi
+
+if [[ -n "${ARTIFACT_S3_URI:-}" ]]; then
+  log "Syncing artifacts to ${ARTIFACT_S3_URI}"
+  aws s3 sync batches "${ARTIFACT_S3_URI%/}/batches" || true
+  aws s3 sync results "${ARTIFACT_S3_URI%/}/results" || true
+  aws s3 sync logs "${ARTIFACT_S3_URI%/}/logs" || true
+fi
+
+log "Done. Comparison: results/ec2-comparison.json"
+if [[ -f results/ec2-comparison.json ]]; then
+  cat results/ec2-comparison.json
+fi

--- a/benchmarks/swebench-har/scripts/ec2_run.sh
+++ b/benchmarks/swebench-har/scripts/ec2_run.sh
@@ -9,6 +9,8 @@ REPO_ROOT="$(cd "${BENCHMARK_ROOT}/../.." && pwd)"
 COUNT="${COUNT:-10}"
 SEED="${SEED:-42}"
 ARM="${ARM:-both}"
+MAX_PER_REPO="${MAX_PER_REPO:-}"
+MAX_REPOS_PER_LANGUAGE="${MAX_REPOS_PER_LANGUAGE:-}"
 SKIP_BOOTSTRAP=0
 SKIP_EVAL=0
 DRY_RUN=0
@@ -24,6 +26,8 @@ Options:
   --count N           Instances to sample (default: ${COUNT})
   --seed N            Sample seed (default: ${SEED})
   --arm raw|har|both  Arms to run (default: ${ARM})
+  --max-per-repo N    Cap instances per repository (diversity)
+  --max-repos-per-language N  Cap repos per language (diversity)
   --bootstrap         Run ec2_bootstrap.sh first
   --skip-bootstrap    Do not bootstrap (default)
   --skip-eval         Skip official Docker evaluation
@@ -32,7 +36,7 @@ Options:
   -h, --help          Show help
 
 Env:
-  COUNT SEED ARM OPENAI_API_KEY HF_TOKEN ARTIFACT_S3_URI
+  COUNT SEED ARM MAX_PER_REPO MAX_REPOS_PER_LANGUAGE OPENAI_API_KEY HF_TOKEN ARTIFACT_S3_URI
 EOF
 }
 
@@ -41,6 +45,8 @@ while [[ $# -gt 0 ]]; do
     --count) COUNT="$2"; shift 2 ;;
     --seed) SEED="$2"; shift 2 ;;
     --arm) ARM="$2"; shift 2 ;;
+    --max-per-repo) MAX_PER_REPO="$2"; shift 2 ;;
+    --max-repos-per-language) MAX_REPOS_PER_LANGUAGE="$2"; shift 2 ;;
     --bootstrap) SKIP_BOOTSTRAP=0; DO_BOOTSTRAP=1; shift ;;
     --skip-bootstrap) SKIP_BOOTSTRAP=1; shift ;;
     --skip-eval) SKIP_EVAL=1; shift ;;
@@ -115,11 +121,17 @@ if [[ "${CLEAR_CACHE}" -eq 1 ]]; then
 fi
 
 BATCH_ARGS=(scripts/run_batch.py --count "${COUNT}" --seed "${SEED}" --arm "${ARM}")
+if [[ -n "${MAX_PER_REPO}" ]]; then
+  BATCH_ARGS+=(--max-per-repo "${MAX_PER_REPO}")
+fi
+if [[ -n "${MAX_REPOS_PER_LANGUAGE}" ]]; then
+  BATCH_ARGS+=(--max-repos-per-language "${MAX_REPOS_PER_LANGUAGE}")
+fi
 if [[ "${DRY_RUN}" -eq 1 ]]; then
   BATCH_ARGS+=(--dry-run)
 fi
 
-log "Starting batch: count=${COUNT} seed=${SEED} arm=${ARM} (log=${BATCH_LOG})"
+log "Starting batch: count=${COUNT} seed=${SEED} arm=${ARM} max_per_repo=${MAX_PER_REPO:-config} max_repos_per_language=${MAX_REPOS_PER_LANGUAGE:-config} (log=${BATCH_LOG})"
 set -o pipefail
 uv run "${BATCH_ARGS[@]}" 2>&1 | tee "${BATCH_LOG}"
 set +o pipefail

--- a/benchmarks/swebench-har/scripts/evaluate_batch.py
+++ b/benchmarks/swebench-har/scripts/evaluate_batch.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Evaluate all predictions in a SWE-bench HAR batch with the official harness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from evaluate_predictions import evaluate_one  # noqa: E402
+from lib.common import BENCHMARK_ROOT, benchmark_config, ensure_dir, read_json, write_json  # noqa: E402
+
+BASELINE = {
+    "batch_id": "20260708-173731",
+    "raw_patches": 10,
+    "har_patches": 5,
+    "count": 10,
+    "seed": 42,
+    "note": "orchestration only; official Docker eval was not run",
+}
+
+
+def latest_batch_dir() -> Path:
+    batches_dir = BENCHMARK_ROOT / "batches"
+    if not batches_dir.is_dir():
+        raise SystemExit("No batches/ directory found")
+    candidates = [path for path in batches_dir.iterdir() if path.is_dir() and (path / "batch.json").exists()]
+    if not candidates:
+        raise SystemExit("No batch.json found under batches/")
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def resolve_batch_dir(batch_id: str | None, latest: bool) -> Path:
+    if latest or not batch_id:
+        return latest_batch_dir()
+    path = BENCHMARK_ROOT / "batches" / batch_id
+    if not (path / "batch.json").exists():
+        raise SystemExit(f"Batch not found: {path}")
+    return path
+
+
+def prediction_has_patch(pred_path: Path) -> bool:
+    if not pred_path.exists():
+        return False
+    try:
+        line = pred_path.read_text(encoding="utf-8").strip().splitlines()[0]
+        data = json.loads(line)
+        return bool(str(data.get("model_patch", "")).strip())
+    except (IndexError, json.JSONDecodeError, OSError):
+        return False
+
+
+def find_resolved(instance_id: str, eval_run_id: str, arm: str, eval_report: dict[str, Any]) -> bool | None:
+    """Best-effort parse of official SWE-bench resolve outcome."""
+    logs_root = BENCHMARK_ROOT / "logs" / "run_evaluation" / eval_run_id
+    if logs_root.is_dir():
+        for report_path in logs_root.rglob("report.json"):
+            try:
+                report = read_json(report_path)
+            except (OSError, json.JSONDecodeError):
+                continue
+            entry = report.get(instance_id)
+            if isinstance(entry, dict) and "resolved" in entry:
+                return bool(entry["resolved"])
+
+    # Official harness also writes <model>.<run_id>.json in cwd
+    for path in BENCHMARK_ROOT.glob(f"*.{eval_run_id}.json"):
+        try:
+            data = read_json(path)
+        except (OSError, json.JSONDecodeError):
+            continue
+        resolved_ids = data.get("resolved_ids") or []
+        if instance_id in resolved_ids:
+            return True
+        unresolved_ids = data.get("unresolved_ids") or []
+        if instance_id in unresolved_ids:
+            return False
+        if data.get("resolved_instances") == 1 and instance_id in (data.get("completed_ids") or []):
+            return True
+
+    # Fallback: scan evaluation JSON for resolved markers in stdout
+    stdout = eval_report.get("stdout") or ""
+    if f'"resolved": true' in stdout and instance_id in stdout:
+        return True
+    if f'"resolved": false' in stdout and instance_id in stdout:
+        return False
+    return None
+
+
+def arm_row(run_dir: Path, instance_id: str, run_id: str, arm: str, *, max_workers: int, dry_run: bool) -> dict[str, Any]:
+    run_json_path = run_dir / "run.json"
+    run_json = read_json(run_json_path) if run_json_path.exists() else {}
+    arm_meta = (run_json.get("arms") or {}).get(arm) or {}
+    pred = run_dir / "predictions" / f"{arm}.jsonl"
+    patch_produced = prediction_has_patch(pred)
+    if not patch_produced and arm_meta.get("model_patch_empty") is False:
+        patch_produced = True
+
+    row: dict[str, Any] = {
+        "arm": arm,
+        "status": arm_meta.get("status"),
+        "patch_produced": patch_produced,
+        "har_ready_for_fix": arm_meta.get("har_ready_for_fix"),
+        "model_patch_empty": arm_meta.get("model_patch_empty"),
+        "error": arm_meta.get("error"),
+    }
+
+    if not patch_produced and not dry_run:
+        row["evaluation"] = {"status": "skipped_no_patch"}
+        row["resolved"] = None
+        return row
+
+    evaluation = evaluate_one(
+        pred,
+        instance_id,
+        run_id,
+        arm,
+        max_workers=max_workers,
+        dry_run=dry_run,
+    )
+    row["evaluation"] = {
+        "status": evaluation.get("status"),
+        "exit_code": evaluation.get("exit_code"),
+        "eval_run_id": evaluation.get("eval_run_id"),
+    }
+    if dry_run:
+        row["resolved"] = None
+    else:
+        row["resolved"] = find_resolved(instance_id, evaluation.get("eval_run_id", f"{run_id}-{arm}"), arm, evaluation)
+    return row
+
+
+def build_comparison(batch: dict[str, Any], rows: list[dict[str, Any]]) -> dict[str, Any]:
+    count = int(batch.get("count") or len(rows))
+    raw_patches = sum(1 for r in rows if (r.get("arms") or {}).get("raw", {}).get("patch_produced"))
+    har_patches = sum(1 for r in rows if (r.get("arms") or {}).get("har", {}).get("patch_produced"))
+    raw_resolved = sum(1 for r in rows if (r.get("arms") or {}).get("raw", {}).get("resolved") is True)
+    har_resolved = sum(1 for r in rows if (r.get("arms") or {}).get("har", {}).get("resolved") is True)
+    raw_evaled = sum(1 for r in rows if (r.get("arms") or {}).get("raw", {}).get("resolved") is not None)
+    har_evaled = sum(1 for r in rows if (r.get("arms") or {}).get("har", {}).get("resolved") is not None)
+
+    return {
+        "batch_id": batch.get("batch_id"),
+        "seed": batch.get("seed"),
+        "count": count,
+        "model": batch.get("model"),
+        "setup_model": batch.get("setup_model"),
+        "orchestration": {
+            "raw_patches": raw_patches,
+            "har_patches": har_patches,
+            "raw_patch_rate": f"{raw_patches}/{count}",
+            "har_patch_rate": f"{har_patches}/{count}",
+        },
+        "resolve": {
+            "raw_resolved": raw_resolved,
+            "har_resolved": har_resolved,
+            "raw_resolve_rate": f"{raw_resolved}/{raw_evaled}" if raw_evaled else "n/a",
+            "har_resolve_rate": f"{har_resolved}/{har_evaled}" if har_evaled else "n/a",
+        },
+        "baseline": BASELINE,
+        "delta_vs_baseline": {
+            "raw_patches": raw_patches - BASELINE["raw_patches"],
+            "har_patches": har_patches - BASELINE["har_patches"],
+        },
+    }
+
+
+def markdown_table(rows: list[dict[str, Any]]) -> str:
+    lines = [
+        "| # | Instance | Raw patch | Raw resolved | HAR patch | HAR ready | HAR resolved |",
+        "|---|----------|-----------|--------------|-----------|-----------|--------------|",
+    ]
+    for index, row in enumerate(rows, start=1):
+        arms = row.get("arms") or {}
+        raw = arms.get("raw") or {}
+        har = arms.get("har") or {}
+
+        def fmt(val: Any) -> str:
+            if val is True:
+                return "yes"
+            if val is False:
+                return "no"
+            return "—"
+
+        lines.append(
+            "| {idx} | `{iid}` | {rp} | {rr} | {hp} | {hrdy} | {hres} |".format(
+                idx=index,
+                iid=row.get("instance_id", ""),
+                rp=fmt(raw.get("patch_produced")),
+                rr=fmt(raw.get("resolved")),
+                hp=fmt(har.get("patch_produced")),
+                hrdy=fmt(har.get("har_ready_for_fix")),
+                hres=fmt(har.get("resolved")),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch-id", help="Batch id under batches/")
+    parser.add_argument("--latest-batch", action="store_true", help="Use most recent batches/*/batch.json")
+    parser.add_argument("--arm", choices=["raw", "har", "both"], default="both")
+    parser.add_argument("--max-workers", type=int, default=1)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    batch_dir = resolve_batch_dir(args.batch_id, args.latest_batch)
+    batch = read_json(batch_dir / "batch.json")
+    cfg = benchmark_config()
+    runs_dir = BENCHMARK_ROOT / cfg.get("runs_dir", "runs")
+    results_dir = ensure_dir(BENCHMARK_ROOT / cfg.get("results_dir", "results") / f"batch-{batch['batch_id']}")
+
+    arms = ["raw", "har"] if args.arm == "both" else [args.arm]
+    rows: list[dict[str, Any]] = []
+
+    print(f"Evaluating batch {batch['batch_id']} ({len(batch.get('instances') or [])} instances)", flush=True)
+    for entry in batch.get("instances") or []:
+        instance_id = entry.get("instance_id")
+        run_id = entry.get("run_id")
+        row: dict[str, Any] = {
+            "instance_id": instance_id,
+            "run_id": run_id,
+            "batch_status": entry.get("status"),
+            "arms": {},
+        }
+        if not run_id:
+            row["error"] = entry.get("error") or "missing run_id"
+            rows.append(row)
+            continue
+
+        run_dir = runs_dir / run_id
+        if not run_dir.is_dir():
+            row["error"] = f"run dir missing: {run_dir}"
+            rows.append(row)
+            continue
+
+        print(f"  {instance_id} ({run_id}) ...", flush=True)
+        for arm in arms:
+            row["arms"][arm] = arm_row(
+                run_dir,
+                instance_id,
+                run_id,
+                arm,
+                max_workers=args.max_workers,
+                dry_run=args.dry_run,
+            )
+        rows.append(row)
+        write_json(results_dir / "batch-evaluation.json", {"batch_id": batch["batch_id"], "instances": rows})
+
+    comparison = build_comparison(batch, rows)
+    report = {
+        "batch_id": batch["batch_id"],
+        "batch_dir": str(batch_dir),
+        "dry_run": args.dry_run,
+        "instances": rows,
+        "comparison": comparison,
+    }
+    write_json(results_dir / "batch-evaluation.json", report)
+    write_json(BENCHMARK_ROOT / cfg.get("results_dir", "results") / "ec2-comparison.json", comparison)
+    table = markdown_table(rows)
+    (results_dir / "batch-evaluation.md").write_text(
+        f"# Batch {batch['batch_id']} evaluation\n\n"
+        f"```json\n{json.dumps(comparison, indent=2)}\n```\n\n"
+        f"{table}",
+        encoding="utf-8",
+    )
+    print(table)
+    print(json.dumps(comparison, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/swebench-har/scripts/lib/common.py
+++ b/benchmarks/swebench-har/scripts/lib/common.py
@@ -91,6 +91,7 @@ def run_command(
         cmd,
         cwd=cwd,
         env=env,
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         timeout=timeout,
@@ -108,6 +109,10 @@ def resolve_har_base_cmd(env: dict[str, str] | None = None) -> list[str]:
     env = env or load_benchmark_env()
     har_bin = env.get("HAR_BIN")
     if har_bin:
+        path = Path(har_bin)
+        # HAR_BIN may point at the bundled JS entry; always invoke via node.
+        if path.suffix == ".js" or path.name == "index.js":
+            return ["node", str(path)]
         return [har_bin]
     which = shutil.which("har")
     if which:

--- a/benchmarks/swebench-har/scripts/lib/dataset.py
+++ b/benchmarks/swebench-har/scripts/lib/dataset.py
@@ -3,7 +3,50 @@
 from __future__ import annotations
 
 import random
+from collections import defaultdict
 from typing import Any
+
+# SWE-bench / SWE-bench Lite repos are overwhelmingly Python today.
+# Keep an explicit map so multi-language full SWE-bench stays correct if we expand.
+_REPO_LANGUAGE: dict[str, str] = {
+    "django/django": "python",
+    "sympy/sympy": "python",
+    "matplotlib/matplotlib": "python",
+    "scikit-learn/scikit-learn": "python",
+    "pytest-dev/pytest": "python",
+    "sphinx-doc/sphinx": "python",
+    "astropy/astropy": "python",
+    "psf/requests": "python",
+    "pylint-dev/pylint": "python",
+    "pydata/xarray": "python",
+    "mwaskom/seaborn": "python",
+    "pallets/flask": "python",
+    # Common full SWE-bench non-Python examples (for future splits)
+    "npm/cli": "javascript",
+    "prettier/prettier": "javascript",
+    "alibaba/fastjson": "java",
+    "google/gson": "java",
+}
+
+
+def infer_language(row: dict[str, Any]) -> str:
+    """Return a coarse language label for diversity sampling."""
+    if row.get("language"):
+        return str(row["language"]).strip().lower()
+    repo = str(row.get("repo") or "")
+    if repo in _REPO_LANGUAGE:
+        return _REPO_LANGUAGE[repo]
+    # Heuristic fallbacks from repo slug
+    lower = repo.lower()
+    if any(tok in lower for tok in ("java", "spring", "jackson", "gson")):
+        return "java"
+    if any(tok in lower for tok in ("npm", "node", "react", "vue", "prettier", "eslint")):
+        return "javascript"
+    if any(tok in lower for tok in ("rust", "tokio")):
+        return "rust"
+    if any(tok in lower for tok in ("go-", "/go", "golang")):
+        return "go"
+    return "python"
 
 
 def load_split(dataset_name: str, split: str) -> list[dict[str, Any]]:
@@ -28,10 +71,102 @@ def sample_rows(
     rows: list[dict[str, Any]],
     count: int,
     seed: int | None = None,
+    *,
+    max_per_repo: int | None = None,
+    max_repos_per_language: int | None = None,
 ) -> list[dict[str, Any]]:
+    """Sample instances, optionally capping per-repo and per-language repo fan-out.
+
+    When diversity caps are unset, behaves as uniform ``random.sample``.
+    With caps:
+      - at most ``max_repos_per_language`` distinct repos per language
+      - at most ``max_per_repo`` instances per repo
+      - repos within a language are preferred by size (seeded tie-break) so a
+        target ``count`` remains achievable on skewed datasets like SWE-bench Lite
+    """
     if count < 1:
         raise ValueError("count must be >= 1")
     if count > len(rows):
         raise ValueError(f"count {count} exceeds dataset size {len(rows)}")
+
+    if max_per_repo is None and max_repos_per_language is None:
+        rng = random.Random(seed)
+        return rng.sample(rows, count)
+
+    return sample_rows_diverse(
+        rows,
+        count,
+        seed=seed,
+        max_per_repo=max_per_repo if max_per_repo is not None else count,
+        max_repos_per_language=(
+            max_repos_per_language if max_repos_per_language is not None else count
+        ),
+    )
+
+
+def sample_rows_diverse(
+    rows: list[dict[str, Any]],
+    count: int,
+    *,
+    seed: int | None = None,
+    max_per_repo: int = 5,
+    max_repos_per_language: int = 10,
+) -> list[dict[str, Any]]:
+    if max_per_repo < 1:
+        raise ValueError("max_per_repo must be >= 1")
+    if max_repos_per_language < 1:
+        raise ValueError("max_repos_per_language must be >= 1")
+
     rng = random.Random(seed)
-    return rng.sample(rows, count)
+
+    by_lang_repo: dict[str, dict[str, list[dict[str, Any]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for row in rows:
+        lang = infer_language(row)
+        by_lang_repo[lang][str(row["repo"])].append(row)
+
+    pool: list[dict[str, Any]] = []
+    selection_meta: dict[str, Any] = {"languages": {}, "constraints": {
+        "max_per_repo": max_per_repo,
+        "max_repos_per_language": max_repos_per_language,
+        "count": count,
+        "seed": seed,
+    }}
+
+    for lang in sorted(by_lang_repo.keys()):
+        repos = by_lang_repo[lang]
+        # Prefer larger repos so count remains fillable; seeded shuffle breaks ties.
+        ranked = sorted(
+            repos.keys(),
+            key=lambda repo: (-len(repos[repo]), rng.random()),
+        )
+        chosen_repos = ranked[:max_repos_per_language]
+        lang_picked = 0
+        for repo in chosen_repos:
+            items = list(repos[repo])
+            rng.shuffle(items)
+            take = items[: min(max_per_repo, len(items))]
+            pool.extend(take)
+            lang_picked += len(take)
+        selection_meta["languages"][lang] = {
+            "repos_available": len(repos),
+            "repos_selected": chosen_repos,
+            "instances_selected": lang_picked,
+        }
+
+    if len(pool) < count:
+        raise ValueError(
+            f"diversity constraints yield only {len(pool)} instances "
+            f"(need {count}); relax max_per_repo / max_repos_per_language "
+            f"or lower count. meta={selection_meta}"
+        )
+
+    selected = rng.sample(pool, count) if len(pool) > count else list(pool)
+    # Stable-ish print order: shuffle once more for run order diversity
+    rng.shuffle(selected)
+    # Attach sampling meta on a side channel via function attribute for callers/tests
+    sample_rows_diverse.last_meta = selection_meta  # type: ignore[attr-defined]
+    sample_rows_diverse.last_meta["pool_size"] = len(pool)  # type: ignore[attr-defined]
+    sample_rows_diverse.last_meta["returned"] = len(selected)  # type: ignore[attr-defined]
+    return selected

--- a/benchmarks/swebench-har/scripts/lib/har_cache.py
+++ b/benchmarks/swebench-har/scripts/lib/har_cache.py
@@ -67,7 +67,70 @@ def invalidate_har_cache(repo_slug: str) -> bool:
     return True
 
 
-def save_har_cache(repo_slug: str, harness_root: Path, profile: str) -> Path:
+def list_verification_stage_ids(harness_root: Path) -> list[str]:
+    stages_path = harness_root / ".har" / "stages.json"
+    if not stages_path.exists():
+        return []
+    data = read_json(stages_path)
+    return [str(x) for x in (data.get("verificationStages") or [])]
+
+
+def _stage_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
+    stages = data.get("stages")
+    if isinstance(stages, dict):
+        out: list[dict[str, Any]] = []
+        for key, value in stages.items():
+            if isinstance(value, dict):
+                entry = dict(value)
+                entry.setdefault("id", key)
+                out.append(entry)
+        return out
+    if isinstance(stages, list):
+        return [s for s in stages if isinstance(s, dict)]
+    return []
+
+
+def strip_verification_stages(harness_root: Path, keep_ids: set[str] | frozenset[str]) -> list[str]:
+    """Remove verification stages (and scripts) not in keep_ids. Returns removed ids."""
+    stages_path = harness_root / ".har" / "stages.json"
+    if not stages_path.exists():
+        return []
+    data = read_json(stages_path)
+    current = [str(x) for x in (data.get("verificationStages") or [])]
+    removed = [sid for sid in current if sid not in keep_ids]
+    if not removed:
+        return []
+
+    data["verificationStages"] = [sid for sid in current if sid in keep_ids]
+    kept_entries: list[dict[str, Any]] = []
+    har_root = (harness_root / ".har").resolve()
+    for entry in _stage_entries(data):
+        sid = str(entry.get("id") or "")
+        if sid in removed:
+            script = entry.get("script")
+            if isinstance(script, str) and script:
+                script_path = (harness_root / ".har" / script).resolve()
+                if str(script_path).startswith(str(har_root)) and script_path.exists():
+                    script_path.unlink()
+            continue
+        kept_entries.append(entry)
+    data["stages"] = kept_entries
+    write_json(stages_path, data)
+    return removed
+
+
+def save_har_cache(
+    repo_slug: str,
+    harness_root: Path,
+    profile: str,
+    *,
+    keep_verification_stage_ids: set[str] | frozenset[str] | None = None,
+) -> Path:
+    """Persist repo-generic `.har/`. Optionally strip task-scoped verification stages first."""
+    removed: list[str] = []
+    if keep_verification_stage_ids is not None:
+        removed = strip_verification_stages(harness_root, keep_verification_stage_ids)
+
     dest_root = cache_dir_for_repo(repo_slug)
     har_src = harness_root / ".har"
     har_dest = dest_root / ".har"
@@ -85,6 +148,8 @@ def save_har_cache(repo_slug: str, harness_root: Path, profile: str) -> Path:
             "repo": repo_slug,
             "profile": profile,
             "adapted_at": now_iso(),
+            "verification_stage_ids": list_verification_stage_ids(harness_root),
+            "stripped_task_stages": removed,
         },
     )
     return dest_root

--- a/benchmarks/swebench-har/scripts/lib/har_utils.py
+++ b/benchmarks/swebench-har/scripts/lib/har_utils.py
@@ -20,10 +20,27 @@ def har_init_scaffold(repo_path: Path, profile: str, env: dict[str, str] | None 
     launch = repo_path / ".har" / "launch.sh"
     if launch.exists():
         return
-    run_command(
-        [*har_cmd("init", "--profile", profile, env=env)],
+    # Non-interactive: skip cursor-rule / agent-skills prompts (tmux/SSH is a TTY).
+    # Also tolerate exit 1 from a known yargs --no-agents quirk if scaffold landed.
+    result = run_command(
+        [
+            *har_cmd(
+                "init",
+                "--profile",
+                profile,
+                "--no-cursor-rule",
+                "--no-agents",
+                env=env,
+            )
+        ],
         cwd=repo_path,
-        check=True,
+        check=False,
+    )
+    if launch.exists():
+        return
+    raise RuntimeError(
+        f"har env init failed ({result.returncode}): {' '.join(result.args) if hasattr(result, 'args') else 'init'}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
 
 

--- a/benchmarks/swebench-har/scripts/run_batch.py
+++ b/benchmarks/swebench-har/scripts/run_batch.py
@@ -64,6 +64,7 @@ def run_one_instance(
     post_fix_verify_full: bool,
     setup_budget_minutes: int,
     setup_max_rounds: int,
+    fix_max_rounds: int = 3,
 ) -> dict[str, Any]:
     instance, run_dir = prepare_instance_row(row, seed)
     record: dict[str, Any] = {
@@ -102,6 +103,7 @@ def run_one_instance(
             post_fix_verify_full=post_fix_verify_full,
             setup_budget_minutes=setup_budget_minutes,
             setup_max_rounds=setup_max_rounds,
+            fix_max_rounds=fix_max_rounds,
         )
 
     record["finished_at"] = now_iso()
@@ -130,6 +132,7 @@ def main() -> int:
     readiness_timeout = int(cfg.get("readiness_timeout_minutes", 20))
     setup_budget = int(cfg.get("setup_budget_minutes", 120))
     setup_max_rounds = int(cfg.get("setup_max_rounds", 6))
+    fix_max_rounds = int(cfg.get("fix_max_rounds", 3))
     post_fix_verify_full = bool(cfg.get("har_verify_full", False))
 
     rows = load_split(cfg["dataset_name"], cfg["split"])
@@ -175,6 +178,7 @@ def main() -> int:
                 post_fix_verify_full=post_fix_verify_full,
                 setup_budget_minutes=setup_budget,
                 setup_max_rounds=setup_max_rounds,
+                fix_max_rounds=fix_max_rounds,
             )
             entry["run_id"] = result["run_id"]
             entry["status"] = "completed"

--- a/benchmarks/swebench-har/scripts/run_batch.py
+++ b/benchmarks/swebench-har/scripts/run_batch.py
@@ -21,7 +21,12 @@ from lib.common import (  # noqa: E402
     now_iso,
     write_json,
 )
-from lib.dataset import load_split, sample_rows
+from lib.dataset import (  # noqa: E402
+    infer_language,
+    load_split,
+    sample_rows,
+    sample_rows_diverse,
+)
 from run_one import run_har_arm, run_raw_arm  # noqa: E402
 
 
@@ -115,6 +120,18 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--count", type=int, default=10, help="Number of instances to run")
     parser.add_argument("--seed", type=int, default=42, help="Random seed for sampling instances")
+    parser.add_argument(
+        "--max-per-repo",
+        type=int,
+        default=None,
+        help="Cap instances per repository (diversity). Overrides config when set.",
+    )
+    parser.add_argument(
+        "--max-repos-per-language",
+        type=int,
+        default=None,
+        help="Cap distinct repos per language (diversity). Overrides config when set.",
+    )
     parser.add_argument("--model", help="Codex model for raw/fix arms")
     parser.add_argument("--setup-model", help="Codex model for HAR setup")
     parser.add_argument("--arm", choices=["raw", "har", "both"], default="both")
@@ -134,14 +151,29 @@ def main() -> int:
     setup_max_rounds = int(cfg.get("setup_max_rounds", 6))
     fix_max_rounds = int(cfg.get("fix_max_rounds", 3))
     post_fix_verify_full = bool(cfg.get("har_verify_full", False))
+    max_per_repo = args.max_per_repo
+    if max_per_repo is None and cfg.get("sample_max_per_repo") is not None:
+        max_per_repo = int(cfg["sample_max_per_repo"])
+    max_repos_per_language = args.max_repos_per_language
+    if max_repos_per_language is None and cfg.get("sample_max_repos_per_language") is not None:
+        max_repos_per_language = int(cfg["sample_max_repos_per_language"])
 
     rows = load_split(cfg["dataset_name"], cfg["split"])
-    selected = sample_rows(rows, args.count, args.seed)
+    selected = sample_rows(
+        rows,
+        args.count,
+        args.seed,
+        max_per_repo=max_per_repo,
+        max_repos_per_language=max_repos_per_language,
+    )
 
     batch_id = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
     batch_dir = BENCHMARK_ROOT / "batches" / batch_id
     batch_dir.mkdir(parents=True, exist_ok=True)
 
+    from collections import Counter
+
+    sample_meta = getattr(sample_rows_diverse, "last_meta", None)
     batch_record: dict[str, Any] = {
         "batch_id": batch_id,
         "count": args.count,
@@ -149,11 +181,25 @@ def main() -> int:
         "arm": args.arm,
         "model": model,
         "setup_model": setup_model,
+        "sample_max_per_repo": max_per_repo,
+        "sample_max_repos_per_language": max_repos_per_language,
+        "sample_repo_counts": dict(Counter(str(r["repo"]) for r in selected)),
+        "sample_language_counts": dict(Counter(infer_language(r) for r in selected)),
+        "sample_meta": sample_meta,
         "started_at": now_iso(),
         "instances": [],
     }
 
-    print(f"Batch {batch_id}: running {args.count} instances (seed={args.seed}, arm={args.arm})")
+    print(
+        f"Batch {batch_id}: running {args.count} instances "
+        f"(seed={args.seed}, arm={args.arm}, "
+        f"max_per_repo={max_per_repo}, max_repos_per_language={max_repos_per_language})"
+    )
+    print(
+        f"  sample repos={batch_record['sample_repo_counts']} "
+        f"languages={batch_record['sample_language_counts']}",
+        flush=True,
+    )
     for index, row in enumerate(selected, start=1):
         instance_id = row["instance_id"]
         print(f"[{index}/{args.count}] {instance_id} ...", flush=True)
@@ -161,6 +207,7 @@ def main() -> int:
             "index": index,
             "instance_id": instance_id,
             "repo": row["repo"],
+            "language": infer_language(row),
             "started_at": now_iso(),
         }
         try:

--- a/benchmarks/swebench-har/scripts/run_one.py
+++ b/benchmarks/swebench-har/scripts/run_one.py
@@ -206,6 +206,7 @@ def run_har_arm(
     gate_rounds: list[dict[str, Any]] = []
     cache_invalidated = False
     gate: dict[str, Any] = {"ready": False}
+    oracle_ready = False
     failure_context = ""
     readiness_failure_context = ""
 
@@ -292,6 +293,45 @@ def run_har_arm(
                 set(list_verification_stage_ids(harness_root)) - baseline_verification_ids
             )
             record["har_task_verification_stages"] = task_stage_ids
+
+            if not task_stage_ids:
+                readiness_failure_context = (
+                    f"\n## Previous readiness round {round_index}: missing task-scoped stage\n"
+                    "You must register at least one **issue-specific** verification stage "
+                    "(`har env add-stage <id> --custom … --verification`) that encodes the "
+                    "bug from the problem statement.\n"
+                    "Repo-generic compile/import/smoke stages alone are **not** enough.\n"
+                    "The stage must be written to **fail on this buggy tree** (fail-before).\n"
+                )
+                har_teardown_slot(harness_root, env=env)
+                continue
+
+            # Fail-before gate: task stages must fail on the buggy tree for a behavioral reason.
+            fail_before_verify = har_verify(
+                harness_root,
+                full=True,
+                env=_merge_task_overlay_env(env, task_overlay_dir),
+            )
+            fb_ok, fb_reason, fb_detail = _assess_fail_before(
+                fail_before_verify, task_stage_ids
+            )
+            record["har_fail_before"] = {
+                "ok": fb_ok,
+                "reason": fb_reason,
+                "detail": fb_detail,
+                "verified": fail_before_verify.get("verified"),
+                "exit_code": fail_before_verify.get("exit_code"),
+            }
+            if not fb_ok:
+                readiness_failure_context = _format_fail_before_failure(
+                    round_index,
+                    fb_reason,
+                    fail_before_verify,
+                    task_stage_ids,
+                )
+                har_teardown_slot(harness_root, env=env)
+                continue
+
             _snapshot_task_stages(harness_root, task_overlay_dir, task_stage_ids)
             save_har_cache(
                 instance["repo"],
@@ -302,6 +342,7 @@ def run_har_arm(
             # Re-apply task stages after cache strip so fix/verify still see them.
             _restore_task_stages(harness_root, task_overlay_dir)
             record["har_cache_saved"] = True
+            oracle_ready = True
             break
 
         if cache_hit or har_cache_exists(instance["repo"], profile):
@@ -325,30 +366,47 @@ def run_har_arm(
         "skipped_bootstrap": bool(record.get("har_cache_hit")) and not bootstrap_attempts,
         "overlay_dir": str(task_overlay_dir),
         "overlay_files": _list_task_overlay_files(task_overlay_dir),
-        "status": "passed" if gate.get("ready") else "failed",
+        "status": "passed" if oracle_ready else "failed",
+        "task_stages": record.get("har_task_verification_stages") or [],
+        "fail_before": record.get("har_fail_before"),
     }
     if bootstrap_attempts:
         record["codex_bootstrap"] = bootstrap_attempts[-1]["codex"]
-    elif record.get("har_cache_hit") and gate.get("ready"):
+    elif record.get("har_cache_hit") and oracle_ready:
         record["codex_bootstrap"] = {"status": "skipped", "reason": "har_cache_valid"}
     if readiness_attempts:
         record["codex_readiness"] = readiness_attempts[-1]["codex"]
     record["har_setup_attempts"] = bootstrap_attempts
     if bootstrap_attempts:
         record["codex_setup"] = bootstrap_attempts[-1]["codex"]
-    elif record.get("har_cache_hit") and gate.get("ready"):
+    elif record.get("har_cache_hit") and oracle_ready:
         record["codex_setup"] = {"status": "skipped", "reason": "har_cache_valid"}
     record["har_gate_initial"] = gate_rounds[0]["gate"] if gate_rounds else gate
 
-    if not gate["ready"] or not gate.get("workdir"):
+    if not oracle_ready or not gate.get("workdir"):
+        record["har_ready_for_fix"] = False
         record["har_launch"] = {
             "ok": gate.get("launch_ok", False),
             "log": gate.get("launch_log", ""),
             "workdir": gate.get("workdir"),
         }
         record["har_verify"] = gate.get("verify")
+        reasons: list[str] = []
+        if not gate.get("ready"):
+            reasons.append("launch_or_smoke_gate_failed")
+        if not (record.get("har_task_verification_stages") or []):
+            reasons.append("missing_task_stage")
+        fb = record.get("har_fail_before") or {}
+        if fb and not fb.get("ok"):
+            reasons.append(f"fail_before:{fb.get('reason')}")
+        if not reasons:
+            reasons.append("oracle_gate_failed")
+        record["har_invalid_reasons"] = reasons
         record["status"] = "failed"
-        record["error"] = "HAR pre-fix gate failed (launch or smoke verify) before fix stage"
+        record["error"] = (
+            "HAR pre-fix oracle gate failed "
+            f"({', '.join(reasons)}) before fix stage"
+        )
         record["finished_at"] = now_iso()
         return record
 
@@ -436,6 +494,11 @@ def run_har_arm(
         invalid_reasons.append("no_verify_attempt")
     if post_fix_verify_full and not record["har_verify_passed"]:
         invalid_reasons.append("post_fix_verify_failed")
+    if not (record.get("har_task_verification_stages") or []):
+        invalid_reasons.append("missing_task_stage")
+    fb = record.get("har_fail_before") or {}
+    if fb and not fb.get("ok"):
+        invalid_reasons.append("fail_before_not_established")
     if not record["har_runs_recorded"]:
         invalid_reasons.append("no_har_run_records")
 
@@ -579,16 +642,122 @@ def _format_post_fix_verify_failure(verify: dict[str, Any], fix_round: int) -> s
     return (
         f"\n## Previous fix round {fix_round}: HAR verify --full failed\n"
         "HAR is a sandbox for verifying that your change works. Do not stop until "
-        "`har env verify 1 --full` passes.\n"
-        "- You may add or update a verification stage on the fly "
-        "(`har env add-stage … --custom --verification`).\n"
-        "- You may add a small focused regression check / test that proves the fix "
-        "(prefer a stage; keep it narrow — not the full suite).\n"
-        "- Prefer fail-before/pass-after: the check should fail on the broken tree and "
-        "pass after your fix.\n\n"
+        "`har env verify 1 --full` passes with a **behavioral** task stage.\n"
+        "- Keep (or add) an issue-specific stage that encodes the bug from the problem "
+        "statement — smoke/compile alone is not done.\n"
+        "- Fail-before/pass-after: the stage must have failed on the buggy tree and "
+        "must pass after your fix.\n"
+        "- If the stage fails with ImportError/ModuleNotFoundError, fix the slot "
+        "install/build so the oracle can run, then re-check behavior.\n"
+        "- You may add `har env add-stage … --custom --verification` or a small "
+        "focused regression script wired as that stage.\n\n"
         f"exit_code: {verify.get('exit_code')}\n"
         f"stderr (tail):\n```\n{(verify.get('stderr') or '')[-3000:]}\n```\n"
         f"stdout (tail):\n```\n{(verify.get('stdout') or '')[-2000:]}\n```\n"
+    )
+
+
+_ENV_FAILURE_MARKERS = (
+    "ModuleNotFoundError",
+    "ImportError",
+    "No module named",
+    "DLL load failed",
+    "cannot import name",
+    "error: Microsoft Visual C++",
+    "pkg_resources.DistributionNotFound",
+)
+
+
+def _parse_verify_stages(verify: dict[str, Any]) -> list[dict[str, Any]]:
+    stdout = verify.get("stdout") or ""
+    if not stdout.strip():
+        return []
+    try:
+        decoder = json.JSONDecoder()
+        idx = stdout.find("{")
+        if idx < 0:
+            return []
+        payload, _ = decoder.raw_decode(stdout[idx:])
+        stages = payload.get("stages") or []
+        return stages if isinstance(stages, list) else []
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _assess_fail_before(
+    verify: dict[str, Any],
+    task_stage_ids: list[str],
+) -> tuple[bool, str, dict[str, Any]]:
+    """Return whether task stages fail on the buggy tree for a non-env reason."""
+    stages = _parse_verify_stages(verify)
+    by_name = {
+        str(stage.get("name") or stage.get("id") or ""): stage
+        for stage in stages
+        if isinstance(stage, dict)
+    }
+    task_results = []
+    for stage_id in task_stage_ids:
+        stage = by_name.get(stage_id)
+        if stage is None:
+            continue
+        output = str(stage.get("output") or "")
+        passed = bool(stage.get("pass"))
+        env_only = (not passed) and any(marker in output for marker in _ENV_FAILURE_MARKERS)
+        task_results.append(
+            {
+                "id": stage_id,
+                "pass": passed,
+                "env_failure": env_only,
+                "output_tail": output[-500:],
+            }
+        )
+
+    detail = {"task_results": task_results, "all_stages": list(by_name.keys())}
+    if not task_results:
+        return False, "task_stages_not_executed", detail
+    if all(item["pass"] for item in task_results):
+        return False, "stages_pass_on_buggy_tree", detail
+    if all(item["env_failure"] or item["pass"] for item in task_results) and any(
+        item["env_failure"] for item in task_results
+    ):
+        return False, "env_blocks_oracle", detail
+    # At least one behavioral failure among task stages.
+    return True, "task_stage_failed_as_expected", detail
+
+
+def _format_fail_before_failure(
+    round_index: int,
+    reason: str,
+    verify: dict[str, Any],
+    task_stage_ids: list[str],
+) -> str:
+    guidance = {
+        "stages_pass_on_buggy_tree": (
+            "Your task stage(s) already **pass** on the buggy tree — they do not prove "
+            "the bug. Tighten the assertion so it fails before a correct fix "
+            "(fail-before), using only the problem statement."
+        ),
+        "env_blocks_oracle": (
+            "Your task stage failed only because the package/deps/extensions are not "
+            "importable in the slot. Fix install/build in harness.env / quick verify "
+            "so the behavioral check can run, then ensure it fails for the ticket reason."
+        ),
+        "task_stages_not_executed": (
+            "Task stage ids were registered but did not appear in verify --full output. "
+            "Ensure they are listed in verificationStages and the command/script path is valid."
+        ),
+    }.get(
+        reason,
+        "Establish a task-scoped behavioral stage that fails on this buggy tree "
+        "for the problem-statement reason (fail-before).",
+    )
+    return (
+        f"\n## Previous readiness round {round_index}: fail-before gate failed ({reason})\n"
+        f"{guidance}\n"
+        f"Task stage ids: {task_stage_ids}\n"
+        f"verify exit_code: {verify.get('exit_code')}\n"
+        f"stdout (tail):\n```\n{(verify.get('stdout') or '')[-2500:]}\n```\n"
+        f"stderr (tail):\n```\n{(verify.get('stderr') or '')[-1500:]}\n```\n"
     )
 
 

--- a/benchmarks/swebench-har/scripts/run_one.py
+++ b/benchmarks/swebench-har/scripts/run_one.py
@@ -23,6 +23,7 @@ from lib.common import (  # noqa: E402
     load_benchmark_env,
     new_run_id,
     now_iso,
+    read_json,
     render_template,
     sanitize_instance_row,
     write_json,
@@ -40,6 +41,7 @@ from lib.har_utils import (  # noqa: E402
 from lib.har_cache import (  # noqa: E402
     har_cache_exists,
     invalidate_har_cache,
+    list_verification_stage_ids,
     load_har_cache,
     save_har_cache,
 )
@@ -161,6 +163,7 @@ def run_har_arm(
     post_fix_verify_full: bool,
     setup_budget_minutes: int,
     setup_max_rounds: int,
+    fix_max_rounds: int = 3,
 ) -> dict[str, Any]:
     cfg = benchmark_config()
     harness_root = run_dir / "har" / "repo"
@@ -192,6 +195,10 @@ def run_har_arm(
     if har_cache_exists(instance["repo"], profile):
         cache_hit = load_har_cache(instance["repo"], harness_root)
         record["har_cache_hit"] = cache_hit
+
+    # Repo-generic verification stages only — task-scoped stages must not enter .har-cache.
+    baseline_verification_ids = set(list_verification_stage_ids(harness_root))
+    record["har_baseline_verification_stages"] = sorted(baseline_verification_ids)
 
     need_bootstrap = not cache_hit
     bootstrap_attempts: list[dict[str, Any]] = []
@@ -238,6 +245,9 @@ def run_har_arm(
             )
             har_teardown_slot(harness_root, env=env)
             need_bootstrap = False
+            # After bootstrap, treat current verificationStages as the new repo baseline.
+            baseline_verification_ids = set(list_verification_stage_ids(harness_root))
+            record["har_baseline_verification_stages"] = sorted(baseline_verification_ids)
 
         readiness_prompt = render_template(
             PROMPTS / "har-task-readiness.md",
@@ -277,7 +287,20 @@ def run_har_arm(
         record[f"har_gate_round_{round_index}"] = gate
 
         if gate["ready"]:
-            save_har_cache(instance["repo"], harness_root, profile)
+            # Persist only repo-generic stages; keep task-scoped ones live for this run.
+            task_stage_ids = sorted(
+                set(list_verification_stage_ids(harness_root)) - baseline_verification_ids
+            )
+            record["har_task_verification_stages"] = task_stage_ids
+            _snapshot_task_stages(harness_root, task_overlay_dir, task_stage_ids)
+            save_har_cache(
+                instance["repo"],
+                harness_root,
+                profile,
+                keep_verification_stage_ids=baseline_verification_ids,
+            )
+            # Re-apply task stages after cache strip so fix/verify still see them.
+            _restore_task_stages(harness_root, task_overlay_dir)
             record["har_cache_saved"] = True
             break
 
@@ -340,25 +363,61 @@ def run_har_arm(
     record["har_ready_for_fix"] = True
 
     solve_started = time.time()
-    fix_prompt = render_template(
-        PROMPTS / "har-fix.md",
-        prompt_values(instance, work_dir=str(workdir)),
-    )
-    fix_codex = run_codex_turn(
-        cwd=workdir,
-        prompt=fix_prompt,
-        model=model,
-        api_key=env.get("OPENAI_API_KEY"),
-        timeout_seconds=solve_timeout_minutes * 60,
-        artifacts_dir=run_dir / "har" / "codex-fix",
-    )
-    record["codex_fix"] = fix_codex.result
-    record["solve_seconds"] = round(time.time() - solve_started, 2)
+    fix_attempts: list[dict[str, Any]] = []
+    verify_result: dict[str, Any] = {"verified": False, "full": post_fix_verify_full}
+    fix_failure_context = ""
 
-    verify_result = har_verify(harness_root, full=post_fix_verify_full, env=env)
+    for fix_round in range(1, max(1, fix_max_rounds) + 1):
+        remaining_solve = max(
+            60,
+            solve_timeout_minutes * 60 - int(time.time() - solve_started),
+        )
+        fix_prompt = render_template(
+            PROMPTS / "har-fix.md",
+            prompt_values(
+                instance,
+                work_dir=str(workdir),
+                fix_failure_context=fix_failure_context,
+                fix_round=str(fix_round),
+                fix_max_rounds=str(fix_max_rounds),
+            ),
+        )
+        fix_codex = run_codex_turn(
+            cwd=workdir,
+            prompt=fix_prompt,
+            model=model,
+            api_key=env.get("OPENAI_API_KEY"),
+            timeout_seconds=remaining_solve,
+            artifacts_dir=run_dir / "har" / f"codex-fix-r{fix_round}",
+        )
+        verify_result = har_verify(
+            harness_root,
+            full=post_fix_verify_full,
+            env=_merge_task_overlay_env(env, task_overlay_dir),
+        )
+        fix_attempts.append(
+            {
+                "round": fix_round,
+                "codex": fix_codex.result,
+                "wall_clock_seconds": fix_codex.wall_clock_seconds,
+                "verify": {
+                    "verified": verify_result.get("verified"),
+                    "full": verify_result.get("full"),
+                    "exit_code": verify_result.get("exit_code"),
+                },
+            }
+        )
+        if verify_result.get("verified"):
+            break
+        fix_failure_context = _format_post_fix_verify_failure(verify_result, fix_round)
+
+    record["codex_fix"] = fix_attempts[-1]["codex"] if fix_attempts else {}
+    record["har_fix_attempts"] = fix_attempts
+    record["har_fix_rounds"] = len(fix_attempts)
+    record["solve_seconds"] = round(time.time() - solve_started, 2)
     record["har_verify"] = verify_result
     record["har_verify_attempted"] = True
-    record["har_verify_passed"] = verify_result["verified"]
+    record["har_verify_passed"] = bool(verify_result.get("verified"))
     record["har_runs_recorded"] = har_runs_exist(harness_root)
 
     patch = extract_model_patch(workdir, instance["base_commit"])
@@ -375,6 +434,8 @@ def run_har_arm(
         invalid_reasons.append("launch_gate_failed")
     if not record["har_verify_attempted"]:
         invalid_reasons.append("no_verify_attempt")
+    if post_fix_verify_full and not record["har_verify_passed"]:
+        invalid_reasons.append("post_fix_verify_failed")
     if not record["har_runs_recorded"]:
         invalid_reasons.append("no_har_run_records")
 
@@ -402,6 +463,104 @@ def _list_task_overlay_files(task_overlay_dir: Path) -> list[str]:
     )
 
 
+def _snapshot_task_stages(
+    harness_root: Path,
+    task_overlay_dir: Path,
+    task_stage_ids: list[str],
+) -> None:
+    """Copy task-scoped stage definitions/scripts into the per-run overlay."""
+    if not task_stage_ids:
+        return
+    stages_path = harness_root / ".har" / "stages.json"
+    if not stages_path.exists():
+        return
+    data = read_json(stages_path)
+    stages = data.get("stages") or []
+    if isinstance(stages, dict):
+        entries = []
+        for key, value in stages.items():
+            if isinstance(value, dict):
+                entry = dict(value)
+                entry.setdefault("id", key)
+                entries.append(entry)
+    else:
+        entries = [s for s in stages if isinstance(s, dict)]
+
+    wanted = set(task_stage_ids)
+    snap_entries: list[dict[str, Any]] = []
+    overlay_stages = task_overlay_dir / "stages"
+    overlay_stages.mkdir(parents=True, exist_ok=True)
+    for entry in entries:
+        sid = str(entry.get("id") or "")
+        if sid not in wanted:
+            continue
+        copied = dict(entry)
+        script = copied.get("script")
+        if isinstance(script, str) and script:
+            src = harness_root / ".har" / script
+            if src.exists():
+                dest = overlay_stages / Path(script).name
+                dest.write_bytes(src.read_bytes())
+                copied["script"] = f"stages/{dest.name}"
+        snap_entries.append(copied)
+    write_json(
+        task_overlay_dir / "task-stages.json",
+        {"verificationStages": task_stage_ids, "stages": snap_entries},
+    )
+
+
+def _restore_task_stages(harness_root: Path, task_overlay_dir: Path) -> None:
+    """Merge task-scoped stages from overlay back into the live harness."""
+    snap_path = task_overlay_dir / "task-stages.json"
+    if not snap_path.exists():
+        return
+    snap = read_json(snap_path)
+    stages_path = harness_root / ".har" / "stages.json"
+    if stages_path.exists():
+        data = read_json(stages_path)
+    else:
+        data = {"verificationStages": [], "stages": []}
+
+    existing_ids = {str(x) for x in (data.get("verificationStages") or [])}
+    for sid in snap.get("verificationStages") or []:
+        sid = str(sid)
+        if sid not in existing_ids:
+            data.setdefault("verificationStages", []).append(sid)
+            existing_ids.add(sid)
+
+    live_entries = data.get("stages") or []
+    if isinstance(live_entries, dict):
+        live_list = []
+        for key, value in live_entries.items():
+            if isinstance(value, dict):
+                entry = dict(value)
+                entry.setdefault("id", key)
+                live_list.append(entry)
+        live_entries = live_list
+    live_by_id = {str(e.get("id") or ""): e for e in live_entries if isinstance(e, dict)}
+
+    stages_dir = harness_root / ".har" / "stages"
+    stages_dir.mkdir(parents=True, exist_ok=True)
+    for entry in snap.get("stages") or []:
+        if not isinstance(entry, dict):
+            continue
+        entry = dict(entry)
+        sid = str(entry.get("id") or "")
+        script = entry.get("script")
+        if isinstance(script, str) and script:
+            overlay_script = task_overlay_dir / script
+            if not overlay_script.exists():
+                overlay_script = task_overlay_dir / "stages" / Path(script).name
+            if overlay_script.exists():
+                dest = stages_dir / Path(script).name
+                dest.write_bytes(overlay_script.read_bytes())
+                entry["script"] = f"stages/{dest.name}"
+        live_by_id[sid] = entry
+
+    data["stages"] = list(live_by_id.values())
+    write_json(stages_path, data)
+
+
 def _merge_task_overlay_env(env: dict[str, str], task_overlay_dir: Path) -> dict[str, str]:
     merged = dict(env)
     task_env = task_overlay_dir / "task.env"
@@ -414,6 +573,23 @@ def _merge_task_overlay_env(env: dict[str, str], task_overlay_dir: Path) -> dict
         key, value = line.split("=", 1)
         merged[key.strip()] = value.strip().strip('"').strip("'")
     return merged
+
+
+def _format_post_fix_verify_failure(verify: dict[str, Any], fix_round: int) -> str:
+    return (
+        f"\n## Previous fix round {fix_round}: HAR verify --full failed\n"
+        "HAR is a sandbox for verifying that your change works. Do not stop until "
+        "`har env verify 1 --full` passes.\n"
+        "- You may add or update a verification stage on the fly "
+        "(`har env add-stage … --custom --verification`).\n"
+        "- You may add a small focused regression check / test that proves the fix "
+        "(prefer a stage; keep it narrow — not the full suite).\n"
+        "- Prefer fail-before/pass-after: the check should fail on the broken tree and "
+        "pass after your fix.\n\n"
+        f"exit_code: {verify.get('exit_code')}\n"
+        f"stderr (tail):\n```\n{(verify.get('stderr') or '')[-3000:]}\n```\n"
+        f"stdout (tail):\n```\n{(verify.get('stdout') or '')[-2000:]}\n```\n"
+    )
 
 
 def _format_readiness_failure(gate: dict[str, Any], round_index: int) -> str:
@@ -524,6 +700,7 @@ def main() -> int:
             post_fix_verify_full=bool(cfg.get("har_verify_full", False)),
             setup_budget_minutes=setup_budget,
             setup_max_rounds=setup_max_rounds,
+            fix_max_rounds=int(cfg.get("fix_max_rounds", 3)),
         )
 
     run_record["finished_at"] = now_iso()

--- a/benchmarks/swebench-har/scripts/test_swebench_har.py
+++ b/benchmarks/swebench-har/scripts/test_swebench_har.py
@@ -74,6 +74,52 @@ def test_diverse_sampling_caps() -> None:
         assert "diversity constraints" in str(exc)
 
 
+def test_assess_fail_before_helpers() -> None:
+    from run_one import _assess_fail_before
+
+    ok_verify = {
+        "stdout": json.dumps(
+            {
+                "status": "fail",
+                "stages": [
+                    {"name": "python-compile", "pass": True, "output": ""},
+                    {"name": "bug-repro", "pass": False, "output": "AssertionError: expected label"},
+                ],
+            }
+        )
+    }
+    ok, reason, _ = _assess_fail_before(ok_verify, ["bug-repro"])
+    assert ok and reason == "task_stage_failed_as_expected"
+
+    pass_verify = {
+        "stdout": json.dumps(
+            {
+                "status": "pass",
+                "stages": [{"name": "bug-repro", "pass": True, "output": "OK"}],
+            }
+        )
+    }
+    ok, reason, _ = _assess_fail_before(pass_verify, ["bug-repro"])
+    assert not ok and reason == "stages_pass_on_buggy_tree"
+
+    env_verify = {
+        "stdout": json.dumps(
+            {
+                "status": "fail",
+                "stages": [
+                    {
+                        "name": "bug-repro",
+                        "pass": False,
+                        "output": "ModuleNotFoundError: No module named 'sklearn.utils.murmurhash'",
+                    }
+                ],
+            }
+        )
+    }
+    ok, reason, _ = _assess_fail_before(env_verify, ["bug-repro"])
+    assert not ok and reason == "env_blocks_oracle"
+
+
 def test_har_cache_roundtrip() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
@@ -285,6 +331,7 @@ def main() -> int:
     tests = [
         test_config_loads,
         test_diverse_sampling_caps,
+        test_assess_fail_before_helpers,
         test_har_cache_roundtrip,
         test_har_cache_invalidate,
         test_task_readiness_prompt_render,

--- a/benchmarks/swebench-har/scripts/test_swebench_har.py
+++ b/benchmarks/swebench-har/scripts/test_swebench_har.py
@@ -14,6 +14,7 @@ SCRIPTS = ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from lib.common import benchmark_config, render_template, sanitize_instance_row  # noqa: E402
+from lib.dataset import infer_language, sample_rows, sample_rows_diverse  # noqa: E402
 from lib.har_cache import har_cache_exists, invalidate_har_cache, load_har_cache, save_har_cache  # noqa: E402
 from lib.har_utils import (  # noqa: E402
     build_init_adapt_prompt,
@@ -38,6 +39,39 @@ def test_config_loads() -> None:
     assert cfg["setup_budget_minutes"] == 120
     assert cfg["setup_max_rounds"] == 6
     assert cfg["readiness_timeout_minutes"] == 20
+    assert cfg.get("sample_max_per_repo") == 5
+    assert cfg.get("sample_max_repos_per_language") == 10
+
+
+def test_diverse_sampling_caps() -> None:
+    rows = []
+    for i in range(20):
+        rows.append({"instance_id": f"django__django-{i}", "repo": "django/django"})
+    for i in range(20):
+        rows.append({"instance_id": f"sympy__sympy-{i}", "repo": "sympy/sympy"})
+    for i in range(8):
+        rows.append({"instance_id": f"flask__flask-{i}", "repo": "pallets/flask"})
+    selected = sample_rows(
+        rows,
+        count=12,
+        seed=42,
+        max_per_repo=5,
+        max_repos_per_language=10,
+    )
+    assert len(selected) == 12
+    from collections import Counter
+
+    counts = Counter(r["repo"] for r in selected)
+    assert all(v <= 5 for v in counts.values())
+    assert infer_language({"repo": "django/django"}) == "python"
+
+    # Under-constrained pool should error clearly
+    tiny = [{"instance_id": "a", "repo": "pallets/flask"}]
+    try:
+        sample_rows_diverse(tiny, count=5, seed=0, max_per_repo=1, max_repos_per_language=1)
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "diversity constraints" in str(exc)
 
 
 def test_har_cache_roundtrip() -> None:
@@ -250,6 +284,7 @@ def test_evaluate_dry_run() -> None:
 def main() -> int:
     tests = [
         test_config_loads,
+        test_diverse_sampling_caps,
         test_har_cache_roundtrip,
         test_har_cache_invalidate,
         test_task_readiness_prompt_render,

--- a/src/core/control-port.ts
+++ b/src/core/control-port.ts
@@ -49,6 +49,7 @@ export function listDockerContainers(): DockerRow[] {
       stdio: ['pipe', 'pipe', 'ignore'],
       timeout: 3000,
     });
+    if (typeof raw !== 'string') return [];
     return raw
       .split('\n')
       .map((line) => line.trim())

--- a/src/harness/agent-skills.ts
+++ b/src/harness/agent-skills.ts
@@ -214,6 +214,9 @@ export function detectAgentTargets(repoPath: string): AgentSkillTarget[] {
 }
 
 export function parseAgentTargets(raw: string): AgentSkillTarget[] {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return [];
+  }
   const parts = raw
     .split(',')
     .map((part) => part.trim().toLowerCase())
@@ -244,8 +247,14 @@ export async function handleAgentSkills(options: AgentSkillsScaffoldOptions): Pr
   if (options.enabled === false) return false;
 
   let targets: AgentSkillTarget[];
+<<<<<<< HEAD
+=======
+  // yargs can set `agents: false` when `--no-agents` is also a flag name collision
+>>>>>>> b817956 (feat(har): guide agents to prove changes via functional verify stages)
   if (typeof options.agents === 'string') {
     targets = parseAgentTargets(options.agents);
+  } else if (options.agents !== undefined) {
+    return false;
   } else {
     targets = detectAgentTargets(repoPath);
     if (targets.length === 0) return false;

--- a/src/harness/agent-skills.ts
+++ b/src/harness/agent-skills.ts
@@ -247,10 +247,7 @@ export async function handleAgentSkills(options: AgentSkillsScaffoldOptions): Pr
   if (options.enabled === false) return false;
 
   let targets: AgentSkillTarget[];
-<<<<<<< HEAD
-=======
   // yargs can set `agents: false` when `--no-agents` is also a flag name collision
->>>>>>> b817956 (feat(har): guide agents to prove changes via functional verify stages)
   if (typeof options.agents === 'string') {
     targets = parseAgentTargets(options.agents);
   } else if (options.agents !== undefined) {

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -74,10 +74,16 @@ not the repo's final contract. Replace conventions that do not match this projec
 | Mode | Command | Intent |
 |------|---------|--------|
 | Quick (default) | `har env verify 1` | Smoke — compile / import / build / health only |
-| Full | `har env verify 1 --full` | Stricter — unit tests, lint, readiness, optional browser-e2e |
+| Full | `har env verify 1 --full` | Functional proof — registered `verificationStages` that show the work actually works |
 
 - **Quick** must stay fast and minimal (syntax, compile, import smoke) — not the full test suite.
-- **Full** holds unit tests, lint, and heavier checks; optional Playwright runs on `--full` when installed.
+- **Full** is how agents prove changes are **functional**, not merely compiling. Register stages in `.har/stages.json` `verificationStages` (see `.har/STAGES.md`). Prefer a small **behavior** check over dumping the entire CI suite: a CLI dry-run, one API/workflow smoke, import+exercise of the changed module, a focused regression script, health+auth path, etc. Full-suite unit tests are fine when they are already the project's real check — they are not the goal by themselves.
+- During adaptation, add at least one verification stage that a coding agent can use as definition of done for product changes. Example:
+
+  ```bash
+  har env add-stage feature-smoke --custom --kind test --command "<project-appropriate functional check>" --verification
+  ```
+
 - Reuse real commands from `package.json`, `Makefile`, CI, `pyproject.toml`, etc.
 - Remove stock npm/pytest/go/cargo/maven/gradle examples that do not apply.
 - Replace all TODO placeholders in both tiers.
@@ -182,6 +188,7 @@ If **no `AGENT.md` exists**, create one at the repo root using this structure:
 - Shell fallback: `./.har/launch.sh`, `./.har/verify.sh`, `./.har/teardown.sh` (when CLI is not installed)
 - Rules (no hardcoded ports, use `./.har/agent-cli.sh`, do not touch other agents' resources)
 - Project-specific notes (stack, credentials, definition of done)
+- **Definition of done:** quick verify is smoke only; finishing a change requires `har env verify <id> --full` (registered functional `verificationStages`). If no stage proves the change works, add one with `har env add-stage … --custom --verification` before stopping — do not declare done on compile/import alone.
 
 If **`AGENT.md` already exists**, add or update a concise **HAR / agent environment** section — do not replace unrelated content.
 

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -84,6 +84,13 @@ not the repo's final contract. Replace conventions that do not match this projec
   har env add-stage feature-smoke --custom --kind test --command "<project-appropriate functional check>" --verification
   ```
 
+- Document in `.har/CLAUDE.agent.md` that for a **specific bug/feature**, agents must
+  add or reuse a **change-specific** stage with **fail-before / pass-after** (fails
+  on the broken behavior, passes after the fix). Smoke-only `--full` is not done.
+- Ensure verification stages can **run in the slot** (editable installs, built
+  native extensions, `${PYTHON_BIN}` / toolchain from `.env.agent.<id>`). Stages
+  that only fail with missing modules because launch never built the package are
+  harness bugs — fix `launch` / install, do not treat them as product proof.
 - Reuse real commands from `package.json`, `Makefile`, CI, `pyproject.toml`, etc.
 - Remove stock npm/pytest/go/cargo/maven/gradle examples that do not apply.
 - Replace all TODO placeholders in both tiers.

--- a/src/templates/agent-skills/setup-har.md
+++ b/src/templates/agent-skills/setup-har.md
@@ -40,9 +40,7 @@ If `.har/` already exists, stop and suggest `/har-maintain` instead.
 
 ## 5. Register functional verification stages
 
-HAR's job is to let coding agents **prove their changes work** (better PRs), not
-only that the project compiles. Convert the repository's real checks into
-registered stages so they run in `verify --full`. Read `.har/STAGES.md`, then:
+HAR's job is to let coding agents **prove their changes work** (better PRs), not only that the project compiles. Convert the repository's real checks into registered stages so they run in `verify --full`. Read `.har/STAGES.md`, then:
 
 ```bash
 # Prefer a small functional / workflow check for definition of done:
@@ -53,14 +51,11 @@ har env add-stage unit-tests --custom --kind test --command "npm test" --verific
 ```
 
 - **Quick verify** (`har env verify 1`) stays smoke (compile/import/build/health).
-- **Full verify** (`har env verify 1 --full`) must include at least one stage that
-  exercises **real behavior**. Compile/import-only stages are not enough for done.
-- When agents later fix a bug, they should add a **change-specific** stage that
-  **fails before** the fix and **passes after** (see `.har/STAGES.md`).
+- **Full verify** (`har env verify 1 --full`) must include at least one stage that exercises **real behavior**. Compile/import-only stages are not enough for done.
+- When agents later fix a bug, they should add a **change-specific** stage that **fails before** the fix and **passes after** (see `.har/STAGES.md`).
 - Use `--command` for one-liner checks; use `--script` when a check needs the slot's env, ports, or artifacts (then implement the scaffolded `.har/stages/<id>.sh`).
 - Rich integrations ship as **plugins**: `har env add-plugin --list`, then e.g. `har env add-plugin playwright` (web) or `har env add-plugin rocketsim` (iOS). Plugins install stages; agents only talk to the stage registry.
-- Update `AGENT.md` / `.har/CLAUDE.agent.md` so definition of done requires `--full`,
-  a behavioral oracle, and fail-before/pass-after when adding stages for a change.
+- Update `AGENT.md` / `.har/CLAUDE.agent.md` so definition of done requires `--full`, a behavioral oracle, and fail-before/pass-after when adding stages for a change.
 
 ## 6. Prove the harness works
 
@@ -81,6 +76,4 @@ git add .har/ AGENT.md CLAUDE.md .claude/ .cursor/ 2>/dev/null || git add .har/ 
 git commit -m "chore: add har agent harness"
 ```
 
-Init applies the user's `har preferences` commit-gate policy. Confirm with
-`har hooks status`; recommend `har hooks install --claude` separately when the
-Claude Code main-checkout worktree guard is useful.
+Init applies the user's `har preferences` commit-gate policy. Confirm with `har hooks status`; recommend `har hooks install --claude` separately when the Claude Code main-checkout worktree guard is useful.

--- a/src/templates/agent-skills/setup-har.md
+++ b/src/templates/agent-skills/setup-har.md
@@ -38,25 +38,33 @@ If `.har/` already exists, stop and suggest `/har-maintain` instead.
 
 `har env init` prints an adaptation prompt and writes it to `.har/ADAPT-PROMPT.md`. Read that file and **execute its instructions yourself, now, in this session** — tailor `.har/` scripts (`launch.sh`, `verify.sh`, `setup-infra.sh`, `harness.env`, `stages.json`) and `AGENT.md` to this repository's real stack, ports, and commands. Do not use `--auto` and do not ask the user to paste anything.
 
-## 5. Register the project's checks as stages
+## 5. Register functional verification stages
 
-Convert the repository's real check commands (test, lint, typecheck, whatever CI runs) into registered stages so they run in `verify --full` and are visible to every agent. Read `.har/STAGES.md` for the contract, then:
+HAR's job is to let coding agents **prove their changes work**, not only that the project compiles. Convert the repository's real checks into registered stages so they run in `verify --full`. Read `.har/STAGES.md`, then:
 
 ```bash
+# Prefer a small functional / workflow check for definition of done:
+har env add-stage feature-smoke --custom --kind test --command "<cli dry-run | api smoke | focused check>" --verification
+
+# Add CI-style checks when they are how this repo actually validates work:
 har env add-stage unit-tests --custom --kind test --command "npm test" --verification
 ```
 
+- **Quick verify** (`har env verify 1`) stays smoke (compile/import/build/health).
+- **Full verify** (`har env verify 1 --full`) must include at least one stage that exercises real behavior agents can use as done criteria.
 - Use `--command` for one-liner checks; use `--script` when a check needs the slot's env, ports, or artifacts (then implement the scaffolded `.har/stages/<id>.sh`).
 - Rich integrations ship as **plugins**: `har env add-plugin --list`, then e.g. `har env add-plugin playwright` (web) or `har env add-plugin rocketsim` (iOS). Plugins install stages; agents only talk to the stage registry.
+- Update `AGENT.md` / `.har/CLAUDE.agent.md` so definition of done requires `--full` (and adding a stage if none covers the change).
 
 ## 6. Prove the harness works
 
 ```bash
 har env launch 1
 har env verify 1
+har env verify 1 --full
 ```
 
-Fix the harness scripts until both pass. Then tear down or keep the slot as the user prefers (`har env teardown 1` keeps the branch).
+Fix the harness until quick verify passes and full verify runs the functional stage(s) you registered. Then tear down or keep the slot as the user prefers (`har env teardown 1` keeps the branch).
 
 ## 7. Commit
 

--- a/src/templates/agent-skills/setup-har.md
+++ b/src/templates/agent-skills/setup-har.md
@@ -40,7 +40,9 @@ If `.har/` already exists, stop and suggest `/har-maintain` instead.
 
 ## 5. Register functional verification stages
 
-HAR's job is to let coding agents **prove their changes work**, not only that the project compiles. Convert the repository's real checks into registered stages so they run in `verify --full`. Read `.har/STAGES.md`, then:
+HAR's job is to let coding agents **prove their changes work** (better PRs), not
+only that the project compiles. Convert the repository's real checks into
+registered stages so they run in `verify --full`. Read `.har/STAGES.md`, then:
 
 ```bash
 # Prefer a small functional / workflow check for definition of done:
@@ -51,10 +53,14 @@ har env add-stage unit-tests --custom --kind test --command "npm test" --verific
 ```
 
 - **Quick verify** (`har env verify 1`) stays smoke (compile/import/build/health).
-- **Full verify** (`har env verify 1 --full`) must include at least one stage that exercises real behavior agents can use as done criteria.
+- **Full verify** (`har env verify 1 --full`) must include at least one stage that
+  exercises **real behavior**. Compile/import-only stages are not enough for done.
+- When agents later fix a bug, they should add a **change-specific** stage that
+  **fails before** the fix and **passes after** (see `.har/STAGES.md`).
 - Use `--command` for one-liner checks; use `--script` when a check needs the slot's env, ports, or artifacts (then implement the scaffolded `.har/stages/<id>.sh`).
 - Rich integrations ship as **plugins**: `har env add-plugin --list`, then e.g. `har env add-plugin playwright` (web) or `har env add-plugin rocketsim` (iOS). Plugins install stages; agents only talk to the stage registry.
-- Update `AGENT.md` / `.har/CLAUDE.agent.md` so definition of done requires `--full` (and adding a stage if none covers the change).
+- Update `AGENT.md` / `.har/CLAUDE.agent.md` so definition of done requires `--full`,
+  a behavioral oracle, and fail-before/pass-after when adding stages for a change.
 
 ## 6. Prove the harness works
 

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -24,19 +24,29 @@ workflow, document the required credentials/default data and wire a smoke into
 
 ## Definition of done
 
-Quick verify is **smoke only** (compile/import/build). Do **not** treat it as proof the change works.
+HAR exists so agents **prove a change works before opening a PR** — not only that the
+tree compiles. Quick verify is **smoke only** (compile/import/build). Smoke alone is
+**never** done, even if it appears under `verificationStages`.
 
-- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP `har_run_verification` with `full: true`) returns `"status": "pass"` — this runs `stages.json` `verificationStages`
-- [ ] Those stages exercise real behavior for this change (CLI/API/workflow/focused check) — not compile-only
-- [ ] If no registered stage can confirm the change is functional, **add one** before stopping (stages can be added on the fly):
+- [ ] **Change-specific oracle:** at least one verification stage exercises the *behavior
+  this change is supposed to fix/add* (CLI/API/workflow/focused regression) — not
+  compile/import alone
+- [ ] **Fail-before / pass-after:** that oracle **fails** on the broken tree (or before
+  your change) and **passes** after. A stage that already passes before the fix is
+  not proving the bug — rewrite it
+- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP
+  `har_run_verification` with `full: true`) returns `"status": "pass"`
+- [ ] If no registered stage can confirm this change, **add one on the fly** before stopping:
 
   ```bash
-  har env add-stage <id> --custom --kind test --command "<functional check>" --verification
+  har env add-stage <id> --custom --kind test --command "<behavioral check>" --verification
   # or: har env add-stage <id> --custom --script --verification
   ```
 
-  You may also add a **small focused test/regression check** and wire it as that stage.
-  See `.har/STAGES.md`. Then re-run `har env verify ${AGENT_ID} --full`.
+  Prefer a small focused regression script wired as that stage. See `.har/STAGES.md`.
+  Make sure the check runs in this slot (editable install / `${PYTHON_BIN}` / toolchain
+  from `.env.agent.${AGENT_ID}` — do not leave stages that fail only because imports
+  or extensions were never built).
 - [ ] The slot is agent-usable for this repo's documented smoke workflow when runtime services are involved
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
@@ -52,7 +62,7 @@ else as alternatives. If PR tooling is unavailable, recommend complete and repor
 the session branch for a manual push. Prefer `complete` over bare `teardown` when
 the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
-Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full`.
+Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full` with a real behavioral stage green.
 
 Stages are the harness's single vocabulary for checks: templates and custom stages compile to generic kinds in `.har/stages.json`, and you interact with them only through the registry (`har_run_stage`, `verify`), never stack-specific tooling. Authoring guide: `.har/STAGES.md`.
 

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -28,13 +28,14 @@ Quick verify is **smoke only** (compile/import/build). Do **not** treat it as pr
 
 - [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP `har_run_verification` with `full: true`) returns `"status": "pass"` — this runs `stages.json` `verificationStages`
 - [ ] Those stages exercise real behavior for this change (CLI/API/workflow/focused check) — not compile-only
-- [ ] If no registered stage can confirm the change is functional, **add one** before stopping:
+- [ ] If no registered stage can confirm the change is functional, **add one** before stopping (stages can be added on the fly):
 
   ```bash
   har env add-stage <id> --custom --kind test --command "<functional check>" --verification
   # or: har env add-stage <id> --custom --script --verification
   ```
 
+  You may also add a **small focused test/regression check** and wire it as that stage.
   See `.har/STAGES.md`. Then re-run `har env verify ${AGENT_ID} --full`.
 - [ ] The slot is agent-usable for this repo's documented smoke workflow when runtime services are involved
 - [ ] Changes committed **in the session worktree** with a clear message

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -24,10 +24,19 @@ workflow, document the required credentials/default data and wire a smoke into
 
 ## Definition of done
 
-- [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)
+Quick verify is **smoke only** (compile/import/build). Do **not** treat it as proof the change works.
+
+- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP `har_run_verification` with `full: true`) returns `"status": "pass"` — this runs `stages.json` `verificationStages`
+- [ ] Those stages exercise real behavior for this change (CLI/API/workflow/focused check) — not compile-only
+- [ ] If no registered stage can confirm the change is functional, **add one** before stopping:
+
+  ```bash
+  har env add-stage <id> --custom --kind test --command "<functional check>" --verification
+  # or: har env add-stage <id> --custom --script --verification
+  ```
+
+  See `.har/STAGES.md`. Then re-run `har env verify ${AGENT_ID} --full`.
 - [ ] The slot is agent-usable for this repo's documented smoke workflow when runtime services are involved
-- [ ] Full verify runs every registered stage in `stages.json` `verificationStages` (Playwright, custom checks, …) — when `stages/browser-e2e.sh` exists, adapt specs under `tests/` for UI changes
-- [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
 - [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
@@ -42,7 +51,7 @@ else as alternatives. If PR tooling is unavailable, recommend complete and repor
 the session branch for a manual push. Prefer `complete` over bare `teardown` when
 the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
-Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
+Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full`.
 
 Stages are the harness's single vocabulary for checks: templates and custom stages compile to generic kinds in `.har/stages.json`, and you interact with them only through the registry (`har_run_stage`, `verify`), never stack-specific tooling. Authoring guide: `.har/STAGES.md`.
 

--- a/src/templates/har-boilerplate-cli/STAGES.md
+++ b/src/templates/har-boilerplate-cli/STAGES.md
@@ -80,6 +80,28 @@ are inline steps owned by `.har/verify.sh`. Lifecycle kinds
 (`setup`/`launch`/`reset`/`teardown`/`inspect`) and `verify` itself never run
 as part of verification, even if listed.
 
+## Authoring a good verification stage (PR quality)
+
+Agents open better PRs when `--full` proves the **change**, not only that the
+repo still builds. When you add a stage for a bugfix or feature:
+
+1. **Behavioral** — assert the user-visible or API behavior from the ticket
+   (repro steps, expected output/error). Do not stop at compile/import/health.
+2. **Fail-before / pass-after** — on the broken tree the stage must **fail**;
+   after the fix it must **pass**. If it already passes before you change code,
+   it is not an oracle for this bug — tighten or rewrite it.
+3. **Runnable in the slot** — use toolchain vars from `.env.agent.<id>`
+   (`PYTHON_BIN`, editable installs, built extensions). A stage that only fails
+   with `ModuleNotFoundError` because deps were never built is a harness gap,
+   not proof the product is wrong.
+4. **Narrow** — one focused check beats dumping the entire CI suite into
+   `verificationStages`. Keep issue-specific stages out of any long-lived
+   shared harness defaults when they would pollute other tasks.
+
+Smoke stages (syntax, import, render hello-world) may stay in
+`verificationStages` for health, but **definition of done requires a
+change-specific behavioral stage** as well.
+
 ## Commit gate
 
 The registry also holds the optional `commitGate` config (installed via

--- a/src/templates/har-boilerplate-ios/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-ios/CLAUDE.agent.md
@@ -26,10 +26,17 @@ seeded data, or a simulator flow, document it here and wire the smoke into
 
 ## Definition of done
 
-Quick verify is **smoke only**. Do **not** treat it as proof the change works.
+HAR exists so agents **prove a change works before opening a PR** — not only that the
+app builds. Quick verify is **smoke only**. Smoke alone is **never** done.
 
-- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` returns `"status": "pass"` (runs `verificationStages` — e.g. RocketSim flows when installed)
-- [ ] If no stage confirms the change is functional, add one (`har env add-stage … --custom --verification` or `rocketsim`) then re-run `--full`
+- [ ] **Change-specific oracle:** at least one verification stage exercises the *behavior
+  this change is supposed to fix/add* (user flow / focused check) — not build-only
+- [ ] **Fail-before / pass-after:** that oracle **fails** before the fix and **passes** after.
+  If a new stage already passes on the broken behavior, rewrite it
+- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` returns `"status": "pass"`
+  (runs `verificationStages` — e.g. RocketSim flows when installed)
+- [ ] If no stage confirms the change is functional, add one
+  (`har env add-stage … --custom --verification` or `rocketsim`) then re-run `--full`
 - [ ] The slot is agent-usable for this repo's documented smoke workflow when runtime services are involved
 - [ ] When `stages/rocketsim-flows.sh` exists, full verify includes user-flow validation — add or update flow scripts in `flows/` for UI changes
 - [ ] Changes committed **in the session worktree** with a clear message
@@ -46,7 +53,7 @@ else as alternatives. If PR tooling is unavailable, recommend complete and repor
 the session branch for a manual push. Prefer `complete` over bare `teardown` when
 the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
-Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full`.
+Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full` with a real behavioral stage green.
 
 Stages are the harness's single vocabulary for checks: templates and custom stages compile to generic kinds in `.har/stages.json`, and you interact with them only through the registry (`har_run_stage`, `verify`), never stack-specific tooling. Authoring guide: `.har/STAGES.md`.
 

--- a/src/templates/har-boilerplate-ios/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-ios/CLAUDE.agent.md
@@ -26,10 +26,12 @@ seeded data, or a simulator flow, document it here and wire the smoke into
 
 ## Definition of done
 
-- [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)
+Quick verify is **smoke only**. Do **not** treat it as proof the change works.
+
+- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` returns `"status": "pass"` (runs `verificationStages` — e.g. RocketSim flows when installed)
+- [ ] If no stage confirms the change is functional, add one (`har env add-stage … --custom --verification` or `rocketsim`) then re-run `--full`
 - [ ] The slot is agent-usable for this repo's documented smoke workflow when runtime services are involved
 - [ ] When `stages/rocketsim-flows.sh` exists, full verify includes user-flow validation — add or update flow scripts in `flows/` for UI changes
-- [ ] New behavior has automated test coverage (unit tests via XCTest)
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
 - [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
@@ -44,7 +46,7 @@ else as alternatives. If PR tooling is unavailable, recommend complete and repor
 the session branch for a manual push. Prefer `complete` over bare `teardown` when
 the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
-Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
+Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full`.
 
 Stages are the harness's single vocabulary for checks: templates and custom stages compile to generic kinds in `.har/stages.json`, and you interact with them only through the registry (`har_run_stage`, `verify`), never stack-specific tooling. Authoring guide: `.har/STAGES.md`.
 

--- a/src/templates/har-boilerplate-ios/STAGES.md
+++ b/src/templates/har-boilerplate-ios/STAGES.md
@@ -80,6 +80,24 @@ are inline steps owned by `.har/verify.sh`. Lifecycle kinds
 (`setup`/`launch`/`reset`/`teardown`/`inspect`) and `verify` itself never run
 as part of verification, even if listed.
 
+## Authoring a good verification stage (PR quality)
+
+Agents open better PRs when `--full` proves the **change**, not only that the
+app still builds. When you add a stage for a bugfix or feature:
+
+1. **Behavioral** — assert the user-visible flow from the ticket (repro steps,
+   expected UI/state). Do not stop at compile/build alone.
+2. **Fail-before / pass-after** — on the broken tree the stage must **fail**;
+   after the fix it must **pass**. If it already passes before you change code,
+   rewrite it.
+3. **Runnable in the slot** — use the simulator / scheme / toolchain from
+   `.env.agent.<id>` and `harness.env`.
+4. **Narrow** — one focused flow beats dumping the entire test plan into
+   `verificationStages`.
+
+Smoke/build stages may stay in `verificationStages` for health, but
+**definition of done requires a change-specific behavioral stage** as well.
+
 ## Commit gate
 
 The registry also holds the optional `commitGate` config (installed via

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -37,19 +37,28 @@ is alive; it does not automatically mean an agent can use the app.
 
 ## Definition of done
 
-Quick verify is **smoke only** (compile/import/build/health). Do **not** treat it as proof the change works.
+HAR exists so agents **prove a change works before opening a PR** — not only that the
+tree compiles. Quick verify is **smoke only** (compile/import/build/health). Smoke
+alone is **never** done, even if it is listed under `verificationStages`.
 
-- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP `har_run_verification` with `full: true`) returns `"status": "pass"` — runs `stages.json` `verificationStages`
-- [ ] Those stages exercise real behavior for this change (API/UI/workflow/focused check) — not health/compile alone
-- [ ] If no registered stage can confirm the change is functional, **add one** before stopping (stages can be added on the fly):
+- [ ] **Change-specific oracle:** at least one verification stage exercises the *behavior
+  this change is supposed to fix/add* (API/UI/workflow/focused regression) — not
+  health/compile/import alone
+- [ ] **Fail-before / pass-after:** that oracle **fails** on the broken tree (or before
+  your change) and **passes** after. If a new stage already passes before you fix
+  anything, it is not proving the bug — rewrite it
+- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP
+  `har_run_verification` with `full: true`) returns `"status": "pass"`
+- [ ] If no registered stage can confirm this change, **add one on the fly** before stopping:
 
   ```bash
-  har env add-stage <id> --custom --kind test --command "<functional check>" --verification
+  har env add-stage <id> --custom --kind test --command "<behavioral check>" --verification
   # or: har env add-stage <id> --custom --script --verification
   ```
 
-  You may also add a **small focused test/regression check** and wire it as that stage.
-  See `.har/STAGES.md`. Then re-run `har env verify ${AGENT_ID} --full`.
+  Prefer a small focused regression script wired as that stage. See `.har/STAGES.md`.
+  Ensure the check can actually run in this slot (deps installed, correct
+  `${PYTHON_BIN}` / toolchain from `.env.agent.${AGENT_ID}`).
 - [ ] The slot is agent-usable for this repo's documented smoke workflow, not only health-check green
 - [ ] When `stages/browser-e2e.sh` exists, adapt specs under `tests/` for UI changes
 - [ ] Changes committed **in the session worktree** with a clear message
@@ -67,7 +76,7 @@ else as alternatives. If PR tooling is unavailable, recommend complete and repor
 the session branch for a manual push. Prefer `complete` over bare `teardown` when
 the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
-Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full`.
+Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full` with a real behavioral stage green.
 
 Stages are the harness's single vocabulary for checks: templates and custom stages compile to generic kinds in `.har/stages.json`, and you interact with them only through the registry (`har_run_stage`, `verify`), never stack-specific tooling. Authoring guide: `.har/STAGES.md`.
 

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -41,13 +41,14 @@ Quick verify is **smoke only** (compile/import/build/health). Do **not** treat i
 
 - [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP `har_run_verification` with `full: true`) returns `"status": "pass"` — runs `stages.json` `verificationStages`
 - [ ] Those stages exercise real behavior for this change (API/UI/workflow/focused check) — not health/compile alone
-- [ ] If no registered stage can confirm the change is functional, **add one** before stopping:
+- [ ] If no registered stage can confirm the change is functional, **add one** before stopping (stages can be added on the fly):
 
   ```bash
   har env add-stage <id> --custom --kind test --command "<functional check>" --verification
   # or: har env add-stage <id> --custom --script --verification
   ```
 
+  You may also add a **small focused test/regression check** and wire it as that stage.
   See `.har/STAGES.md`. Then re-run `har env verify ${AGENT_ID} --full`.
 - [ ] The slot is agent-usable for this repo's documented smoke workflow, not only health-check green
 - [ ] When `stages/browser-e2e.sh` exists, adapt specs under `tests/` for UI changes

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -37,10 +37,20 @@ is alive; it does not automatically mean an agent can use the app.
 
 ## Definition of done
 
-- [ ] Full verification returns `"status": "pass"` (`har env verify ${AGENT_ID} --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh ${AGENT_ID} --full`)
+Quick verify is **smoke only** (compile/import/build/health). Do **not** treat it as proof the change works.
+
+- [ ] **Functional proof:** `har env verify ${AGENT_ID} --full` (or MCP `har_run_verification` with `full: true`) returns `"status": "pass"` — runs `stages.json` `verificationStages`
+- [ ] Those stages exercise real behavior for this change (API/UI/workflow/focused check) — not health/compile alone
+- [ ] If no registered stage can confirm the change is functional, **add one** before stopping:
+
+  ```bash
+  har env add-stage <id> --custom --kind test --command "<functional check>" --verification
+  # or: har env add-stage <id> --custom --script --verification
+  ```
+
+  See `.har/STAGES.md`. Then re-run `har env verify ${AGENT_ID} --full`.
 - [ ] The slot is agent-usable for this repo's documented smoke workflow, not only health-check green
-- [ ] Full verify runs every registered stage in `stages.json` `verificationStages` (Playwright, custom checks, …) — when `stages/browser-e2e.sh` exists, adapt specs under `tests/` for UI changes
-- [ ] New behavior has automated test coverage (unit and/or browser as appropriate)
+- [ ] When `stages/browser-e2e.sh` exists, adapt specs under `tests/` for UI changes
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] The user got the preview URLs to test the app themselves
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
@@ -56,7 +66,7 @@ else as alternatives. If PR tooling is unavailable, recommend complete and repor
 the session branch for a manual push. Prefer `complete` over bare `teardown` when
 the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
-Quick loop during development: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}` (smoke + health only; `--full` adds the registered verification stages).
+Quick loop while iterating: `har env verify ${AGENT_ID}` (smoke). Before you stop: `--full`.
 
 Stages are the harness's single vocabulary for checks: templates and custom stages compile to generic kinds in `.har/stages.json`, and you interact with them only through the registry (`har_run_stage`, `verify`), never stack-specific tooling. Authoring guide: `.har/STAGES.md`.
 

--- a/src/templates/har-boilerplate/STAGES.md
+++ b/src/templates/har-boilerplate/STAGES.md
@@ -80,6 +80,28 @@ are inline steps owned by `.har/verify.sh`. Lifecycle kinds
 (`setup`/`launch`/`reset`/`teardown`/`inspect`) and `verify` itself never run
 as part of verification, even if listed.
 
+## Authoring a good verification stage (PR quality)
+
+Agents open better PRs when `--full` proves the **change**, not only that the
+repo still builds. When you add a stage for a bugfix or feature:
+
+1. **Behavioral** — assert the user-visible or API behavior from the ticket
+   (repro steps, expected output/error). Do not stop at compile/import/health.
+2. **Fail-before / pass-after** — on the broken tree the stage must **fail**;
+   after the fix it must **pass**. If it already passes before you change code,
+   it is not an oracle for this bug — tighten or rewrite it.
+3. **Runnable in the slot** — use toolchain vars from `.env.agent.<id>`
+   (`PYTHON_BIN`, editable installs, built extensions). A stage that only fails
+   with `ModuleNotFoundError` because deps were never built is a harness gap,
+   not proof the product is wrong.
+4. **Narrow** — one focused check beats dumping the entire CI suite into
+   `verificationStages`. Keep issue-specific stages out of any long-lived
+   shared harness defaults when they would pollute other tasks.
+
+Smoke stages (syntax, import, render hello-world) may stay in
+`verificationStages` for health, but **definition of done requires a
+change-specific behavioral stage** as well.
+
 ## Commit gate
 
 The registry also holds the optional `commitGate` config (installed via


### PR DESCRIPTION
https://github.com/os-factory/har/issues/24

## Goal

We want to measure whether **HAR improves task accuracy** compared to a raw coding agent alone.

The benchmark design is a head-to-head comparison:

| Arm | Setup |
|-----|--------|
| **Raw** | Coding agent only (Claude Code, Cursor, Codex, …) — no HAR harness |
| **HAR** | Same agent + HAR — launch in a worktree, iterate with `verify`, finish with `verify --full` |

Primary metric: **official SWE-bench resolve rate** (gold test suite), not just “did the agent produce a patch?” Secondary signals: patch yield, post-fix `verify --full`, and unique resolves per arm.

This PR ships the **HAR-side improvements** needed for that comparison: sandbox framing in agent prompts, task-scoped verification stages, fail-closed post-fix `--full`, and diversified sampling so campaigns are not dominated by a few repos.

## Early results (SWE-bench Lite, n=50)

First stable head-to-head under the improved stack — [full report](https://github.com/os-factory/har/blob/d3287568af21dca95a6d4a3af04eed5ee69c10b1/benchmarks/swebench-har/BENCHMARK-50-REPORT.md) (batch `20260723-113828`, seed 42, max 5 instances/repo × 10 repos).

| Metric | Raw Codex | HAR + Codex |
|--------|-----------|-------------|
| Patches produced | **50/50** | **50/50** |
| Official resolve | **23/50 (46%)** | **24/50 (48%)** |
| Unique resolves | 2 | **3** |
| Both resolved | 21 | 21 |
| Neither | 24 | 24 |

HAR edges raw by **+1 resolve** on this diversified sample. HAR-only wins: `psf__requests-1963`, `pylint-dev__pylint-7993`, `sympy__sympy-15609`. Raw-only: `matplotlib__matplotlib-23987`, `scikit-learn__scikit-learn-12471`.

Orchestration is solid (50/50 patches, no failed instances). Post-fix `verify --full` passed **22/50** but remains a **weak proxy** for official resolve (10 TP / 12 FP / 14 FN / 14 TN vs gold tests) — agents add useful stages, but alignment with FAIL_TO_PASS is the next lever.

Campaign history (iterations 0–4) is in `benchmarks/swebench-har/BENCHMARK-ITERATIONS.md`.

## What this PR changes

- Teach agents that HAR is a **verification sandbox**: done = `verify --full`, and they may **add stages / small tests on the fly** (product prompts + SWE-bench prompts).
- Make the SWE-bench runner **fail-closed** on post-fix `--full` (with `fix_max_rounds`) and keep **task-scoped stages out of `.har-cache`**.
- Add **diversity sampling** (`max_per_repo=5`, `max_repos_per_language=10`) plus EC2 campaign tooling and a paper-facing iteration log (`BENCHMARK-ITERATIONS.md`).
- Require **fail-before behavioral oracles** for `verify --full` — task-specific stages that fail on the buggy tree and pass after the fix.

## Test plan

- [ ] `cd benchmarks/swebench-har && uv run scripts/test_swebench_har.py`
- [ ] Confirm `config.yaml` has `har_verify_full: true`, `fix_max_rounds: 3`, diversity caps
- [ ] Dry-run sample: `uv run scripts/run_batch.py --count 50 --seed 42 --dry-run --max-per-repo 5 --max-repos-per-language 10` (expect 10 repos × ≤5)
- [ ] EC2 batch `20260723-113828` results documented in `BENCHMARK-50-REPORT.md`

Made with [Cursor](https://cursor.com)