### PR TITLE
docs(cli): clarify launch lifecycle (--replace/--force/complete) (#73)

### DIFF
--- a/.cursor/rules/har-workflow.mdc
+++ b/.cursor/rules/har-workflow.mdc
@@ -15,13 +15,24 @@ work around it with ad-hoc commands.
 
 ## Before making changes
 
-1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP), `har env launch 1`, or `./.har/launch.sh 1`. Launch always creates a **fresh session worktree** from the current HEAD and returns its **work dir**.
+1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP), `har env launch 1 --purpose=label`, or `./.har/launch.sh 1 --purpose=label`. Launch always creates a **new session worktree** from the current HEAD of the **main checkout** and returns its **work dir**.
 2. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `./.har/agent-cli.sh <id> restart` if a change doesn't take.
 3. Read [AGENT.md](./AGENT.md) at the repo root
 4. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)
 5. After launch, read [.har/CLAUDE.agent.md](./.har/CLAUDE.agent.md) for slot URLs and definition of done
 
-Relaunching a slot **replaces** its previous session (the old branch is kept). Replacement requires explicit confirmation (`--replace`, `confirmReplace=true`, or an interactive prompt). If the previous session has uncommitted changes, you must also pass `force`/`--force` after **explicit user approval** — never autonomously.
+### Slot / session lifecycle
+
+- **Slot** = reusable lane (id, ports, DB). **Session** = one task’s worktree + env.
+- Typical flow: `status` / `preflight` → `launch` → work + `verify` → `complete` (or `teardown` to abandon).
+- User says free/clean slots → prefer `complete` / `teardown`, then `launch`. Do **not** treat `--replace` as “start a clean new task.”
+- New unrelated task → ensure the main checkout is on `main` (or the user-named base) before launch. `--replace` does **not** select `main` and does **not** inherit the previous task’s branch.
+- Finished handoff → `har env complete <id>`.
+- Always set `--purpose` / `HAR_SESSION_PURPOSE` / MCP `purpose` as the human-facing task label.
+- Replacement requires explicit confirmation (`--replace`, `confirmReplace=true`, or an interactive prompt). Dirty sessions also need `force`/`--force` after **explicit user approval** — never autonomously.
+- If launch failed partway (registry `status: failed`), **resume** instead of replacing:
+  `har env launch <id> --resume`, `har env recover <id>`, or `./.har/launch.sh <id> --resume`.
+  Do not hand-roll PM2 or skip the harness.
 
 ### Slot safety (read before launch)
 
@@ -30,9 +41,6 @@ Relaunching a slot **replaces** its previous session (the old branch is kept). R
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
-- If launch failed partway (registry `status: failed`), **resume** instead of replacing:
-  `har env launch <id> --resume`, `har env recover <id>`, or `./.har/launch.sh <id> --resume`.
-  Do not hand-roll PM2 or skip the harness.
 
 <!-- Monorepo: if this repository contains multiple .har harnesses, list them here
      and pick by the files you are changing. Example:
@@ -62,7 +70,7 @@ Validate through the harness — do not skip verification or substitute ad-hoc n
 ### 2. HAR CLI (when `har` is installed)
 
 ```bash
-har env launch 1        # FIRST, before editing — prints the work dir
+har env launch 1 --purpose=label   # FIRST, before editing — prints the work dir
 har env verify 1
 har env verify 1 --full
 har env complete 1      # done: verify + validate + teardown, branch kept for PR
@@ -72,7 +80,7 @@ har env teardown 1      # plain cleanup (--delete-branch to drop the branch)
 ### 3. Shell fallback (no CLI/MCP installed)
 
 ```bash
-./.har/launch.sh 1
+./.har/launch.sh 1 --purpose=label
 ./.har/verify.sh 1
 ./.har/verify.sh 1 --full
 ./.har/teardown.sh 1

--- a/.har/CLAUDE.agent.md
+++ b/.har/CLAUDE.agent.md
@@ -13,7 +13,7 @@ Run `har env maintain` to refresh it.
 - **Work dir**: fresh session worktree per launch — see the launch output or `.har/slots/agent-${AGENT_ID}.json` (path looks like `~/worktrees/<base>-<sha4>-har-agent-${AGENT_ID}-<rand4>`)
 - **Infra**: none for this repo (`HARNESS_INFRA_SERVICES` is empty)
 
-Launch FIRST, then make ALL file edits under the work dir. Relaunching replaces the session (branch kept); a dirty previous session is refused unless `--force`.
+Launch FIRST, then make ALL file edits under the work dir. Prefer complete/teardown then launch to free a slot. `--replace` abandons the previous session from main-checkout HEAD (does not select main). Always set `--purpose`. Dirty previous sessions need `--force` after user approval.
 
 ```bash
 ./.har/agent-cli.sh ${AGENT_ID} status

--- a/.har/README.md
+++ b/.har/README.md
@@ -104,22 +104,26 @@ har env maintain --no-cursor-rule  # skip Cursor rule scaffolding
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **new session**: a git worktree from the current HEAD of the
+**main checkout** (`$REPO_ROOT`) at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
+Set `--purpose=label` / `HAR_SESSION_PURPOSE` on every launch as the human-facing task label.
 The session is recorded in `.har/slots/agent-<id>.json` (the slot registry) — status,
 verify, and teardown resolve the work dir through it. Make ALL file edits under the
 work dir printed by launch, never in the main checkout.
 
-- Relaunching a slot **replaces** its previous session and **requires explicit confirmation**
-  (`--replace`, `HAR_CONFIRM_REPLACE=1`, `har env launch --replace`, or MCP `confirmReplace=true`).
-  Launch prints a warning showing the occupied worktree, branch, and dirty state.
-- If the old worktree has uncommitted changes, you must also pass `--force` — **only after
-  explicit user approval** (agents must never set force autonomously).
+- To free/clean a slot: prefer `har env complete <id>` or `teardown`, then `launch`.
+  `--replace` is only for reusing the same slot id immediately — it does **not** select
+  `main` or inherit the previous task’s branch.
+- For a new unrelated task, switch the main checkout to `main` before launch.
+- Occupied-slot warnings show what will be destroyed **and** the new session base
+  (`$REPO_ROOT` branch @ sha).
+- Replacement requires explicit confirmation (`--replace`, `HAR_CONFIRM_REPLACE=1`,
+  or MCP `confirmReplace=true`). Dirty worktrees also need `--force` after **explicit
+  user approval** (never autonomously).
 - The session **branch is kept** on teardown if you committed; gitignored paths (`state/`,
   `runs/`, local clones) are **not** preserved when the worktree is removed.
 - Use **separate slots** for parallel unrelated tasks (`agentSlots.max` in `stages.json`).
-- `teardown` removes the worktree but **keeps the session branch** so you can push it
-  or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, the slot registry records
   `status: failed`. Resume without `--replace`:
   `har env launch <id> --resume` or `har env recover <id>` (alias).

--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -428,7 +428,7 @@ try {
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
-#             SLOT_STATUS, SLOT_LAST_ERROR
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -450,6 +450,7 @@ if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
 if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
+if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
 if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
@@ -493,11 +494,12 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir created status last_error dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
+  purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
   status="$(read_slot_field "$reg" status || true)"
   last_error="$(read_slot_field "$reg" lastError || true)"
@@ -508,6 +510,7 @@ print_slot_replace_warning() {
 
   echo "" >&2
   echo "⚠ Slot ${agent_id} is already in use — replacing will REMOVE the worktree." >&2
+  [ -n "$purpose" ] && echo "  Purpose:   ${purpose}" >&2
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
@@ -519,6 +522,15 @@ print_slot_replace_warning() {
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2
+  base_branch="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  base_sha="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -n "$base_branch" ] || [ -n "$base_sha" ]; then
+    echo "  New session will be based on: ${base_branch:-unknown} @ ${base_sha:-unknown}" >&2
+    echo "    (HEAD of $(cd "${REPO_ROOT:-$SCRIPT_DIR/..}" && pwd))" >&2
+    echo "    --replace does not select main; switch the main checkout first for a new unrelated task." >&2
+    echo "    Prefer: har env complete ${agent_id} / teardown, then launch — not replace to 'clean'." >&2
+    echo "" >&2
+  fi
 }
 
 # Require explicit confirmation before replacing an occupied slot.

--- a/.har/launch.sh
+++ b/.har/launch.sh
@@ -3,7 +3,7 @@
 # Every launch starts a FRESH session: any previous session for the slot is torn
 # down (its branch is kept) and a new suffixed worktree is created from HEAD.
 #
-# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--replace] [--force] [--resume]
+# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--replace] [--force] [--resume] [--purpose=label]
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,6 +19,7 @@ USE_WORKTREE="${HARNESS_USE_WORKTREE:-true}"
 FORCE=false
 REPLACE=false
 RESUME=false
+PURPOSE="${HAR_SESSION_PURPOSE:-}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -27,12 +28,13 @@ for arg in "$@"; do
     --replace)  REPLACE=true ;;
     --force)    FORCE=true ;;
     --resume)   RESUME=true ;;
+    --purpose=*) PURPOSE="${arg#--purpose=}" ;;
   esac
 done
 
 if [[ -z "$AGENT_ID" ]]; then
   har_load_agent_slot_limits
-  echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--resume] " >&2
+  echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--resume] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
 fi
@@ -67,6 +69,7 @@ if [ "$RESUME" = true ]; then
       SLOT_BRANCH="${BRANCH:-}" \
       SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
       SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+      SLOT_PURPOSE="${PURPOSE}" \
       SLOT_STATUS="failed" \
       SLOT_LAST_ERROR="launch.sh --resume exited with code ${exit_code}" \
         write_slot_registry
@@ -137,6 +140,7 @@ if [ "$RESUME" != true ]; then
       SLOT_BRANCH="${BRANCH:-}" \
       SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
       SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+      SLOT_PURPOSE="${PURPOSE}" \
       SLOT_STATUS="failed" \
       SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
         write_slot_registry
@@ -155,6 +159,7 @@ if [ "$RESUME" != true ]; then
   SLOT_BRANCH="${BRANCH:-}" \
   SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
   SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+  SLOT_PURPOSE="${PURPOSE}" \
   SLOT_STATUS="starting" \
     write_slot_registry
   REGISTRY_WRITTEN=true
@@ -170,6 +175,7 @@ else
   SLOT_BRANCH="${BRANCH:-}" \
   SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
   SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+  SLOT_PURPOSE="${PURPOSE}" \
   SLOT_STATUS="starting" \
     write_slot_registry
 fi
@@ -197,6 +203,7 @@ SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
 SLOT_BRANCH="${BRANCH:-}" \
 SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
 SLOT_STATUS="active" \
   write_slot_registry
 

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -3,35 +3,88 @@ title: Agent workflow
 description: The safe lifecycle for parallel coding tasks.
 ---
 
+## Mental model
+
+| Concept | Role |
+| --- | --- |
+| **Slot** | Scarce reusable lane (id, ports, DB) |
+| **Session** | One task’s ephemeral worktree + env |
+
+Every `launch` creates a **new** session from the current HEAD of the main
+checkout (`$REPO_ROOT`). It does **not** inherit the previous session’s branch
+identity. `--replace` only means: abandon the previous session on this slot and
+start another from whatever that HEAD is right now.
+
+```text
+status / preflight
+    → launch          (slot free: new session from $REPO_ROOT HEAD)
+    → work + verify
+    → complete        (done: full verify + free slot, keep branch)
+       or teardown    (abandon: free slot, keep branch)
+
+If slot occupied and previous task is done / abandoned:
+    → complete or teardown   (preferred)
+    → then launch
+
+If slot occupied and you must reuse the same id immediately:
+    → --replace              (destroy previous session worktree)
+    → --force only if dirty and user approved discard
+    → NEW session still comes from main-checkout HEAD
+         → switch that checkout to main first for a new unrelated task
+
+If launch failed partway:
+    → --resume / recover     (never --replace)
+```
+
 ## Before editing
 
 1. Read the repository's `AGENT.md`, `.har/README.md`, and `.har/stages.json`.
 2. Check status before choosing a slot.
-3. Launch once and record the returned work directory.
-4. Read `.har/CLAUDE.agent.md` in that worktree for resolved URLs and the
+3. For a **new unrelated task**, ensure the main checkout is on `main` (or the
+   base the user named) before launch — until `launch --base` exists, HEAD is
+   the base.
+4. Launch once with a purpose label and record the returned work directory.
+5. Read `.har/CLAUDE.agent.md` in that worktree for resolved URLs and the
    repository-specific definition of done.
 
 ```bash
 har env status
 har env preflight 2
-har env launch 2
+har env launch 2 --purpose="fix sqlite backend"
 ```
 
 Use one slot per task. Separate parallel tasks use separate slots.
+Always set `--purpose` / `HAR_SESSION_PURPOSE` (or MCP `purpose`) as the
+human-facing task label shown in status and occupied-slot warnings.
 With telemetry prompts enabled (`har telemetry on --prompts`), Mission Control
-fills the session purpose from the first captured user prompt.
+can also fill purpose from the first captured user prompt.
 
 ## Occupied and failed slots
 
 A normal launch never silently replaces an active session.
 
+When the user asks to **free** or **clean** slots, prefer:
+
 ```bash
-har env launch 2 --replace
+har env complete 2    # finished handoff
+# or
+har env teardown 2    # abandon
+har env launch 2 --purpose="next task"
 ```
 
-Only use `--replace` after reviewing the current branch and worktree. If that
-worktree has uncommitted changes, replacement remains blocked until the owner
-explicitly approves `--force`.
+Only use `--replace` when you must reuse the same slot id immediately:
+
+```bash
+har env launch 2 --replace --purpose="next task"
+```
+
+`--replace` does **not** select `main` and does **not** mean “continue / inherit
+the previous task.” Review the occupied-slot warning: it shows what will be
+destroyed **and** what the new session will be based on (`$REPO_ROOT` branch @
+sha). If that base is a leftover feature branch, switch the main checkout first.
+
+If that worktree has uncommitted changes, replacement remains blocked until the
+owner explicitly approves `--force`.
 
 A launch that failed partway is different. Preserve and resume its existing state:
 
@@ -59,7 +112,8 @@ har env status --json
 2. Run full verification.
 3. Stage exactly the state that passed.
 4. Commit inside the session worktree.
-5. Complete the environment.
+5. Complete the environment so Mission Control does not keep a misleading active
+   worktree path.
 
 ```bash
 har env verify 2 --full

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -13,11 +13,11 @@ All repository commands accept `--repo <path>`; the default is the current direc
 | `maintain` | Validate, compare templates, and prepare or finalize an upgrade |
 | `add-stage [template]` | List/install shipped templates or register a custom stage |
 | `preflight <id>` | Check ports, processes, Docker, and slot occupation |
-| `launch <id>` | Create and start a fresh slot session |
+| `launch <id>` | New session worktree from main-checkout HEAD |
 | `recover <id>` | Resume a failed or partial launch |
 | `verify <id>` | Run quick or full verification |
 | `complete <id>` | Full verify, record validation, teardown, keep branch |
-| `teardown <id>` | Stop a slot and keep its branch |
+| `teardown <id>` | Free a slot and keep its branch |
 | `status` | Inspect all slots |
 | `runs list` | List persisted run records |
 | `runs get <runId>` | Return one run record |
@@ -62,11 +62,23 @@ har env add-stage <id> --custom --kind <kind>
 ```bash
 har env preflight 1 [--json] [--replace] [--force]
 har env launch 1 [--no-worktree] [--claude] [--replace] [--force] [--resume]
+                 [--purpose=<label>]
 har env recover 1
 ```
 
-`--replace` confirms replacement of an occupied slot. `--force` additionally
-permits discarding dirty uncommitted work and must only follow explicit approval.
+Every launch creates a **new** session from `$REPO_ROOT` HEAD (the main checkout).
+It does not inherit the previous session’s branch.
+
+| Flag | Meaning |
+| --- | --- |
+| `--purpose` | Human-facing task label (also `HAR_SESSION_PURPOSE`). Recommended on every launch. Does not select the git base. |
+| `--replace` | Abandon the previous session on this slot and start another from main-checkout HEAD. Does **not** select `main`. Prefer `complete` / `teardown`, then `launch`, when cleaning a slot. |
+| `--force` | With `--replace` only: discard dirty uncommitted work after explicit approval. |
+| `--resume` | Recover a failed/starting launch without replacing (alias: `har env recover`). |
+
+Occupied-slot warnings show what will be destroyed **and** what the new session
+will be based on (`branch @ sha` of `$REPO_ROOT`). For a new unrelated task,
+switch the main checkout to `main` before launch.
 
 ### Verify and finish
 

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -18,16 +18,20 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 | Tool | Inputs | Result |
 | --- | --- | --- |
 | `har_preflight_environment` | `agentId`, `confirmReplace`, `force` | Readiness, blockers, and whether launch is safe |
-| `har_launch_environment` | `agentId`, `worktree`, `claude`, `confirmReplace`, `force`, `resume` | Work directory, branch, URLs, and normalized stage result |
+| `har_launch_environment` | `agentId`, `worktree`, `claude`, `confirmReplace`, `force`, `resume`, `purpose` | Work directory, branch, URLs, and normalized stage result |
 | `har_recover_environment` | `agentId` | Resumed failed or partial launch |
 | `har_get_status` | optional `agentId` | Slot, process, worktree, branch, and dirty state |
 | `har_get_logs` | `agentId`, optional `service` | Recent service output |
 | `har_complete_environment` | `agentId`, `skipVerify` | Validation, teardown, and retained branch |
 | `har_teardown_environment` | `agentId`, `deleteBranch` | Teardown result |
 
-Launch is blocked when a slot is occupied until `confirmReplace` is true. Dirty
-replacement additionally requires `force`; agents should never set either without
-review and explicit approval. Use recovery, not replacement, for a failed launch.
+Launch creates a new session from main-checkout HEAD. Prefer
+`har_complete_environment` / `har_teardown_environment`, then launch, when freeing
+a slot. `confirmReplace` abandons the previous session on that slot — it does not
+select `main` or inherit the old task. Set `purpose` as the human-facing task
+label. Dirty replacement additionally requires `force`; agents should never set
+either without review and explicit approval. Use recovery, not replacement, for a
+failed launch.
 
 ## Execution
 

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -270,6 +270,8 @@ export const SlotRegistryEntrySchema = z
     createdAt: z.string(),
     ports: z.record(z.number()).optional(),
     previewUrls: z.record(z.string()).optional(),
+    /** Optional human-facing task label from launch --purpose / HAR_SESSION_PURPOSE. */
+    purpose: z.string().optional(),
     status: z.enum(['starting', 'active', 'failed', 'completed']).default('active'),
     lastError: z.string().optional(),
   })
@@ -329,7 +331,10 @@ export const AgentSlotStatusSchema = z.object({
   baseBranch: z.string().optional(),
   baseCommit: z.string().optional(),
   sessionCreatedAt: z.string().optional(),
-  /** Derived from first captured user prompt (OTEL hooks); not set at launch. */
+  /**
+   * Human-facing task label: launch --purpose / HAR_SESSION_PURPOSE on the slot
+   * registry, or Mission Control OTEL-derived purpose from the first captured prompt.
+   */
   purpose: z.string().optional(),
   sessionStatus: z.enum(['starting', 'active', 'failed', 'completed']).optional(),
   lastError: z.string().optional(),

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -35,12 +35,18 @@ import { recordRepoForControlSync } from '../../core/control-registry';
 import { writeFileSafe } from '../../utils/file-ops';
 import { requireApiKey, validateAgentId } from '../../utils/validation';
 import { info, success, error, header, divider, warn } from '../../utils/logging';
+import {
+  ENV_LIFECYCLE_EPILOG,
+  LAUNCH_COMMAND_DESCRIBE,
+  LAUNCH_LIFECYCLE_EPILOG,
+} from '../lifecycle-help';
 
 export const envCommand = {
   command: 'env <subcommand>',
-  describe: 'Manage agent environments',
+  describe: 'Manage agent environments (launch → verify → complete)',
   builder: (yargs: Argv) =>
     yargs
+      .epilog(ENV_LIFECYCLE_EPILOG)
       .command(
         'init',
         'Copy harness boilerplate into .har/ (use --auto for built-in Claude adaptation)',
@@ -175,7 +181,7 @@ export const envCommand = {
       )
       .command(
         'launch <id>',
-        'Launch a fresh agent session (replaces any previous session for the slot)',
+        LAUNCH_COMMAND_DESCRIBE,
         (y: Argv) =>
           y
             .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
@@ -189,19 +195,27 @@ export const envCommand = {
             .option('replace', {
               type: 'boolean',
               default: false,
-              describe: 'Replace an occupied slot (prompts on TTY when omitted)',
+              describe:
+                'Abandon the previous session on this slot and start another from main-checkout HEAD (does not select main; prefer complete/teardown then launch)',
             })
             .option('force', {
               type: 'boolean',
               default: false,
               describe:
-                'Discard uncommitted changes when replacing a dirty worktree (only after explicit approval)',
+                'With --replace only: discard dirty uncommitted work after explicit user approval — never set autonomously',
             })
             .option('resume', {
               type: 'boolean',
               default: false,
-              describe: 'Resume a failed or partial launch without creating a new worktree',
-            }),
+              describe:
+                'Resume a failed or partial launch without --replace (alias: har env recover)',
+            })
+            .option('purpose', {
+              type: 'string',
+              describe:
+                'Human-facing task label stored in the slot registry (recommended; also HAR_SESSION_PURPOSE). Does not select the git base.',
+            })
+            .epilog(LAUNCH_LIFECYCLE_EPILOG),
         handleLaunch,
       )
       .command(
@@ -684,6 +698,7 @@ export async function handleLaunch(argv: {
   replace: boolean;
   force: boolean;
   resume: boolean;
+  purpose?: string;
 }): Promise<void> {
   const repo = path.resolve(argv.repo);
   const agentId = validateAgentId(argv.id, repo);
@@ -741,6 +756,7 @@ export async function handleLaunch(argv: {
     confirmReplace,
     force,
     resume: argv.resume,
+    purpose: argv.purpose,
     capture: false,
   });
   if (result.blocked) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { controlCommand } from './commands/control';
 import { hooksCommand } from './commands/hooks';
 import { mcpCommand } from './commands/mcp';
 import { telemetryCommand } from './commands/telemetry';
+import { HAR_TYPICAL_WORKFLOW_EPILOG } from './lifecycle-help';
 
 export async function runCli(): Promise<void> {
   await yargs(hideBin(process.argv))
@@ -19,6 +20,7 @@ export async function runCli(): Promise<void> {
     .command(mcpCommand)
     .command(telemetryCommand)
     .demandCommand(1, 'Please specify a command. Try: har env init')
+    .epilog(HAR_TYPICAL_WORKFLOW_EPILOG)
     .strict()
     .help()
     .version(getHarPackageVersion())

--- a/src/cli/lifecycle-help.ts
+++ b/src/cli/lifecycle-help.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared CLI epilog / describe copy for the slot→session launch lifecycle.
+ * Keep in sync with docs/guides/agent-workflow.md and the cursor-rule template.
+ */
+
+export const HAR_TYPICAL_WORKFLOW_EPILOG = `
+Typical agent workflow:
+  har env status / preflight <id>
+  har env launch <id> [--purpose=label]   # new session from main-checkout HEAD
+  har env verify <id>                     # fast loop
+  har env verify <id> --full              # before done
+  har env complete <id>                   # done: full verify + free slot, keep branch
+  # or: har env teardown <id>             # abandon: free slot, keep branch
+
+Slot = reusable lane (id, ports, DB). Session = one task's worktree + env.
+--replace abandons the previous session on that slot; it does NOT select main
+or inherit the old task's branch. Prefer complete/teardown, then launch.
+For a new unrelated task, switch the main checkout to main before launch.
+`.trim();
+
+export const ENV_LIFECYCLE_EPILOG = `
+Session lifecycle (env subcommands):
+  preflight  Check whether a slot can launch (ports, PM2, Docker, occupation)
+  launch     New session worktree from $REPO_ROOT HEAD (main checkout)
+  recover    Resume a failed/partial launch (alias: launch --resume)
+  verify     Quick or --full verification in the session work dir
+  complete   Done handoff: full verify + teardown; keep branch for PR
+  teardown   Abandon/cleanup: free the slot; keep branch (--delete-branch to drop)
+  status     Inspect slots
+
+Cleaning a slot: prefer complete or teardown, then launch — not launch --replace.
+--replace only when you must reuse the same slot id immediately.
+`.trim();
+
+export const LAUNCH_COMMAND_DESCRIBE =
+  'Create a new session worktree from main-checkout HEAD ($REPO_ROOT); does not inherit the previous task';
+
+export const LAUNCH_LIFECYCLE_EPILOG = `
+Every launch creates a NEW session from the current HEAD of the main checkout
+($REPO_ROOT) — not from the previous session's branch.
+
+  --purpose     Human/Mission-Control-facing task label (also HAR_SESSION_PURPOSE).
+                Recommended on every launch. Does not select the git base.
+  --replace     Abandon the previous session on this slot and start another.
+                Does NOT mean "continue the old task" and does NOT select main.
+                Prefer: complete/teardown, then launch.
+  --force       With --replace only: discard dirty uncommitted work after
+                explicit user approval. Never set autonomously.
+  --resume      Recover a failed/starting launch without --replace
+                (alias: har env recover <id>).
+
+For a new unrelated task, ensure the main checkout is on main (or your named
+base) before launch. Stacking on the current feature branch is intentional when
+that checkout is already on that branch.
+`.trim();

--- a/src/core/local-executor.ts
+++ b/src/core/local-executor.ts
@@ -34,6 +34,7 @@ export function buildLaunchFlagArgs(flags: LaunchFlags): string[] {
   if (flags.confirmReplace) args.push('--replace');
   if (flags.force) args.push('--force');
   if (flags.resume) args.push('--resume');
+  if (flags.purpose) args.push(`--purpose=${flags.purpose}`);
   return args;
 }
 
@@ -154,6 +155,9 @@ function buildExecutionPlan(
     stage.kind === 'launch' && options.launchFlags
       ? buildLaunchFlagArgs(options.launchFlags)
       : [];
+  if (stage.kind === 'launch' && options.launchFlags?.purpose) {
+    mergedEnv.HAR_SESSION_PURPOSE = options.launchFlags.purpose;
+  }
 
   if (stage.command) {
     let shellCommand = substituteAgentId(stage.command, options.agentId);

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -177,6 +177,7 @@ export class RunService {
               branch: slot.branch,
               dirty: slot.dirty,
               sessionCreatedAt: slot.sessionCreatedAt,
+              purpose: slot.purpose,
             }
           : undefined,
       };
@@ -212,6 +213,7 @@ export class RunService {
         confirmReplace: options.confirmReplace,
         force: options.force,
         resume: options.resume,
+        purpose: options.purpose,
       },
       trigger: 'cli',
     });

--- a/src/core/slot-launch-guard-occupied.ts
+++ b/src/core/slot-launch-guard-occupied.ts
@@ -100,14 +100,33 @@ function collectOccupiedSlot(repoPath: string, agentId: number): AgentSlotStatus
     sessionStatus: session?.status,
     lastError: session?.lastError,
     sessionCreatedAt: session?.createdAt,
+    purpose: session?.purpose,
     dirty,
     harnessUsage: 'none',
   };
 }
 
-function formatOccupiedSlot(slot: AgentSlotStatus, resume?: boolean): string {
+function formatNewSessionBase(repoPath: string, agentId: number): string[] {
+  const resolved = path.resolve(repoPath);
+  const branch = runGit(resolved, 'rev-parse --abbrev-ref HEAD');
+  const sha = runGit(resolved, 'rev-parse --short HEAD');
+  if (!branch && !sha) return [];
+  return [
+    `New session will be based on: ${branch ?? 'unknown'} @ ${sha ?? 'unknown'}`,
+    `  (HEAD of ${resolved})`,
+    '  --replace does not select main; switch the main checkout first for a new unrelated task.',
+    `  Prefer: har env complete ${agentId} / teardown, then launch — not replace to "clean".`,
+  ];
+}
+
+function formatOccupiedSlot(
+  slot: AgentSlotStatus,
+  options: { resume?: boolean; repoPath?: string } = {},
+): string {
+  const { resume, repoPath } = options;
   const lines = [
     `Slot ${slot.agentId} is already in use.`,
+    slot.purpose ? `  Purpose:  ${slot.purpose}` : undefined,
     slot.worktreePath ? `  Worktree: ${slot.worktreePath}` : undefined,
     slot.branch ? `  Branch:   ${slot.branch}` : undefined,
     slot.workDir ? `  Work dir: ${slot.workDir}` : undefined,
@@ -134,11 +153,19 @@ function formatOccupiedSlot(slot: AgentSlotStatus, resume?: boolean): string {
     );
   }
 
+  if (repoPath) {
+    const base = formatNewSessionBase(repoPath, slot.agentId);
+    if (base.length > 0) {
+      lines.push(...base, '');
+    }
+  }
+
   lines.push(
     'Replacing removes the worktree. The session branch is kept only if you committed.',
     'Gitignored paths (state/, runs/, local clones) are NOT preserved.',
     '',
-    'To replace: pass confirmReplace=true (MCP), --replace (CLI), or answer y at the prompt.',
+    'To free the slot cleanly: har env complete / teardown, then launch.',
+    'To replace immediately: confirmReplace=true (MCP), --replace (CLI), or answer y at the prompt.',
     'If the worktree is dirty, also pass force=true / --force after explicit user approval.',
   );
   return lines.filter(Boolean).join('\n');
@@ -178,7 +205,7 @@ export function checkLaunchGuard(
       allowed: false,
       blocked: true,
       slot,
-      reason: formatOccupiedSlot(slot),
+      reason: formatOccupiedSlot(slot, { repoPath }),
     };
   }
 
@@ -187,7 +214,7 @@ export function checkLaunchGuard(
       allowed: false,
       blocked: true,
       slot,
-      reason: formatOccupiedSlot(slot),
+      reason: formatOccupiedSlot(slot, { repoPath }),
     };
   }
 
@@ -197,7 +224,7 @@ export function checkLaunchGuard(
       blocked: true,
       slot,
       reason: [
-        formatOccupiedSlot(slot),
+        formatOccupiedSlot(slot, { repoPath }),
         '',
         'The occupied worktree has uncommitted changes.',
         'Pass force=true / --force to discard them (only after explicit user approval).',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -29,6 +29,8 @@ export interface LaunchFlags {
   force?: boolean;
   /** Resume a failed or partial launch without creating a new worktree. */
   resume?: boolean;
+  /** Optional human-facing task label stored on the session (status / occupied warnings). */
+  purpose?: string;
 }
 
 export interface StageRunOptions {
@@ -49,6 +51,8 @@ export interface LaunchOptions {
   confirmReplace?: boolean;
   force?: boolean;
   resume?: boolean;
+  /** Optional human-facing task label stored on the session (status / occupied warnings). */
+  purpose?: string;
   capture?: boolean;
 }
 
@@ -85,6 +89,7 @@ export interface EnvironmentRunResult {
     branch?: string;
     dirty?: boolean;
     sessionCreatedAt?: string;
+    purpose?: string;
   };
 }
 

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -84,6 +84,12 @@ export const LaunchEnvironmentInputSchema = z.object({
     .boolean()
     .default(false)
     .describe('Resume a failed or partial launch without creating a new worktree.'),
+  purpose: z
+    .string()
+    .optional()
+    .describe(
+      'Human-facing task label stored in the slot registry (recommended). Does not select the git base.',
+    ),
 });
 
 export const LaunchEnvironmentOutputSchema = ShellRunOutputSchema.extend({
@@ -103,6 +109,7 @@ export const LaunchEnvironmentOutputSchema = ShellRunOutputSchema.extend({
       branch: z.string().optional(),
       dirty: z.boolean().optional(),
       sessionCreatedAt: z.string().optional(),
+      purpose: z.string().optional(),
     })
     .optional(),
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -75,7 +75,7 @@ export const HAR_MCP_TOOLS: Tool[] = [
   {
     name: 'har_launch_environment',
     description:
-      'Start a FRESH agent session. Run this BEFORE editing any file: it returns workDir — ALL file edits must go under that path, never the main checkout. If the slot is already occupied, launch is BLOCKED until confirmReplace=true (call har_get_status first; get explicit user approval). force=true discards dirty uncommitted work — never set without user approval. Edits under workDir hot-reload in the running slot.',
+      'Start a NEW agent session worktree from main-checkout HEAD. Run BEFORE editing any file: returns workDir — ALL edits go there. confirmReplace abandons the previous session on this slot (does not select main or inherit the old task); prefer complete/teardown then launch. force discards dirty work — never without user approval. Set purpose as the human-facing task label.',
     inputSchema: objectJsonSchema(
       {
         repo: repoJsonProperty,
@@ -85,7 +85,7 @@ export const HAR_MCP_TOOLS: Tool[] = [
         confirmReplace: {
           type: 'boolean',
           description:
-            'Replace an occupied slot. Required when a session is active. Call har_get_status first; get explicit user approval before setting true.',
+            'Abandon the previous session on this slot and start another from main-checkout HEAD. Does not select main. Prefer complete/teardown then launch. Get explicit user approval before setting true.',
         },
         force: {
           type: 'boolean',
@@ -96,6 +96,11 @@ export const HAR_MCP_TOOLS: Tool[] = [
           type: 'boolean',
           description:
             'Resume a failed or partial launch (status failed/starting) without --replace. Preserves worktree and env.',
+        },
+        purpose: {
+          type: 'string',
+          description:
+            'Human-facing task label stored in the slot registry (recommended). Does not select the git base.',
         },
       },
       ['agentId'],
@@ -293,6 +298,7 @@ export async function handleMcpToolCall(
         confirmReplace: input.confirmReplace,
         force: input.force,
         resume: input.resume,
+        purpose: input.purpose,
         capture: true,
       });
       const parsed = LaunchEnvironmentOutputSchema.parse(result);

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -15,13 +15,22 @@ work around it with ad-hoc commands.
 
 ## Before making changes
 
-1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP) or `har env launch 1`. Launch always creates a **fresh session worktree** from the current HEAD and returns its **work dir**.
+1. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP) or `har env launch 1 --purpose=label`. Launch always creates a **new session worktree** from the current HEAD of the **main checkout** (`$REPO_ROOT`) and returns its **work dir**.
 2. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `har env restart <id>` or `./.har/agent-cli.sh <id> restart` if a change doesn't take.
 3. Read [AGENT.md](./AGENT.md) at the repo root
 4. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)
 5. After launch, read [.har/CLAUDE.agent.md](./.har/CLAUDE.agent.md) for slot URLs and definition of done
 
-Relaunching a slot **replaces** its previous session (the old branch is kept). Replacement requires explicit confirmation (`--replace`, `confirmReplace=true`, or an interactive prompt). If the previous session has uncommitted changes, you must also pass `force`/`--force` after **explicit user approval** — never autonomously.
+### Slot / session lifecycle
+
+- **Slot** = reusable lane (id, ports, DB). **Session** = one task’s worktree + env.
+- Typical flow: `status` / `preflight` → `launch` → work + `verify` → `complete` (or `teardown` to abandon).
+- User says free/clean slots → prefer `complete` / `teardown`, then `launch`. Do **not** treat `--replace` as “start a clean new task.”
+- New unrelated task → ensure the main checkout is on `main` (or the user-named base) before launch. `--replace` does **not** select `main` and does **not** inherit the previous task’s branch.
+- Finished handoff → `har env complete <id>` so Mission Control does not keep a misleading active worktree.
+- Always set `--purpose` / `HAR_SESSION_PURPOSE` / MCP `purpose` as the human-facing task label.
+- Replacement (`--replace` / `confirmReplace`) requires explicit confirmation. Dirty sessions also need `force`/`--force` after **explicit user approval** — never autonomously.
+- Failed/starting launch → `--resume` / `recover` (never `--replace`).
 
 ### Slot safety (read before launch)
 
@@ -30,7 +39,6 @@ Relaunching a slot **replaces** its previous session (the old branch is kept). R
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
-- Optional: set `har env launch <id> --purpose=label`, `HAR_SESSION_PURPOSE=label`, or `./.har/launch.sh <id> --purpose=label` so occupied-slot warnings show what you were doing.
 
 <!-- Monorepo: if this repository contains multiple .har harnesses, list them here
      and pick by the files you are changing. Example:
@@ -60,17 +68,17 @@ Validate through the harness — do not skip verification or substitute ad-hoc n
 ### 2. HAR CLI (when `har` is installed)
 
 ```bash
-har env launch 1        # FIRST, before editing — prints the work dir
+har env launch 1 --purpose=label   # FIRST, before editing — prints the work dir
 har env verify 1
 har env verify 1 --full
-har env complete 1      # done: verify + validate + teardown, branch kept for PR
-har env teardown 1      # plain cleanup (--delete-branch to drop the branch)
+har env complete 1                 # done: verify + validate + teardown, branch kept for PR
+har env teardown 1                 # plain cleanup (--delete-branch to drop the branch)
 ```
 
 ### 3. Shell fallback (no CLI/MCP installed)
 
 ```bash
-./.har/launch.sh 1
+./.har/launch.sh 1 --purpose=label
 ./.har/verify.sh 1
 ./.har/verify.sh 1 --full
 ./.har/teardown.sh 1

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -9,7 +9,7 @@
 | **Agent ID** | ${AGENT_ID} |
 | **Work dir** | Fresh session worktree per launch — see the launch output or `.har/slots/agent-${AGENT_ID}.json` |
 
-**Never edit the main checkout** — launch FIRST, then make ALL file edits under the work dir from the launch output. Relaunching replaces the session (branch kept) and requires explicit confirmation (`--replace` / `confirmReplace`); dirty worktrees also need `--force` after user approval — never autonomously.
+**Never edit the main checkout** — launch FIRST with `--purpose=label`, then make ALL file edits under the work dir from the launch output. Prefer `complete`/`teardown` then `launch` to free a slot; `--replace` / `confirmReplace` abandons the previous session from main-checkout HEAD (does not select main). Dirty worktrees need `--force` after user approval — never autonomously.
 
 ```bash
 ./.har/agent-cli.sh ${AGENT_ID} status

--- a/src/templates/har-boilerplate-cli/README.md
+++ b/src/templates/har-boilerplate-cli/README.md
@@ -137,15 +137,21 @@ The authoring agent updates scripts and this README. Review changes before commi
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **new session**: a git worktree from the current HEAD of the
+**main checkout** (`$REPO_ROOT`) at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
+Set `--purpose=label` / `HAR_SESSION_PURPOSE` on every launch as the human-facing task label.
 The session is recorded in `.har/slots/agent-<id>.json` (the slot registry) — status,
 verify, and teardown resolve the work dir through it. Make ALL file edits under the
 work dir printed by launch, never in the main checkout.
 
-- Relaunching a slot **replaces** its previous session; replacement requires `--replace` /
-  `confirmReplace=true` (or an interactive prompt). Uncommitted changes also need `--force`
-  after explicit user approval.
+- To free/clean a slot: prefer `complete` / `teardown`, then `launch`. `--replace` only
+  reuses the same slot id immediately — it does **not** select `main` or inherit the
+  previous task. For a new unrelated task, switch the main checkout to `main` first.
+- Occupied-slot warnings show what will be destroyed **and** the new session base
+  (`$REPO_ROOT` branch @ sha).
+- Replacement requires `--replace` / `confirmReplace=true` (or an interactive prompt).
+  Dirty worktrees also need `--force` after explicit user approval.
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, resume with

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -427,7 +427,7 @@ try {
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
-#             SLOT_STATUS, SLOT_LAST_ERROR
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -449,6 +449,7 @@ if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
 if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
+if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
 if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
@@ -492,11 +493,12 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir created status last_error dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
+  purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
   status="$(read_slot_field "$reg" status || true)"
   last_error="$(read_slot_field "$reg" lastError || true)"
@@ -507,6 +509,7 @@ print_slot_replace_warning() {
 
   echo "" >&2
   echo "⚠ Slot ${agent_id} is already in use — replacing will REMOVE the worktree." >&2
+  [ -n "$purpose" ] && echo "  Purpose:   ${purpose}" >&2
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
@@ -518,6 +521,15 @@ print_slot_replace_warning() {
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2
+  base_branch="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  base_sha="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -n "$base_branch" ] || [ -n "$base_sha" ]; then
+    echo "  New session will be based on: ${base_branch:-unknown} @ ${base_sha:-unknown}" >&2
+    echo "    (HEAD of $(cd "${REPO_ROOT:-$SCRIPT_DIR/..}" && pwd))" >&2
+    echo "    --replace does not select main; switch the main checkout first for a new unrelated task." >&2
+    echo "    Prefer: har env complete ${agent_id} / teardown, then launch — not replace to 'clean'." >&2
+    echo "" >&2
+  fi
 }
 
 # Require explicit confirmation before replacing an occupied slot.

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -3,7 +3,7 @@
 # Every launch starts a FRESH session: any previous session for the slot is torn
 # down (its branch is kept) and a new suffixed worktree is created from HEAD.
 #
-# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--replace] [--force] [--resume]
+# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--replace] [--force] [--resume] [--purpose=label]
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,6 +19,7 @@ USE_WORKTREE="${HARNESS_USE_WORKTREE:-true}"
 FORCE=false
 REPLACE=false
 RESUME=false
+PURPOSE="${HAR_SESSION_PURPOSE:-}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -27,12 +28,13 @@ for arg in "$@"; do
     --replace)  REPLACE=true ;;
     --force)    FORCE=true ;;
     --resume)   RESUME=true ;;
+    --purpose=*) PURPOSE="${arg#--purpose=}" ;;
   esac
 done
 
 if [[ -z "$AGENT_ID" ]]; then
   har_load_agent_slot_limits
-  echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--resume] " >&2
+  echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--resume] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
 fi
@@ -67,6 +69,7 @@ if [ "$RESUME" = true ]; then
       SLOT_BRANCH="${BRANCH:-}" \
       SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
       SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+      SLOT_PURPOSE="${PURPOSE}" \
       SLOT_STATUS="failed" \
       SLOT_LAST_ERROR="launch.sh --resume exited with code ${exit_code}" \
         write_slot_registry
@@ -137,6 +140,7 @@ if [ "$RESUME" != true ]; then
       SLOT_BRANCH="${BRANCH:-}" \
       SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
       SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+      SLOT_PURPOSE="${PURPOSE}" \
       SLOT_STATUS="failed" \
       SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
         write_slot_registry
@@ -155,6 +159,7 @@ if [ "$RESUME" != true ]; then
   SLOT_BRANCH="${BRANCH:-}" \
   SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
   SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+  SLOT_PURPOSE="${PURPOSE}" \
   SLOT_STATUS="starting" \
     write_slot_registry
   REGISTRY_WRITTEN=true
@@ -170,6 +175,7 @@ else
   SLOT_BRANCH="${BRANCH:-}" \
   SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
   SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+  SLOT_PURPOSE="${PURPOSE}" \
   SLOT_STATUS="starting" \
     write_slot_registry
 fi
@@ -197,6 +203,7 @@ SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
 SLOT_BRANCH="${BRANCH:-}" \
 SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
 SLOT_STATUS="active" \
   write_slot_registry
 

--- a/src/templates/har-boilerplate-ios/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-ios/CLAUDE.agent.md
@@ -11,7 +11,7 @@
 | **Simulator** | Configured in `.har/harness.env` — `HARNESS_SIMULATOR_NAME` |
 | **Scheme** | Configured in `.har/harness.env` — `HARNESS_XCODE_SCHEME` |
 
-**Never edit the main checkout** — launch FIRST, then make ALL file edits under the work dir from the launch output. Relaunching replaces the session (branch kept) and requires explicit confirmation; dirty worktrees also need `--force` after user approval.
+**Never edit the main checkout** — launch FIRST with `--purpose=label`, then make ALL file edits under the work dir from the launch output. Prefer `complete`/`teardown` then `launch` to free a slot; `--replace` abandons the previous session from main-checkout HEAD (does not select main). Dirty worktrees need `--force` after user approval.
 
 ```bash
 ./.har/agent-cli.sh ${AGENT_ID} status

--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -113,10 +113,12 @@ When your app talks to a local backend, read the resolved host port from `.env.a
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
-`~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
+Every `launch` starts a **new session** from the main checkout HEAD at
+`~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`. Set `--purpose=label` on
+every launch. Prefer `complete` / `teardown`, then `launch`, to free a slot;
+`--replace` does not select `main`. Occupied warnings show the new session base.
 The session is recorded in `.har/slots/agent-<id>.json`.
 
-- Relaunching a slot **replaces** its previous session; uncommitted changes require `--force`.
+- Uncommitted previous sessions require `--force` after explicit approval.
 - `teardown` removes the worktree but **keeps the session branch** for push / PR.
 - `har env complete <id>` finishes a session: full verify + teardown, branch kept.

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -88,7 +88,7 @@ try {
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
-#             SLOT_STATUS, SLOT_LAST_ERROR
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -110,6 +110,7 @@ if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
 if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
+if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
 if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
@@ -153,11 +154,12 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir created status last_error dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
+  purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
   status="$(read_slot_field "$reg" status || true)"
   last_error="$(read_slot_field "$reg" lastError || true)"
@@ -168,6 +170,7 @@ print_slot_replace_warning() {
 
   echo "" >&2
   echo "⚠ Slot ${agent_id} is already in use — replacing will REMOVE the worktree." >&2
+  [ -n "$purpose" ] && echo "  Purpose:   ${purpose}" >&2
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
@@ -179,6 +182,15 @@ print_slot_replace_warning() {
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2
+  base_branch="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  base_sha="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -n "$base_branch" ] || [ -n "$base_sha" ]; then
+    echo "  New session will be based on: ${base_branch:-unknown} @ ${base_sha:-unknown}" >&2
+    echo "    (HEAD of $(cd "${REPO_ROOT:-$SCRIPT_DIR/..}" && pwd))" >&2
+    echo "    --replace does not select main; switch the main checkout first for a new unrelated task." >&2
+    echo "    Prefer: har env complete ${agent_id} / teardown, then launch — not replace to 'clean'." >&2
+    echo "" >&2
+  fi
 }
 
 # Require explicit confirmation before replacing an occupied slot.

--- a/src/templates/har-boilerplate-ios/launch.sh
+++ b/src/templates/har-boilerplate-ios/launch.sh
@@ -3,7 +3,7 @@
 # Every launch starts a FRESH session: any previous session for the slot is torn
 # down (its branch is kept) and a new suffixed worktree is created from HEAD.
 #
-# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--replace] [--force]
+# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--replace] [--force] [--purpose=label]
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -18,6 +18,7 @@ AGENT_ID="${1:-}"
 USE_WORKTREE="${HARNESS_USE_WORKTREE:-true}"
 FORCE=false
 REPLACE=false
+PURPOSE="${HAR_SESSION_PURPOSE:-}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -25,12 +26,13 @@ for arg in "$@"; do
     --worktree) USE_WORKTREE=true ;;
     --replace)  REPLACE=true ;;
     --force)    FORCE=true ;;
+    --purpose=*) PURPOSE="${arg#--purpose=}" ;;
   esac
 done
 
 if [[ -z "$AGENT_ID" ]]; then
   har_load_agent_slot_limits
-  echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] " >&2
+  echo "Usage: $0 <agent-id> [--no-worktree] [--replace] [--force] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
 fi
@@ -107,7 +109,8 @@ mark_slot_failed() {
     SLOT_BRANCH="${BRANCH:-}" \
     SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
     SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
-    SLOT_STATUS="failed" \
+    SLOT_PURPOSE="${PURPOSE}" \
+      SLOT_STATUS="failed" \
     SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
       write_slot_registry
     log "  Work dir:  ${WORK_DIR}"
@@ -127,7 +130,8 @@ SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
 SLOT_BRANCH="${BRANCH:-}" \
 SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
-SLOT_STATUS="starting" \
+SLOT_PURPOSE="${PURPOSE}" \
+  SLOT_STATUS="starting" \
   write_slot_registry
 REGISTRY_WRITTEN=true
 
@@ -149,6 +153,7 @@ SLOT_WORKTREE_PATH="${WORKTREE_DIR:-}" \
 SLOT_BRANCH="${BRANCH:-}" \
 SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
+SLOT_PURPOSE="${PURPOSE}" \
 SLOT_STATUS="active" \
   write_slot_registry
 

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -12,7 +12,7 @@
 | **Database** | `agent_${AGENT_ID}` on `localhost:${DB_PORT}` (when `db` is in `HARNESS_INFRA_SERVICES`) |
 | **Work dir** | Fresh session worktree per launch — see the launch output or `.har/slots/agent-${AGENT_ID}.json` |
 
-**Never edit the main checkout** — launch FIRST, then make ALL file edits under the work dir from the launch output. Edits there hot-reload in the running slot; use `./.har/agent-cli.sh ${AGENT_ID} restart` if a change doesn't take. Relaunching replaces the session (branch kept) and requires explicit confirmation; dirty worktrees also need `--force` after user approval.
+**Never edit the main checkout** — launch FIRST with `--purpose=label`, then make ALL file edits under the work dir from the launch output. Edits there hot-reload in the running slot; use `./.har/agent-cli.sh ${AGENT_ID} restart` if a change doesn't take. Prefer `complete`/`teardown` then `launch` to free a slot; `--replace` abandons the previous session from main-checkout HEAD (does not select main). Dirty worktrees need `--force` after user approval.
 
 This slot runs **only the primary application** (`HARNESS_PRIMARY_APP`). External dependencies and any supporting services run once, shared by all slots — `setup-infra.sh` manages them; never start them yourself.
 

--- a/src/templates/har-boilerplate/README.md
+++ b/src/templates/har-boilerplate/README.md
@@ -179,15 +179,21 @@ The authoring agent updates scripts and this README. Review changes before commi
 
 ## Session lifecycle
 
-Every `launch` starts a **fresh session**: a new git worktree from the current HEAD at
+Every `launch` starts a **new session**: a git worktree from the current HEAD of the
+**main checkout** (`$REPO_ROOT`) at
 `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>`, on a branch of the same name.
+Set `--purpose=label` / `HAR_SESSION_PURPOSE` on every launch as the human-facing task label.
 The session is recorded in `.har/slots/agent-<id>.json` (the slot registry) — status,
 verify, and teardown resolve the work dir through it. Make ALL file edits under the
 work dir printed by launch, never in the main checkout.
 
-- Relaunching a slot **replaces** its previous session; replacement requires `--replace` /
-  `confirmReplace=true` (or an interactive prompt). Uncommitted changes also need `--force`
-  after explicit user approval.
+- To free/clean a slot: prefer `complete` / `teardown`, then `launch`. `--replace` only
+  reuses the same slot id immediately — it does **not** select `main` or inherit the
+  previous task. For a new unrelated task, switch the main checkout to `main` first.
+- Occupied-slot warnings show what will be destroyed **and** the new session base
+  (`$REPO_ROOT` branch @ sha).
+- Replacement requires `--replace` / `confirmReplace=true` (or an interactive prompt).
+  Dirty worktrees also need `--force` after explicit user approval.
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, the registry records `status: failed`.

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -447,7 +447,7 @@ try {
 #   required: SLOT_AGENT_ID, SLOT_MODE (worktree|root), SLOT_WORK_DIR
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
-#             SLOT_STATUS, SLOT_LAST_ERROR
+#             SLOT_PURPOSE, SLOT_STATUS, SLOT_LAST_ERROR
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -469,6 +469,7 @@ if (e.SLOT_WORKTREE_PATH) entry.worktreePath = e.SLOT_WORKTREE_PATH;
 if (e.SLOT_BRANCH) entry.branch = e.SLOT_BRANCH;
 if (e.SLOT_BASE_BRANCH) entry.baseBranch = e.SLOT_BASE_BRANCH;
 if (e.SLOT_BASE_COMMIT) entry.baseCommit = e.SLOT_BASE_COMMIT;
+if (e.SLOT_PURPOSE) entry.purpose = e.SLOT_PURPOSE;
 if (e.SLOT_LAST_ERROR) entry.lastError = e.SLOT_LAST_ERROR;
 for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PREVIEW_URLS_JSON"]]) {
   if (e[env]) try { entry[key] = JSON.parse(e[env]); } catch {}
@@ -512,11 +513,12 @@ slot_dirty_summary() {
 # Print a warning before replacing an occupied slot (stdout — visible to agents).
 print_slot_replace_warning() {
   local agent_id="$1"
-  local reg wt branch work_dir created status last_error dirty_summary head
+  local reg wt branch work_dir purpose created status last_error dirty_summary head
   reg="$(slot_registry_file "$agent_id")"
   wt="$(existing_slot_worktree "$agent_id")"
   branch="$(read_slot_field "$reg" branch || true)"
   work_dir="$(read_slot_field "$reg" workDir || true)"
+  purpose="$(read_slot_field "$reg" purpose || true)"
   created="$(read_slot_field "$reg" createdAt || true)"
   status="$(read_slot_field "$reg" status || true)"
   last_error="$(read_slot_field "$reg" lastError || true)"
@@ -527,6 +529,7 @@ print_slot_replace_warning() {
 
   echo "" >&2
   echo "⚠ Slot ${agent_id} is already in use — replacing will REMOVE the worktree." >&2
+  [ -n "$purpose" ] && echo "  Purpose:   ${purpose}" >&2
   [ -n "$wt" ] && echo "  Worktree:  ${wt}" >&2
   [ -n "$work_dir" ] && echo "  Work dir:  ${work_dir}" >&2
   [ -n "$branch" ] && echo "  Branch:    ${branch}${head:+ @ ${head}}" >&2
@@ -538,6 +541,15 @@ print_slot_replace_warning() {
   echo "  The session branch is kept only if you committed. Gitignored paths" >&2
   echo "  (state/, runs/, local clones, .env.local) are NOT preserved." >&2
   echo "" >&2
+  base_branch="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  base_sha="$(git -C "${REPO_ROOT:-$SCRIPT_DIR/..}" rev-parse --short HEAD 2>/dev/null || true)"
+  if [ -n "$base_branch" ] || [ -n "$base_sha" ]; then
+    echo "  New session will be based on: ${base_branch:-unknown} @ ${base_sha:-unknown}" >&2
+    echo "    (HEAD of $(cd "${REPO_ROOT:-$SCRIPT_DIR/..}" && pwd))" >&2
+    echo "    --replace does not select main; switch the main checkout first for a new unrelated task." >&2
+    echo "    Prefer: har env complete ${agent_id} / teardown, then launch — not replace to 'clean'." >&2
+    echo "" >&2
+  fi
 }
 
 # Require explicit confirmation before replacing an occupied slot.

--- a/src/templates/har-boilerplate/launch.sh
+++ b/src/templates/har-boilerplate/launch.sh
@@ -3,7 +3,7 @@
 # Every launch starts a FRESH session: any previous session for the slot is torn
 # down (its branch is kept) and a new suffixed worktree is created from HEAD.
 #
-# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--claude] [--replace] [--force] [--resume]
+# Usage: ./.har/launch.sh <agent-id> [--no-worktree] [--claude] [--replace] [--force] [--resume] [--purpose=label]
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,6 +20,7 @@ USE_CLAUDE=false
 FORCE=false
 REPLACE=false
 RESUME=false
+PURPOSE="${HAR_SESSION_PURPOSE:-}"
 
 for arg in "$@"; do
   case "$arg" in
@@ -29,12 +30,13 @@ for arg in "$@"; do
     --replace)  REPLACE=true ;;
     --force)    FORCE=true ;;
     --resume)   RESUME=true ;;
+    --purpose=*) PURPOSE="${arg#--purpose=}" ;;
   esac
 done
 
 if [[ -z "$AGENT_ID" ]]; then
   har_load_agent_slot_limits
-  echo "Usage: $0 <agent-id> [--no-worktree] [--claude] [--replace] [--force] [--resume] " >&2
+  echo "Usage: $0 <agent-id> [--no-worktree] [--claude] [--replace] [--force] [--resume] [--purpose=label]" >&2
   echo "  agent-id must be between ${HARNESS_AGENT_SLOT_MIN} and ${HARNESS_AGENT_SLOT_MAX}" >&2
   exit 1
 fi
@@ -71,6 +73,7 @@ if [ "$RESUME" = true ]; then
       SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
       SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT},\"db\":${DB_PORT}}" \
       SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+      SLOT_PURPOSE="${PURPOSE}" \
       SLOT_STATUS="failed" \
       SLOT_LAST_ERROR="launch.sh --resume exited with code ${exit_code}" \
         write_slot_registry
@@ -178,6 +181,7 @@ if [ "$RESUME" != true ]; then
       SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
       SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT},\"db\":${DB_PORT}}" \
       SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+      SLOT_PURPOSE="${PURPOSE}" \
       SLOT_STATUS="failed" \
       SLOT_LAST_ERROR="launch.sh exited with code ${exit_code}" \
         write_slot_registry
@@ -198,6 +202,7 @@ if [ "$RESUME" != true ]; then
   SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
   SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT},\"db\":${DB_PORT}}" \
   SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+  SLOT_PURPOSE="${PURPOSE}" \
   SLOT_STATUS="starting" \
     write_slot_registry
   REGISTRY_WRITTEN=true
@@ -215,6 +220,7 @@ else
   SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
   SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT},\"db\":${DB_PORT}}" \
   SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+  SLOT_PURPOSE="${PURPOSE}" \
   SLOT_STATUS="starting" \
     write_slot_registry
 fi
@@ -289,6 +295,7 @@ SLOT_BASE_BRANCH="${BASE_BRANCH:-}" \
 SLOT_BASE_COMMIT="${BASE_COMMIT:-}" \
 SLOT_PORTS_JSON="{\"frontend\":${FE_PORT},\"api\":${API_PORT},\"debug\":${DEBUG_PORT},\"db\":${DB_PORT}}" \
 SLOT_PREVIEW_URLS_JSON="{\"frontend\":\"http://localhost:${FE_PORT}\",\"api\":\"http://localhost:${API_PORT}\"}" \
+SLOT_PURPOSE="${PURPOSE}" \
 SLOT_STATUS="active" \
   write_slot_registry
 

--- a/tests/launch-flags.test.ts
+++ b/tests/launch-flags.test.ts
@@ -2,7 +2,7 @@ import { buildLaunchFlagArgs, quoteShellArg } from '../src/core/local-executor';
 import { LaunchEnvironmentInputSchema } from '../src/mcp/schemas';
 
 describe('launch flag plumbing', () => {
-  it('forwards replace/force/resume flags to launch.sh argv', () => {
+  it('forwards replace/force/resume/purpose flags to launch.sh argv', () => {
     expect(
       buildLaunchFlagArgs({
         worktree: false,
@@ -10,8 +10,25 @@ describe('launch flag plumbing', () => {
         force: true,
         resume: true,
         claude: true,
+        purpose: 'label',
       }),
-    ).toEqual(['--no-worktree', '--claude', '--replace', '--force', '--resume']);
+    ).toEqual([
+      '--no-worktree',
+      '--claude',
+      '--replace',
+      '--force',
+      '--resume',
+      '--purpose=label',
+    ]);
+  });
+
+  it('forwards --purpose alone', () => {
+    expect(
+      buildLaunchFlagArgs({
+        worktree: true,
+        purpose: 'fix sqlite backend',
+      }),
+    ).toEqual(['--purpose=fix sqlite backend']);
   });
 
   it('shell-quotes values that contain spaces', () => {
@@ -21,6 +38,14 @@ describe('launch flag plumbing', () => {
     expect(quoteShellArg('--replace')).toBe('--replace');
   });
 
+  it('accepts purpose on MCP launch input', () => {
+    const parsed = LaunchEnvironmentInputSchema.parse({
+      agentId: 1,
+      purpose: 'wire launch purpose',
+    });
+    expect(parsed.purpose).toBe('wire launch purpose');
+  });
+
   it('accepts MCP launch input without purpose', () => {
     const parsed = LaunchEnvironmentInputSchema.parse({
       agentId: 1,
@@ -28,6 +53,6 @@ describe('launch flag plumbing', () => {
     });
     expect(parsed.agentId).toBe(1);
     expect(parsed.resume).toBe(true);
-    expect('purpose' in parsed).toBe(false);
+    expect(parsed.purpose).toBeUndefined();
   });
 });

--- a/tests/lifecycle-help.test.ts
+++ b/tests/lifecycle-help.test.ts
@@ -1,0 +1,32 @@
+import {
+  ENV_LIFECYCLE_EPILOG,
+  HAR_TYPICAL_WORKFLOW_EPILOG,
+  LAUNCH_COMMAND_DESCRIBE,
+  LAUNCH_LIFECYCLE_EPILOG,
+} from '../src/cli/lifecycle-help';
+
+describe('lifecycle help copy', () => {
+  it('teaches the typical launch → verify → complete workflow', () => {
+    expect(HAR_TYPICAL_WORKFLOW_EPILOG).toContain('har env launch');
+    expect(HAR_TYPICAL_WORKFLOW_EPILOG).toContain('har env verify');
+    expect(HAR_TYPICAL_WORKFLOW_EPILOG).toContain('har env complete');
+    expect(HAR_TYPICAL_WORKFLOW_EPILOG).toContain('--replace');
+    expect(HAR_TYPICAL_WORKFLOW_EPILOG).toContain('does NOT select main');
+  });
+
+  it('contrasts env lifecycle subcommands', () => {
+    for (const term of ['preflight', 'launch', 'recover', 'complete', 'teardown', 'status']) {
+      expect(ENV_LIFECYCLE_EPILOG).toContain(term);
+    }
+    expect(ENV_LIFECYCLE_EPILOG).toContain('prefer complete or teardown');
+  });
+
+  it('documents launch base, purpose, and replace semantics', () => {
+    expect(LAUNCH_COMMAND_DESCRIBE).toContain('main-checkout HEAD');
+    expect(LAUNCH_LIFECYCLE_EPILOG).toContain('--purpose');
+    expect(LAUNCH_LIFECYCLE_EPILOG).toContain('--replace');
+    expect(LAUNCH_LIFECYCLE_EPILOG).toContain('Does NOT mean');
+    expect(LAUNCH_LIFECYCLE_EPILOG).toContain('does NOT select main');
+    expect(LAUNCH_LIFECYCLE_EPILOG).toContain('--resume');
+  });
+});

--- a/tests/slot-launch-guard.test.ts
+++ b/tests/slot-launch-guard.test.ts
@@ -15,6 +15,7 @@ function writeSlotRegistry(
   harDir: string,
   agentId: number,
   worktreePath: string,
+  extras: { purpose?: string } = {},
 ): void {
   const slotsDir = path.join(harDir, 'slots');
   fs.mkdirSync(slotsDir, { recursive: true });
@@ -31,6 +32,7 @@ function writeSlotRegistry(
         branch: 'session-branch',
         createdAt: '2026-01-01T00:00:00Z',
         status: 'active',
+        ...(extras.purpose ? { purpose: extras.purpose } : {}),
       },
       null,
       2,
@@ -71,16 +73,21 @@ describe('slot launch guard', () => {
     );
 
     initGitRepo(repoPath);
+    execSync('git checkout -B main', { cwd: repoPath });
     const worktreePath = path.join(os.tmpdir(), `har-guard-wt-${Date.now()}`);
     execSync(`git worktree add -b session-branch ${worktreePath}`, { cwd: repoPath });
-    writeSlotRegistry(harDir, 1, worktreePath);
+    writeSlotRegistry(harDir, 1, worktreePath, { purpose: 'fix sqlite backend' });
 
     const result = checkLaunchGuard(repoPath, 1, {});
     expect(result.allowed).toBe(false);
     expect(result.blocked).toBe(true);
     expect(result.slot?.worktreePath).toBe(worktreePath);
+    expect(result.slot?.purpose).toBe('fix sqlite backend');
     expect(result.reason).toContain('already in use');
-    expect(result.reason).not.toContain('Purpose:');
+    expect(result.reason).toContain('Purpose:  fix sqlite backend');
+    expect(result.reason).toContain('New session will be based on:');
+    expect(result.reason).toContain('(HEAD of');
+    expect(result.reason).toContain('does not select main');
   });
 
   it('requires force when replacing a dirty occupied slot', () => {

--- a/tests/slot-preflight.test.ts
+++ b/tests/slot-preflight.test.ts
@@ -6,15 +6,24 @@ import { allocateAppPorts, isPortInUse } from '../src/core/slot-ports';
 
 const tmpDirs: string[] = [];
 
-function makeHarness(options: { pm2?: boolean; infraDb?: boolean } = {}): string {
+function makeHarness(
+  options: {
+    pm2?: boolean;
+    infraDb?: boolean;
+    feBase?: number;
+    apiBase?: number;
+  } = {},
+): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-preflight-'));
   tmpDirs.push(dir);
   const harDir = path.join(dir, '.har');
   fs.mkdirSync(harDir, { recursive: true });
+  const feBase = options.feBase ?? 3000;
+  const apiBase = options.apiBase ?? 8000;
   const lines = [
     'export HARNESS_PROJECT_NAME=test-project',
-    'export HARNESS_FE_BASE_PORT=3000',
-    'export HARNESS_API_BASE_PORT=8000',
+    `export HARNESS_FE_BASE_PORT=${feBase}`,
+    `export HARNESS_API_BASE_PORT=${apiBase}`,
     'export HARNESS_PORT_STEP=10',
     'export HARNESS_AGENT_SLOT_MIN=1',
     'export HARNESS_AGENT_SLOT_MAX=3',
@@ -97,12 +106,15 @@ describe('inspectSlotReadiness', () => {
 
 describe('allocateAppPorts', () => {
   it('returns defaults when ports are free', () => {
-    const repo = makeHarness({ pm2: true });
+    // Use high bases so busy local stacks (e.g. docker on 3010) do not flake this unit test.
+    const feBase = 47000;
+    const apiBase = 48000;
+    const repo = makeHarness({ pm2: true, feBase, apiBase });
     const ports = allocateAppPorts(repo, 1);
     expect('error' in ports).toBe(false);
     if (!('error' in ports)) {
-      expect(ports.frontend).toBe(3010);
-      expect(ports.api).toBe(8010);
+      expect(ports.frontend).toBe(feBase + 10);
+      expect(ports.api).toBe(apiBase + 10);
       expect(ports.allocated).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary
- Expand `har --help`, `har env --help`, and `har env launch --help` so the slot/session lifecycle (launch → verify → complete) is self-explanatory without the docs site.
- Restore `--purpose` / MCP `purpose` / `HAR_SESSION_PURPOSE` as the human-facing task label, and teach agents that `--replace` abandons the previous session from **main-checkout HEAD** — it does not select `main` or inherit the old task.
- Occupied-slot warnings now show the **new session base** (`branch @ sha` of `$REPO_ROOT`) alongside what will be destroyed; docs, cursor rule, and boilerplate templates match.

## Test plan
- [x] `har env verify 2 --full` (pass)
- [ ] `har --help`, `har env --help`, `har env launch --help` show lifecycle epilog + purpose
- [ ] Occupied-slot warning includes `New session will be based on:` when replacing
- [ ] `har env launch <id> --purpose=label` stores purpose in `.har/slots/agent-<id>.json`

Closes #73


Made with [Cursor](https://cursor.com)