### PR TITLE
feat(control): control sync interactive multi-repo selection with persisted choice

### DIFF
--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import inquirer from 'inquirer';
 import type { Argv } from 'yargs';
 import {
   getControlApiUrl,
@@ -6,8 +7,15 @@ import {
 } from '../../core/control-config';
 import { inspectControlUpReadiness } from '../../core/control-port';
 import {
+  discoverHarRepos,
   syncRepoWithControl,
+  syncReposWithControl,
 } from '../../core/control-sync';
+import {
+  readSyncSelection,
+  resolveSyncSelection,
+  writeSyncSelection,
+} from '../../core/control-sync-selection';
 import { writePortalCredentials } from '../../core/portal-credentials';
 import { loginViaBrowser } from '../../core/portal-login';
 import { startMissionControl, syncReposAfterControlStart, stopMissionControl } from '../../core/control-lifecycle';
@@ -85,7 +93,11 @@ export const controlCommand = {
         'Sync runs and slot status to Mission Control',
         (y: Argv) =>
           y
-            .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+            .option('select', {
+              type: 'boolean',
+              default: false,
+              describe: 'Choose which repositories to sync (interactive)',
+            })
             .option('api-url', { type: 'string', describe: 'Control API URL' })
             .option('dry-run', { type: 'boolean', default: false })
             .option('json', { type: 'boolean', default: false })
@@ -301,37 +313,95 @@ async function handleUnregister(argv: {
 }
 
 async function handleSync(argv: {
-  repo: string;
+  select: boolean;
   apiUrl?: string;
   dryRun: boolean;
   json: boolean;
   cloud?: boolean;
 }): Promise<void> {
-  const repoPath = path.resolve(argv.repo);
+  const isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const discovered = await discoverHarRepos({ apiUrl: argv.apiUrl, cwd: process.cwd() });
 
-  try {
-    await syncRepoWithControl({
-      repoPath,
-      apiUrl: argv.apiUrl,
-      dryRun: argv.dryRun,
-      cloud: argv.cloud,
-    });
+  if (argv.select && !isTTY) {
+    error('--select needs an interactive terminal.');
+    process.exit(1);
+  }
 
+  if (discovered.length === 0) {
     if (argv.json) {
-      process.stdout.write(JSON.stringify({ ok: true, repoPath }, null, 2) + '\n');
+      process.stdout.write(JSON.stringify({ ok: true, synced: 0, failed: 0, results: [] }, null, 2) + '\n');
     } else {
       header('har control sync');
-      info(`Repository: ${repoPath}`);
-      success('Sync complete');
+      info('No repositories are registered with Mission Control.');
+      info('Register one with: har control register --repo <path>');
     }
-  } catch (err: unknown) {
+    return;
+  }
+
+  const resolution = resolveSyncSelection({
+    discovered,
+    stored: readSyncSelection(),
+    forceSelect: argv.select,
+    isTTY,
+  });
+
+  let repoPaths = resolution.toSync;
+  if (resolution.needsPrompt) {
+    info('Only repositories registered with Mission Control are listed.');
+    info('Missing one? Register it with: har control register --repo <path>');
+    const defaults = new Set(resolution.promptDefaults);
+    const { selection } = await inquirer.prompt<{ selection: string[] }>([
+      {
+        type: 'checkbox',
+        name: 'selection',
+        message: 'Select repositories to sync',
+        choices: discovered.map((repoPath) => ({
+          name: repoPath,
+          value: repoPath,
+          checked: defaults.has(repoPath),
+        })),
+      },
+    ]);
+    writeSyncSelection(selection);
+    repoPaths = selection;
+  }
+
+  if (repoPaths.length === 0) {
     if (argv.json) {
-      process.stdout.write(
-        JSON.stringify({ ok: false, error: (err as Error).message }, null, 2) + '\n',
-      );
-      process.exit(1);
+      process.stdout.write(JSON.stringify({ ok: true, results: [] }, null, 2) + '\n');
+    } else {
+      header('har control sync');
+      info('No repositories selected to sync.');
     }
-    error((err as Error).message);
+    return;
+  }
+
+  const { synced, failed, results } = await syncReposWithControl({
+    repoPaths,
+    apiUrl: argv.apiUrl,
+    dryRun: argv.dryRun,
+    cloud: argv.cloud,
+  });
+
+  if (argv.json) {
+    process.stdout.write(JSON.stringify({ ok: failed === 0, synced, failed, results }, null, 2) + '\n');
+    if (failed > 0) process.exit(1);
+    return;
+  }
+
+  header('har control sync');
+  for (const result of results) {
+    if (result.ok) {
+      success(`Synced ${result.repoPath}`);
+    } else {
+      warn(`Failed ${result.repoPath}: ${result.error}`);
+    }
+  }
+  if (synced > 0) {
+    success(`Synced ${synced} ${synced === 1 ? 'repository' : 'repositories'}`);
+  }
+  if (failed > 0) {
+    warn(`${failed} ${failed === 1 ? 'repository' : 'repositories'} could not be synced`);
     process.exit(1);
   }
 }

--- a/src/core/control-sync-selection.ts
+++ b/src/core/control-sync-selection.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { canonicalizeControlRepoPath } from './control-repo-path';
+
+interface SyncSelection {
+  repos: string[];
+}
+
+function getSelectionPath(): string {
+  if (process.env.HAR_CONTROL_SYNC_SELECTION_PATH) {
+    return path.resolve(process.env.HAR_CONTROL_SYNC_SELECTION_PATH);
+  }
+  return path.join(os.homedir(), '.har', 'sync-selection.json');
+}
+
+/** Persisted sync selection, or null when the user has never chosen one. */
+export function readSyncSelection(): string[] | null {
+  const selectionPath = getSelectionPath();
+  try {
+    if (!fs.existsSync(selectionPath)) return null;
+    const parsed = JSON.parse(fs.readFileSync(selectionPath, 'utf8')) as SyncSelection;
+    if (!Array.isArray(parsed.repos)) return null;
+    return parsed.repos.map((repoPath) => canonicalizeControlRepoPath(repoPath));
+  } catch {
+    return null;
+  }
+}
+
+export function writeSyncSelection(repos: string[]): void {
+  const selectionPath = getSelectionPath();
+  const canonical = Array.from(new Set(repos.map((repoPath) => canonicalizeControlRepoPath(repoPath))));
+  fs.mkdirSync(path.dirname(selectionPath), { recursive: true });
+  fs.writeFileSync(selectionPath, JSON.stringify({ repos: canonical }, null, 2) + '\n');
+}
+
+export function getSyncSelectionPath(): string {
+  return getSelectionPath();
+}
+
+export interface SyncSelectionResolution {
+  /** CLI should open the interactive checkbox with `promptDefaults` pre-checked. */
+  needsPrompt: boolean;
+  promptDefaults: string[];
+  /** Repos to sync directly when `needsPrompt` is false. */
+  toSync: string[];
+}
+
+/**
+ * Decide what `har control sync` should push, given the repos discovered this
+ * run and the persisted selection. Pure — the CLI owns the actual prompt and
+ * persistence; persisting only ever follows a completed prompt.
+ *
+ * - First run, interactive → prompt (all discovered pre-checked).
+ * - First run, non-TTY → sync all discovered (no persist).
+ * - Stored selection, a new repo appeared, interactive → re-prompt (stored + new
+ *   pre-checked).
+ * - Stored selection otherwise (or non-TTY) → sync the stored set silently.
+ * - `--select` (forceSelect), interactive → always prompt (current selection
+ *   pre-checked); non-TTY → sync stored/all without prompting.
+ */
+export function resolveSyncSelection(input: {
+  discovered: string[];
+  stored: string[] | null;
+  forceSelect: boolean;
+  isTTY: boolean;
+}): SyncSelectionResolution {
+  const { discovered, stored, forceSelect, isTTY } = input;
+  const discoveredSet = new Set(discovered);
+  const effectiveStored = stored ? stored.filter((repo) => discoveredSet.has(repo)) : null;
+
+  if (forceSelect) {
+    if (isTTY) {
+      const defaults = effectiveStored && effectiveStored.length > 0 ? effectiveStored : discovered;
+      return { needsPrompt: true, promptDefaults: defaults, toSync: [] };
+    }
+    return { needsPrompt: false, promptDefaults: [], toSync: effectiveStored ?? discovered };
+  }
+
+  if (effectiveStored === null) {
+    if (isTTY) {
+      return { needsPrompt: true, promptDefaults: discovered, toSync: [] };
+    }
+    return { needsPrompt: false, promptDefaults: [], toSync: discovered };
+  }
+
+  const newRepos = discovered.filter((repo) => !(stored ?? []).includes(repo));
+  if (newRepos.length > 0 && isTTY) {
+    return { needsPrompt: true, promptDefaults: [...effectiveStored, ...newRepos], toSync: [] };
+  }
+
+  return { needsPrompt: false, promptDefaults: [], toSync: effectiveStored };
+}

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -243,18 +243,23 @@ export async function waitForControlApi(
   return false;
 }
 
-export async function syncAllKnownReposWithControl(options?: {
+export interface SyncRepoResult {
+  repoPath: string;
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Every har repo Mission Control knows about: the local registry, an optional
+ * cwd, and whatever the portal/control API already tracks — all manifest-gated
+ * and canonicalized. Shared by the all-repos auto-sync and the interactive
+ * `har control sync` selection.
+ */
+export async function discoverHarRepos(options?: {
   apiUrl?: string;
   cwd?: string;
-}): Promise<{ synced: number; failed: number }> {
-  if (!isControlEnabled()) return { synced: 0, failed: 0 };
-
+}): Promise<string[]> {
   const apiUrl = options?.apiUrl ?? getControlApiUrl();
-  const portal = getPortalTarget();
-  if (!(await isControlApiReachable(portal ? portal.url : apiUrl))) {
-    return { synced: 0, failed: 0 };
-  }
-
   const repoPaths = new Set<string>(listRegisteredRepos());
 
   if (options?.cwd) {
@@ -275,17 +280,56 @@ export async function syncAllKnownReposWithControl(options?: {
     // Best-effort — registry + cwd repos are enough for first sync.
   }
 
+  return [...repoPaths];
+}
+
+/**
+ * Push a specific set of repos, one per timeout-guarded call. Returns the
+ * summary counts plus a per-repo result so callers can print outcomes.
+ */
+export async function syncReposWithControl(options: {
+  repoPaths: string[];
+  apiUrl?: string;
+  dryRun?: boolean;
+  cloud?: boolean;
+}): Promise<{ synced: number; failed: number; results: SyncRepoResult[] }> {
+  const apiUrl = options.apiUrl ?? getControlApiUrl();
+  const results: SyncRepoResult[] = [];
   let synced = 0;
   let failed = 0;
-  for (const repoPath of repoPaths) {
+
+  for (const repoPath of options.repoPaths) {
     try {
-      await withTimeout(syncRepoWithControl({ repoPath, apiUrl }), SYNC_TIMEOUT_MS, 'control sync');
+      await withTimeout(
+        syncRepoWithControl({ repoPath, apiUrl, dryRun: options.dryRun, cloud: options.cloud }),
+        SYNC_TIMEOUT_MS,
+        'control sync',
+      );
       synced++;
-    } catch {
+      results.push({ repoPath, ok: true });
+    } catch (err: unknown) {
       failed++;
+      results.push({ repoPath, ok: false, error: err instanceof Error ? err.message : String(err) });
     }
   }
 
+  return { synced, failed, results };
+}
+
+export async function syncAllKnownReposWithControl(options?: {
+  apiUrl?: string;
+  cwd?: string;
+}): Promise<{ synced: number; failed: number }> {
+  if (!isControlEnabled()) return { synced: 0, failed: 0 };
+
+  const apiUrl = options?.apiUrl ?? getControlApiUrl();
+  const portal = getPortalTarget();
+  if (!(await isControlApiReachable(portal ? portal.url : apiUrl))) {
+    return { synced: 0, failed: 0 };
+  }
+
+  const repoPaths = await discoverHarRepos({ apiUrl, cwd: options?.cwd });
+  const { synced, failed } = await syncReposWithControl({ repoPaths, apiUrl });
   return { synced, failed };
 }
 

--- a/tests/control-sync-repos.test.ts
+++ b/tests/control-sync-repos.test.ts
@@ -1,0 +1,100 @@
+// Exercises the subset push loop end-to-end through the portal path: mock the
+// data collectors (covered by their own suites) and drive success/failure via
+// the portal fetch, so we only assert the synced/failed/results accounting.
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+jest.mock('../src/core/portal-credentials', () => ({ readPortalCredentials: jest.fn(() => null) }));
+jest.mock('../src/core/runs', () => ({ listRuns: () => [] }));
+jest.mock('../src/core/slot-status', () => ({
+  collectEnvironmentStatus: () => ({ slots: [], generatedAt: '2026-01-01T00:00:00.000Z' }),
+}));
+jest.mock('../src/core/validations', () => ({ listValidations: () => [] }));
+jest.mock('../src/core/work-units', () => ({
+  listWorkUnits: () => [],
+  listWorkAttempts: () => [],
+  listValidationBindings: () => [],
+}));
+jest.mock('../src/core/usage-harvest', () => ({
+  harvestUsageForSlot: () => [],
+  harvestEventsForSlot: () => [],
+}));
+jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => false }));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => null,
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
+
+import { syncReposWithControl } from '../src/core/control-sync';
+
+const realFetch = global.fetch;
+
+function setPortalEnv(): void {
+  process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+  process.env.HAR_PORTAL_TOKEN = 'har_ingest_test';
+}
+
+function clearPortalEnv(): void {
+  delete process.env.HAR_PORTAL_URL;
+  delete process.env.HAR_PORTAL_TOKEN;
+}
+
+// Any repo whose path includes "fail" gets an HTTP 500 from the portal.
+function mockFetchByRepo(): void {
+  (global as unknown as { fetch: unknown }).fetch = jest.fn(async (_url: string, init?: RequestInit) => {
+    const body = init?.body ? (JSON.parse(String(init.body)) as { path?: string }) : {};
+    const failed = typeof body.path === 'string' && body.path.includes('fail');
+    return {
+      ok: !failed,
+      status: failed ? 500 : 200,
+      statusText: failed ? 'Internal Server Error' : 'OK',
+      text: async () => (failed ? 'boom' : ''),
+      json: async () => ({}),
+    };
+  });
+}
+
+describe('syncReposWithControl', () => {
+  beforeEach(() => {
+    setPortalEnv();
+    mockFetchByRepo();
+  });
+  afterEach(() => {
+    clearPortalEnv();
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  it('counts every repo as synced when all succeed', async () => {
+    const result = await syncReposWithControl({ repoPaths: ['/repos/a', '/repos/b'] });
+    expect(result.synced).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.results).toEqual([
+      { repoPath: '/repos/a', ok: true },
+      { repoPath: '/repos/b', ok: true },
+    ]);
+  });
+
+  it('records per-repo failures without aborting the loop', async () => {
+    const result = await syncReposWithControl({
+      repoPaths: ['/repos/ok', '/repos/fail', '/repos/ok2'],
+    });
+    expect(result.synced).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.results.map((r) => r.ok)).toEqual([true, false, true]);
+    const failure = result.results.find((r) => !r.ok);
+    expect(failure?.repoPath).toBe('/repos/fail');
+    expect(failure?.error).toContain('500');
+  });
+
+  it('returns zeroes for an empty selection', async () => {
+    const result = await syncReposWithControl({ repoPaths: [] });
+    expect(result).toEqual({ synced: 0, failed: 0, results: [] });
+  });
+
+  it('makes no network calls in dry-run mode', async () => {
+    const result = await syncReposWithControl({ repoPaths: ['/repos/a'], dryRun: true });
+    expect(result.synced).toBe(1);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/control-sync-selection.test.ts
+++ b/tests/control-sync-selection.test.ts
@@ -1,0 +1,131 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+
+import {
+  getSyncSelectionPath,
+  readSyncSelection,
+  resolveSyncSelection,
+  writeSyncSelection,
+} from '../src/core/control-sync-selection';
+
+describe('sync selection persistence', () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'har-sync-selection-'));
+    process.env.HAR_CONTROL_SYNC_SELECTION_PATH = path.join(tempHome, 'sync-selection.json');
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_CONTROL_SYNC_SELECTION_PATH;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('returns null before any selection is saved', () => {
+    expect(readSyncSelection()).toBeNull();
+  });
+
+  it('round-trips a saved selection', () => {
+    writeSyncSelection(['/repos/a', '/repos/b']);
+    expect(fs.existsSync(getSyncSelectionPath())).toBe(true);
+    expect(readSyncSelection()).toEqual(['/repos/a', '/repos/b']);
+  });
+
+  it('deduplicates repos on write', () => {
+    writeSyncSelection(['/repos/a', '/repos/a', '/repos/b']);
+    expect(readSyncSelection()).toEqual(['/repos/a', '/repos/b']);
+  });
+
+  it('returns null on malformed selection files', () => {
+    fs.mkdirSync(path.dirname(getSyncSelectionPath()), { recursive: true });
+    fs.writeFileSync(getSyncSelectionPath(), 'not json');
+    expect(readSyncSelection()).toBeNull();
+  });
+});
+
+describe('resolveSyncSelection', () => {
+  it('prompts with all discovered pre-checked on first interactive run', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a', '/b'],
+      stored: null,
+      forceSelect: false,
+      isTTY: true,
+    });
+    expect(result).toEqual({ needsPrompt: true, promptDefaults: ['/a', '/b'], toSync: [] });
+  });
+
+  it('syncs all discovered without prompting on first non-TTY run', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a', '/b'],
+      stored: null,
+      forceSelect: false,
+      isTTY: false,
+    });
+    expect(result).toEqual({ needsPrompt: false, promptDefaults: [], toSync: ['/a', '/b'] });
+  });
+
+  it('syncs the stored selection silently when nothing changed', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a', '/b'],
+      stored: ['/a', '/b'],
+      forceSelect: false,
+      isTTY: true,
+    });
+    expect(result).toEqual({ needsPrompt: false, promptDefaults: [], toSync: ['/a', '/b'] });
+  });
+
+  it('drops vanished repos from the stored selection', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a'],
+      stored: ['/a', '/gone'],
+      forceSelect: false,
+      isTTY: false,
+    });
+    expect(result.toSync).toEqual(['/a']);
+  });
+
+  it('re-prompts when a new repo appears (stored + new pre-checked)', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a', '/b', '/c'],
+      stored: ['/a'],
+      forceSelect: false,
+      isTTY: true,
+    });
+    expect(result).toEqual({ needsPrompt: true, promptDefaults: ['/a', '/b', '/c'], toSync: [] });
+  });
+
+  it('does not prompt for new repos when non-TTY (syncs stored only)', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a', '/b'],
+      stored: ['/a'],
+      forceSelect: false,
+      isTTY: false,
+    });
+    expect(result).toEqual({ needsPrompt: false, promptDefaults: [], toSync: ['/a'] });
+  });
+
+  it('always prompts with --select, pre-checking the current selection', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a', '/b'],
+      stored: ['/b'],
+      forceSelect: true,
+      isTTY: true,
+    });
+    expect(result).toEqual({ needsPrompt: true, promptDefaults: ['/b'], toSync: [] });
+  });
+
+  it('falls back to the stored set for --select without a TTY', () => {
+    const result = resolveSyncSelection({
+      discovered: ['/a', '/b'],
+      stored: ['/b'],
+      forceSelect: true,
+      isTTY: false,
+    });
+    expect(result).toEqual({ needsPrompt: false, promptDefaults: [], toSync: ['/b'] });
+  });
+});


### PR DESCRIPTION
## Summary

<img width="750" height="105" alt="image" src="https://github.com/user-attachments/assets/9ccc1364-2a33-474e-98de-769a10891b21" />

`har control sync` now discovers every har repo Mission Control tracks (local registry + cwd + portal `/api/repos`) and syncs a **persisted selection** of them, instead of only the current repo.

- **First interactive run** shows a checkbox to choose repos; the choice is saved to `~/.har/sync-selection.json` and reused silently on later runs.
- **New repo appears** → the checkbox re-opens (existing + new pre-checked). `--select` reopens it on demand.
- **Non-interactive shells** (CI, `control up` auto-sync) fall back to syncing *all* discovered repos without prompting or persisting.
- Prints one result line per repo + a summary; when a repo is missing from the list, points the user at `har control register`.

## Implementation

- New `discoverHarRepos()` (extracted from `syncAllKnownReposWithControl`) and `syncReposWithControl({ repoPaths }) → { synced, failed, results[] }`; `syncAllKnownReposWithControl` now delegates to both, so there's a single push loop.
- New `control-sync-selection.ts`: persistence + a pure `resolveSyncSelection()` holding the first-run / stored / new-repo / `--select` / non-TTY decision logic.
- Selection-flow flags: `--select`. (`--repo` override removed — sync is selection-based.)

## Test plan

- `npm run typecheck`, `npm run lint` (changed files), `npm run build` — all green.
- New Jest suites: `tests/control-sync-selection.test.ts` (persistence round-trip + full `resolveSyncSelection` matrix) and `tests/control-sync-repos.test.ts` (synced/failed/results accounting incl. dry-run). 16 tests pass.
- Existing `control-*` suites (incl. `control-portal-sync`, `control-lifecycle`) still pass.
