### PR TITLE
feat(cli): add onboarding preferences and commit gate setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ See `.har/stages/PLAYWRIGHT.md` in the target repo after applying the template.
 | `har env teardown 1` | Tear down agent slot 1 |
 | `har agents install` | Scaffold agent skills (`/setup-har`, `/har-wt`, `/har-maintain`) for Claude Code / Cursor / Codex |
 | `har agents remove` | Remove har-managed agent skill files |
+| `har preferences configure` | Select user defaults for rules, skills, and commit-gate onboarding |
 | `har hooks install` | Install the git commit gate (`--claude` for the Claude Code worktree guard) |
 | `har control up` | Start local Mission Control dashboard (Docker Compose) |
 | `har control register` | Register a repo with Mission Control |
@@ -182,7 +183,8 @@ See `.har/stages/PLAYWRIGHT.md` in the target repo after applying the template.
 | `har control watch` | Continuously sync registered repos |
 | `har mcp` | Start the HAR MCP server (stdio) |
 
-Options: `--force`, `--auto` (built-in Claude adaptation), `--smoke`, `--yes` (auto-apply AGENT.md with `--auto`), `--verbose`, `--profile <default|cli|ios>`
+Options: `--force`, `--auto` (built-in Claude adaptation), `--smoke`, `--yes`
+(accept recommended onboarding actions), `--verbose`, `--profile <default|cli|ios>`
 
 ## MCP Surface
 

--- a/docs/src/content/docs/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/docs/getting-started/quick-start.md
@@ -8,8 +8,13 @@ description: Initialize a harness and complete the first isolated agent session.
 From your project root:
 
 ```bash
+har preferences configure
 har env init
 ```
+
+The preferences wizard stores user-level onboarding defaults in
+`~/.har/preferences.json`. It controls Cursor rules, agent skills, and whether
+init/maintain should install the commit gate. Explicit command flags still win.
 
 The default profile targets web applications. Use `--profile cli` for libraries
 and command-line tools or `--profile ios` for an Xcode project.

--- a/docs/src/content/docs/docs/guides/verification.md
+++ b/docs/src/content/docs/docs/guides/verification.md
@@ -20,6 +20,15 @@ for full verification. A later source edit invalidates that validation.
 
 ## Install the commit gate
 
+Init and maintain now offer to install the gate according to the user's onboarding
+preferences. Configure that default once:
+
+```bash
+har preferences configure
+```
+
+Install or inspect it directly at any time:
+
 ```bash
 har hooks install
 har hooks status

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -101,6 +101,21 @@ har agents remove [--claude] [--cursor] [--codex]
 
 Without target flags, HAR detects supported agent directories.
 
+## `har preferences`
+
+```bash
+har preferences show [--json]
+har preferences configure
+har preferences configure --cursor-rule <auto|on|off>
+  --agents <auto|none|claude,cursor,codex>
+  --commit-gate <prompt|always|never>
+  --gate-mode <block|warn>
+  --gate-scope <worktrees|all>
+```
+
+Preferences are user-level defaults stored in `~/.har/preferences.json`.
+Repository policy remains visible and versioned in `.har/stages.json`.
+
 ## `har hooks`
 
 ```bash

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -124,6 +124,23 @@ export const CommitGateConfigSchema = z.object({
 
 export type CommitGateConfig = z.infer<typeof CommitGateConfigSchema>;
 
+/** User-level defaults applied when init/maintain flags are omitted. */
+export const OnboardingPreferencesSchema = z.object({
+  version: z.literal(1).default(1),
+  cursorRule: z.enum(['auto', 'on', 'off']).default('auto'),
+  agentSkills: z.union([z.literal('auto'), z.array(AgentSkillTargetSchema)]).default('auto'),
+  commitGate: z
+    .object({
+      install: z.enum(['prompt', 'always', 'never']).default('prompt'),
+      mode: z.enum(['block', 'warn']).default('block'),
+      scope: z.enum(['worktrees', 'all']).default('worktrees'),
+    })
+    .default({}),
+  updatedAt: z.string().optional(),
+});
+
+export type OnboardingPreferences = z.infer<typeof OnboardingPreferencesSchema>;
+
 export const HarnessStageRegistrySchema = z
   .object({
     version: z.string().default('1'),

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -30,6 +30,8 @@ import {
 import { checkLaunchGuard } from '../../core/slot-launch-guard';
 import { listRuns, getRun } from '../../core/runs';
 import { collectEnvironmentStatus } from '../../core/slot-status';
+import { handleCommitGateOnboarding } from '../../core/commit-gate-onboarding';
+import { readOnboardingPreferences } from '../../core/onboarding-preferences';
 import { EnvironmentStatusSchema, SlotReadinessSchema } from '../../harness/schema';
 import { recordRepoForControlSync } from '../../core/control-registry';
 import { writeFileSafe } from '../../utils/file-ops';
@@ -73,7 +75,7 @@ export const envCommand = {
             .option('yes', {
               type: 'boolean',
               default: false,
-              describe: 'Auto-apply AGENT.md proposal without prompting (--auto only)',
+              describe: 'Accept recommended onboarding actions without prompting',
             })
             .option('cursor-rule', {
               type: 'boolean',
@@ -88,6 +90,18 @@ export const envCommand = {
               // declare a separate --no-agents boolean — it collides and crashes parseAgentTargets.
               describe:
                 'Scaffold agent skills for these targets (comma-separated: claude,cursor,codex); auto-detected when omitted; --no-agents to skip',
+            })
+            .option('commit-gate', {
+              choices: ['prompt', 'always', 'never'] as const,
+              describe: 'Install commit hooks during onboarding (defaults to user preferences)',
+            })
+            .option('gate-mode', {
+              choices: ['block', 'warn'] as const,
+              describe: 'Policy for commits without a passing full verification',
+            })
+            .option('gate-scope', {
+              choices: ['worktrees', 'all'] as const,
+              describe: 'Apply the commit policy to HAR worktrees or every checkout',
             }),
         handleInit,
       )
@@ -104,7 +118,11 @@ export const envCommand = {
               default: false,
               describe: 'Run built-in Claude adaptation (requires ANTHROPIC_API_KEY)',
             })
-            .option('yes', { type: 'boolean', default: false, describe: 'Auto-apply AGENT.md proposal (--auto only)' })
+            .option('yes', {
+              type: 'boolean',
+              default: false,
+              describe: 'Accept recommended maintenance actions without prompting',
+            })
             .option('finalize', {
               type: 'boolean',
               default: false,
@@ -124,6 +142,18 @@ export const envCommand = {
               type: 'string',
               describe:
                 'Scaffold agent skills for these targets (comma-separated: claude,cursor,codex); auto-detected when omitted; --no-agents to skip',
+            })
+            .option('commit-gate', {
+              choices: ['prompt', 'always', 'never'] as const,
+              describe: 'Install or refresh commit hooks (defaults to user preferences)',
+            })
+            .option('gate-mode', {
+              choices: ['block', 'warn'] as const,
+              describe: 'Policy for commits without a passing full verification',
+            })
+            .option('gate-scope', {
+              choices: ['worktrees', 'all'] as const,
+              describe: 'Apply the commit policy to HAR worktrees or every checkout',
             }),
         handleMaintain,
       )
@@ -347,8 +377,12 @@ export async function handleInit(argv: {
   cursorRule?: boolean;
   /** String from --agents=…, or `false` when --no-agents (yargs negation). */
   agents?: string | false;
+  commitGate?: 'prompt' | 'always' | 'never';
+  gateMode?: 'block' | 'warn';
+  gateScope?: 'worktrees' | 'all';
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
+  const onboarding = resolveOnboardingOptions(argv);
 
   header('har env init');
   info(`Repository: ${repoPath}`);
@@ -394,15 +428,20 @@ export async function handleInit(argv: {
     divider();
     success('Harness initialized!');
     recordRepoForControlSync(repoPath);
+    await handleCommitGateOnboarding({
+      repoPath,
+      ...onboarding.commitGate,
+      autoYes: argv.yes,
+    });
     await handleCursorRule({
       repoPath,
-      cursorRule: resolveCursorRuleFlag(argv.cursorRule),
+      cursorRule: onboarding.cursorRule,
       autoYes: argv.yes,
       mode: 'init',
     });
     await handleAgentSkills({
       repoPath,
-      ...resolveAgentsScaffoldOptions(argv.agents),
+      ...onboarding.agentSkills,
       autoYes: argv.yes,
       force: argv.force,
       mode: 'init',
@@ -426,8 +465,12 @@ export async function handleMaintain(argv: {
   cursorRule?: boolean;
   /** String from --agents=…, or `false` when --no-agents (yargs negation). */
   agents?: string | false;
+  commitGate?: 'prompt' | 'always' | 'never';
+  gateMode?: 'block' | 'warn';
+  gateScope?: 'worktrees' | 'all';
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
+  const onboarding = resolveOnboardingOptions(argv);
 
   header('har env maintain');
   info(`Repository: ${repoPath}`);
@@ -486,15 +529,20 @@ export async function handleMaintain(argv: {
     } else {
       success('Harness updated!');
     }
+    await handleCommitGateOnboarding({
+      repoPath,
+      ...onboarding.commitGate,
+      autoYes: argv.yes,
+    });
     await handleCursorRule({
       repoPath,
-      cursorRule: resolveCursorRuleFlag(argv.cursorRule),
+      cursorRule: onboarding.cursorRule,
       autoYes: argv.yes,
       mode: 'maintain',
     });
     await handleAgentSkills({
       repoPath,
-      ...resolveAgentsScaffoldOptions(argv.agents),
+      ...onboarding.agentSkills,
       autoYes: argv.yes,
       mode: 'maintain',
     });
@@ -523,6 +571,43 @@ export function resolveAgentsScaffoldOptions(agents: string | false | undefined)
   if (agents === false) return { enabled: false };
   if (typeof agents === 'string') return { agents };
   return {};
+}
+
+export function resolveOnboardingOptions(argv: {
+  cursorRule?: boolean;
+  agents?: string | false;
+  commitGate?: 'prompt' | 'always' | 'never';
+  gateMode?: 'block' | 'warn';
+  gateScope?: 'worktrees' | 'all';
+}): {
+  cursorRule?: boolean;
+  agentSkills: { agents?: string; enabled?: boolean };
+  commitGate: {
+    install: 'prompt' | 'always' | 'never';
+    mode: 'block' | 'warn';
+    scope: 'worktrees' | 'all';
+  };
+} {
+  const preferences = readOnboardingPreferences();
+  const preferredCursorRule =
+    preferences.cursorRule === 'auto' ? undefined : preferences.cursorRule === 'on';
+  const preferredAgentSkills =
+    preferences.agentSkills === 'auto'
+      ? {}
+      : preferences.agentSkills.length === 0
+        ? { enabled: false }
+        : { agents: preferences.agentSkills.join(',') };
+
+  return {
+    cursorRule: argv.cursorRule ?? preferredCursorRule,
+    agentSkills:
+      argv.agents === undefined ? preferredAgentSkills : resolveAgentsScaffoldOptions(argv.agents),
+    commitGate: {
+      install: argv.commitGate ?? preferences.commitGate.install,
+      mode: argv.gateMode ?? preferences.commitGate.mode,
+      scope: argv.gateScope ?? preferences.commitGate.scope,
+    },
+  };
 }
 
 function emitManualAdaptationPrompt(

--- a/src/cli/commands/preferences.ts
+++ b/src/cli/commands/preferences.ts
@@ -1,0 +1,157 @@
+import inquirer from 'inquirer';
+import type { Argv } from 'yargs';
+import {
+  OnboardingPreferenceOverrides,
+  getOnboardingPreferencesPath,
+  readOnboardingPreferences,
+  writeOnboardingPreferences,
+} from '../../core/onboarding-preferences';
+import { AgentSkillTarget } from '../../harness/schema';
+import { header, info, success } from '../../utils/logging';
+
+interface ConfigureArgs {
+  cursorRule?: 'auto' | 'on' | 'off';
+  agents?: string;
+  commitGate?: 'prompt' | 'always' | 'never';
+  gateMode?: 'block' | 'warn';
+  gateScope?: 'worktrees' | 'all';
+}
+
+function parseAgents(raw: string): 'auto' | AgentSkillTarget[] {
+  if (raw === 'auto') return 'auto';
+  if (raw === 'none') return [];
+  const valid: AgentSkillTarget[] = ['claude', 'cursor', 'codex'];
+  const selected = raw.split(',').map((value) => value.trim().toLowerCase());
+  const invalid = selected.filter((value) => !valid.includes(value as AgentSkillTarget));
+  if (invalid.length > 0) {
+    throw new Error(`Unknown agent target(s): ${invalid.join(', ')}. Valid: auto, none, ${valid.join(',')}`);
+  }
+  return valid.filter((value) => selected.includes(value));
+}
+
+function printPreferences(json: boolean): void {
+  const preferences = readOnboardingPreferences();
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ path: getOnboardingPreferencesPath(), ...preferences }, null, 2)}\n`);
+    return;
+  }
+  header('har preferences');
+  info(`File:          ${getOnboardingPreferencesPath()}`);
+  info(`Cursor rule:   ${preferences.cursorRule}`);
+  info(
+    `Agent skills:  ${preferences.agentSkills === 'auto' ? 'auto' : preferences.agentSkills.join(',') || 'none'}`,
+  );
+  info(
+    `Commit gate:   install=${preferences.commitGate.install} mode=${preferences.commitGate.mode} scope=${preferences.commitGate.scope}`,
+  );
+}
+
+async function promptOverrides(): Promise<OnboardingPreferenceOverrides> {
+  const current = readOnboardingPreferences();
+  const answers = await inquirer.prompt<{
+    cursorRule: 'auto' | 'on' | 'off';
+    agentSkills: AgentSkillTarget[];
+    commitGateInstall: 'prompt' | 'always' | 'never';
+    commitGateMode: 'block' | 'warn';
+    commitGateScope: 'worktrees' | 'all';
+  }>([
+    {
+      type: 'list',
+      name: 'cursorRule',
+      message: 'Cursor workflow rule',
+      choices: [
+        { name: 'Auto-detect', value: 'auto' },
+        { name: 'Always install', value: 'on' },
+        { name: 'Never install', value: 'off' },
+      ],
+      default: current.cursorRule,
+    },
+    {
+      type: 'checkbox',
+      name: 'agentSkills',
+      message: 'Agent integrations (leave empty for none)',
+      choices: ['claude', 'cursor', 'codex'],
+      default: current.agentSkills === 'auto' ? [] : current.agentSkills,
+    },
+    {
+      type: 'list',
+      name: 'commitGateInstall',
+      message: 'Install the commit gate during onboarding',
+      choices: [
+        { name: 'Ask per repository', value: 'prompt' },
+        { name: 'Always', value: 'always' },
+        { name: 'Never', value: 'never' },
+      ],
+      default: current.commitGate.install,
+    },
+    {
+      type: 'list',
+      name: 'commitGateMode',
+      message: 'Unverified commit policy',
+      choices: ['block', 'warn'],
+      default: current.commitGate.mode,
+    },
+    {
+      type: 'list',
+      name: 'commitGateScope',
+      message: 'Commit gate scope',
+      choices: ['worktrees', 'all'],
+      default: current.commitGate.scope,
+    },
+  ]);
+  return answers;
+}
+
+async function handleConfigure(argv: ConfigureArgs): Promise<void> {
+  const hasFlags =
+    argv.cursorRule !== undefined ||
+    argv.agents !== undefined ||
+    argv.commitGate !== undefined ||
+    argv.gateMode !== undefined ||
+    argv.gateScope !== undefined;
+  if (!hasFlags && (!process.stdin.isTTY || !process.stdout.isTTY)) {
+    throw new Error('Interactive preferences require a TTY; pass configuration flags instead.');
+  }
+  const overrides = hasFlags
+    ? {
+        cursorRule: argv.cursorRule,
+        agentSkills: argv.agents === undefined ? undefined : parseAgents(argv.agents),
+        commitGateInstall: argv.commitGate,
+        commitGateMode: argv.gateMode,
+        commitGateScope: argv.gateScope,
+      }
+    : await promptOverrides();
+  writeOnboardingPreferences(overrides);
+  success(`Saved onboarding defaults to ${getOnboardingPreferencesPath()}`);
+  printPreferences(false);
+}
+
+export const preferencesCommand = {
+  command: 'preferences <subcommand>',
+  describe: 'Configure user defaults for HAR repository onboarding',
+  builder: (yargs: Argv) =>
+    yargs
+      .command(
+        'show',
+        'Show onboarding preferences',
+        (y: Argv) => y.option('json', { type: 'boolean', default: false }),
+        (argv: { json: boolean }) => printPreferences(argv.json),
+      )
+      .command(
+        'configure',
+        'Select onboarding defaults interactively or with flags',
+        (y: Argv) =>
+          y
+            .option('cursor-rule', { choices: ['auto', 'on', 'off'] as const })
+            .option('agents', {
+              type: 'string',
+              describe: 'auto, none, or comma-separated claude,cursor,codex',
+            })
+            .option('commit-gate', { choices: ['prompt', 'always', 'never'] as const })
+            .option('gate-mode', { choices: ['block', 'warn'] as const })
+            .option('gate-scope', { choices: ['worktrees', 'all'] as const }),
+        handleConfigure,
+      )
+      .demandCommand(1, 'Specify a subcommand: show or configure'),
+  handler: () => {},
+};

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { envCommand } from './commands/env';
 import { controlCommand } from './commands/control';
 import { hooksCommand } from './commands/hooks';
 import { mcpCommand } from './commands/mcp';
+import { preferencesCommand } from './commands/preferences';
 import { telemetryCommand } from './commands/telemetry';
 import { HAR_ROOT_EPILOG } from './help-text';
 
@@ -18,6 +19,7 @@ export async function runCli(): Promise<void> {
     .command(controlCommand)
     .command(hooksCommand)
     .command(mcpCommand)
+    .command(preferencesCommand)
     .command(telemetryCommand)
     .demandCommand(1, 'Please specify a command. Try: har env --help')
     .epilog(HAR_ROOT_EPILOG)

--- a/src/core/commit-gate-onboarding.ts
+++ b/src/core/commit-gate-onboarding.ts
@@ -1,0 +1,72 @@
+import * as readline from 'readline';
+import { getHooksStatus, installHooks } from './hooks';
+import { readStageRegistry, writeStageRegistry } from '../harness/stages';
+import { info, warn } from '../utils/logging';
+
+export interface CommitGateOnboardingOptions {
+  repoPath: string;
+  install: 'prompt' | 'always' | 'never';
+  mode: 'block' | 'warn';
+  scope: 'worktrees' | 'all';
+  autoYes?: boolean;
+}
+
+function askYesNo(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    process.stderr.write(`${question} `);
+    rl.once('line', (answer) => {
+      rl.close();
+      const trimmed = answer.trim();
+      resolve(trimmed === '' || /^y(es)?$/i.test(trimmed));
+    });
+  });
+}
+
+export async function handleCommitGateOnboarding(
+  options: CommitGateOnboardingOptions,
+): Promise<boolean> {
+  const registry = readStageRegistry(options.repoPath);
+  const gate = registry.commitGate;
+  if (
+    !gate ||
+    gate.enabled !== true ||
+    gate.mode !== options.mode ||
+    gate.scope !== options.scope
+  ) {
+    writeStageRegistry(options.repoPath, {
+      ...registry,
+      commitGate: {
+        enabled: true,
+        mode: options.mode,
+        scope: options.scope,
+      },
+    });
+  }
+  info(`Commit policy: mode=${options.mode} scope=${options.scope}`);
+
+  if (options.install === 'never') {
+    info('Skipped commit gate installation (user preference)');
+    return false;
+  }
+
+  const status = getHooksStatus(options.repoPath);
+  let shouldInstall =
+    status.preCommitInstalled || status.postCommitInstalled || options.install === 'always' || options.autoYes === true;
+  if (!shouldInstall && options.install === 'prompt' && process.stdin.isTTY && process.stdout.isTTY) {
+    shouldInstall = await askYesNo('Install the HAR commit gate for this repository? [Y/n]');
+  }
+  if (!shouldInstall) {
+    info('Commit gate is not installed; run `har hooks install` when ready.');
+    return false;
+  }
+
+  try {
+    installHooks({ repoPath: options.repoPath });
+    info('Installed HAR pre-commit and post-commit hooks');
+    return true;
+  } catch (err) {
+    warn(`Commit gate was not installed: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -208,14 +208,20 @@ export function getCommitGateConfig(checkoutDir: string): CommitGateConfig {
   }
 }
 
-/** True when this checkout is a har agent worktree (har-agent-N branch or slot worktree path). */
+/** True when this checkout is a HAR session worktree (current or legacy naming). */
 export function isAgentWorktree(checkoutDir: string): boolean {
   const branch = getCurrentBranch(checkoutDir);
-  if (branch && /^har-agent-\d+$/.test(branch)) return true;
+  if (branch && (/^har-agent-\d+$/.test(branch) || /-har-agent-\d+-[a-z0-9]+$/.test(branch))) {
+    return true;
+  }
 
   const worktreesRoot = path.join(os.homedir(), 'worktrees');
   const resolved = path.resolve(checkoutDir);
-  return resolved.startsWith(`${worktreesRoot}${path.sep}`) && /-agent-\d+$/.test(path.basename(resolved));
+  const name = path.basename(resolved);
+  return (
+    resolved.startsWith(`${worktreesRoot}${path.sep}`) &&
+    (/-agent-\d+$/.test(name) || /-har-agent-\d+-[a-z0-9]+$/.test(name))
+  );
 }
 
 export function resolveEffectiveMode(checkoutDir: string, gate: CommitGateConfig): 'block' | 'warn' | 'off' {

--- a/src/core/onboarding-preferences.ts
+++ b/src/core/onboarding-preferences.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  AgentSkillTarget,
+  OnboardingPreferences,
+  OnboardingPreferencesSchema,
+} from '../harness/schema';
+
+export interface OnboardingPreferenceOverrides {
+  cursorRule?: 'auto' | 'on' | 'off';
+  agentSkills?: 'auto' | AgentSkillTarget[];
+  commitGateInstall?: 'prompt' | 'always' | 'never';
+  commitGateMode?: 'block' | 'warn';
+  commitGateScope?: 'worktrees' | 'all';
+}
+
+export function getOnboardingPreferencesPath(): string {
+  if (process.env.HAR_PREFERENCES_PATH) {
+    return path.resolve(process.env.HAR_PREFERENCES_PATH);
+  }
+  return path.join(os.homedir(), '.har', 'preferences.json');
+}
+
+export function readOnboardingPreferences(): OnboardingPreferences {
+  const preferencePath = getOnboardingPreferencesPath();
+  try {
+    if (!fs.existsSync(preferencePath)) return OnboardingPreferencesSchema.parse({});
+    return OnboardingPreferencesSchema.parse(JSON.parse(fs.readFileSync(preferencePath, 'utf8')));
+  } catch {
+    return OnboardingPreferencesSchema.parse({});
+  }
+}
+
+export function mergeOnboardingPreferences(
+  current: OnboardingPreferences,
+  overrides: OnboardingPreferenceOverrides,
+): OnboardingPreferences {
+  return OnboardingPreferencesSchema.parse({
+    ...current,
+    cursorRule: overrides.cursorRule ?? current.cursorRule,
+    agentSkills: overrides.agentSkills ?? current.agentSkills,
+    commitGate: {
+      ...current.commitGate,
+      install: overrides.commitGateInstall ?? current.commitGate.install,
+      mode: overrides.commitGateMode ?? current.commitGate.mode,
+      scope: overrides.commitGateScope ?? current.commitGate.scope,
+    },
+  });
+}
+
+export function writeOnboardingPreferences(
+  overrides: OnboardingPreferenceOverrides,
+): OnboardingPreferences {
+  const preference = {
+    ...mergeOnboardingPreferences(readOnboardingPreferences(), overrides),
+    updatedAt: new Date().toISOString(),
+  };
+  const parsed = OnboardingPreferencesSchema.parse(preference);
+  const preferencePath = getOnboardingPreferencesPath();
+  fs.mkdirSync(path.dirname(preferencePath), { recursive: true });
+  fs.writeFileSync(preferencePath, `${JSON.stringify(parsed, null, 2)}\n`);
+  return parsed;
+}

--- a/src/templates/agent-skills/setup-har.md
+++ b/src/templates/agent-skills/setup-har.md
@@ -67,4 +67,6 @@ git add .har/ AGENT.md CLAUDE.md .claude/ .cursor/ 2>/dev/null || git add .har/ 
 git commit -m "chore: add har agent harness"
 ```
 
-Optionally recommend `har hooks install` (commit gate) and `har hooks install --claude` (worktree guard for Claude Code).
+Init applies the user's `har preferences` commit-gate policy. Confirm with
+`har hooks status`; recommend `har hooks install --claude` separately when the
+Claude Code main-checkout worktree guard is useful.

--- a/src/templates/har-boilerplate-cli/stages.json
+++ b/src/templates/har-boilerplate-cli/stages.json
@@ -4,6 +4,11 @@
     "min": 1,
     "max": 3
   },
+  "commitGate": {
+    "enabled": true,
+    "mode": "block",
+    "scope": "worktrees"
+  },
   "stages": [
     {
       "id": "setup-infra",

--- a/src/templates/har-boilerplate-ios/stages.json
+++ b/src/templates/har-boilerplate-ios/stages.json
@@ -4,6 +4,11 @@
     "min": 1,
     "max": 3
   },
+  "commitGate": {
+    "enabled": true,
+    "mode": "block",
+    "scope": "worktrees"
+  },
   "stages": [
     {
       "id": "setup-infra",

--- a/src/templates/har-boilerplate/stages.json
+++ b/src/templates/har-boilerplate/stages.json
@@ -4,6 +4,11 @@
     "min": 1,
     "max": 5
   },
+  "commitGate": {
+    "enabled": true,
+    "mode": "block",
+    "scope": "worktrees"
+  },
   "stages": [
     {
       "id": "setup-infra",

--- a/tests/commit-gate-onboarding.test.ts
+++ b/tests/commit-gate-onboarding.test.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { handleCommitGateOnboarding } from '../src/core/commit-gate-onboarding';
+import { getHooksStatus } from '../src/core/hooks';
+import { readStageRegistry } from '../src/harness/stages';
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-gate-onboarding-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  fs.mkdirSync(path.join(dir, '.har'));
+  fs.writeFileSync(
+    path.join(dir, '.har', 'stages.json'),
+    `${JSON.stringify({ version: '1', stages: [] }, null, 2)}\n`,
+  );
+  return dir;
+}
+
+describe('commit gate onboarding', () => {
+  it('persists visible policy without installing hooks when preference is never', async () => {
+    const dir = initRepo();
+    await handleCommitGateOnboarding({
+      repoPath: dir,
+      install: 'never',
+      mode: 'warn',
+      scope: 'all',
+    });
+
+    expect(readStageRegistry(dir).commitGate).toEqual({
+      enabled: true,
+      mode: 'warn',
+      scope: 'all',
+    });
+    expect(getHooksStatus(dir).preCommitInstalled).toBe(false);
+  });
+
+  it('installs repository-wide hooks for always', async () => {
+    const dir = initRepo();
+    await handleCommitGateOnboarding({
+      repoPath: dir,
+      install: 'always',
+      mode: 'block',
+      scope: 'worktrees',
+    });
+
+    expect(getHooksStatus(dir).preCommitInstalled).toBe(true);
+    expect(getHooksStatus(dir).postCommitInstalled).toBe(true);
+  });
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -176,6 +176,12 @@ describe('isAgentWorktree', () => {
     const worktree = addAgentWorktree(dir, 3);
     expect(isAgentWorktree(worktree)).toBe(true);
   });
+
+  it('detects current suffixed HAR session branches', () => {
+    const dir = initRepo();
+    sh(dir, 'git checkout -q -b main-ab12-har-agent-3-z9x8');
+    expect(isAgentWorktree(dir)).toBe(true);
+  });
 });
 
 describe('install/uninstall/status', () => {

--- a/tests/onboarding-preferences.test.ts
+++ b/tests/onboarding-preferences.test.ts
@@ -1,0 +1,66 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  getOnboardingPreferencesPath,
+  readOnboardingPreferences,
+  writeOnboardingPreferences,
+} from '../src/core/onboarding-preferences';
+
+describe('onboarding preferences', () => {
+  let tmpDir: string;
+  let preferencePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-preferences-'));
+    preferencePath = path.join(tmpDir, 'preferences.json');
+    process.env.HAR_PREFERENCES_PATH = preferencePath;
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_PREFERENCES_PATH;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns safe defaults when no preference file exists', () => {
+    expect(getOnboardingPreferencesPath()).toBe(preferencePath);
+    expect(readOnboardingPreferences()).toMatchObject({
+      version: 1,
+      cursorRule: 'auto',
+      agentSkills: 'auto',
+      commitGate: {
+        install: 'prompt',
+        mode: 'block',
+        scope: 'worktrees',
+      },
+    });
+  });
+
+  it('persists partial updates without losing existing choices', () => {
+    writeOnboardingPreferences({
+      cursorRule: 'off',
+      agentSkills: ['cursor'],
+      commitGateInstall: 'always',
+    });
+    const updated = writeOnboardingPreferences({
+      commitGateMode: 'warn',
+      commitGateScope: 'all',
+    });
+
+    expect(updated).toMatchObject({
+      cursorRule: 'off',
+      agentSkills: ['cursor'],
+      commitGate: {
+        install: 'always',
+        mode: 'warn',
+        scope: 'all',
+      },
+    });
+    expect(updated.updatedAt).toBeDefined();
+  });
+
+  it('falls back to defaults for malformed files', () => {
+    fs.writeFileSync(preferencePath, '{not-json');
+    expect(readOnboardingPreferences().commitGate.mode).toBe('block');
+  });
+});


### PR DESCRIPTION
## Summary
- add schema-backed user onboarding preferences with interactive and flag-driven CLI configuration
- apply commit-gate policy during init and maintain while keeping repository policy visible in `.har/stages.json`
- fix current HAR session worktree detection and document the preference-driven workflow

## Test plan
- [x] `har env verify 1 --full`
- [x] onboarding preference persistence and partial-update tests
- [x] commit-gate policy, installation, and worktree detection tests


Made with [Cursor](https://cursor.com)