### PR TITLE
feat(cli): clipboard copy for adaptation prompts

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -88,7 +88,7 @@ The repo-owned `.har/` directory remains the runtime contract. HAR should make i
 
 **A:** It creates a `.har/` directory with scripts, docs, metadata, environment templates, and optional stage definitions for the current repo.
 
-By default, `har env init` scaffolds boilerplate and prints a copy-paste prompt for your coding agent to adapt the harness and repo-root `AGENT.md`. Pass `--auto` to run built-in Claude adaptation instead (requires `ANTHROPIC_API_KEY`).
+By default, `har env init` scaffolds boilerplate and prints a copy-paste prompt for your coding agent to adapt the harness and repo-root `AGENT.md`. In a TTY it also offers to copy that prompt to the clipboard (or copies automatically with `--yes`). Pass `--auto` to run built-in Claude adaptation instead (requires `ANTHROPIC_API_KEY`).
 
 A typical harness includes scripts such as:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd MyApp && har env init --profile ios
 har env add-stage rocketsim   # optional: UI flow validation on the simulator
 ```
 
-After init, paste the printed adaptation prompt into your coding agent to tailor scripts to your stack. For built-in Claude adaptation: `har env init --auto` (requires `ANTHROPIC_API_KEY`).
+After init, paste the adaptation prompt into your coding agent (interactive terminals offer a clipboard copy; also saved to `.har/ADAPT-PROMPT.md`) to tailor scripts to your stack. For built-in Claude adaptation: `har env init --auto` (requires `ANTHROPIC_API_KEY`).
 
 Optional stage templates depend on the profile: `har env add-stage playwright` for browser E2E on web apps, `har env add-stage rocketsim` for simulator user-flow checks on iOS.
 

--- a/docs/src/content/docs/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/docs/getting-started/quick-start.md
@@ -20,8 +20,10 @@ The default profile targets web applications. Use `--profile cli` for libraries
 and command-line tools or `--profile ios` for an Xcode project.
 
 HAR copies an editable `.har/` scaffold, validates it, and writes an adaptation
-prompt to `.har/ADAPT-PROMPT.md`. Give that prompt to your coding agent so it can
-replace placeholders with your actual install, launch, database, and test commands.
+prompt to `.har/ADAPT-PROMPT.md`. In an interactive terminal it offers to copy
+that prompt to the clipboard (macOS / Linux / Windows, with OSC 52 fallback)
+so you can paste it into your coding agent. The agent can also read the file
+directly.
 
 To let HAR perform the Claude-based adaptation:
 

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -13,6 +13,7 @@ import type { MaintainBundleReport } from '../../harness/maintain-bundle';
 import {
   buildInitAdaptationPrompt,
   buildMaintainAdaptationPrompt,
+  offerAdaptationPromptClipboard,
   printAdaptationPrompt,
   writeAdaptationPrompt,
 } from '../../harness/adaptation-prompt';
@@ -436,7 +437,7 @@ export async function handleInit(argv: {
     if (argv.auto) {
       await handleAgentMdProposal(repoPath, argv.yes);
     } else {
-      emitManualAdaptationPrompt(repoPath, 'init', argv.profile);
+      await emitManualAdaptationPrompt(repoPath, 'init', argv.profile, undefined, argv.yes);
     }
 
     divider();
@@ -531,7 +532,13 @@ export async function handleMaintain(argv: {
       if (!result.validation.pass) {
         warn('Harness has validation errors — fix them before running --finalize.');
       }
-      emitManualAdaptationPrompt(repoPath, 'maintain', 'default', result.bundle?.report);
+      await emitManualAdaptationPrompt(
+        repoPath,
+        'maintain',
+        'default',
+        result.bundle?.report,
+        argv.yes,
+      );
       info('After your coding agent finishes adapting, record it with: har env maintain --finalize');
     }
 
@@ -624,12 +631,13 @@ export function resolveOnboardingOptions(argv: {
   };
 }
 
-function emitManualAdaptationPrompt(
+async function emitManualAdaptationPrompt(
   repoPath: string,
   mode: 'init' | 'maintain',
   profile: 'default' | 'cli' | 'ios' = 'default',
   bundleReport?: MaintainBundleReport,
-): void {
+  autoYes = false,
+): Promise<void> {
   const prompt =
     mode === 'init'
       ? buildInitAdaptationPrompt(repoPath, profile)
@@ -650,6 +658,7 @@ function emitManualAdaptationPrompt(
     info('  Reference templates are in .har/maintain/templates/');
   }
   printAdaptationPrompt(prompt);
+  await offerAdaptationPromptClipboard(prompt, { autoYes });
 }
 
 async function handleAgentMdProposal(repoPath: string, autoYes: boolean): Promise<void> {
@@ -1087,7 +1096,7 @@ function printNextSteps(auto: boolean): void {
   console.error('');
   console.error('  Read:         .har/README.md');
   if (!auto) {
-    console.error('  Adapt:        paste prompt above into your coding agent');
+    console.error('  Adapt:        paste clipboard / prompt above into your coding agent');
     console.error('  Prompt file:  .har/ADAPT-PROMPT.md');
   } else {
     console.error('  Agent guide:  AGENT.md (repo root, if applied)');

--- a/src/harness/adaptation-prompt.ts
+++ b/src/harness/adaptation-prompt.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as readline from 'readline';
+import { copyTextToClipboard } from '../utils/clipboard';
 import { writeFileSafe } from '../utils/file-ops';
+import { info, success, warn } from '../utils/logging';
 import { resolveTemplateFile } from '../utils/paths';
 import { getHarnessDir } from './manifest';
 import type { HarnessProfile } from './generator';
@@ -72,4 +75,59 @@ export function printAdaptationPrompt(content: string): void {
   }
   process.stderr.write(`${border}\n`);
   process.stderr.write('\n');
+}
+
+function askYesNo(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  return new Promise((resolve) => {
+    process.stderr.write(`${question} `);
+    rl.once('line', (answer) => {
+      rl.close();
+      const trimmed = answer.trim();
+      resolve(trimmed === '' || /^y(es)?$/i.test(trimmed));
+    });
+  });
+}
+
+export interface OfferClipboardCopyOptions {
+  /** When true, copy without prompting (still requires a TTY for OSC 52 fallback). */
+  autoYes?: boolean;
+}
+
+/**
+ * Offer to copy the adaptation prompt so the user can paste it into a coding agent.
+ * Interactive TTY: prompt [Y/n]. With autoYes: copy immediately. Non-TTY: skip.
+ */
+export async function offerAdaptationPromptClipboard(
+  content: string,
+  options: OfferClipboardCopyOptions = {},
+): Promise<boolean> {
+  const interactive = Boolean(process.stdin.isTTY && process.stderr.isTTY);
+  if (!interactive && !options.autoYes) {
+    info('Prompt also saved to .har/ADAPT-PROMPT.md (open or copy from there)');
+    return false;
+  }
+
+  let shouldCopy = options.autoYes === true;
+  if (!shouldCopy && interactive) {
+    shouldCopy = await askYesNo('Copy adaptation prompt to clipboard for your coding agent? [Y/n]');
+  }
+  if (!shouldCopy) {
+    info('Skipped clipboard copy — prompt is in .har/ADAPT-PROMPT.md');
+    return false;
+  }
+
+  const result = copyTextToClipboard(content);
+  if (result.ok) {
+    success(
+      result.method === 'osc52'
+        ? 'Copied adaptation prompt to clipboard (terminal OSC 52) — paste into your coding agent'
+        : 'Copied adaptation prompt to clipboard — paste into your coding agent',
+    );
+    return true;
+  }
+
+  warn(`Could not copy to clipboard: ${result.detail}`);
+  info('Open .har/ADAPT-PROMPT.md and paste that into your coding agent instead');
+  return false;
 }

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,103 @@
+import { spawnSync } from 'child_process';
+
+export type ClipboardMethod =
+  | 'pbcopy'
+  | 'wl-copy'
+  | 'xclip'
+  | 'xsel'
+  | 'clip'
+  | 'powershell'
+  | 'osc52';
+
+export type ClipboardResult =
+  | { ok: true; method: ClipboardMethod }
+  | { ok: false; detail: string };
+
+function commandExists(command: string): boolean {
+  const probe =
+    process.platform === 'win32'
+      ? spawnSync('where', [command], { encoding: 'utf8', stdio: ['ignore', 'ignore', 'ignore'] })
+      : spawnSync('which', [command], { encoding: 'utf8', stdio: ['ignore', 'ignore', 'ignore'] });
+  return probe.status === 0;
+}
+
+function tryPipeCommand(command: string, args: string[], text: string): boolean {
+  const result = spawnSync(command, args, {
+    input: text,
+    encoding: 'utf8',
+    stdio: ['pipe', 'ignore', 'ignore'],
+  });
+  return result.status === 0 && !result.error;
+}
+
+/** OSC 52 — works in many modern terminals (incl. remote SSH) when the emulator allows it. */
+export function writeOsc52Clipboard(text: string, stream: NodeJS.WritableStream = process.stderr): boolean {
+  if (!('isTTY' in stream) || !(stream as NodeJS.WriteStream).isTTY) return false;
+  // Soft cap: some terminals truncate large OSC 52 payloads.
+  if (Buffer.byteLength(text, 'utf8') > 200_000) return false;
+  const b64 = Buffer.from(text, 'utf8').toString('base64');
+  stream.write(`\x1b]52;c;${b64}\x07`);
+  return true;
+}
+
+function copyViaPlatformTools(text: string): ClipboardResult {
+  if (process.platform === 'darwin' && commandExists('pbcopy')) {
+    if (tryPipeCommand('pbcopy', [], text)) return { ok: true, method: 'pbcopy' };
+  }
+
+  if (process.platform === 'win32') {
+    // Prefer stdin over -Command string args (adaptation prompts can exceed cmd length limits).
+    if (commandExists('powershell')) {
+      const result = spawnSync(
+        'powershell',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          '$OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new(); Set-Clipboard -Value ([Console]::In.ReadToEnd())',
+        ],
+        {
+          input: text,
+          encoding: 'utf8',
+          stdio: ['pipe', 'ignore', 'ignore'],
+        },
+      );
+      if (result.status === 0 && !result.error) return { ok: true, method: 'powershell' };
+    }
+    if (commandExists('clip') && tryPipeCommand('clip', [], text)) {
+      return { ok: true, method: 'clip' };
+    }
+  }
+
+  if (process.platform === 'linux' || process.platform === 'freebsd' || process.platform === 'openbsd') {
+    if (commandExists('wl-copy') && tryPipeCommand('wl-copy', [], text)) {
+      return { ok: true, method: 'wl-copy' };
+    }
+    if (commandExists('xclip') && tryPipeCommand('xclip', ['-selection', 'clipboard'], text)) {
+      return { ok: true, method: 'xclip' };
+    }
+    if (commandExists('xsel') && tryPipeCommand('xsel', ['--clipboard', '--input'], text)) {
+      return { ok: true, method: 'xsel' };
+    }
+  }
+
+  return {
+    ok: false,
+    detail: 'No system clipboard command available (pbcopy, wl-copy/xclip/xsel, or clip)',
+  };
+}
+
+/**
+ * Copy text to the system clipboard when possible.
+ * Prefers native clipboard tools; falls back to OSC 52 for TTY terminals (incl. SSH).
+ */
+export function copyTextToClipboard(text: string): ClipboardResult {
+  const platform = copyViaPlatformTools(text);
+  if (platform.ok) return platform;
+
+  if (writeOsc52Clipboard(text)) {
+    return { ok: true, method: 'osc52' };
+  }
+
+  return platform;
+}

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -1,0 +1,160 @@
+import { spawnSync } from 'child_process';
+import {
+  copyTextToClipboard,
+  writeOsc52Clipboard,
+} from '../src/utils/clipboard';
+import { offerAdaptationPromptClipboard } from '../src/harness/adaptation-prompt';
+
+jest.mock('child_process', () => {
+  const actual = jest.requireActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    spawnSync: jest.fn(),
+  };
+});
+
+const mockedSpawnSync = spawnSync as jest.MockedFunction<typeof spawnSync>;
+
+describe('clipboard', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    mockedSpawnSync.mockReset();
+    jest.restoreAllMocks();
+  });
+
+  it('writeOsc52Clipboard writes base64 OSC 52 when stream is a TTY', () => {
+    const chunks: string[] = [];
+    const stream = {
+      isTTY: true,
+      write: (chunk: string) => {
+        chunks.push(chunk);
+        return true;
+      },
+    };
+
+    expect(writeOsc52Clipboard('hello', stream as unknown as NodeJS.WriteStream)).toBe(true);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toMatch(/^\x1b]52;c;[A-Za-z0-9+/=]+\x07$/);
+    expect(Buffer.from(chunks[0].slice('\x1b]52;c;'.length, -1), 'base64').toString('utf8')).toBe(
+      'hello',
+    );
+  });
+
+  it('writeOsc52Clipboard returns false when stream is not a TTY', () => {
+    const stream = { isTTY: false, write: jest.fn() };
+    expect(writeOsc52Clipboard('hello', stream as unknown as NodeJS.WriteStream)).toBe(false);
+    expect(stream.write).not.toHaveBeenCalled();
+  });
+
+  it('copyTextToClipboard uses pbcopy on macOS', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockedSpawnSync.mockImplementation((command, args) => {
+      if (command === 'which' && Array.isArray(args) && args[0] === 'pbcopy') {
+        return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+      }
+      if (command === 'pbcopy') {
+        return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+      }
+      return { status: 1, error: undefined } as ReturnType<typeof spawnSync>;
+    });
+
+    expect(copyTextToClipboard('adapt me')).toEqual({ ok: true, method: 'pbcopy' });
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
+      'pbcopy',
+      [],
+      expect.objectContaining({ input: 'adapt me' }),
+    );
+  });
+
+  it('copyTextToClipboard prefers wl-copy on Linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    mockedSpawnSync.mockImplementation((command, args) => {
+      if (command === 'which' && Array.isArray(args) && args[0] === 'wl-copy') {
+        return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+      }
+      if (command === 'wl-copy') {
+        return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+      }
+      return { status: 1, error: undefined } as ReturnType<typeof spawnSync>;
+    });
+
+    expect(copyTextToClipboard('linux prompt')).toEqual({ ok: true, method: 'wl-copy' });
+  });
+
+  it('copyTextToClipboard falls back to OSC 52 when no clipboard tool exists', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    mockedSpawnSync.mockReturnValue({ status: 1, error: undefined } as ReturnType<typeof spawnSync>);
+
+    const write = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true });
+
+    expect(copyTextToClipboard('remote ssh')).toEqual({ ok: true, method: 'osc52' });
+    expect(write).toHaveBeenCalledWith(expect.stringMatching(/^\x1b]52;c;/));
+
+    write.mockRestore();
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: process.stderr.isTTY });
+  });
+});
+
+describe('offerAdaptationPromptClipboard', () => {
+  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalStderrIsTTY = process.stderr.isTTY;
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: originalStdinIsTTY });
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: originalStderrIsTTY });
+    jest.restoreAllMocks();
+  });
+
+  it('skips when not a TTY and autoYes is false', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: false });
+
+    const copied = await offerAdaptationPromptClipboard('prompt body');
+    expect(copied).toBe(false);
+  });
+
+  it('auto-copies with --yes without prompting', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true });
+
+    mockedSpawnSync.mockImplementation((command, args) => {
+      if (process.platform === 'darwin') {
+        if (command === 'which' && Array.isArray(args) && args[0] === 'pbcopy') {
+          return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+        }
+        if (command === 'pbcopy') {
+          return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+        }
+      }
+      if (process.platform === 'linux') {
+        if (
+          command === 'which' &&
+          Array.isArray(args) &&
+          (args[0] === 'wl-copy' || args[0] === 'xclip' || args[0] === 'xsel')
+        ) {
+          return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+        }
+        if (command === 'wl-copy' || command === 'xclip' || command === 'xsel') {
+          return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+        }
+      }
+      if (process.platform === 'win32') {
+        if (command === 'where' && Array.isArray(args) && args[0] === 'powershell') {
+          return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+        }
+        if (command === 'powershell') {
+          return { status: 0, error: undefined } as ReturnType<typeof spawnSync>;
+        }
+      }
+      return { status: 1, error: undefined } as ReturnType<typeof spawnSync>;
+    });
+
+    const write = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const copied = await offerAdaptationPromptClipboard('prompt body', { autoYes: true });
+    expect(copied).toBe(true);
+    write.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- After `har env init` / `har env maintain` prints the adaptation prompt, offer to copy it to the clipboard so users can paste into their coding agent
- Multiplatform support via native tools (`pbcopy`, `wl-copy`/`xclip`/`xsel`, PowerShell/`clip`) with OSC 52 fallback for SSH/TTY terminals
- Interactive TTY prompts `[Y/n]`; `--yes` copies without prompting; always still writes `.har/ADAPT-PROMPT.md`

## Test plan
- [x] Unit tests for clipboard helpers + offer flow (`tests/clipboard.test.ts`)
- [x] Full harness verify (`./.har/verify.sh 2 --full`)
- [ ] Manually run `har env init` in a throwaway dir and confirm the copy prompt / clipboard paste works on your platform
- [ ] Confirm non-TTY (piped) skips the prompt and points at `.har/ADAPT-PROMPT.md`


Made with [Cursor](https://cursor.com)