### PR TITLE
feat: authenticate har CLI/control push to a self-hosted portal

### DIFF
--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -8,6 +8,8 @@ import { inspectControlUpReadiness } from '../../core/control-port';
 import {
   syncRepoWithControl,
 } from '../../core/control-sync';
+import { writePortalCredentials } from '../../core/portal-credentials';
+import { loginViaBrowser } from '../../core/portal-login';
 import { startMissionControl, syncReposAfterControlStart, stopMissionControl } from '../../core/control-lifecycle';
 import {
   confirmUnregister,
@@ -106,9 +108,14 @@ export const controlCommand = {
       )
       .command(
         'login',
-        'Configure HAR Cloud API credentials (hosted sync)',
+        'Log in to a har-portal (browser SSO) and store an ingest token',
         (y: Argv) =>
-          y.option('api-key', { type: 'string', describe: 'HAR Cloud API key' }),
+          y
+            .option('portal', { type: 'string', describe: 'Portal base URL (or set HAR_PORTAL_URL)' })
+            .option('api-key', {
+              type: 'string',
+              describe: 'Store this ingest token directly instead of browser login',
+            }),
         handleLogin,
       )
       .demandCommand(
@@ -370,13 +377,34 @@ async function handleWatch(argv: {
   }, argv.interval * 1000);
 }
 
-async function handleLogin(argv: { apiKey?: string }): Promise<void> {
+async function handleLogin(argv: { apiKey?: string; portal?: string }): Promise<void> {
   header('har control login');
-  if (!argv.apiKey) {
-    error('Provide --api-key (HAR Cloud API key)');
+  const portalUrl = (argv.portal ?? process.env.HAR_PORTAL_URL ?? '').replace(/\/+$/, '');
+  if (!portalUrl) {
+    error('Provide --portal <url> (or set HAR_PORTAL_URL)');
     process.exit(1);
   }
-  process.env.HAR_CLOUD_API_KEY = argv.apiKey;
-  success('HAR_CLOUD_API_KEY set for this process. Export it in your shell for persistence.');
-  info('Sync to cloud: har control sync --cloud');
+
+  if (argv.apiKey) {
+    writePortalCredentials({
+      portalUrl,
+      token: argv.apiKey,
+      createdAt: new Date().toISOString(),
+    });
+    success(`Saved ingest token for ${portalUrl}`);
+    info('Sync: har control sync');
+    return;
+  }
+
+  try {
+    const creds = await loginViaBrowser(portalUrl);
+    writePortalCredentials(creds);
+    success(
+      `Logged in to ${portalUrl}${creds.workspace ? ` (workspace: ${creds.workspace})` : ''}`,
+    );
+    info('Sync: har control sync');
+  } catch (err) {
+    error(`Login failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
 }

--- a/src/core/control-config.ts
+++ b/src/core/control-config.ts
@@ -1,3 +1,5 @@
+import { readPortalCredentials } from './portal-credentials';
+
 /** Default Mission Control API base URL (local Docker Compose). */
 export const DEFAULT_CONTROL_API_URL = 'http://localhost:3847';
 
@@ -14,9 +16,29 @@ export interface PortalTarget {
   token: string;
 }
 
+function normalizeUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
 export function getPortalTarget(): PortalTarget | null {
-  const url = process.env.HAR_PORTAL_URL ?? process.env.HAR_CLOUD_API_URL;
-  const token = process.env.HAR_PORTAL_TOKEN ?? process.env.HAR_CLOUD_API_KEY;
-  if (!url || !token) return null;
-  return { url: url.replace(/\/+$/, ''), token };
+  if (process.env.HAR_PORTAL_URL && process.env.HAR_PORTAL_TOKEN) {
+    return {
+      url: normalizeUrl(process.env.HAR_PORTAL_URL),
+      token: process.env.HAR_PORTAL_TOKEN,
+    };
+  }
+
+  const stored = readPortalCredentials();
+  if (stored) {
+    return { url: normalizeUrl(stored.portalUrl), token: stored.token };
+  }
+
+  if (process.env.HAR_CLOUD_API_URL && process.env.HAR_CLOUD_API_KEY) {
+    return {
+      url: normalizeUrl(process.env.HAR_CLOUD_API_URL),
+      token: process.env.HAR_CLOUD_API_KEY,
+    };
+  }
+
+  return null;
 }

--- a/src/core/control-config.ts
+++ b/src/core/control-config.ts
@@ -8,3 +8,15 @@ export function getControlApiUrl(): string {
 export function isControlEnabled(): boolean {
   return process.env.HAR_CONTROL_DISABLED !== 'true';
 }
+
+export interface PortalTarget {
+  url: string;
+  token: string;
+}
+
+export function getPortalTarget(): PortalTarget | null {
+  const url = process.env.HAR_PORTAL_URL ?? process.env.HAR_CLOUD_API_URL;
+  const token = process.env.HAR_PORTAL_TOKEN ?? process.env.HAR_CLOUD_API_KEY;
+  if (!url || !token) return null;
+  return { url: url.replace(/\/+$/, ''), token };
+}

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -2,8 +2,6 @@ import * as path from 'path';
 import { readManifest, resolveHarnessRoot } from '../harness/manifest';
 import { readStageRegistry } from '../harness/stages';
 import {
-  AgentSessionEvent,
-  AgentSessionUsage,
   EnvironmentStatus,
   RegisterRepoInput,
   RunRecord,
@@ -86,59 +84,12 @@ async function postPortalSync(
   }
 }
 
-function collectSessionUsage(
-  status: EnvironmentStatus,
-  repoPath: string,
-): AgentSessionUsage[] {
-  if (!isTelemetryEnabled() || process.env.NODE_ENV === 'test') return [];
-  return status.slots.flatMap((slot) =>
-    harvestUsageForSlot({
-      agentId: slot.agentId,
-      workDir: slot.workDir,
-      worktreePath: slot.worktreePath,
-      branch: slot.branch,
-      suffix: slot.suffix,
-      sessionCreatedAt: slot.sessionCreatedAt,
-      repoPath,
-    }).map((row) => ({
-      ...row,
-      sessionKey:
-        row.sessionKey ||
-        buildSessionKey({
-          branch: slot.branch,
-          agentId: slot.agentId,
-          suffix: slot.suffix,
-          createdAt: slot.sessionCreatedAt,
-        }),
-    })),
-  );
-}
-
-function collectSessionEvents(
-  status: EnvironmentStatus,
-  repoPath: string,
-): AgentSessionEvent[] {
-  if (!isTelemetryEnabled() || process.env.NODE_ENV === 'test') return [];
-  return status.slots.flatMap((slot) =>
-    harvestEventsForSlot({
-      agentId: slot.agentId,
-      workDir: slot.workDir,
-      worktreePath: slot.worktreePath,
-      branch: slot.branch,
-      suffix: slot.suffix,
-      sessionCreatedAt: slot.sessionCreatedAt,
-      repoPath,
-    }),
-  );
-}
-
 function buildPortalSyncBody(repoPath: string): Record<string, unknown> {
   const runs = listRuns(repoPath);
   const status = collectEnvironmentStatus(repoPath);
   const manifest = readManifest(repoPath);
   const stagesRegistry = readStageRegistry(repoPath);
   const validations = listValidations(resolveHarnessRoot(repoPath));
-  const usage = collectSessionUsage(status, repoPath);
 
   return {
     path: repoPath,
@@ -148,7 +99,6 @@ function buildPortalSyncBody(repoPath: string): Record<string, unknown> {
     slots: status.slots,
     generatedAt: status.generatedAt,
     ...(validations.length > 0 ? { validations } : {}),
-    ...(usage.length > 0 ? { usage } : {}),
   };
 }
 
@@ -330,21 +280,53 @@ async function syncRepoRunsAndSlots(
   });
   await postJson(`${apiUrl}/api/repos/${repoId}/slots`, slotsBody, dryRun);
 
-  try {
-    const usage = collectSessionUsage(status, repoPath);
-    if (usage.length > 0) {
-      const usageBody = SyncUsageInputSchema.parse({ usage });
-      await postJson(`${apiUrl}/api/repos/${repoId}/usage`, usageBody, dryRun);
-    }
+  if (isTelemetryEnabled() && process.env.NODE_ENV !== 'test') {
+    try {
+      const usage = status.slots.flatMap((slot) =>
+        harvestUsageForSlot({
+          agentId: slot.agentId,
+          workDir: slot.workDir,
+          worktreePath: slot.worktreePath,
+          branch: slot.branch,
+          suffix: slot.suffix,
+          sessionCreatedAt: slot.sessionCreatedAt,
+          repoPath,
+        }).map((row) => ({
+          ...row,
+          sessionKey:
+            row.sessionKey ||
+            buildSessionKey({
+              branch: slot.branch,
+              agentId: slot.agentId,
+              suffix: slot.suffix,
+              createdAt: slot.sessionCreatedAt,
+            }),
+        })),
+      );
+      if (usage.length > 0) {
+        const usageBody = SyncUsageInputSchema.parse({ usage });
+        await postJson(`${apiUrl}/api/repos/${repoId}/usage`, usageBody, dryRun);
+      }
 
-    const events = collectSessionEvents(status, repoPath);
-    if (events.length > 0) {
-      const eventsBody = SyncSessionEventsInputSchema.parse({ events });
-      await postJson(`${apiUrl}/api/repos/${repoId}/events`, eventsBody, dryRun);
+      const events = status.slots.flatMap((slot) =>
+        harvestEventsForSlot({
+          agentId: slot.agentId,
+          workDir: slot.workDir,
+          worktreePath: slot.worktreePath,
+          branch: slot.branch,
+          suffix: slot.suffix,
+          sessionCreatedAt: slot.sessionCreatedAt,
+          repoPath,
+        }),
+      );
+      if (events.length > 0) {
+        const eventsBody = SyncSessionEventsInputSchema.parse({ events });
+        await postJson(`${apiUrl}/api/repos/${repoId}/events`, eventsBody, dryRun);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[har control] usage harvest skipped: ${message}\n`);
     }
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[har control] usage harvest skipped: ${message}\n`);
   }
 
   const validations = listValidations(resolveHarnessRoot(repoPath));

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 import { readManifest, resolveHarnessRoot } from '../harness/manifest';
 import { readStageRegistry } from '../harness/stages';
 import {
+  AgentSessionEvent,
+  AgentSessionUsage,
   EnvironmentStatus,
   RegisterRepoInput,
   RunRecord,
@@ -11,7 +13,12 @@ import {
   SyncUsageInputSchema,
   SyncValidationsInputSchema,
 } from '../harness/schema';
-import { getControlApiUrl, isControlEnabled } from './control-config';
+import {
+  getControlApiUrl,
+  getPortalTarget,
+  isControlEnabled,
+  PortalTarget,
+} from './control-config';
 import { listRegisteredRepos, removeRegisteredRepo } from './control-registry';
 import { canonicalizeControlRepoPath } from './control-repo-path';
 import { collectEnvironmentStatus } from './slot-status';
@@ -52,6 +59,99 @@ async function postJson<T>(url: string, body: unknown, dryRun?: boolean): Promis
   return (await response.json()) as T;
 }
 
+async function postPortalSync(
+  target: PortalTarget,
+  body: unknown,
+  dryRun?: boolean,
+): Promise<void> {
+  if (dryRun) return;
+
+  const response = await fetch(`${target.url}/api/sync`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${target.token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(
+        `har-portal rejected the ingest token (HTTP ${response.status}) — check HAR_PORTAL_TOKEN.`,
+      );
+    }
+    const text = await response.text().catch(() => '');
+    throw new Error(`har-portal sync failed: HTTP ${response.status}${text ? ` — ${text}` : ''}`);
+  }
+}
+
+function collectSessionUsage(
+  status: EnvironmentStatus,
+  repoPath: string,
+): AgentSessionUsage[] {
+  if (!isTelemetryEnabled() || process.env.NODE_ENV === 'test') return [];
+  return status.slots.flatMap((slot) =>
+    harvestUsageForSlot({
+      agentId: slot.agentId,
+      workDir: slot.workDir,
+      worktreePath: slot.worktreePath,
+      branch: slot.branch,
+      suffix: slot.suffix,
+      sessionCreatedAt: slot.sessionCreatedAt,
+      repoPath,
+    }).map((row) => ({
+      ...row,
+      sessionKey:
+        row.sessionKey ||
+        buildSessionKey({
+          branch: slot.branch,
+          agentId: slot.agentId,
+          suffix: slot.suffix,
+          createdAt: slot.sessionCreatedAt,
+        }),
+    })),
+  );
+}
+
+function collectSessionEvents(
+  status: EnvironmentStatus,
+  repoPath: string,
+): AgentSessionEvent[] {
+  if (!isTelemetryEnabled() || process.env.NODE_ENV === 'test') return [];
+  return status.slots.flatMap((slot) =>
+    harvestEventsForSlot({
+      agentId: slot.agentId,
+      workDir: slot.workDir,
+      worktreePath: slot.worktreePath,
+      branch: slot.branch,
+      suffix: slot.suffix,
+      sessionCreatedAt: slot.sessionCreatedAt,
+      repoPath,
+    }),
+  );
+}
+
+function buildPortalSyncBody(repoPath: string): Record<string, unknown> {
+  const runs = listRuns(repoPath);
+  const status = collectEnvironmentStatus(repoPath);
+  const manifest = readManifest(repoPath);
+  const stagesRegistry = readStageRegistry(repoPath);
+  const validations = listValidations(resolveHarnessRoot(repoPath));
+  const usage = collectSessionUsage(status, repoPath);
+
+  return {
+    path: repoPath,
+    ...(manifest ? { manifest } : {}),
+    ...(stagesRegistry ? { stagesRegistry } : {}),
+    runs,
+    slots: status.slots,
+    generatedAt: status.generatedAt,
+    ...(validations.length > 0 ? { validations } : {}),
+    ...(usage.length > 0 ? { usage } : {}),
+  };
+}
+
 export async function isControlApiReachable(apiUrl = getControlApiUrl()): Promise<boolean> {
   try {
     const response = await fetch(`${apiUrl}/api/health`, {
@@ -84,7 +184,8 @@ export async function syncAllKnownReposWithControl(options?: {
   if (!isControlEnabled()) return { synced: 0, failed: 0 };
 
   const apiUrl = options?.apiUrl ?? getControlApiUrl();
-  if (!(await isControlApiReachable(apiUrl))) {
+  const portal = getPortalTarget();
+  if (!(await isControlApiReachable(portal ? portal.url : apiUrl))) {
     return { synced: 0, failed: 0 };
   }
 
@@ -185,6 +286,12 @@ export async function syncRepoWithControl(options: ControlSyncOptions): Promise<
     return;
   }
 
+  const portal = getPortalTarget();
+  if (portal) {
+    await postPortalSync(portal, buildPortalSyncBody(repoPath), options.dryRun);
+    return;
+  }
+
   const registerResult = await registerRepoWithControl({ ...options, repoPath });
   const repoId = registerResult?.id;
 
@@ -223,53 +330,21 @@ async function syncRepoRunsAndSlots(
   });
   await postJson(`${apiUrl}/api/repos/${repoId}/slots`, slotsBody, dryRun);
 
-  if (isTelemetryEnabled() && process.env.NODE_ENV !== 'test') {
-    try {
-      const usage = status.slots.flatMap((slot) =>
-        harvestUsageForSlot({
-          agentId: slot.agentId,
-          workDir: slot.workDir,
-          worktreePath: slot.worktreePath,
-          branch: slot.branch,
-          suffix: slot.suffix,
-          sessionCreatedAt: slot.sessionCreatedAt,
-          repoPath,
-        }).map((row) => ({
-          ...row,
-          sessionKey:
-            row.sessionKey ||
-            buildSessionKey({
-              branch: slot.branch,
-              agentId: slot.agentId,
-              suffix: slot.suffix,
-              createdAt: slot.sessionCreatedAt,
-            }),
-        })),
-      );
-      if (usage.length > 0) {
-        const usageBody = SyncUsageInputSchema.parse({ usage });
-        await postJson(`${apiUrl}/api/repos/${repoId}/usage`, usageBody, dryRun);
-      }
-
-      const events = status.slots.flatMap((slot) =>
-        harvestEventsForSlot({
-          agentId: slot.agentId,
-          workDir: slot.workDir,
-          worktreePath: slot.worktreePath,
-          branch: slot.branch,
-          suffix: slot.suffix,
-          sessionCreatedAt: slot.sessionCreatedAt,
-          repoPath,
-        }),
-      );
-      if (events.length > 0) {
-        const eventsBody = SyncSessionEventsInputSchema.parse({ events });
-        await postJson(`${apiUrl}/api/repos/${repoId}/events`, eventsBody, dryRun);
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[har control] usage harvest skipped: ${message}\n`);
+  try {
+    const usage = collectSessionUsage(status, repoPath);
+    if (usage.length > 0) {
+      const usageBody = SyncUsageInputSchema.parse({ usage });
+      await postJson(`${apiUrl}/api/repos/${repoId}/usage`, usageBody, dryRun);
     }
+
+    const events = collectSessionEvents(status, repoPath);
+    if (events.length > 0) {
+      const eventsBody = SyncSessionEventsInputSchema.parse({ events });
+      await postJson(`${apiUrl}/api/repos/${repoId}/events`, eventsBody, dryRun);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[har control] usage harvest skipped: ${message}\n`);
   }
 
   const validations = listValidations(resolveHarnessRoot(repoPath));
@@ -301,16 +376,17 @@ export async function syncRepoWithControlAsync(repoPath: string): Promise<void> 
 
   const verbose = process.env.HAR_CONTROL_VERBOSE === 'true';
   try {
-    const apiUrl = getControlApiUrl();
-    if (!(await isControlApiReachable(apiUrl))) {
+    const portal = getPortalTarget();
+    const healthUrl = portal ? portal.url : getControlApiUrl();
+    if (!(await isControlApiReachable(healthUrl))) {
       if (verbose) {
-        process.stderr.write(`[har control] sync skipped: control API not reachable at ${apiUrl}\n`);
+        process.stderr.write(`[har control] sync skipped: not reachable at ${healthUrl}\n`);
       }
       return;
     }
     const canonical = canonicalizeControlRepoPath(repoPath);
     await withTimeout(
-      syncRepoWithControl({ repoPath: canonical, apiUrl }),
+      syncRepoWithControl({ repoPath: canonical }),
       SYNC_TIMEOUT_MS,
       'control sync',
     );
@@ -324,6 +400,19 @@ export async function syncRepoWithControlAsync(repoPath: string): Promise<void> 
 
 export async function syncRunWithControlAsync(repoPath: string, run: RunRecord): Promise<void> {
   if (process.env.HAR_CONTROL_DISABLED === 'true') return;
+
+  const portal = getPortalTarget();
+  if (portal) {
+    try {
+      if (!(await isControlApiReachable(portal.url))) return;
+      const canonical = canonicalizeControlRepoPath(repoPath);
+      await postPortalSync(portal, { path: canonical, runs: [run] });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[har control] run sync skipped: ${message}\n`);
+    }
+    return;
+  }
 
   const apiUrl = getControlApiUrl();
   try {

--- a/src/core/portal-credentials.ts
+++ b/src/core/portal-credentials.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface PortalCredentials {
+  portalUrl: string;
+  token: string;
+  workspace?: string;
+  createdAt: string;
+}
+
+export function portalCredentialsPath(): string {
+  if (process.env.HAR_CREDENTIALS_PATH) {
+    return path.resolve(process.env.HAR_CREDENTIALS_PATH);
+  }
+  return path.join(os.homedir(), '.har', 'credentials.json');
+}
+
+export function readPortalCredentials(): PortalCredentials | null {
+  try {
+    const raw = fs.readFileSync(portalCredentialsPath(), 'utf8');
+    const parsed = JSON.parse(raw) as Partial<PortalCredentials>;
+    if (!parsed.portalUrl || !parsed.token) return null;
+    return {
+      portalUrl: parsed.portalUrl,
+      token: parsed.token,
+      workspace: parsed.workspace,
+      createdAt: parsed.createdAt ?? '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writePortalCredentials(creds: PortalCredentials): void {
+  const file = portalCredentialsPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
+}

--- a/src/core/portal-login.ts
+++ b/src/core/portal-login.ts
@@ -1,0 +1,83 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { randomUUID } from 'crypto';
+import { spawn } from 'child_process';
+
+import { PortalCredentials } from './portal-credentials';
+
+const CALLBACK_PATH = '/callback';
+const LOGIN_TIMEOUT_MS = 3 * 60_000;
+
+function openBrowser(url: string): void {
+  const [cmd, args] =
+    process.platform === 'darwin'
+      ? ['open', [url]]
+      : process.platform === 'win32'
+        ? ['cmd', ['/c', 'start', '', url]]
+        : ['xdg-open', [url]];
+  try {
+    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // Caller prints the URL so the user can open it manually.
+  }
+}
+
+export async function loginViaBrowser(
+  portalUrl: string,
+  openUrl: (url: string) => void = openBrowser,
+): Promise<PortalCredentials> {
+  const state = randomUUID();
+
+  return new Promise<PortalCredentials>((resolve, reject) => {
+    let timer: NodeJS.Timeout;
+    const server = http.createServer((req, res) => {
+      const requestUrl = new URL(req.url ?? '', 'http://127.0.0.1');
+      if (requestUrl.pathname !== CALLBACK_PATH) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const token = requestUrl.searchParams.get('token');
+      const returnedState = requestUrl.searchParams.get('state');
+      const workspace = requestUrl.searchParams.get('workspace') ?? undefined;
+
+      if (returnedState !== state || !token) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end('<h1>Login failed</h1><p>You can close this tab and try again.</p>');
+        cleanup();
+        reject(new Error('state mismatch or missing token'));
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<h1>Logged in</h1><p>You can close this tab and return to the terminal.</p>');
+      cleanup();
+      resolve({ portalUrl, token, workspace, createdAt: new Date().toISOString() });
+    });
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      server.close();
+    };
+
+    server.on('error', (err) => {
+      cleanup();
+      reject(err);
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      const callback = `http://127.0.0.1:${port}${CALLBACK_PATH}`;
+      const loginUrl = `${portalUrl}/cli/login?callback=${encodeURIComponent(callback)}&state=${state}`;
+      openUrl(loginUrl);
+      process.stderr.write(`Opening ${loginUrl}\nIf your browser did not open, paste that URL.\n`);
+      timer = setTimeout(() => {
+        cleanup();
+        reject(new Error('timed out'));
+      }, LOGIN_TIMEOUT_MS);
+    });
+  });
+}

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -1,0 +1,150 @@
+import { getPortalTarget } from '../src/core/control-config';
+import { syncRepoWithControl } from '../src/core/control-sync';
+
+// Keep buildPortalSyncBody deterministic and filesystem-free: the data
+// collectors are exercised by their own suites — here we only care that the
+// portal push targets the right URL, sends the bearer token, and shapes the
+// omnibus body from whatever the collectors return.
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+jest.mock('../src/core/runs', () => ({ listRuns: () => [] }));
+jest.mock('../src/core/slot-status', () => ({
+  collectEnvironmentStatus: () => ({
+    slots: [],
+    generatedAt: '2026-01-01T00:00:00.000Z',
+  }),
+}));
+jest.mock('../src/core/validations', () => ({ listValidations: () => [] }));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => null,
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
+
+const PORTAL_ENV = [
+  'HAR_PORTAL_URL',
+  'HAR_PORTAL_TOKEN',
+  'HAR_CLOUD_API_URL',
+  'HAR_CLOUD_API_KEY',
+] as const;
+
+function clearPortalEnv(): void {
+  for (const key of PORTAL_ENV) delete process.env[key];
+}
+
+type FetchResult = { status: number; body?: string };
+
+function mockFetch(result: FetchResult): jest.Mock {
+  const fn = jest.fn(async () => ({
+    ok: result.status >= 200 && result.status < 300,
+    status: result.status,
+    text: async () => result.body ?? '',
+    json: async () => ({}),
+  }));
+  (global as unknown as { fetch: unknown }).fetch = fn;
+  return fn;
+}
+
+describe('getPortalTarget', () => {
+  beforeEach(clearPortalEnv);
+  afterAll(clearPortalEnv);
+
+  it('prefers HAR_PORTAL_* over the legacy HAR_CLOUD_* alias', () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_new';
+    process.env.HAR_CLOUD_API_URL = 'https://cloud.example.com';
+    process.env.HAR_CLOUD_API_KEY = 'har_ingest_old';
+    expect(getPortalTarget()).toEqual({
+      url: 'https://portal.example.com',
+      token: 'har_ingest_new',
+    });
+  });
+
+  it('falls back to HAR_CLOUD_* when HAR_PORTAL_* is unset', () => {
+    process.env.HAR_CLOUD_API_URL = 'https://cloud.example.com';
+    process.env.HAR_CLOUD_API_KEY = 'har_ingest_old';
+    expect(getPortalTarget()).toEqual({
+      url: 'https://cloud.example.com',
+      token: 'har_ingest_old',
+    });
+  });
+
+  it('strips trailing slashes so `${url}/api/sync` is well-formed', () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com/';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_x';
+    expect(getPortalTarget()?.url).toBe('https://portal.example.com');
+  });
+
+  it('returns null when only one of URL/token is set (opt-in)', () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    expect(getPortalTarget()).toBeNull();
+    clearPortalEnv();
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_x';
+    expect(getPortalTarget()).toBeNull();
+  });
+});
+
+describe('syncRepoWithControl — portal push', () => {
+  const realFetch = global.fetch;
+  beforeEach(clearPortalEnv);
+  afterEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+  afterAll(clearPortalEnv);
+
+  it('POSTs the omnibus body to /api/sync with a bearer token', async () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_secret';
+    const fetchMock = mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://portal.example.com/api/sync');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer har_ingest_secret',
+    );
+    const body = JSON.parse(init.body as string);
+    expect(body.path).toBe('/repo/x');
+    expect(Array.isArray(body.runs)).toBe(true);
+    expect(Array.isArray(body.slots)).toBe(true);
+    expect(body.generatedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('raises a token error on 401 (bad/revoked token)', async () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_bad';
+    mockFetch({ status: 401 });
+    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).rejects.toThrow(
+      /rejected the ingest token/,
+    );
+  });
+
+  it('raises a generic error on other non-2xx responses', async () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_x';
+    mockFetch({ status: 500, body: 'boom' });
+    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).rejects.toThrow(
+      /har-portal sync failed: HTTP 500/,
+    );
+  });
+
+  it('does not fetch on dryRun', async () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_x';
+    const fetchMock = mockFetch({ status: 200 });
+    await syncRepoWithControl({ repoPath: '/repo/x', dryRun: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a clear error when --cloud is requested but nothing is configured', async () => {
+    const fetchMock = mockFetch({ status: 200 });
+    await expect(
+      syncRepoWithControl({ repoPath: '/repo/x', cloud: true }),
+    ).rejects.toThrow(/not configured/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -5,6 +5,7 @@ import { syncRepoWithControl } from '../src/core/control-sync';
 // collectors are exercised by their own suites — here we only care that the
 // portal push targets the right URL, sends the bearer token, and shapes the
 // omnibus body from whatever the collectors return.
+jest.mock('../src/core/portal-credentials', () => ({ readPortalCredentials: () => null }));
 jest.mock('../src/core/control-repo-path', () => ({
   canonicalizeControlRepoPath: (p: string) => p,
 }));

--- a/tests/enterprise-free.test.ts
+++ b/tests/enterprise-free.test.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Enterprise-free guard (FE-1446).
+ *
+ * The open-core repo — the CLI (`src/`) and the Mission Control app
+ * (`control/src`) — must not carry Team-edition (enterprise) code. The portal
+ * push added in FE-1446 is deliberately generic: a bearer token over HTTP, with
+ * no identity-provider, billing, or EE-specific dependency leaking into core.
+ *
+ * This test fails the build (locally via `verify --full` and in CI) if any
+ * source file references an enterprise marker. har-portal owns all of these;
+ * core must stay free of them. If a match is a genuine false positive, narrow
+ * the pattern here with a comment — do not weaken the guard wholesale.
+ */
+
+// Case-insensitive markers of enterprise/identity/billing code that belongs to
+// har-portal, never the open core.
+const BANNED = [
+  /zitadel/i, // Zitadel OIDC — har-portal EE (FE-1449)
+  /next-auth/i, // Auth.js — har-portal EE
+  /@auth\/core/i, // Auth.js core — har-portal EE
+  /\bstripe\b/i, // billing — har-portal EE (FE-1454)
+];
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.next',
+  'dist',
+  'coverage',
+  '.git',
+  'artifacts',
+  '.har',
+]);
+
+function sourceFiles(root: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) walk(full);
+      } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+        out.push(full);
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+describe('open core stays enterprise-free', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+  const roots = [
+    path.join(repoRoot, 'src'),
+    path.join(repoRoot, 'control', 'src'),
+  ];
+  const files = roots.flatMap(sourceFiles);
+
+  it('scans a non-trivial set of source files', () => {
+    // Guard against the walker silently finding nothing (e.g. a path change).
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it('contains no enterprise markers', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      for (const pattern of BANNED) {
+        if (pattern.test(content)) {
+          offenders.push(`${path.relative(repoRoot, file)} — matched ${pattern}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/portal-credentials.test.ts
+++ b/tests/portal-credentials.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  readPortalCredentials,
+  writePortalCredentials,
+} from '../src/core/portal-credentials';
+import { getPortalTarget } from '../src/core/control-config';
+
+const PORTAL_ENV = [
+  'HAR_PORTAL_URL',
+  'HAR_PORTAL_TOKEN',
+  'HAR_CLOUD_API_URL',
+  'HAR_CLOUD_API_KEY',
+] as const;
+
+let tmpFile: string;
+
+beforeEach(() => {
+  tmpFile = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'har-creds-')),
+    'credentials.json',
+  );
+  process.env.HAR_CREDENTIALS_PATH = tmpFile;
+  for (const key of PORTAL_ENV) delete process.env[key];
+});
+
+afterEach(() => {
+  delete process.env.HAR_CREDENTIALS_PATH;
+});
+
+describe('portal credentials store', () => {
+  it('round-trips credentials and writes the file 0600', () => {
+    writePortalCredentials({
+      portalUrl: 'https://portal.example.com',
+      token: 'har_ingest_x',
+      workspace: 'acme',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const mode = fs.statSync(tmpFile).mode & 0o777;
+    expect(mode).toBe(0o600);
+    expect(readPortalCredentials()).toEqual({
+      portalUrl: 'https://portal.example.com',
+      token: 'har_ingest_x',
+      workspace: 'acme',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('returns null when the file is missing or incomplete', () => {
+    expect(readPortalCredentials()).toBeNull();
+    fs.writeFileSync(tmpFile, JSON.stringify({ portalUrl: 'https://x' }));
+    expect(readPortalCredentials()).toBeNull();
+  });
+});
+
+describe('getPortalTarget source precedence', () => {
+  it('uses stored credentials when no env is set', () => {
+    writePortalCredentials({
+      portalUrl: 'https://portal.example.com/',
+      token: 'har_ingest_stored',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(getPortalTarget()).toEqual({
+      url: 'https://portal.example.com',
+      token: 'har_ingest_stored',
+    });
+  });
+
+  it('prefers HAR_PORTAL_* env over stored credentials', () => {
+    writePortalCredentials({
+      portalUrl: 'https://stored.example.com',
+      token: 'har_ingest_stored',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    process.env.HAR_PORTAL_URL = 'https://env.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_env';
+    expect(getPortalTarget()).toEqual({
+      url: 'https://env.example.com',
+      token: 'har_ingest_env',
+    });
+  });
+});

--- a/tests/portal-login.test.ts
+++ b/tests/portal-login.test.ts
@@ -1,0 +1,37 @@
+import * as http from 'http';
+
+import { loginViaBrowser } from '../src/core/portal-login';
+
+function hitCallback(
+  loginUrl: string,
+  opts: { token?: string; state?: string; workspace?: string },
+): void {
+  const url = new URL(loginUrl);
+  const callback = url.searchParams.get('callback') as string;
+  const params = new URLSearchParams();
+  if (opts.token) params.set('token', opts.token);
+  params.set('state', opts.state ?? (url.searchParams.get('state') as string));
+  if (opts.workspace) params.set('workspace', opts.workspace);
+  http.get(`${callback}?${params.toString()}`, (res) => res.resume());
+}
+
+describe('loginViaBrowser', () => {
+  it('captures the token from the loopback callback', async () => {
+    const creds = await loginViaBrowser('https://portal.example.com', (url) =>
+      hitCallback(url, { token: 'har_ingest_abc', workspace: 'acme' }),
+    );
+    expect(creds).toMatchObject({
+      portalUrl: 'https://portal.example.com',
+      token: 'har_ingest_abc',
+      workspace: 'acme',
+    });
+  });
+
+  it('rejects on state mismatch', async () => {
+    await expect(
+      loginViaBrowser('https://portal.example.com', (url) =>
+        hitCallback(url, { token: 'har_ingest_abc', state: 'wrong-state' }),
+      ),
+    ).rejects.toThrow(/state mismatch/);
+  });
+});


### PR DESCRIPTION
Authenticated push from the `har` CLI/control to a self-hosted portal instance.

- `control-sync`: configurable portal target (base URL + bearer token) via `HAR_PORTAL_URL`/`HAR_PORTAL_TOKEN` (legacy `HAR_CLOUD_*` honored); auto-selects the authenticated omnibus `POST /api/sync` when a token is set, else the existing local Mission Control path. `--cloud` and local paths preserved.
- `har control login`: browser + loopback-callback flow; stores the returned ingest token at `~/.har/credentials.json`. `sync` reads env → stored creds → legacy alias.
- Guard test keeping `control/` + core enterprise-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)