### PR TITLE
feat(control): unregister repositories from CLI and Mission Control

### DIFF
--- a/control/prisma/schema.prisma
+++ b/control/prisma/schema.prisma
@@ -175,3 +175,10 @@ model CloudConfig {
   enabled   Boolean  @default(false)
   updatedAt DateTime @updatedAt
 }
+
+/** Paths removed via unregister — blocks auto-sync re-registration until force register. */
+model UnregisteredRepository {
+  path             String   @id
+  unregisteredAt   DateTime @default(now())
+  deleteWorktrees  Boolean  @default(false)
+}

--- a/control/src/app/api/repos/[id]/route.ts
+++ b/control/src/app/api/repos/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getRepository } from '@/server/repositories';
+import { deleteRepository, getRepository } from '@/server/repositories';
 
 export async function GET(
   _request: Request,
@@ -9,4 +9,29 @@ export async function GET(
   const repo = await getRepository(id);
   if (!repo) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(repo);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  let body: unknown = {};
+  try {
+    body = await request.json();
+  } catch {
+    const { searchParams } = new URL(request.url);
+    body = {
+      deleteWorktrees: searchParams.get('deleteWorktrees') === 'true',
+    };
+  }
+
+  try {
+    const result = await deleteRepository(id, body);
+    if (!result) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json(result);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
 }

--- a/control/src/app/api/repos/route.ts
+++ b/control/src/app/api/repos/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server';
-import { listRepositories, registerRepository } from '@/server/repositories';
+import {
+  listRepositories,
+  registerRepository,
+  RepositoryUnregisteredError,
+} from '@/server/repositories';
 
 export async function GET() {
   const repos = await listRepositories();
@@ -22,6 +26,9 @@ export async function POST(request: Request) {
     const repo = await registerRepository(body);
     return NextResponse.json({ id: repo.id, path: repo.path });
   } catch (err: unknown) {
+    if (err instanceof RepositoryUnregisteredError) {
+      return NextResponse.json({ error: err.message, path: err.path }, { status: 409 });
+    }
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ error: message }, { status: 400 });
   }

--- a/control/src/app/layout.tsx
+++ b/control/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { AppShell } from '@/components/app-shell';
 import { ThemeProvider } from '@/components/theme-provider';
+import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-screen antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <AppShell>{children}</AppShell>
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/control/src/app/repos/[id]/page.tsx
+++ b/control/src/app/repos/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ArtifactTable } from '@/components/artifact-table';
 import { ChangeBatchList } from '@/components/change-batch-list';
 import { RunTimeline } from '@/components/run-timeline';
 import { SlotGrid } from '@/components/slot-grid';
+import { UnregisterRepoButton } from '@/components/unregister-repo-button';
 import { ValidationPipeline } from '@/components/validation-pipeline';
 import { ValidationStages } from '@/components/validation-stages';
 import { VerificationTrendChart } from '@/components/verification-trend-chart';
@@ -50,12 +51,26 @@ export default async function RepoDetailPage({
 
   return (
     <div className="space-y-6 px-4 py-4 md:px-6 md:py-6">
-      <div>
-        <Link href="/repos" className="text-sm text-muted-foreground hover:underline">
-          ← Repos
-        </Link>
-        <h2 className="mt-2 text-2xl font-semibold">{repo.path}</h2>
-        {repo.gitRemote && <p className="text-sm text-muted-foreground">{repo.gitRemote}</p>}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <Link href="/repos" className="text-sm text-muted-foreground hover:underline">
+            ← Repos
+          </Link>
+          <h2 className="mt-2 text-2xl font-semibold">{repo.path}</h2>
+          {repo.gitRemote && <p className="text-sm text-muted-foreground">{repo.gitRemote}</p>}
+        </div>
+        <UnregisterRepoButton
+          repoId={repo.id}
+          repoPath={repo.path}
+          worktrees={repo.slots
+            .filter((slot) => Boolean(slot.worktreePath || slot.workDir))
+            .map((slot) => ({
+              agentId: slot.slotId,
+              path: slot.worktreePath ?? slot.workDir ?? '',
+              active: slot.active,
+              dirty: slot.dirty,
+            }))}
+        />
       </div>
 
       {health && (

--- a/control/src/components/unregister-repo-button.tsx
+++ b/control/src/components/unregister-repo-button.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+
+export interface UnregisterWorktreeRow {
+  agentId: number;
+  path: string;
+  active: boolean;
+  dirty: boolean | null;
+}
+
+interface UnregisterRepoButtonProps {
+  repoId: string;
+  repoPath: string;
+  worktrees: UnregisterWorktreeRow[];
+}
+
+export function UnregisterRepoButton({
+  repoId,
+  repoPath,
+  worktrees,
+}: UnregisterRepoButtonProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [deleteWorktrees, setDeleteWorktrees] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  const existing = worktrees.filter((w) => Boolean(w.path));
+
+  async function handleUnregister() {
+    setPending(true);
+    try {
+      const response = await fetch(`/api/repos/${encodeURIComponent(repoId)}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deleteWorktrees }),
+      });
+      const payload = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        worktrees?: { path: string; deleted: boolean; error?: string }[];
+      };
+      if (!response.ok) {
+        throw new Error(payload.error || `Unregister failed (${response.status})`);
+      }
+
+      const deleted = (payload.worktrees ?? []).filter((w) => w.deleted).length;
+      const failed = (payload.worktrees ?? []).filter((w) => !w.deleted && w.error);
+
+      if (deleteWorktrees && failed.length > 0) {
+        toast.warning(
+          `Unregistered. ${deleted} worktree(s) removed; ${failed.length} need CLI cleanup.`,
+          {
+            description:
+              'Docker Mission Control often cannot see host worktrees. Run: har control unregister --repo <path> --yes --delete-worktrees',
+          },
+        );
+      } else if (deleteWorktrees) {
+        toast.success(`Unregistered and removed ${deleted} worktree(s)`);
+      } else {
+        toast.success('Repository unregistered from Mission Control');
+      }
+
+      setOpen(false);
+      router.push('/repos');
+      router.refresh();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        Unregister
+      </Button>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent className="sm:max-w-md">
+          <SheetHeader>
+            <SheetTitle>Unregister repository</SheetTitle>
+            <SheetDescription>
+              Removes this repository from Mission Control (runs, slots, and telemetry for
+              this path). It will not be re-synced until you run{' '}
+              <code className="text-xs">har control register</code>.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-4 space-y-4">
+            <p className="break-all font-mono text-xs text-muted-foreground">{repoPath}</p>
+
+            {existing.length > 0 ? (
+              <div className="space-y-3 rounded-md border p-3">
+                <p className="text-sm font-medium">
+                  {existing.length} session worktree{existing.length === 1 ? '' : 's'}
+                </p>
+                <ul className="max-h-40 space-y-1 overflow-y-auto text-xs text-muted-foreground">
+                  {existing.map((wt) => (
+                    <li key={`${wt.agentId}-${wt.path}`} className="break-all">
+                      agent-{wt.agentId}: {wt.path}
+                      {wt.dirty ? ' (dirty)' : ''}
+                      {!wt.active ? ' (inactive)' : ''}
+                    </li>
+                  ))}
+                </ul>
+                <label className="flex items-start gap-2 text-sm">
+                  <Checkbox
+                    checked={deleteWorktrees}
+                    onCheckedChange={(value) => setDeleteWorktrees(value === true)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    Also delete these worktrees on disk
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      Packaged Mission Control may not see host paths — use the CLI unregister
+                      command if deletion fails.
+                    </span>
+                  </span>
+                </label>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No session worktrees recorded.</p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setOpen(false)} disabled={pending}>
+                Cancel
+              </Button>
+              <Button variant="destructive" onClick={() => void handleUnregister()} disabled={pending}>
+                {pending ? 'Unregistering…' : 'Unregister'}
+              </Button>
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/control/src/server/repositories.ts
+++ b/control/src/server/repositories.ts
@@ -5,20 +5,43 @@ import {
   RunRecordSchema,
   SyncRunsInputSchema,
   SyncSlotsInputSchema,
+  UnregisterRepoInputSchema,
+  type UnregisterRepoResult,
 } from '@har/schemas';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db';
 import { canonicalizeControlRepoPath } from '@/server/git-repo-path';
 import { buildAgentSlotSyncFields } from '@/server/slot-sync-fields';
+import { cleanupSessionWorktrees } from '@/server/worktree-cleanup';
 
 function toJson(value: unknown) {
   return JSON.parse(JSON.stringify(value)) as object;
+}
+
+export class RepositoryUnregisteredError extends Error {
+  readonly path: string;
+
+  constructor(repoPath: string) {
+    super(
+      `Repository was unregistered: ${repoPath}. Re-register with har control register --force (or force: true).`,
+    );
+    this.name = 'RepositoryUnregisteredError';
+    this.path = repoPath;
+  }
 }
 
 export async function registerRepository(input: unknown) {
   const data = RegisterRepoInputSchema.parse(input);
   const requested = path.resolve(data.path);
   const repoPath = canonicalizeControlRepoPath(requested);
+
+  const blocked = await prisma.unregisteredRepository.findUnique({ where: { path: repoPath } });
+  if (blocked && data.force !== true) {
+    throw new RepositoryUnregisteredError(repoPath);
+  }
+  if (blocked && data.force === true) {
+    await prisma.unregisteredRepository.delete({ where: { path: repoPath } });
+  }
 
   const repo = await prisma.repository.upsert({
     where: { path: repoPath },
@@ -43,6 +66,55 @@ export async function registerRepository(input: unknown) {
   }
 
   return repo;
+}
+
+export async function deleteRepository(
+  id: string,
+  input: unknown = {},
+): Promise<UnregisterRepoResult | null> {
+  const options = UnregisterRepoInputSchema.parse(input ?? {});
+  const repo = await prisma.repository.findUnique({
+    where: { id },
+    include: { slots: true },
+  });
+  if (!repo) return null;
+
+  const targets = repo.slots
+    .map((slot) => ({
+      agentId: slot.slotId,
+      worktreePath: slot.worktreePath ?? slot.workDir ?? '',
+    }))
+    .filter((t) => Boolean(t.worktreePath));
+
+  const worktrees = options.deleteWorktrees
+    ? cleanupSessionWorktrees(repo.path, targets)
+    : targets.map((t) => ({
+        path: path.resolve(t.worktreePath),
+        agentId: t.agentId,
+        deleted: false,
+      }));
+
+  await prisma.unregisteredRepository.upsert({
+    where: { path: repo.path },
+    create: {
+      path: repo.path,
+      deleteWorktrees: options.deleteWorktrees === true,
+    },
+    update: {
+      unregisteredAt: new Date(),
+      deleteWorktrees: options.deleteWorktrees === true,
+    },
+  });
+
+  await prisma.repository.delete({ where: { id: repo.id } });
+
+  return {
+    ok: true,
+    id: repo.id,
+    path: repo.path,
+    deleteWorktrees: options.deleteWorktrees === true,
+    worktrees,
+  };
 }
 
 /** Remove linked-worktree rows when the main checkout is already registered. */

--- a/control/src/server/worktree-cleanup.test.ts
+++ b/control/src/server/worktree-cleanup.test.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanupSessionWorktrees } from './worktree-cleanup';
+
+describe('cleanupSessionWorktrees', () => {
+  const temps: string[] = [];
+
+  afterEach(() => {
+    for (const dir of temps) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    temps.length = 0;
+  });
+
+  it('reports invisible paths without throwing', () => {
+    const results = cleanupSessionWorktrees('/tmp/does-not-exist-repo', [
+      { agentId: 1, worktreePath: '/tmp/definitely-missing-har-worktree' },
+    ]);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.deleted).toBe(false);
+    expect(results[0]?.error).toMatch(/not visible|CLI/i);
+  });
+
+  it('removes an existing directory fallback', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-wt-clean-'));
+    temps.push(dir);
+    const results = cleanupSessionWorktrees('/tmp/does-not-exist-repo', [
+      { agentId: 2, worktreePath: dir },
+    ]);
+    expect(results[0]?.deleted).toBe(true);
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+});

--- a/control/src/server/worktree-cleanup.ts
+++ b/control/src/server/worktree-cleanup.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface WorktreeCleanupTarget {
+  agentId?: number;
+  worktreePath: string;
+}
+
+export interface WorktreeCleanupResult {
+  path: string;
+  agentId?: number;
+  deleted: boolean;
+  error?: string;
+}
+
+/**
+ * Best-effort removal of session worktrees on the host filesystem.
+ * Inside the packaged Docker image host paths are usually invisible — those
+ * targets are reported as not deleted so the CLI can finish the job.
+ */
+export function cleanupSessionWorktrees(
+  repoPath: string,
+  targets: WorktreeCleanupTarget[],
+): WorktreeCleanupResult[] {
+  const results: WorktreeCleanupResult[] = [];
+  const seen = new Set<string>();
+
+  for (const target of targets) {
+    const worktreePath = path.resolve(target.worktreePath);
+    if (!worktreePath || seen.has(worktreePath)) continue;
+    seen.add(worktreePath);
+
+    if (!fs.existsSync(worktreePath)) {
+      results.push({
+        path: worktreePath,
+        agentId: target.agentId,
+        deleted: false,
+        error: 'path not visible to Mission Control (use har control unregister --delete-worktrees)',
+      });
+      continue;
+    }
+
+    try {
+      const gitRemove = spawnSync(
+        'git',
+        ['-C', repoPath, 'worktree', 'remove', worktreePath, '--force'],
+        { encoding: 'utf8' },
+      );
+      if (gitRemove.status !== 0 && fs.existsSync(worktreePath)) {
+        fs.rmSync(worktreePath, { recursive: true, force: true });
+      }
+      results.push({
+        path: worktreePath,
+        agentId: target.agentId,
+        deleted: !fs.existsSync(worktreePath),
+        error:
+          fs.existsSync(worktreePath)
+            ? gitRemove.stderr?.trim() || 'failed to remove worktree'
+            : undefined,
+      });
+    } catch (err: unknown) {
+      results.push({
+        path: worktreePath,
+        agentId: target.agentId,
+        deleted: !fs.existsSync(worktreePath),
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return results;
+}

--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -37,6 +37,24 @@ har control watch --interval 10
 `--dry-run` previews registration or sync, and `sync --json` produces structured
 output.
 
+## Unregister
+
+Remove a repository from Mission Control (and stop auto-sync) from the CLI or the
+repo detail page (**Unregister**):
+
+```bash
+har control unregister --repo /path/to/project
+# non-interactive:
+har control unregister --repo /path/to/project --yes --delete-worktrees
+```
+
+Unregister deletes synced runs/slots/telemetry for that path and records a
+blocklist entry so background sync does not immediately re-add it. The CLI
+proposes deleting session worktrees; confirm interactively or pass
+`--delete-worktrees`. The dashboard checkbox does the same, but the packaged
+Docker image often cannot see host worktree paths — use the CLI when host cleanup
+is required. Re-register with `har control register`.
+
 ## What the dashboard shows
 
 The repository overview summarizes registered projects, total runs, active slots,

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -113,11 +113,17 @@ main-checkout edit guard instead. `check` and `record-commit` are hook workers.
 ```bash
 har control up [--build] [--no-detach]
 har control down
-har control register [--api-url <url>] [--dry-run]
+har control register [--repo .] [--api-url <url>] [--dry-run] [--force]
+har control unregister [--repo .] [--api-url <url>] [--yes] [--delete-worktrees] [--dry-run] [--json]
 har control sync [--api-url <url>] [--dry-run] [--json] [--cloud]
 har control watch [--interval 10] [--api-url <url>]
 har control login --api-key <key>
 ```
+
+`unregister` removes the repository from Mission Control and `~/.har/repos.json`.
+Interactively it lists session worktrees and asks whether to delete them; pass
+`--delete-worktrees` (with `--yes` in non-TTY) to remove worktrees via harness
+teardown. Re-add later with `har control register`.
 
 ## `har telemetry`
 

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/schemas",
-  "version": "0.16.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "0.16.0",
+      "version": "0.18.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.23.8"

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -370,9 +370,37 @@ export const RegisterRepoInputSchema = z.object({
   gitRemote: z.string().optional(),
   manifest: HarnessManifestSchema.optional(),
   stagesRegistry: HarnessStageRegistrySchema.optional(),
+  /** Clear a prior unregister blocklist entry and re-register. */
+  force: z.boolean().optional(),
 });
 
 export type RegisterRepoInput = z.infer<typeof RegisterRepoInputSchema>;
+
+export const UnregisterRepoInputSchema = z.object({
+  /** When true, attempt to remove session worktrees on disk (host paths). */
+  deleteWorktrees: z.boolean().optional().default(false),
+});
+
+export type UnregisterRepoInput = z.infer<typeof UnregisterRepoInputSchema>;
+
+export const UnregisterWorktreeResultSchema = z.object({
+  path: z.string(),
+  agentId: z.number().optional(),
+  deleted: z.boolean(),
+  error: z.string().optional(),
+});
+
+export type UnregisterWorktreeResult = z.infer<typeof UnregisterWorktreeResultSchema>;
+
+export const UnregisterRepoResultSchema = z.object({
+  ok: z.literal(true),
+  id: z.string(),
+  path: z.string(),
+  deleteWorktrees: z.boolean(),
+  worktrees: z.array(UnregisterWorktreeResultSchema),
+});
+
+export type UnregisterRepoResult = z.infer<typeof UnregisterRepoResultSchema>;
 
 export const SyncRunsInputSchema = z.object({
   runs: z.array(RunRecordSchema),

--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -9,7 +9,13 @@ import {
   syncRepoWithControl,
 } from '../../core/control-sync';
 import { startMissionControl, syncReposAfterControlStart, stopMissionControl } from '../../core/control-lifecycle';
+import {
+  confirmUnregister,
+  listUnregisterWorktreeCandidates,
+  unregisterRepoWithControl,
+} from '../../core/control-unregister';
 import { error, header, info, success, warn } from '../../utils/logging';
+import { recordRepoForControlSync } from '../../core/control-registry';
 
 export const controlCommand = {
   command: 'control <subcommand>',
@@ -42,8 +48,35 @@ export const controlCommand = {
           y
             .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
             .option('api-url', { type: 'string', describe: 'Control API URL' })
-            .option('dry-run', { type: 'boolean', default: false }),
+            .option('dry-run', { type: 'boolean', default: false })
+            .option('force', {
+              type: 'boolean',
+              default: false,
+              describe: 'Re-register even if previously unregistered',
+            }),
         handleRegister,
+      )
+      .command(
+        'unregister',
+        'Remove a repository from Mission Control (optionally delete session worktrees)',
+        (y: Argv) =>
+          y
+            .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+            .option('api-url', { type: 'string', describe: 'Control API URL' })
+            .option('dry-run', { type: 'boolean', default: false })
+            .option('yes', {
+              alias: 'y',
+              type: 'boolean',
+              default: false,
+              describe: 'Skip confirmation prompts',
+            })
+            .option('delete-worktrees', {
+              type: 'boolean',
+              default: false,
+              describe: 'Delete session worktrees for this repo (prompted interactively when omitted)',
+            })
+            .option('json', { type: 'boolean', default: false }),
+        handleUnregister,
       )
       .command(
         'sync',
@@ -78,7 +111,10 @@ export const controlCommand = {
           y.option('api-key', { type: 'string', describe: 'HAR Cloud API key' }),
         handleLogin,
       )
-      .demandCommand(1, 'Please specify a subcommand: up, down, register, sync, watch, login'),
+      .demandCommand(
+        1,
+        'Please specify a subcommand: up, down, register, unregister, sync, watch, login',
+      ),
   handler: () => {},
 };
 
@@ -145,16 +181,22 @@ async function handleRegister(argv: {
   repo: string;
   apiUrl?: string;
   dryRun: boolean;
+  force: boolean;
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
   header('har control register');
   info(`Repository: ${repoPath}`);
 
   try {
+    if (!argv.dryRun) {
+      recordRepoForControlSync(repoPath);
+    }
+    // Explicit register always clears a prior unregister blocklist entry.
     await syncRepoWithControl({
       repoPath,
       apiUrl: argv.apiUrl,
       dryRun: argv.dryRun,
+      force: true,
     });
     if (argv.dryRun) {
       info('Dry run — no API call made');
@@ -162,6 +204,90 @@ async function handleRegister(argv: {
       success('Registered and synced with Mission Control');
     }
   } catch (err: unknown) {
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+async function handleUnregister(argv: {
+  repo: string;
+  apiUrl?: string;
+  dryRun: boolean;
+  yes: boolean;
+  deleteWorktrees: boolean;
+  json: boolean;
+}): Promise<void> {
+  const repoPath = path.resolve(argv.repo);
+  const worktrees = listUnregisterWorktreeCandidates(repoPath);
+
+  try {
+    let deleteWorktrees = argv.deleteWorktrees;
+    if (!argv.yes && !argv.dryRun) {
+      const confirmation = await confirmUnregister({ yes: false, worktrees });
+      if (!confirmation.proceed) {
+        error('Aborted — repository left registered.');
+        process.exit(2);
+      }
+      // Explicit flag wins; otherwise use the interactive answer.
+      deleteWorktrees = argv.deleteWorktrees || confirmation.deleteWorktrees;
+    } else if (argv.yes && !argv.deleteWorktrees && worktrees.some((w) => w.exists)) {
+      // --yes without --delete-worktrees keeps worktrees (safe default).
+      deleteWorktrees = false;
+    }
+
+    const result = await unregisterRepoWithControl({
+      repoPath,
+      apiUrl: argv.apiUrl,
+      dryRun: argv.dryRun,
+      deleteWorktrees,
+    });
+
+    if (argv.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+      return;
+    }
+
+    header('har control unregister');
+    info(`Repository: ${result.path}`);
+    if (argv.dryRun) {
+      info('Dry run — no changes made');
+      if (worktrees.filter((w) => w.exists).length > 0) {
+        info(
+          `Would propose deleting ${worktrees.filter((w) => w.exists).length} session worktree(s)`,
+        );
+      }
+      return;
+    }
+
+    if (result.apiUnreachable) {
+      warn('Mission Control API unreachable — removed from local registry only');
+    } else if (result.id) {
+      success('Removed from Mission Control');
+    } else {
+      info('Repository was not present in Mission Control');
+    }
+    if (result.removedFromRegistry) {
+      success('Removed from local sync registry (~/.har/repos.json)');
+    }
+    if (result.deleteWorktrees) {
+      const deleted = result.worktrees.filter((w) => w.deleted).length;
+      const failed = result.worktrees.filter((w) => !w.deleted && w.error);
+      success(`Deleted ${deleted} session worktree(s)`);
+      for (const failure of failed) {
+        warn(`Failed to delete ${failure.path}: ${failure.error}`);
+      }
+    } else if (result.worktrees.length > 0) {
+      info(
+        `Left ${result.worktrees.length} session worktree(s) on disk (rerun with --delete-worktrees to remove)`,
+      );
+    }
+  } catch (err: unknown) {
+    if (argv.json) {
+      process.stdout.write(
+        JSON.stringify({ ok: false, error: (err as Error).message }, null, 2) + '\n',
+      );
+      process.exit(1);
+    }
     error((err as Error).message);
     process.exit(1);
   }

--- a/src/core/control-registry.ts
+++ b/src/core/control-registry.ts
@@ -50,6 +50,22 @@ export function recordRepoForControlSync(repoPath: string): void {
   writeRegistry(registry);
 }
 
+/** Drop a repo from the local sync registry (does not touch Mission Control DB). */
+export function removeRegisteredRepo(repoPath: string): boolean {
+  const resolved = canonicalizeControlRepoPath(repoPath);
+  const registry = readRegistry();
+  const next = registry.repos.filter((entry) => {
+    try {
+      return canonicalizeControlRepoPath(entry) !== resolved;
+    } catch {
+      return path.resolve(entry) !== resolved;
+    }
+  });
+  if (next.length === registry.repos.length) return false;
+  writeRegistry({ repos: next });
+  return true;
+}
+
 /** Registered repos that still exist and have a harness manifest. */
 export function listRegisteredRepos(): string[] {
   const registry = readRegistry();

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -12,7 +12,7 @@ import {
   SyncValidationsInputSchema,
 } from '../harness/schema';
 import { getControlApiUrl, isControlEnabled } from './control-config';
-import { listRegisteredRepos } from './control-registry';
+import { listRegisteredRepos, removeRegisteredRepo } from './control-registry';
 import { canonicalizeControlRepoPath } from './control-repo-path';
 import { collectEnvironmentStatus } from './slot-status';
 import { listRuns } from './runs';
@@ -27,6 +27,8 @@ export interface ControlSyncOptions {
   apiUrl?: string;
   dryRun?: boolean;
   cloud?: boolean;
+  /** Re-register even if the path was previously unregistered. */
+  force?: boolean;
 }
 
 export interface ControlRegisterOptions extends ControlSyncOptions {
@@ -133,9 +135,29 @@ export async function registerRepoWithControl(
     gitRemote: options.gitRemote,
     manifest: manifest ?? undefined,
     stagesRegistry: stagesRegistry ?? undefined,
+    force: options.force,
   };
 
-  return postJson<{ id: string }>(`${apiUrl}/api/repos`, body, options.dryRun);
+  if (options.dryRun) return null;
+
+  const response = await fetch(`${apiUrl}/api/repos`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (response.status === 409) {
+    // Previously unregistered — drop from local registry so auto-sync stops retrying.
+    removeRegisteredRepo(repoPath);
+    return null;
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Control API ${response.status}: ${text || response.statusText}`);
+  }
+
+  return (await response.json()) as { id: string };
 }
 
 export async function syncRepoWithControl(options: ControlSyncOptions): Promise<void> {
@@ -171,7 +193,10 @@ export async function syncRepoWithControl(options: ControlSyncOptions): Promise<
     if (!listResponse.ok) throw new Error('Failed to list repos from Control API');
     const repos = (await listResponse.json()) as { id: string; path: string }[];
     const existing = repos.find((r) => path.resolve(r.path) === repoPath);
-    if (!existing) throw new Error(`Repo not registered: ${repoPath}`);
+    if (!existing) {
+      // Unregistered / blocked — nothing to sync.
+      return;
+    }
     await syncRepoRunsAndSlots(apiUrl, existing.id, repoPath, options.dryRun);
     return;
   }

--- a/src/core/control-unregister.ts
+++ b/src/core/control-unregister.ts
@@ -1,0 +1,297 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { canonicalizeControlRepoPath } from './control-repo-path';
+import { removeRegisteredRepo } from './control-registry';
+import { getControlApiUrl } from './control-config';
+import { listSlotRegistryEntries } from './slot-registry';
+import { collectEnvironmentStatus } from './slot-status';
+import { createRunService } from './run-service';
+
+export interface SessionWorktreeCandidate {
+  agentId: number;
+  worktreePath: string;
+  workDir?: string;
+  branch?: string;
+  dirty?: boolean;
+  exists: boolean;
+}
+
+export interface UnregisterOptions {
+  repoPath: string;
+  apiUrl?: string;
+  dryRun?: boolean;
+  deleteWorktrees?: boolean;
+}
+
+export interface UnregisterWorktreeOutcome {
+  path: string;
+  agentId?: number;
+  deleted: boolean;
+  error?: string;
+}
+
+export interface UnregisterResult {
+  ok: true;
+  id: string | null;
+  path: string;
+  removedFromRegistry: boolean;
+  deleteWorktrees: boolean;
+  worktrees: UnregisterWorktreeOutcome[];
+  apiUnreachable?: boolean;
+}
+
+/** Collect session worktrees that unregister may propose deleting. */
+export function listUnregisterWorktreeCandidates(repoPath: string): SessionWorktreeCandidate[] {
+  const harnessRoot = canonicalizeControlRepoPath(repoPath);
+  const byPath = new Map<string, SessionWorktreeCandidate>();
+
+  const add = (partial: Omit<SessionWorktreeCandidate, 'exists'> & { exists?: boolean }) => {
+    const resolved = path.resolve(partial.worktreePath);
+    if (!resolved || resolved === harnessRoot) return;
+    const exists = partial.exists ?? fs.existsSync(resolved);
+    const prev = byPath.get(resolved);
+    if (prev) {
+      byPath.set(resolved, {
+        ...prev,
+        dirty: prev.dirty || partial.dirty,
+        branch: prev.branch ?? partial.branch,
+        workDir: prev.workDir ?? partial.workDir,
+      });
+      return;
+    }
+    byPath.set(resolved, {
+      agentId: partial.agentId,
+      worktreePath: resolved,
+      workDir: partial.workDir,
+      branch: partial.branch,
+      dirty: partial.dirty,
+      exists,
+    });
+  };
+
+  for (const entry of listSlotRegistryEntries(harnessRoot)) {
+    const worktreePath = entry.worktreePath ?? entry.workDir;
+    if (!worktreePath) continue;
+    add({
+      agentId: entry.agentId,
+      worktreePath,
+      workDir: entry.workDir,
+      branch: entry.branch,
+    });
+  }
+
+  try {
+    const status = collectEnvironmentStatus(harnessRoot);
+    for (const slot of status.slots) {
+      const worktreePath = slot.worktreePath ?? slot.workDir;
+      if (!worktreePath) continue;
+      add({
+        agentId: slot.agentId,
+        worktreePath,
+        workDir: slot.workDir,
+        branch: slot.branch,
+        dirty: slot.dirty === true,
+      });
+    }
+  } catch {
+    // Slot status is best-effort when the harness is incomplete.
+  }
+
+  return [...byPath.values()].sort((a, b) => a.agentId - b.agentId);
+}
+
+async function askYesNo(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  const readline = await import('readline');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(question, resolve);
+  });
+  rl.close();
+  return /^[Yy]$/.test(answer.trim());
+}
+
+/** Prompt helpers for CLI unregister (default No). */
+export async function confirmUnregister(options: {
+  yes?: boolean;
+  worktrees: SessionWorktreeCandidate[];
+}): Promise<{ proceed: boolean; deleteWorktrees: boolean }> {
+  if (options.yes) {
+    return { proceed: true, deleteWorktrees: false };
+  }
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error('Non-interactive terminal — pass --yes (and optionally --delete-worktrees)');
+  }
+
+  const proceed = await askYesNo('Unregister this repository from Mission Control? [y/N] ');
+  if (!proceed) return { proceed: false, deleteWorktrees: false };
+
+  const existing = options.worktrees.filter((w) => w.exists);
+  if (existing.length === 0) {
+    return { proceed: true, deleteWorktrees: false };
+  }
+
+  process.stderr.write('\nSession worktrees:\n');
+  for (const wt of existing) {
+    const dirty = wt.dirty ? ' (dirty)' : '';
+    process.stderr.write(`  agent-${wt.agentId}: ${wt.worktreePath}${dirty}\n`);
+  }
+
+  const deleteWorktrees = await askYesNo(
+    `Also delete ${existing.length} session worktree(s) on disk? [y/N] `,
+  );
+  return { proceed: true, deleteWorktrees };
+}
+
+async function deleteJson<T>(
+  url: string,
+  body: unknown,
+  dryRun?: boolean,
+): Promise<{ ok: true; data: T } | { ok: false; status: number; text: string } | null> {
+  if (dryRun) return null;
+
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    return { ok: false, status: response.status, text: text || response.statusText };
+  }
+
+  return { ok: true, data: (await response.json()) as T };
+}
+
+async function teardownWorktrees(
+  repoPath: string,
+  candidates: SessionWorktreeCandidate[],
+  dryRun?: boolean,
+): Promise<UnregisterWorktreeOutcome[]> {
+  const outcomes: UnregisterWorktreeOutcome[] = [];
+  const service = createRunService();
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (!candidate.exists) continue;
+    if (seen.has(candidate.worktreePath)) continue;
+    seen.add(candidate.worktreePath);
+
+    if (dryRun) {
+      outcomes.push({ path: candidate.worktreePath, agentId: candidate.agentId, deleted: false });
+      continue;
+    }
+
+    try {
+      const result = await service.teardownEnvironment({
+        repoPath,
+        agentId: candidate.agentId,
+        capture: false,
+        trigger: 'cli',
+      });
+      if (result.code !== 0) {
+        // Teardown may fail if the slot registry was already cleared; remove the directory.
+        if (fs.existsSync(candidate.worktreePath)) {
+          fs.rmSync(candidate.worktreePath, { recursive: true, force: true });
+        }
+      }
+      outcomes.push({
+        path: candidate.worktreePath,
+        agentId: candidate.agentId,
+        deleted: !fs.existsSync(candidate.worktreePath),
+        error: result.code !== 0 && fs.existsSync(candidate.worktreePath) ? result.stderr : undefined,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      try {
+        if (fs.existsSync(candidate.worktreePath)) {
+          fs.rmSync(candidate.worktreePath, { recursive: true, force: true });
+        }
+      } catch {
+        // ignore secondary failure
+      }
+      outcomes.push({
+        path: candidate.worktreePath,
+        agentId: candidate.agentId,
+        deleted: !fs.existsSync(candidate.worktreePath),
+        error: message,
+      });
+    }
+  }
+
+  return outcomes;
+}
+
+/**
+ * Unregister a repository from Mission Control and the local sync registry.
+ * Optionally tears down session worktrees on the host.
+ */
+export async function unregisterRepoWithControl(
+  options: UnregisterOptions,
+): Promise<UnregisterResult> {
+  const repoPath = canonicalizeControlRepoPath(options.repoPath);
+  const apiUrl = options.apiUrl ?? getControlApiUrl();
+  const deleteWorktrees = options.deleteWorktrees === true;
+  const candidates = listUnregisterWorktreeCandidates(repoPath);
+
+  let id: string | null = null;
+  let apiUnreachable = false;
+  let apiWorktrees: UnregisterWorktreeOutcome[] = [];
+
+  if (!options.dryRun) {
+    try {
+      const listResponse = await fetch(`${apiUrl}/api/repos`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (listResponse.ok) {
+        const repos = (await listResponse.json()) as { id: string; path: string }[];
+        id = repos.find((r) => canonicalizeControlRepoPath(r.path) === repoPath)?.id ?? null;
+      } else {
+        apiUnreachable = true;
+      }
+    } catch {
+      apiUnreachable = true;
+    }
+  }
+
+  if (id && !options.dryRun) {
+    const deleted = await deleteJson<{
+      ok: true;
+      id: string;
+      path: string;
+      deleteWorktrees: boolean;
+      worktrees: UnregisterWorktreeOutcome[];
+    }>(`${apiUrl}/api/repos/${id}`, { deleteWorktrees: false }, options.dryRun);
+
+    if (deleted && !deleted.ok && deleted.status !== 404) {
+      throw new Error(`Control API ${deleted.status}: ${deleted.text}`);
+    }
+    if (deleted?.ok) {
+      apiWorktrees = deleted.data.worktrees ?? [];
+    }
+  } else if (!id && !options.dryRun && !apiUnreachable) {
+    // Not in MC — still clear local registry / worktrees.
+  }
+
+  const removedFromRegistry = options.dryRun ? false : removeRegisteredRepo(repoPath);
+
+  let worktrees: UnregisterWorktreeOutcome[] = apiWorktrees;
+  if (deleteWorktrees) {
+    worktrees = await teardownWorktrees(repoPath, candidates, options.dryRun);
+  } else {
+    worktrees = candidates
+      .filter((c) => c.exists)
+      .map((c) => ({ path: c.worktreePath, agentId: c.agentId, deleted: false }));
+  }
+
+  return {
+    ok: true,
+    id,
+    path: repoPath,
+    removedFromRegistry,
+    deleteWorktrees,
+    worktrees,
+    apiUnreachable: apiUnreachable || undefined,
+  };
+}

--- a/tests/control-registry.test.ts
+++ b/tests/control-registry.test.ts
@@ -5,6 +5,7 @@ import {
   getControlRegistryPath,
   listRegisteredRepos,
   recordRepoForControlSync,
+  removeRegisteredRepo,
 } from '../src/core/control-registry';
 import { canonicalizeControlRepoPath } from '../src/core/control-repo-path';
 
@@ -60,5 +61,12 @@ describe('control registry', () => {
 
     expect(listRegisteredRepos()).toEqual([FIXTURE_CANONICAL]);
     expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).repos).toEqual([FIXTURE_CANONICAL]);
+  });
+
+  it('removes a registered repo from the registry', () => {
+    recordRepoForControlSync(FIXTURE);
+    expect(removeRegisteredRepo(FIXTURE)).toBe(true);
+    expect(listRegisteredRepos()).toEqual([]);
+    expect(removeRegisteredRepo(FIXTURE)).toBe(false);
   });
 });

--- a/tests/control-unregister.test.ts
+++ b/tests/control-unregister.test.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { listUnregisterWorktreeCandidates } from '../src/core/control-unregister';
+
+const FIXTURE = path.join(__dirname, 'fixtures/minimal-harness');
+
+describe('listUnregisterWorktreeCandidates', () => {
+  let tempHome: string;
+  let repo: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'har-unregister-'));
+    process.env.HOME = tempHome;
+    repo = fs.mkdtempSync(path.join(tempHome, 'repo-'));
+    fs.cpSync(FIXTURE, repo, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('returns empty when no slots exist', () => {
+    expect(listUnregisterWorktreeCandidates(repo)).toEqual([]);
+  });
+
+  it('lists worktrees from slot registry files', () => {
+    const worktree = path.join(tempHome, 'wt-agent-1');
+    fs.mkdirSync(worktree, { recursive: true });
+    const slotsDir = path.join(repo, '.har', 'slots');
+    fs.mkdirSync(slotsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(slotsDir, 'agent-1.json'),
+      JSON.stringify({
+        version: 1,
+        agentId: 1,
+        projectName: 'demo',
+        mode: 'worktree',
+        workDir: worktree,
+        worktreePath: worktree,
+        createdAt: new Date().toISOString(),
+        status: 'active',
+        branch: 'demo-branch',
+      }),
+    );
+
+    const candidates = listUnregisterWorktreeCandidates(repo);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.agentId).toBe(1);
+    expect(candidates[0]?.worktreePath).toBe(worktree);
+    expect(candidates[0]?.exists).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `har control unregister` to remove a repo from Mission Control and `~/.har/repos.json`, with an interactive prompt (or `--delete-worktrees`) to tear down session worktrees.
- Add Mission Control **Unregister** on the repo detail page (optional worktree deletion), backed by `DELETE /api/repos/:id` and a blocklist so auto-sync does not immediately re-register the path.
- Document the flow in the CLI reference and Mission Control guide.

## Test plan
- [ ] `har control unregister --repo <path>` prompts to confirm and optionally delete worktrees; `--yes` leaves worktrees unless `--delete-worktrees` is set
- [ ] After unregister, `har control sync` / watch does not re-add the repo until `har control register`
- [ ] Mission Control repo detail → Unregister removes the repo from `/repos`; checkbox attempts host worktree cleanup (CLI fallback when Docker cannot see host paths)
- [ ] Full verify: CLI harness + control harness (already green in session)


Made with [Cursor](https://cursor.com)