### PR TITLE
docs: refresh README and CONTRIBUTING for clearer onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 Guide for developing the CLI locally and testing it against real (or sample) repositories.
 
-**Coding agents:** read [AGENT.md](./AGENT.md) first for architecture rules, where to put changes, and extension points. This file covers setup, workflow, and PR details.
+**Coding agents:** read [AGENT.md](./AGENT.md) first for architecture rules, where to put changes, and extension points. This file covers setup, the dogfood harness loop, workflow, and PR details.
+
+**Maintainers:** release pipeline, npm/Docker secrets, and version coupling live in [RELEASING.md](./RELEASING.md).
 
 By participating in this project, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
@@ -13,13 +15,13 @@ By submitting a pull request or other contribution, you agree to the [Contributo
 - **Node.js ≥ 20**
 - **npm**
 - **`ANTHROPIC_API_KEY`** — required only for `--auto` on `har env init` / `har env maintain`
-- **Docker** — optional; needed when running harness scripts (`setup-infra.sh`, `launch.sh`, etc.) on projects that use containers
+- **Docker** — optional; needed when running harness scripts on projects that use containers, and for `har control up`
 
 ## Setup
 
 ```bash
-git clone https://github.com/antoineFrau/har har-project
-cd har-project
+git clone https://github.com/os-factory/har.git
+cd har
 npm install
 npm run build
 ```
@@ -32,9 +34,82 @@ To use HAR tools from Cursor (`har_launch_environment`, `har_run_verification`, 
 cp .cursor/mcp.json.example .cursor/mcp.json
 ```
 
-Edit `.cursor/mcp.json` and replace `/path/to/your/checkout` with the absolute path to your clone of this repo. The file is gitignored — each contributor keeps their own copy.
+Edit `.cursor/mcp.json` and replace `/path/to/your-checkout` with the absolute path to your clone of this repo. The file is gitignored — each contributor keeps their own copy.
 
 Restart Cursor (or reload MCP servers) after creating or changing the file.
+
+## How HAR works
+
+HAR is a layered CLI + MCP control plane. Business logic lives in `core/` and `harness/`. `cli/` and `mcp/` are thin adapters: parse input, call core, format output.
+
+```
+cli/  mcp/          ← adapters (flags, JSON, MCP tool schemas)
+  ↓
+core/               ← orchestration, public execution API (run-service.ts)
+  ↓
+harness/            ← .har/ contract, schemas, manifest/stages I/O
+  ↓
+utils/              ← generic helpers (shell, paths, logging)
+```
+
+`llm/` is the optional authoring agent for `har env init --auto` and `har env maintain --auto`. `templates/` holds scaffold assets copied into target repos — not runtime logic.
+
+Canonical schemas live in [`packages/schemas/src/schema.ts`](packages/schemas/src/schema.ts) and are re-exported by [`src/harness/schema.ts`](src/harness/schema.ts).
+
+### Dependency rules
+
+| Layer | May import | Must not import |
+|-------|------------|-----------------|
+| `cli/`, `mcp/` | `core/`, `harness/`, `utils/` | each other |
+| `core/` | `harness/`, `utils/`, `llm/` | `cli/`, `mcp/` |
+| `harness/` | `utils/` | `core/`, `cli/`, `mcp/`, `llm/` |
+| `utils/` | other `utils/` | anything with HAR domain concepts |
+| `llm/` | `harness/`, `utils/` | `core/`, `cli/`, `mcp/` |
+
+### Concepts you will hit often
+
+| Concept | Meaning | Primary code |
+|---------|---------|--------------|
+| **Slot** | Numbered agent environment (1..N) with its own ports/env | [`src/core/slot-registry.ts`](src/core/slot-registry.ts) |
+| **Session worktree** | Isolated git worktree created on `launch`; all edits go here | [`src/core/run-service.ts`](src/core/run-service.ts) + `.har/launch.sh` |
+| **Stage** | Project-defined runnable step (`launch`, `verify`, `test`, …) | [`src/harness/stages.ts`](src/harness/stages.ts) |
+| **Validation** | Tree-hash record written after a passing full verify | [`src/core/validations.ts`](src/core/validations.ts) |
+| **Commit gate** | Git hooks that block commits unless the staged tree matches a validation | [`src/core/hooks.ts`](src/core/hooks.ts) |
+
+## Use HAR to develop HAR
+
+This repository **dogfoods** HAR. Prefer the harness over ad-hoc shell commands.
+
+| Harness | Profile | Use when changing |
+|---------|---------|-------------------|
+| [`.har/`](.har/) | `cli` | `src/`, `packages/`, `tests/`, root docs |
+| [`control/.har/`](control/.har/) | `default` | `control/` Mission Control app |
+
+Run harness commands from the directory that owns the harness (e.g. `cd control` for Mission Control).
+
+### Required loop
+
+1. **Launch before editing** — `har env launch 1` (or `./.har/launch.sh 1`). Launch creates a fresh session worktree and prints its **work dir**.
+2. **Edit only in that work dir** — never in the main checkout. Changes there hot-reload for running slots when applicable.
+3. **Verify through the harness** — `har env verify 1` (fast) then `har env verify 1 --full` before declaring done.
+4. **Commit in the session worktree** — if the commit gate is installed, commits that do not match a passing full-verify validation are blocked.
+5. **Complete or teardown when finished** — `har env complete 1` (full verify + validation + teardown) or `har env teardown 1`. The session **branch is kept** so you can push a PR.
+
+```bash
+har env launch 1
+# make ALL edits under the printed work dir
+har env verify 1
+har env verify 1 --full
+har env complete 1
+```
+
+Shell fallback when the CLI is not installed: `./.har/launch.sh 1`, `./.har/verify.sh 1 --full`, `./.har/teardown.sh 1`.
+
+In Cursor, prefer MCP tools (`har_launch_environment`, `har_run_verification`, `har_complete_environment`) once [`.cursor/mcp.json`](.cursor/mcp.json.example) points at your checkout.
+
+### Commit gate
+
+With `har hooks install`, `git commit` is blocked unless the staged tree matches a state that passed full verify (a tree hash under `.har/validations/`). Any edit after verify requires re-running `har env verify <id> --full`. Stage everything you verified (`git add -A`); do not bypass the gate (`--no-verify`, `HAR_SKIP_GATE=1`).
 
 ## Running the CLI locally
 
@@ -70,8 +145,6 @@ npm run dev -- env --help
 npm install -g .
 ```
 
-Same as a global npm install, but from your working tree. Re-run after rebuilding.
-
 ### Run the built binary directly
 
 ```bash
@@ -94,6 +167,7 @@ npm unlink -g @osfactory/har
 | `npm run test:watch` | Run tests in watch mode |
 | `npm run typecheck` | TypeScript check (`tsc --noEmit`) |
 | `npm run lint` | ESLint on `src/` |
+| `npm run drift --prefix docs` | Docs contract check (CLI/MCP/schemas vs docs site) |
 
 The build step bundles TypeScript with esbuild and copies:
 
@@ -102,24 +176,38 @@ The build step bundles TypeScript with esbuild and copies:
 
 If you change templates or prompts, rebuild before testing a linked install.
 
+### Docs drift
+
+Full verify runs `docs-drift` (`npm run drift --prefix docs`). Changing public CLI commands, MCP tools, stage kinds, stage templates, or skill IDs without updating the docs site will fail verification. Fix the docs under `docs/src/content/docs/` (and keep [docs/check-drift.mjs](docs/check-drift.mjs) green).
+
+## CLI surface
+
+Top-level command groups (see `har <cmd> --help`):
+
+| Command | Purpose |
+|---------|---------|
+| `har env …` | Harness lifecycle (init, maintain, launch, verify, complete, …) |
+| `har agents …` | Scaffold/remove agent skills (`/setup-har`, `/har-wt`, `/har-maintain`) |
+| `har control …` | Local Mission Control dashboard |
+| `har hooks …` | Commit gate and Claude worktree guard |
+| `har mcp` | MCP stdio server |
+| `har preferences …` | User onboarding defaults (`~/.har/preferences.json`) |
+| `har telemetry …` | Agent usage telemetry via opentelemetry-hooks |
+
 ## Testing on a project
 
 ### Quick test (no API key)
-
-Scaffold boilerplate and print the coding-agent adaptation prompt:
 
 ```bash
 cd /path/to/your-project
 har env init
 ```
 
-For CLI/library repos (no PM2; optional Docker via `harness.env` infra flags):
+For CLI/library repos:
 
 ```bash
 har env init --profile cli
 ```
-
-This creates `.har/` with scripts and config. Validation will warn about TODO placeholders in `harness.env` and `verify.sh` until you paste the prompt into your coding agent (or edit manually).
 
 ### Full test (with built-in Claude adaptation)
 
@@ -128,8 +216,6 @@ export ANTHROPIC_API_KEY=your_key
 cd /path/to/your-project
 har env init --auto
 ```
-
-The CLI will copy the boilerplate, call Claude to adapt it to the repo, and propose `AGENT.md` at the repo root. Apply the proposal when prompted, or pass `--yes` to auto-apply.
 
 ### Useful flags
 
@@ -141,10 +227,9 @@ The CLI will copy the boilerplate, call Claude to adapt it to the repo, and prop
 | `--yes` | Auto-apply the `AGENT.md` proposal (with `--auto`) |
 | `--smoke` | Run `setup-infra.sh` after init |
 | `--verbose` | Extra logging |
+| `--profile <default\|cli\|ios>` | Choose harness boilerplate |
 
 ### Mission Control dashboard
-
-Local observability UI (Next.js + shadcn/ui + Postgres):
 
 ```bash
 har control up          # pulls theosfactory/har-control:<cli-version> from Docker Hub
@@ -156,22 +241,18 @@ cd control && npm run dev   # dashboard development without Docker app image
 
 **Port 3847** is shared by `har control up` (Docker) and Mission Control harness slot 1 (`cd control && har env launch 1`). Do not run both at once on the default port:
 
-- **Agent dev** (hot reload, worktrees): `cd control && har env launch 1` — preflight auto-picks an alternate port when 3847 is busy and names `har control up` as the cause.
-- **Packaged dashboard** (Docker image): `har control up` / `har control down` — warns if harness slot 1 is already active.
+- **Agent dev** (hot reload, worktrees): `cd control && har env launch 1`
+- **Packaged dashboard** (Docker image): `har control up` / `har control down`
 
 See [`control/AGENT.md`](./control/AGENT.md).
 
 ### Sample fixtures
 
-The repo includes minimal apps under `tests/fixtures/`:
-
 | Fixture | Stack | Notes |
 |---------|-------|-------|
-| `go-gin-pg/` | Go + Gin + PostgreSQL | Clean — no `.har/` yet |
-| `python-fastapi-pg/` | Python + FastAPI + PostgreSQL | Clean |
-| `node-react-pg/` | Node + Express + PostgreSQL | May already have `.har/` — use `--force` or another fixture |
-
-Copy a fixture to a temp directory to avoid modifying the repo:
+| `tests/fixtures/go-gin-pg/` | Go + Gin + PostgreSQL | Clean — no `.har/` yet |
+| `tests/fixtures/python-fastapi-pg/` | Python + FastAPI + PostgreSQL | Clean |
+| `tests/fixtures/node-react-pg/` | Node + Express + PostgreSQL | May already have `.har/` — use `--force` or another fixture |
 
 ```bash
 cp -r tests/fixtures/go-gin-pg /tmp/har-test
@@ -181,8 +262,6 @@ har env init
 
 ### After init — run the harness
 
-**Preferred — har CLI or MCP** (persists run history):
-
 ```bash
 har env launch 1
 har env verify 1
@@ -191,16 +270,7 @@ har env teardown 1
 har env status
 ```
 
-In Cursor: use `har_launch_environment`, `har_run_verification`, and `har_teardown_environment`.
-
-**Shell fallback** (no CLI/MCP installed):
-
-```bash
-./.har/setup-infra.sh
-./.har/launch.sh 1
-./.har/verify.sh 1
-./.har/teardown.sh 1
-```
+Shell fallback: `./.har/setup-infra.sh`, `./.har/launch.sh 1`, `./.har/verify.sh 1`, `./.har/teardown.sh 1`.
 
 ## Upgrading HAR
 
@@ -228,63 +298,70 @@ src/
 ├── index.ts                 # Entry point
 ├── cli/
 │   ├── index.ts             # yargs setup
-│   └── commands/            # env.ts, mcp.ts
+│   └── commands/            # env, agents, control, hooks, mcp, preferences, telemetry
 ├── core/
 │   ├── harness.ts           # init, maintain, describe
 │   ├── run-service.ts       # Public execution API (CLI/MCP import this)
 │   ├── local-executor.ts    # Local bash/script stage runner
+│   ├── slot-registry.ts     # .har/slots/agent-<id>.json
+│   ├── validations.ts       # Tree-hash validation records
+│   ├── hooks.ts             # Commit gate install / check
 │   ├── runs.ts              # Local run history (.har/runs/)
-│   ├── results.ts           # Normalized stage result parsing
-│   ├── types.ts             # ExecutionContext, StageExecutor, shared types
-│   └── run.ts               # Re-exports from run-service (compat)
+│   └── types.ts             # ExecutionContext, StageExecutor, shared types
 ├── harness/
 │   ├── generator.ts         # Copy boilerplate into .har/
-│   ├── drift.ts             # Compare .har/ to bundled templates
-│   ├── manifest.ts          # manifest.json read/write
 │   ├── stages.ts            # stages.json registry I/O
-│   ├── validator.ts         # Post-scaffold validation + smoke tests
-│   ├── parser.ts            # harness presence helpers
-│   ├── agent-md.ts          # AGENT.md proposal flow
-│   └── schema.ts            # Canonical Zod schemas
-├── mcp/
-│   ├── server.ts            # MCP tool handlers
-│   ├── schemas.ts           # MCP input/output Zod schemas
-│   └── schema-tools.ts      # Shared JSON Schema helpers
-├── llm/
-│   ├── authoring-agent.ts   # Claude agent for repo adaptation
-│   ├── tools.ts             # LLM tool definitions
-│   └── prompts/             # System prompts (copied to dist/ on build)
-├── templates/
-│   ├── har-boilerplate/     # Files copied into target .har/
-│   └── AGENT.md.template    # Template for root AGENT.md proposal
+│   ├── schema.ts            # Re-exports packages/schemas
+│   ├── stage-templates.ts   # har env add-stage playwright|rocketsim
+│   └── …
+├── mcp/                     # MCP stdio adapter
+├── llm/                     # Optional --auto authoring agent
+├── templates/               # Files copied into target .har/ on init
 └── utils/                   # File ops, shell, logging, validation
 
-tests/
-├── fixtures/                # minimal-harness, node-react-pg, go-gin-pg, ...
-└── *.test.ts                # Unit/integration tests
+packages/schemas/            # Canonical Zod schemas (@har/schemas)
+control/                     # Mission Control (Next.js) + control/.har/
+docs/                        # Astro/Starlight site (harproject.cloud)
+tests/                       # Jest tests + fixtures/
+release/                     # semantic-release helpers
+.har/                        # Dogfood harness for the CLI
 ```
+
+## Where to put changes
+
+| Change | Location |
+|--------|----------|
+| Schema, stage kinds, result shapes | `packages/schemas/src/schema.ts` (+ `src/harness/schema.ts` re-export) |
+| Manifest / stages.json I/O | `src/harness/manifest.ts`, `stages.ts` |
+| Scaffold copy, boilerplate wiring | `src/harness/generator.ts` |
+| Init / maintain / describe orchestration | `src/core/harness.ts` |
+| Run orchestration (launch, verify, teardown) | `src/core/run-service.ts` |
+| CLI subcommand or flag | `src/cli/commands/<group>.ts` (+ register in `src/cli/index.ts` if new top-level) |
+| MCP tool handler or JSON Schema | `src/mcp/server.ts`, `schemas.ts` |
+| Files copied into target `.har/` | `src/templates/har-boilerplate*/` |
+| Optional stage templates | `src/templates/stage-templates/` (via `har env add-stage`) |
+| Generic shell/path/logging helper | `src/utils/` |
+
+When unsure: put domain logic in `harness/` or `core/`, never in an adapter. See [AGENT.md](./AGENT.md) for anti-patterns and extension points.
 
 ## TypeScript conventions
 
-- **Zod at boundaries** — canonical schemas live in `src/harness/schema.ts`. Parse CLI/MCP inputs with `.parse()` / `.safeParse()`; infer types with `z.infer`.
+- **Zod at boundaries** — parse CLI/MCP inputs with `.parse()` / `.safeParse()`; infer types with `z.infer`.
 - **`strict: true` always** — do not weaken compiler settings in `tsconfig.json`.
 - **Prefer `unknown` over `any`** — narrow with Zod or type guards before use.
 - **Const arrays for enums** — e.g. `HAR_STAGE_KINDS` drives Zod, MCP JSON Schema, and tests from one source.
 - **Core vs adapters** — business logic in `src/core/` and `src/harness/`; `cli/` and `mcp/` handle argument parsing and formatting only.
-- **Dependency direction** — `harness/` must not import from `core/` or `mcp/`; `utils/` stays generic.
-- **Explicit public API** — import execution from `src/core/run-service.ts` (or `run.ts` re-export).
 - **Fixture-first tests** — mock `.har/` scripts under `tests/fixtures/minimal-harness/`; avoid real Docker in unit tests.
-- **Parity tests** — when legacy wrappers delegate to `runStage`, keep tests that both paths behave the same.
-- **Run `npm run typecheck`, `npm run lint`, and `npm test`** before opening a PR.
+- **Run `npm run typecheck`, `npm run lint`, and `npm test`** before opening a PR (or rely on `har env verify 1 --full`).
 
 ## Making changes
 
-### Templates (`src/templates/har-boilerplate/`)
+### Templates (`src/templates/har-boilerplate*/`)
 
 These files are copied verbatim into a target repo's `.har/` on `har env init`. After editing:
 
 1. Run `npm run build`
-2. Test with `har env init --force --profile cli` on a fixture
+2. Test with `har env init --force --profile cli` on a fixture (or `--profile default` / `ios`)
 
 Placeholders like `__PROJECT_NAME__` in `harness.env` are substituted during scaffold.
 
@@ -294,21 +371,27 @@ System prompts for the optional `--auto` authoring agent. Rebuild to copy them i
 
 ### CLI commands
 
-Add or modify subcommands in `src/cli/commands/env.ts` and register them in the yargs builder there.
+Add or modify subcommands in the matching file under `src/cli/commands/` (`env.ts`, `agents.ts`, `control.ts`, `hooks.ts`, `mcp.ts`, `preferences.ts`, `telemetry.ts`). Register new top-level commands in `src/cli/index.ts`. Prefer implementing orchestration in `src/core/` and keeping the CLI as a thin adapter.
+
+### Stage templates
+
+1. Add a bundle under `src/templates/stage-templates/<name>/`
+2. Register the id in `src/harness/stage-templates.ts`
+3. Rebuild and test with `har env add-stage <name>` on a fixture
 
 ### Tests
 
-Jest is configured to pick up `tests/**/*.test.ts`. Add unit tests alongside fixtures as the test suite grows.
+Jest picks up `tests/**/*.test.ts`. Add unit tests alongside fixtures as the suite grows. Mission Control uses Vitest and Playwright under `control/`.
 
 ## Pull requests
 
 Before opening a PR:
 
 ```bash
-npm run typecheck
-npm run lint
-npm test
-npm run build
+har env verify 1 --full
+# or, without the harness:
+npm run typecheck && npm run lint && npm test && npm run build
+npm run drift --prefix docs   # if you touched CLI/MCP/schemas/templates/docs
 ```
 
 Describe how you tested (e.g. `har env init` on `go-gin-pg` fixture).
@@ -337,101 +420,4 @@ BREAKING CHANGE: run records now require runId v2 fields
 
 Use scopes when helpful (`feat(cli):`, `fix(control):`). Squash-merge PR titles should follow the same format — they become the commit on `main`.
 
-## Releases
-
-### npm packages
-
-| Package | Published? | Notes |
-|---------|------------|-------|
-| `@osfactory/har` | **Yes** | Public npm package; global `har` binary |
-| `@har/control` | No | `"private": true`; Mission Control source in monorepo |
-| `@har/schemas` | No | `"private": true`; consumed via monorepo path in `control/` |
-
-### npm organization (`@osfactory`)
-
-Before the first public release, maintainers must own the **`@osfactory`** scope on npm:
-
-1. Sign in at [npmjs.com](https://www.npmjs.com/) as a project maintainer.
-2. Create the **`@osfactory`** organization: [npmjs.com/org/create](https://www.npmjs.com/org/create) (free for public packages).
-3. Add other maintainers under **Organization → Members**.
-4. Create an **Automation** token with **Publish** access to `@osfactory/har` (and scope-wide publish if you prefer).
-5. Add the token as the `NPM_TOKEN` repository secret (see below).
-
-The root `package.json` sets `"publishConfig": { "access": "public" }` so scoped publishes are public by default.
-
-### Initial public version
-
-The first npm release is **`0.1.0`**, matching the current root `package.json`. Tag that baseline on `main` once before enabling automated releases (see below).
-
-### Test a publish tarball locally
-
-`prepublishOnly` runs `npm run build` automatically. To smoke-test the packed artifact before release:
-
-```bash
-npm run build
-npm pack
-npm install -g osfactory-har-*.tgz
-har --help
-npm uninstall -g @osfactory/har
-rm osfactory-har-*.tgz
-```
-
-The tarball should contain `dist/` (bundled CLI + templates + prompts), `control/docker-compose*.yml`, plus `package.json`, `README.md`, `LICENSE`, and this changelog — not the Mission Control app source or test fixtures.
-
-Maintainers do **not** hand-cut version tags after the baseline. Merge conventional commits to `main`; the [Release workflow](.github/workflows/release.yml) runs on every push to `main` and, when semantic-release finds releasable commits:
-
-1. Runs full CLI + Mission Control verification
-2. Bumps `@osfactory/har`, `@har/control`, and `@har/schemas` to the same version (npm package prepared, **not** published yet)
-3. Creates git tag `vX.Y.Z` and a **GitHub Release** (with CLI tarball + compose assets)
-4. Pushes **`theosfactory/har-control`** to Docker Hub (`X.Y.Z`, `X.Y`, `X`, and `latest`)
-5. Publishes `@osfactory/har` to **npm** only after the Docker push succeeds
-
-If there is nothing to release, verify still runs and publish steps are skipped. If Docker publish fails, npm is **not** published for that tag (fix the image, then use [Publish Docker (manual)](.github/workflows/publish-docker.yml) and publish npm from the tag, or re-run the failed jobs).
-
-### Maintainer setup
-
-Before the first automated release, tag the current baseline on `main` so semantic-release continues from the existing version:
-
-```bash
-# one-time, when package.json is already 0.1.0
-git tag v0.1.0 && git push origin v0.1.0
-```
-
-Repository secrets:
-
-| Secret | Used by |
-|--------|---------|
-| `NPM_TOKEN` | npm publish for `@osfactory/har` (Automation token with publish access to the `@osfactory` scope) |
-| `DOCKERHUB_TOKEN` | Docker Hub publish for `theosfactory/har-control` (PAT with read/write on the repo) |
-| `GITHUB_TOKEN` | GitHub Release (provided by Actions) |
-
-Dry-run the next release from the Actions tab (**Release → Run workflow → Dry run**) or locally:
-
-```bash
-npm ci
-GITHUB_TOKEN=... NPM_TOKEN=... npx semantic-release --dry-run
-```
-
-### Version coupling
-
-`@osfactory/har`, Mission Control (`control/`), and `@har/schemas` share one semver. [semantic-release](release.config.cjs) keeps them aligned:
-
-1. `@semantic-release/npm` bumps root `package.json` with `npmPublish: false` (prepare only)
-2. [`release/sync-package-versions.js`](release/sync-package-versions.js) syncs `control/` and `packages/schemas/`
-3. `@semantic-release/github` creates git tag `vX.Y.Z` and the GitHub Release
-4. The Release workflow `publish-docker` job pushes `theosfactory/har-control:X.Y.Z` (plus `X.Y`, `X`, and **`latest`**)
-5. The `publish-npm` job publishes `@osfactory/har@X.Y.Z` to npmjs **after** Docker succeeds
-6. Installed CLI reads its own `package.json` version and pulls `theosfactory/har-control:<same-version>` on `har control up`
-
-Override with `HAR_CONTROL_IMAGE` / `HAR_CONTROL_IMAGE_TAG`, or use `har control up --build` / `HAR_CONTROL_BUILD=true` to build locally from a git checkout.
-
-To publish the Mission Control image manually (maintainers):
-
-```bash
-docker login
-./release/publish-control-image.sh
-```
-
-Releases also publish via the Release workflow automatically. To republish an existing tag manually, use [Publish Docker](.github/workflows/publish-docker.yml) (workflow_dispatch; set **force** to rebuild if the version tag already exists) or `./release/publish-control-image.sh`.
-
-Docker publish builds `linux/amd64` and `linux/arm64` in parallel on native runners (not QEMU), with per-platform GitHub Actions cache. If the exact `theosfactory/har-control:X.Y.Z` tag already exists, the build is skipped unless **force** is set.
+Maintainer release mechanics (npm, Docker Hub, secrets, version coupling): [RELEASING.md](./RELEASING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,7 +321,7 @@ src/
 
 packages/schemas/            # Canonical Zod schemas (@har/schemas)
 control/                     # Mission Control (Next.js) + control/.har/
-docs/                        # Astro/Starlight site (harproject.cloud)
+docs/                        # Astro/Starlight site (harproject.dev)
 tests/                       # Jest tests + fixtures/
 release/                     # semantic-release helpers
 .har/                        # Dogfood harness for the CLI

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Release](https://img.shields.io/github/v/release/os-factory/har)](https://github.com/os-factory/har/releases)
 [![CI](https://github.com/os-factory/har/actions/workflows/test.yml/badge.svg)](https://github.com/os-factory/har/actions/workflows/test.yml)
-[![Documentation](https://img.shields.io/badge/docs-harproject.cloud-38c976)](https://harproject.cloud/)
+[![Documentation](https://img.shields.io/badge/docs-harproject.dev-38c976)](https://harproject.dev/)
 
 **Give coding agents a real place to work.**
 
@@ -31,7 +31,7 @@ har env verify 1 --full   # run the project's real checks, record what passed
 
 That’s it. Your agents discover launch, verify, and teardown through the project’s `.har/` contract — not by guessing shell commands.
 
-Full walkthrough: [Quick start](https://harproject.cloud/docs/getting-started/quick-start/).
+Full walkthrough: [Quick start](https://harproject.dev/docs/getting-started/quick-start/).
 
 ## How it works
 
@@ -58,11 +58,11 @@ HAR coordinates the work around the model so agents can focus on the code — an
 
 ## Documentation
 
-Everything beyond install and first commands lives at **[https://harproject.cloud/](https://harproject.cloud/)**:
+Everything beyond install and first commands lives at **[https://harproject.dev/](https://harproject.dev/)**:
 
-- [Introduction](https://harproject.cloud/docs/getting-started/introduction/) · [Core concepts](https://harproject.cloud/docs/getting-started/concepts/)
-- [CLI reference](https://harproject.cloud/docs/reference/cli/) · [MCP tools](https://harproject.cloud/docs/reference/mcp/)
-- [Mission Control](https://harproject.cloud/docs/guides/mission-control/) · [Architecture](https://harproject.cloud/docs/project/architecture/)
+- [Introduction](https://harproject.dev/docs/getting-started/introduction/) · [Core concepts](https://harproject.dev/docs/getting-started/concepts/)
+- [CLI reference](https://harproject.dev/docs/reference/cli/) · [MCP tools](https://harproject.dev/docs/reference/mcp/)
+- [Mission Control](https://harproject.dev/docs/guides/mission-control/) · [Architecture](https://harproject.dev/docs/project/architecture/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,294 +1,71 @@
 <p align="center">
-  <img src="logo.png" alt="har logo" width="120">
+  <img src="logo.png" alt="HAR logo" width="120">
 </p>
 
-# har — Your AI harness orchestrator
+# HAR — Harnesses for coding agents
 
 [![Release](https://img.shields.io/github/v/release/os-factory/har)](https://github.com/os-factory/har/releases)
 [![CI](https://github.com/os-factory/har/actions/workflows/test.yml/badge.svg)](https://github.com/os-factory/har/actions/workflows/test.yml)
 [![Documentation](https://img.shields.io/badge/docs-harproject.cloud-38c976)](https://harproject.cloud/)
 
-**Make any repository agent-ready without binding it to one coding agent, test runner, or hosted platform.**
+**Give coding agents a real place to work.**
 
-HAR is an open-source CLI and MCP control plane for project-owned development harnesses. It scaffolds an editable `.har/` runtime contract so humans and MCP-capable coding agents can discover how to launch, verify, reset, inspect, and tear down a repository.
+HAR turns any repository into a reproducible workspace with isolated worktrees, project-owned commands, and evidence that changes actually pass.
 
-HAR does not own the coding LLM and does not replace CI/CD. It gives agents a stable, machine-readable way to use the workflow your team already trusts.
-
-Planning tools decide what to build. HAR binds that durable work identity to an
-isolated execution attempt and verifiable evidence: runs, artifacts, telemetry,
-and the exact Git tree that passed.
-
-## How It Works
-
-1. **Project-owned harness** — `.har/` contains editable scripts, docs, environment metadata, logs, artifacts, and optional stage definitions.
-2. **CLI control plane** — `har env ...` scaffolds, maintains, launches, verifies, reports status, and tears down local or self-hosted harness runs.
-3. **MCP adapter** — agents use HAR MCP tools to describe the project, run generic stages, read logs, list artifacts, and inspect status without learning repo-specific shell details.
-4. **Generic stages** — setup, launch, verify, test, inspect, reset, teardown, and custom stages expose normalized status, logs, durations, artifacts, and URLs.
-5. **Configurable agent slots** — parallel environment limits are defined in `.har/stages.json` (`agentSlots`) and `.har/harness.env`, not by the HAR CLI.
-6. **Optional stage templates** — add workflows like Playwright with `har env add-stage playwright`. They compile to generic stages (`test`, `custom`, etc.), not hardcoded HAR APIs.
-7. **Durable work evidence** — optionally launch with `--work-id` so slot sessions, retries, cost, and exact-tree validations remain attributable after teardown.
-
-![Mission Control Factory overview](docs/public/assets/factory-overview.png)
+Works with **Claude Code** · **Cursor** · **Codex** · any MCP agent.
 
 ## Install
 
-**From npm:**
-
 ```bash
-npm install -g @osfactory/har@latest
+npm install -g @osfactory/har
 ```
 
-**From source:**
-
-```bash
-git clone https://github.com/os-factory/har har-project && cd har-project
-npm install && npm run build && npm link
-```
-
-Read the [full documentation](https://harproject.cloud/). See [AGENT.md](./AGENT.md) for architecture and coding-agent guidance, and [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development workflow, testing on sample projects, and project layout. To report security issues, see [SECURITY.md](./SECURITY.md).
-
-## Harness profiles
-
-`har env init` scaffolds `.har/` from a boilerplate profile. Pick the one that matches what agents need to run — you only choose this once at init time.
-
-| Profile | Best for | What you get |
-|---------|----------|--------------|
-| `default` | Web apps (Next.js, Rails, Django, etc.) | Docker Compose for shared infra, PM2 for the primary app, per-slot ports and preview URLs |
-| `cli` | CLI tools, libraries, npm packages | No PM2 or port wiring — agents run project commands in an isolated git worktree; optional Docker for databases |
-| `ios` | iOS / Swift mobile apps | xcodebuild + iOS Simulator; configure scheme, project, and simulator in `harness.env` |
-
-```bash
-# Web app (default — omit --profile)
-cd my-web-app && har env init
-
-# CLI tool or library
-cd my-cli && har env init --profile cli
-
-# iOS app
-cd MyApp && har env init --profile ios
-har env add-stage rocketsim   # optional: UI flow validation on the simulator
-```
-
-After init, paste the printed adaptation prompt into your coding agent to tailor scripts to your stack. For built-in Claude adaptation: `har env init --auto` (requires `ANTHROPIC_API_KEY`).
-
-Optional stage templates depend on the profile: `har env add-stage playwright` for browser E2E on web apps, `har env add-stage rocketsim` for simulator user-flow checks on iOS.
-
-## Quick start
+## Get started
 
 ```bash
 cd my-app
-har env init                  # or --profile cli / --profile ios
-
-# Paste the printed prompt into your coding agent to adapt .har/ and AGENT.md
-git add .har/ AGENT.md
-git commit -m "Add agent harness"
-
-har env launch 1
-har env verify 1
+har env init              # scaffold .har/ and print a prompt for your coding agent
+har env launch 1          # isolated worktree + running stack for agent slot 1
+har env verify 1 --full   # run the project's real checks, record what passed
 ```
 
-To correlate execution with an issue or ticket:
+That’s it. Your agents discover launch, verify, and teardown through the project’s `.har/` contract — not by guessing shell commands.
 
-```bash
-har env launch 1 --work-id "github:acme/widget#123" --work-source github
-har env complete 1
-```
+Full walkthrough: [Quick start](https://harproject.cloud/docs/getting-started/quick-start/).
 
-Shell fallback when the CLI is not installed: `./.har/setup-infra.sh`, `./.har/launch.sh 1`, `./.har/verify.sh 1`.
+## Why HAR
 
-See [Harness profiles](#harness-profiles) above if your repo is a CLI/library or iOS app rather than a web app.
+- **Project-owned** — The workflow lives with the code, not inside a vendor dashboard.
+- **Agent-agnostic** — One stable contract for CLI users, MCP agents, and future tools.
+- **Evidence-first** — Every run can leave logs, artifacts, status, and a validated tree hash.
 
-## Agent skills (/setup-har, /har-wt, /har-maintain)
+## What HAR is not
 
-`har env init` can scaffold **project-owned skills/commands** for coding agents, so the har workflow is one slash command away for every teammate who clones the repo:
+- A coding model
+- A replacement for CI/CD
+- A new test runner
+- A hosted platform lock-in
 
-| Skill | Who invokes it | What it does |
-|-------|----------------|--------------|
-| `/setup-har` | You, once | Installs har if missing, picks a profile, runs `har env init`, performs the adaptation prompt itself, proves launch + verify, commits |
-| `/har-wt` | The agent, on every coding task | Launches a harness slot, does all edits in the session worktree (never the main checkout), verifies through the harness |
-| `/har-maintain` | You, when the harness drifts | Runs `har env maintain`, applies the adaptation, finalizes and re-verifies |
+HAR coordinates the work around the model so agents can focus on the code — and reviewers can trust the result.
 
-Targets are auto-detected at `init`/`maintain` (or forced with `--agents claude,cursor,codex`); you can also manage them standalone:
+## Documentation
 
-```bash
-har agents install --claude --cursor   # .claude/skills/ + .cursor/commands/ (committed to the repo)
-har agents install --codex             # ~/.codex/prompts/ (global — Codex has no per-repo prompts)
-har agents remove --claude
-```
+Everything beyond install and first commands lives at **[https://harproject.cloud/](https://harproject.cloud/)**:
 
-Scaffolded files carry a `managed by har` header and are refreshed by `har env maintain`; files you edit by hand are left alone.
+- [Introduction](https://harproject.cloud/docs/getting-started/introduction/) · [Core concepts](https://harproject.cloud/docs/getting-started/concepts/)
+- [CLI reference](https://harproject.cloud/docs/reference/cli/) · [MCP tools](https://harproject.cloud/docs/reference/mcp/)
+- [Mission Control](https://harproject.cloud/docs/guides/mission-control/) · [Architecture](https://harproject.cloud/docs/project/architecture/)
 
-**Optional enforcement (Claude Code):** make `/har-wt` self-triggering instead of memory-dependent —
+## Contributing
 
-```bash
-har hooks install --claude
-```
-
-installs a `PreToolUse` guard (`.har/hooks/claude-worktree-guard.sh` + an entry in `.claude/settings.json`) that blocks `Edit`/`Write` in the **main checkout** of a har repo and points the agent to `/har-wt`. Edits inside session worktrees pass through. Remove with `har hooks uninstall --claude`; humans can bypass with `HAR_SKIP_WT_GUARD=1`.
-
-## Repo layout after init
-
-```
-my-app/
-├── AGENT.md                 # Short pointer for coding agents (you approve this)
-└── .har/
-    ├── README.md            # Full harness documentation (maintained by har)
-    ├── manifest.json        # Generator metadata
-    ├── stages.json          # Optional generic stage registry
-    ├── setup-infra.sh
-    ├── launch.sh
-    ├── verify.sh
-    ├── agent-cli.sh
-    ├── logs/
-    ├── artifacts/
-    ├── harness.env
-    ├── CLAUDE.agent.md
-    └── ...
-```
-
-## Generic Stage Contract
-
-HAR stages are project-defined operations with stable identifiers and normalized results. A stage can be as simple as `verify` or as specific as `browser-e2e`, `migration-check`, `accessibility`, or `load-smoke`.
-
-The important boundary is that HAR runs and reports stages generically. It does not need a special Playwright, migration, accessibility, or load-test API in the core product. The authoring contract (command vs script stages, the script contract, how `verificationStages` controls `verify --full`) ships into every harness as `.har/STAGES.md`.
-
-### Custom stages
-
-Register the project's real checks so they run in `verify --full` and surface to every agent:
-
-```bash
-har env add-stage unit-tests --custom --kind test --command "npm test" --verification
-har env add-stage db-integrity --custom --script   # scaffolds .har/stages/db-integrity.sh
-```
-
-### Playwright (optional)
-
-```bash
-har env init
-har env add-stage playwright   # registers browser-e2e + scaffolds tests/
-npm install && npx playwright install
-./.har/launch.sh 1
-./.har/stages/browser-e2e.sh 1
-```
-
-See `.har/stages/PLAYWRIGHT.md` in the target repo after applying the template.
-
-## CLI commands
-
-| Command | Description |
-|---------|-------------|
-| `har env init` | Scaffold `.har/` + print coding-agent adaptation prompt |
-| `har env add-stage playwright` | Add a stage template (`playwright`, `rocketsim`; `--list` shows all) |
-| `har env add-stage <id> --custom` | Register a project-specific stage (`--command "npm test"` or `--script`) |
-| `har env maintain` | Validate harness + print maintenance prompt |
-| `har env launch 1` | Launch agent slot 1 |
-| `har env verify 1` | Run verification |
-| `har env status` | Show status for all agent slots (`--json` for structured output) |
-| `har env runs list` | List persisted run history (`--json`) |
-| `har env runs get <runId>` | Fetch one run record |
-| `har env teardown 1` | Tear down agent slot 1 |
-| `har agents install` | Scaffold agent skills (`/setup-har`, `/har-wt`, `/har-maintain`) for Claude Code / Cursor / Codex |
-| `har agents remove` | Remove har-managed agent skill files |
-| `har preferences configure` | Select user defaults for rules, skills, and commit-gate onboarding |
-| `har hooks install` | Install the git commit gate (`--claude` for the Claude Code worktree guard) |
-| `har control up` | Start local Mission Control dashboard (Docker Compose) |
-| `har control register` | Register a repo with Mission Control |
-| `har control sync` | Sync runs + slot status to Mission Control |
-| `har control watch` | Continuously sync registered repos |
-| `har mcp` | Start the HAR MCP server (stdio) |
-
-Options: `--force`, `--auto` (built-in Claude adaptation), `--smoke`, `--yes`
-(accept recommended onboarding actions), `--verbose`, `--profile <default|cli|ios>`
-
-## MCP Surface
-
-Start the server from a repository (or pass `repo` on each tool call):
-
-```bash
-har mcp
-```
-
-Example Cursor MCP config:
-
-```json
-{
-  "mcpServers": {
-    "har": {
-      "command": "har",
-      "args": ["mcp", "--repo", "/path/to/my-app"]
-    }
-  }
-}
-```
-
-Core tools (generic — no stack-specific operations like `run_playwright`):
-
-| Tool | Purpose |
-|------|---------|
-| `har_describe_project` | Manifest, scripts, stages, agent slot limits, stack hints |
-| `har_init_harness` | Scaffold `.har/` (optionally skip LLM) |
-| `har_launch_environment` | Launch slot; return preview URLs |
-| `har_run_stage` | Run one stage by id or kind |
-| `har_run_verification` | Run the verification pipeline |
-| `har_get_status` | Slot/process status |
-| `har_get_logs` | Recent logs for a slot |
-| `har_teardown_environment` | Stop a slot |
-| `har_list_artifacts` | List files under `.har/artifacts/` |
-| `har_list_runs` | List persisted run records from `.har/runs/` |
-| `har_get_run` | Fetch one run record by `runId` |
-
-## Mission Control (local dashboard)
-
-Free OSS dashboard for observing harness runs, worktrees, and agent slots on your machine:
-
-```bash
-har control up          # pulls theosfactory/har-control:<cli-version> + Postgres at http://localhost:3847
-har env init            # remembers the repo for sync when Control starts
-har control sync        # push runs + slot status
-```
-
-**Do not run `har control up` and `cd control && har env launch 1` on port 3847 at the same time.** Use the harness for agent dev (hot reload); use `har control up` for the packaged Docker dashboard. Preflight on each side detects the conflict and suggests `har control down` or an alternate harness slot/port.
-
-See [`control/AGENT.md`](./control/AGENT.md) for dashboard development. Hosted team features are **HAR Cloud** (paid).
-
-Agents can still use GitHub, Linear, observability, and other MCP servers directly. HAR focuses on the repository harness and run state.
-
-## HAR Cloud
-
-The open-source CLI and MCP harness are the core. Paid HAR Cloud should add hosted operational value that teams do not want to build themselves:
-
-- Hosted branch previews and remote harness runs
-- Run history, logs, artifacts, screenshots, traces, and result timelines
-- QA handoff, approvals, and shareable preview links
-- Slack, Linear, GitHub, and observability integrations
-- Team dashboards for status, policy, audit trails, and cost controls
-
-HAR Cloud should coordinate and observe the factory. The repo-owned `.har/` contract remains portable.
-
-## For Coding Agents
-
-Agents should read **`AGENT.md`** first, then **`.har/README.md`**. Prefer **HAR MCP tools** (in Cursor) or **`har env …`** for launch, verify, and teardown — they persist run history. Use `./.har/*.sh` only when the CLI is not installed.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local setup, the dogfood harness loop, and architecture. Coding agents working on this repo should start with [AGENT.md](./AGENT.md). Maintainer release process: [RELEASING.md](./RELEASING.md).
 
 ## License
 
-**Dual licensing.** This project uses different licenses for code, documentation, and branding.
+Software is [AGPL-3.0-only](./LICENSE). Documentation is [CC BY-SA 4.0](./DOCUMENTATION-LICENSE.md). Trademarks are reserved — see [TRADEMARK.md](./TRADEMARK.md). Commercial use without AGPL obligations needs a separate agreement — see [LICENSE-COMMERCIAL.md](./LICENSE-COMMERCIAL.md).
 
-| Material | License | Details |
-|----------|---------|---------|
-| Software (CLI, MCP server, Mission Control code, tooling) | [AGPL-3.0-only](./LICENSE) | Copyleft; network use (SaaS) triggers source-offer obligations |
-| Documentation and written guides | [CC BY-SA 4.0](./DOCUMENTATION-LICENSE.md) | Share and adapt with attribution and share-alike |
-| Name, logo, trademarks | All rights reserved | See [TRADEMARK.md](./TRADEMARK.md) |
-
-**Commercial use without AGPL obligations** — closed-source products, managed hosting, training/certification programs, trademark use, or other rights beyond the public licenses require a separate agreement. See [LICENSE-COMMERCIAL.md](./LICENSE-COMMERCIAL.md).
-
-Copyright © 2026 [Antoine Frau](https://github.com/antoineFrau/har).
-
-Contributors agree to the [Contributor License Agreement](./CLA.md).
-
-**Note:** Earlier releases may have been published under MIT. Those versions remain under MIT; new releases from this license change forward are under AGPL-3.0-only unless you obtain a commercial license.
+Copyright © 2026 [Antoine Frau](https://github.com/antoineFrau). Contributors agree to the [CLA](./CLA.md).
 
 ## Security
 
-Report vulnerabilities via [SECURITY.md](./SECURITY.md) (GitHub private advisory preferred).
-
-Inspired by [Lightdash's agent-harness](https://github.com/lightdash/lightdash/tree/main/agent-harness).
+Report vulnerabilities via [SECURITY.md](./SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Give coding agents a real place to work.**
 
-HAR turns any repository into a reproducible workspace with isolated worktrees, project-owned commands, and evidence that changes actually pass.
+HAR is an open-source, agent-agnostic standard for building multi-agent coding workflows. It makes your repository agent-ready, so you can run a whole fleet of coding agents in parallel, with deterministic validation gates, verifiable proof, and full observability across every agent.
 
 Works with **Claude Code** · **Cursor** · **Codex** · any MCP agent.
 
@@ -32,6 +32,14 @@ har env verify 1 --full   # run the project's real checks, record what passed
 That’s it. Your agents discover launch, verify, and teardown through the project’s `.har/` contract — not by guessing shell commands.
 
 Full walkthrough: [Quick start](https://harproject.cloud/docs/getting-started/quick-start/).
+
+## How it works
+
+1. **Discover** — The agent reads one stable interface instead of guessing project-specific shell commands.
+2. **Isolate** — Every task gets a clean slot: dedicated session worktree, ports, and local services.
+3. **Build** — The agent edits inside the harness, without touching the main checkout.
+4. **Verify** — Project checks become a deterministic pipeline with normalized status, logs, and artifacts.
+5. **Hand off** — Reviewers get a branch plus evidence: what ran and the exact validated tree.
 
 ## Why HAR
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,93 @@
+# Releasing HAR
+
+Maintainer guide for cutting `@osfactory/har` releases. Contributors should use [CONTRIBUTING.md](./CONTRIBUTING.md) for day-to-day development; coding agents should read [AGENT.md](./AGENT.md) first.
+
+Releases are driven by [Conventional Commits](https://www.conventionalcommits.org/) on `main`. See [Commit messages](./CONTRIBUTING.md#commit-messages-required-for-releases) for the prefixes that bump semver.
+
+## npm packages
+
+| Package | Published? | Notes |
+|---------|------------|-------|
+| `@osfactory/har` | **Yes** | Public npm package; global `har` binary |
+| `@har/control` | No | `"private": true`; Mission Control source in monorepo |
+| `@har/schemas` | No | `"private": true`; consumed via monorepo path in `control/` |
+
+## npm organization (`@osfactory`)
+
+Maintainers must own the **`@osfactory`** scope on npm:
+
+1. Sign in at [npmjs.com](https://www.npmjs.com/) as a project maintainer.
+2. Create the **`@osfactory`** organization: [npmjs.com/org/create](https://www.npmjs.com/org/create) (free for public packages).
+3. Add other maintainers under **Organization → Members**.
+4. Create an **Automation** token with **Publish** access to `@osfactory/har` (and scope-wide publish if you prefer).
+5. Add the token as the `NPM_TOKEN` repository secret (see below).
+
+The root `package.json` sets `"publishConfig": { "access": "public" }` so scoped publishes are public by default.
+
+## Test a publish tarball locally
+
+`prepublishOnly` runs `npm run build` automatically. To smoke-test the packed artifact before release:
+
+```bash
+npm run build
+npm pack
+npm install -g osfactory-har-*.tgz
+har --help
+npm uninstall -g @osfactory/har
+rm osfactory-har-*.tgz
+```
+
+The tarball should contain `dist/` (bundled CLI + templates + prompts), `control/docker-compose*.yml`, plus `package.json`, `README.md`, `LICENSE`, and the changelog — not the Mission Control app source or test fixtures.
+
+## Automated release pipeline
+
+Maintainers do **not** hand-cut version tags. Merge conventional commits to `main`; the [Release workflow](.github/workflows/release.yml) runs on every push to `main` and, when semantic-release finds releasable commits:
+
+1. Runs full CLI + Mission Control verification
+2. Bumps `@osfactory/har`, `@har/control`, and `@har/schemas` to the same version (npm package prepared, **not** published yet)
+3. Creates git tag `vX.Y.Z` and a **GitHub Release** (with CLI tarball + compose assets)
+4. Pushes **`theosfactory/har-control`** to Docker Hub (`X.Y.Z`, `X.Y`, `X`, and `latest`)
+5. Publishes `@osfactory/har` to **npm** only after the Docker push succeeds
+
+If there is nothing to release, verify still runs and publish steps are skipped. If Docker publish fails, npm is **not** published for that tag (fix the image, then use [Publish Docker (manual)](.github/workflows/publish-docker.yml) and publish npm from the tag, or re-run the failed jobs).
+
+## Maintainer secrets
+
+| Secret | Used by |
+|--------|---------|
+| `NPM_TOKEN` | npm publish for `@osfactory/har` (Automation token with publish access to the `@osfactory` scope) |
+| `DOCKERHUB_TOKEN` | Docker Hub publish for `theosfactory/har-control` (PAT with read/write on the repo) |
+| `GITHUB_TOKEN` | GitHub Release (provided by Actions) |
+
+Dry-run the next release from the Actions tab (**Release → Run workflow → Dry run**) or locally:
+
+```bash
+npm ci
+GITHUB_TOKEN=... NPM_TOKEN=... npx semantic-release --dry-run
+```
+
+## Version coupling
+
+`@osfactory/har`, Mission Control (`control/`), and `@har/schemas` share one semver. [semantic-release](release.config.cjs) keeps them aligned:
+
+1. `@semantic-release/npm` bumps root `package.json` with `npmPublish: false` (prepare only)
+2. [`release/sync-package-versions.js`](release/sync-package-versions.js) syncs `control/` and `packages/schemas/`
+3. `@semantic-release/github` creates git tag `vX.Y.Z` and the GitHub Release
+4. The Release workflow `publish-docker` job pushes `theosfactory/har-control:X.Y.Z` (plus `X.Y`, `X`, and **`latest`**)
+5. The `publish-npm` job publishes `@osfactory/har@X.Y.Z` to npmjs **after** Docker succeeds
+6. Installed CLI reads its own `package.json` version and pulls `theosfactory/har-control:<same-version>` on `har control up`
+
+Override with `HAR_CONTROL_IMAGE` / `HAR_CONTROL_IMAGE_TAG`, or use `har control up --build` / `HAR_CONTROL_BUILD=true` to build locally from a git checkout.
+
+## Manual Docker publish
+
+To publish the Mission Control image manually:
+
+```bash
+docker login
+./release/publish-control-image.sh
+```
+
+Releases also publish via the Release workflow automatically. To republish an existing tag, use [Publish Docker](.github/workflows/publish-docker.yml) (workflow_dispatch; set **force** to rebuild if the version tag already exists) or `./release/publish-control-image.sh`.
+
+Docker publish builds `linux/amd64` and `linux/arm64` in parallel on native runners (not QEMU), with per-platform GitHub Actions cache. If the exact `theosfactory/har-control:X.Y.Z` tag already exists, the build is skipped unless **force** is set.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # HAR website & documentation
 
 The public site is an [Astro](https://astro.build/) project deployed to GitHub
-Pages at <https://harproject.cloud/>:
+Pages at <https://harproject.dev/>:
 
 - `/` — marketing landing page with interactive workflow hero
 - `/blog` — journal index and articles
@@ -38,7 +38,7 @@ workflow run all three commands.
 `main` through GitHub Pages. In repository settings, set **Pages → Build and
 deployment → Source** to **GitHub Actions** once.
 
-The Astro `site` and `base` values target the custom domain `harproject.cloud`.
+The Astro `site` and `base` values target the custom domain `harproject.dev`.
 Update both if the domain or Pages path changes.
 
 Documentation content is licensed under

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -38,7 +38,7 @@ export default defineConfig({
 		starlight({
 			title: 'HAR',
 			description:
-				'The open-source harness and control plane for reproducible AI agent development environments.',
+				'An open-source, agent-agnostic standard for multi-agent coding workflows — parallel agents, deterministic validation, verifiable proof, and observability.',
 			logo: {
 				src: './public/assets/har-logo.png',
 				alt: '.har',

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -30,7 +30,7 @@ const redirects = Object.fromEntries(
 );
 
 export default defineConfig({
-	site: 'https://harproject.cloud',
+	site: 'https://harproject.dev',
 	base: '/',
 	devToolbar: { enabled: false },
 	redirects,

--- a/docs/check-drift.mjs
+++ b/docs/check-drift.mjs
@@ -116,7 +116,7 @@ const packageJson = JSON.parse(read('package.json'));
 if (!read('README.md').includes(packageJson.homepage)) {
   failures.push(`README is missing package homepage ${packageJson.homepage}`);
 }
-if (!astroConfig.includes("site: 'https://harproject.cloud'") || !astroConfig.includes("base: '/'")) {
+if (!astroConfig.includes("site: 'https://harproject.dev'") || !astroConfig.includes("base: '/'")) {
   failures.push('Astro site/base no longer match the documentation custom domain');
 }
 

--- a/docs/check-links.sh
+++ b/docs/check-links.sh
@@ -25,7 +25,7 @@ lychee \
   --no-progress \
   --root-dir "$DIST" \
   --remap "https://github.com/os-factory/har/blob/main/(.*) file://${REPO_ROOT}/\$1" \
-  --exclude '^https://harproject\.cloud' \
+  --exclude '^https://harproject\.dev' \
   --exclude '^https://www\.npmjs\.com' \
   --exclude '^https://api\.web3forms\.com' \
   --exclude-loopback \

--- a/docs/check-links.sh
+++ b/docs/check-links.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$ROOT/.." && pwd)"
 DIST="$ROOT/dist"
 
 if [ ! -d "$DIST" ]; then
@@ -17,9 +18,13 @@ fi
 # Absolute asset/nav paths are rooted at `/` (custom domain). Point lychee's
 # root-dir at the build output so `/_astro/...` resolves locally. Exclude the
 # live site so canonical URLs are not fetched before deploy.
+#
+# Remap GitHub blob/main links to this checkout so docs can link to files added
+# in the same PR (e.g. RELEASING.md) without waiting for merge to main.
 lychee \
   --no-progress \
   --root-dir "$DIST" \
+  --remap "https://github.com/os-factory/har/blob/main/(.*) file://${REPO_ROOT}/\$1" \
   --exclude '^https://harproject\.cloud' \
   --exclude '^https://www\.npmjs\.com' \
   --exclude '^https://api\.web3forms\.com' \

--- a/docs/src/content/docs/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/docs/getting-started/introduction.md
@@ -3,9 +3,11 @@ title: Introduction
 description: What HAR solves and where it fits in an agent development workflow.
 ---
 
-HAR is an open-source CLI and MCP control plane for **project-owned development
-harnesses**. It makes a repository operable by coding agents without tying that
-repository to one model, editor, test framework, or hosted platform.
+HAR is an open-source, agent-agnostic standard for building **multi-agent coding
+workflows**. It makes your repository agent-ready so you can run a fleet of coding
+agents in parallel, with deterministic validation gates, verifiable proof, and full
+observability across every agent — without tying the repository to one model,
+editor, test framework, or hosted platform.
 
 ## The problem
 

--- a/docs/src/content/docs/docs/index.mdx
+++ b/docs/src/content/docs/docs/index.mdx
@@ -1,14 +1,16 @@
 ---
 title: HAR documentation
-description: Make any repository safe and reproducible for coding agents.
+description: An open-source, agent-agnostic standard for multi-agent coding workflows.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-HAR turns the unwritten knowledge required to run a repository into an editable
-`.har/` contract. Coding agents and developers use the same commands to create
-isolated worktrees, launch services, verify changes, collect artifacts, and hand
-off a validated branch.
+HAR is an open-source, agent-agnostic standard for building multi-agent coding
+workflows. It turns the unwritten knowledge required to run a repository into an
+editable `.har/` contract, so you can run a fleet of coding agents in parallel with
+deterministic validation gates, verifiable proof, and full observability. Coding
+agents and developers use the same commands to create isolated worktrees, launch
+services, verify changes, collect artifacts, and hand off a validated branch.
 
 <CardGrid stagger>
 	<Card title="Project-owned" icon="setting">

--- a/docs/src/content/docs/docs/project/contributing.md
+++ b/docs/src/content/docs/docs/project/contributing.md
@@ -3,7 +3,13 @@ title: Contributing
 description: Develop and validate HAR itself.
 ---
 
-## Setup
+The full contributor guide lives in the repository:
+
+**[CONTRIBUTING.md on GitHub](https://github.com/os-factory/har/blob/main/CONTRIBUTING.md)**
+
+That document covers setup, architecture layers, the dogfood harness loop, commit conventions, and where to put changes. Coding agents should also read [AGENT.md](https://github.com/os-factory/har/blob/main/AGENT.md). Maintainer release mechanics are in [RELEASING.md](https://github.com/os-factory/har/blob/main/RELEASING.md).
+
+## Short version
 
 ```bash
 git clone https://github.com/os-factory/har.git
@@ -12,56 +18,25 @@ npm install
 npm run build
 ```
 
-Node.js 20 or newer is required. Docker is required for Mission Control and fixture
-harnesses that use shared infrastructure.
+Node.js 20 or newer is required. Docker is required for Mission Control and fixture harnesses that use shared infrastructure.
 
-## Use HAR to develop HAR
-
-The repository dogfoods two harnesses:
+This repository dogfoods two harnesses:
 
 | Harness | Owns |
 | --- | --- |
 | root `.har/` (`cli` profile) | CLI, MCP, schemas, templates, and tests |
 | `control/.har/` (`default` profile) | Mission Control Next.js app and browser tests |
 
-Launch the harness that owns the files before editing:
+Launch the harness that owns the files **before** editing, make all changes in the printed work directory, and run full verification before declaring work complete:
 
 ```bash
 har env launch 1
-```
-
-Make all edits in its returned work directory. Full verification is required before
-declaring work complete:
-
-```bash
+# edit only under the printed work dir
 har env verify 1 --full
 ```
 
-## Development commands
+If the commit gate is installed, commits must match a tree that passed full verify.
 
-The root package provides `build`, `dev`, `test`, `test:watch`, `typecheck`, and
-`lint`. Run them through the active harness or its `agent-cli.sh` helper.
+Public CLI, MCP, schema, and template changes must keep the docs contract green (`npm run drift --prefix docs`, also run as `docs-drift` during full verify).
 
-Template changes require a rebuild before testing because the build copies
-`src/templates/` and authoring prompts into `dist/`.
-
-## Tests
-
-Root Jest tests live under `tests/` and use fixture harnesses instead of real Docker
-where possible. Keep CLI/MCP parity tests when adapters share a core path.
-
-Mission Control uses Vitest and Playwright under `control/`. UI behavior should have
-browser coverage in the control harness.
-
-## Pull requests and releases
-
-Use Conventional Commits. `fix:` produces a patch, `feat:` a minor, and a breaking
-change a major release. Documentation, CI, tests, and refactors do not publish a
-package by themselves.
-
-On releasable changes, semantic-release verifies the CLI and dashboard, aligns the
-CLI/control/schema versions, publishes `@osfactory/har`, creates a GitHub release,
-and publishes matching Mission Control Docker tags.
-
-Read the repository's `CONTRIBUTING.md`, Code of Conduct, CLA, security policy, and
-license files before submitting changes.
+Read the repository's Code of Conduct, CLA, security policy, and license files before submitting changes.

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const {
   title,
-  description = 'HAR makes repositories agent-ready with project-owned harnesses, isolated worktrees, and verifiable runs.',
+  description = 'HAR is an open-source, agent-agnostic standard for multi-agent coding workflows — parallel agents, deterministic validation gates, verifiable proof, and full observability.',
   bodyClass = '',
   canonicalPath = Astro.url.pathname,
 } = Astro.props;

--- a/docs/src/pages/blog/index.astro
+++ b/docs/src/pages/blog/index.astro
@@ -24,7 +24,7 @@ import Footer from '../../components/Footer.astro';
           >
             <input type="hidden" name="access_key" value="9650ee0d-81c2-4edb-9cab-69920938f8ab" />
             <input type="hidden" name="subject" value="HAR Journal newsletter signup" />
-            <input type="hidden" name="message" value="Newsletter subscription from harproject.cloud/blog" />
+            <input type="hidden" name="message" value="Newsletter subscription from harproject.dev/blog" />
             <input type="checkbox" name="botcheck" class="hidden" tabindex="-1" autocomplete="off" />
             <label class="sr-only" for="newsletter-email">Email</label>
             <input id="newsletter-email" name="email" type="email" placeholder="you@company.com" required />

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -12,7 +12,7 @@ import HeroFlow from '../components/HeroFlow.astro';
 <div class="hero-copy reveal">
 <div class="eyebrow"><span class="eyebrow-dot"></span> Open-source agent infrastructure</div>
 <h1>Give coding agents a <span class="ink-underline">real place</span> to work.</h1>
-<p class="hero-lede">HAR turns any repository into a reproducible workspace with isolated worktrees, project-owned commands, and evidence that changes actually pass.</p>
+<p class="hero-lede">HAR is an open-source, agent-agnostic standard for building multi-agent coding workflows. It makes your repository agent-ready, so you can run a whole fleet of coding agents in parallel, with deterministic validation gates, verifiable proof, and full observability across every agent.</p>
 <div class="hero-actions">
 <a class="button button-primary" href="/docs/getting-started/quick-start/">Get started <span aria-hidden="true">→</span></a>
 <a class="button button-ghost" href="https://github.com/os-factory/har">View on GitHub <span aria-hidden="true">↗</span></a>
@@ -110,7 +110,7 @@ import HeroFlow from '../components/HeroFlow.astro';
 <div aria-label="Workflow stages" class="workflow-tabs" role="tablist">
 <button class="active" data-workflow-tab="discover" type="button"><span>01</span> Discover</button>
 <button data-workflow-tab="isolate" type="button"><span>02</span> Isolate</button>
-<button data-workflow-tab="execute" type="button"><span>03</span> Execute</button>
+<button data-workflow-tab="build" type="button"><span>03</span> Build</button>
 <button data-workflow-tab="verify" type="button"><span>04</span> Verify</button>
 <button data-workflow-tab="handoff" type="button"><span>05</span> Hand off</button>
 </div>

--- a/docs/src/pages/rss.xml.ts
+++ b/docs/src/pages/rss.xml.ts
@@ -5,13 +5,13 @@ export const GET: APIRoute = () => {
 <rss version="2.0">
   <channel>
     <title>HAR Journal</title>
-    <link>https://harproject.cloud/blog</link>
+    <link>https://harproject.dev/blog</link>
     <description>Architecture, field notes, and practical patterns for reliable coding-agent workflows.</description>
     <language>en</language>
     <item>
       <title>Why coding agents need a harness, not another prompt.</title>
-      <link>https://harproject.cloud/blog/why-coding-agents-need-a-harness</link>
-      <guid>https://harproject.cloud/blog/why-coding-agents-need-a-harness</guid>
+      <link>https://harproject.dev/blog/why-coding-agents-need-a-harness</link>
+      <guid>https://harproject.dev/blog/why-coding-agents-need-a-harness</guid>
       <pubDate>Sat, 18 Jul 2026 10:00:00 GMT</pubDate>
       <description>Coding models can edit files. Reliable software work requires a surrounding system that can isolate, launch, verify, and explain what happened.</description>
     </item>

--- a/docs/src/scripts/site.ts
+++ b/docs/src/scripts/site.ts
@@ -129,15 +129,15 @@ const workflowContent: Record<string, WorkflowContent> = {
   isolate: {
     label: '02 — Isolate',
     title: 'Every task gets a clean slot.',
-    body: 'HAR creates a dedicated session worktree and allocates the environment details the project needs, from ports to local services.',
+    body: 'HAR creates a dedicated session worktree and allocates the environment the project needs, from ports to local services.',
     command: 'har env launch 2',
     method: 'har_launch_environment',
     detail: 'slot allocation',
     json: '{\n  "slot": 2,\n  "worktree": ".../slot-02",\n  "previewUrl": "localhost:4102",\n  "status": "ready"\n}',
   },
-  execute: {
-    label: '03 — Execute',
-    title: 'The model edits inside the harness.',
+  build: {
+    label: '03 — Build',
+    title: 'The agent edits inside the harness.',
     body: 'The agent works in the printed worktree, uses the project’s existing tools, and can inspect logs or status without touching the main checkout.',
     command: 'cd .har/worktrees/slot-02',
     method: 'har_get_status',

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "type": "git",
     "url": "https://github.com/os-factory/har"
   },
-  "homepage": "https://harproject.cloud/",
+  "homepage": "https://harproject.dev/",
   "bugs": "https://github.com/os-factory/har/issues",
   "author": "Antoine Frau",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- Replace the reference-manual README with a lean commercial page (install + first commands, landing-page voice, links out to docs)
- Rewrite CONTRIBUTING around architecture layers, the dogfood harness loop, commit gate, and where to put changes; fix stale clone URL / layout / CLI surface
- Move maintainer release mechanics into `RELEASING.md`, and point the docs site contributing page at the repo guide instead of duplicating it

## Test plan
- [x] `har env verify 1 --full` passed (typecheck, build, docs-check, docs-build, unit-tests, lint, docs-drift)
- [ ] Skim README on GitHub for tone and that install / get-started commands are obvious
- [ ] Confirm CONTRIBUTING anchors still resolve (`#upgrading-har`, `#commit-messages-required-for-releases`)
- [ ] Open docs contributing page build and confirm GitHub links to CONTRIBUTING / RELEASING / AGENT


Made with [Cursor](https://cursor.com)