### PR TITLE
feat(telemetry): enable full telemetry including prompts by default

### DIFF
--- a/.cursor/rules/har-workflow.mdc
+++ b/.cursor/rules/har-workflow.mdc
@@ -31,7 +31,7 @@ When a slot is occupied: prefer `complete` / `teardown` if the previous task is 
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
-- With telemetry prompts enabled, Mission Control derives session purpose from the first captured user prompt.
+- With telemetry on (default, including prompts), Mission Control derives session purpose from the first captured user prompt.
 - If launch failed partway (registry `status: failed`), **resume** instead of replacing:
   `har env launch <id> --resume`, `har env recover <id>`, or `./.har/launch.sh <id> --resume`.
   Do not hand-roll PM2 or skip the harness.

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -86,7 +86,7 @@ export default async function SlotDetailPage({
           </p>
         )}
         <p className="mt-1 text-xs text-muted-foreground">
-          Prompt text is stored only when telemetry prompts are enabled (`har telemetry on --prompts`).
+          Prompt text is included by default (opt out: `har telemetry on --no-prompts`).
           Usage and events stay in local SQLite.
         </p>
       </div>

--- a/control/src/app/usage/page.tsx
+++ b/control/src/app/usage/page.tsx
@@ -21,7 +21,7 @@ export default async function UsagePage() {
         <h2 className="text-2xl font-semibold">Usage</h2>
         <p className="text-sm text-muted-foreground">
           Cross-repo LLM token and cost rollup from OTEL ingest and harvest. Prompt bodies are
-          stored only when `har telemetry on --prompts` is set. Data stays in local SQLite.
+          included by default (opt out: `har telemetry on --no-prompts`). Data stays in local SQLite.
         </p>
       </div>
 

--- a/docs/src/content/docs/docs/getting-started/installation.md
+++ b/docs/src/content/docs/docs/getting-started/installation.md
@@ -21,6 +21,11 @@ har --version
 HAR's CLI, MCP server, bundled harness profiles, and Mission Control launcher ship
 in the same `@osfactory/har` package.
 
+Install activates **full agent telemetry by default** (traces, logs, metrics, and
+prompts → local Mission Control). Preference is written to `~/.har/telemetry.json`
+when missing. Disable with `har telemetry off`, or keep usage without prompt text
+via `har telemetry on --no-prompts`.
+
 ## Install from source
 
 ```bash

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -20,8 +20,8 @@ har env launch 2
 ```
 
 Use one slot per task. Separate parallel tasks use separate slots.
-With telemetry prompts enabled (`har telemetry on --prompts`), Mission Control
-fills the session purpose from the first captured user prompt.
+With telemetry on (the default, including prompts), Mission Control fills the
+session purpose from the first captured user prompt.
 
 ## Occupied and failed slots
 

--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -116,17 +116,18 @@ HAR attributes Cursor, Claude Code, and Codex activity to each worktree/session 
 Mission Control. Preference shape:
 
 ```json
-{ "enabled": true, "signals": { "metrics": true, "logs": true, "prompts": false, "traces": true } }
+{ "enabled": true, "signals": { "metrics": true, "logs": true, "prompts": true, "traces": true } }
 ```
 
-Defaults when telemetry is on: **traces + logs + derived metrics** (events without prompt
-bodies). Prompt text is **opt-in** and also fills the Mission Control **purpose** column
-from the first captured user prompt.
+**Default: full telemetry on** (traces + logs + derived metrics + prompts). Install
+(`npm install -g @osfactory/har`) and the first `har` / MCP invocation persist this
+preference to `~/.har/telemetry.json` when the file is missing. Prompt text also fills
+the Mission Control **purpose** column from the first captured user prompt.
 
 ```bash
 har telemetry status
-har telemetry on              # ensure Mission Control + install/configure opentelemetry-hooks
-har telemetry on --prompts    # also ship user prompt text (session purpose)
+har telemetry on              # full telemetry + Mission Control + opentelemetry-hooks
+har telemetry on --no-prompts # keep traces/logs/metrics; disable prompt text capture
 har telemetry install-hooks   # re-run Cursor / Claude / Codex hook registration
 har telemetry off             # clear hooks OTLP export + stop MC auto-start; keeps historical rows
 ```
@@ -137,17 +138,15 @@ Hooks config lives at `~/.har/otel-hooks/otel_config.json` (`HAR_OTEL_HOOKS_HOME
 When telemetry is on:
 
 1. `har env launch` auto-starts Mission Control if it is not reachable (`har control up`).
-2. `har telemetry on` installs `opentelemetry-hooks` and registers Cursor / Claude / Codex hooks
+2. `har telemetry on` (and launch) install `opentelemetry-hooks` and register Cursor / Claude / Codex hooks
    to export OTLP `http/json` to `{HAR_CONTROL_API_URL}/api/otel`.
 3. Launch writes session attribution into `.env.agent.<id>` (`HAR_SESSION_KEY`, resource attrs).
    Mission Control matches sessions by `har.session_key` or by workspace/cwd → slot work dir.
 4. Token usage is derived from span `gen_ai.usage.*` attributes. `har control sync` also
    **harvests** local Claude/Codex session files as a fallback when hooks telemetry is missing.
 
-**Privacy:** prompt text leaves the agent machine only when the prompts signal is on.
-Mission Control stores usage and events in local SQLite.
-
-Disable anytime: `har telemetry off`.
+**Privacy:** prompt text is included by default and stays in local Mission Control (SQLite).
+Opt out with `har telemetry on --no-prompts` or disable everything with `har telemetry off`.
 
 ## Local development
 

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -156,7 +156,7 @@ teardown. Re-add later with `har control register`.
 
 ```bash
 har telemetry status [--json]
-har telemetry on [--prompts]
+har telemetry on [--prompts|--no-prompts]
 har telemetry off
 har telemetry install-hooks
 har telemetry write-env --agent-id <n> [--repo .] [--env-file path]
@@ -164,9 +164,10 @@ har telemetry print-env --agent-id <n>
 ```
 
 Controls agent usage telemetry (Cursor / Claude / Codex via opentelemetry-hooks → Mission Control).
-**Default: on.** `on` ensures Mission Control is running and installs/configures hooks.
-Preference: `~/.har/telemetry.json` (override with `HAR_TELEMETRY=0|1`). Hooks config:
-`~/.har/otel-hooks/otel_config.json`.
+**Default: full on** (traces, logs, metrics, prompts). Install and the first `har` invocation
+persist `~/.har/telemetry.json` when missing. `on` ensures Mission Control is running and
+installs/configures hooks. Use `--no-prompts` to keep telemetry without prompt text.
+Override with `HAR_TELEMETRY=0|1`. Hooks config: `~/.har/otel-hooks/otel_config.json`.
 
 ## `har mcp`
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "dist",
+    "scripts/ensure-telemetry-default.cjs",
     "control/docker-compose.yml",
     "control/docker-compose.build.yml"
   ],
@@ -26,6 +27,7 @@
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --ext .ts",
+    "postinstall": "node scripts/ensure-telemetry-default.cjs",
     "prepublishOnly": "npm run build",
     "release": "semantic-release"
   },

--- a/scripts/ensure-telemetry-default.cjs
+++ b/scripts/ensure-telemetry-default.cjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * npm postinstall: persist full default telemetry preference when missing.
+ * Does not overwrite an existing ~/.har/telemetry.json (respects prior off / prompts=false).
+ * Hooks + Mission Control are activated on first `har` / `har env launch` / `har telemetry on`.
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function main() {
+  if (process.env.HAR_SKIP_TELEMETRY_POSTINSTALL === '1') return;
+
+  const preferencePath =
+    process.env.HAR_TELEMETRY_CONFIG_PATH || path.join(os.homedir(), '.har', 'telemetry.json');
+
+  if (fs.existsSync(preferencePath)) return;
+
+  const preference = {
+    enabled: true,
+    signals: {
+      metrics: true,
+      logs: true,
+      prompts: true,
+      traces: true,
+    },
+    updatedAt: new Date().toISOString(),
+  };
+
+  fs.mkdirSync(path.dirname(preferencePath), { recursive: true });
+  fs.writeFileSync(preferencePath, `${JSON.stringify(preference, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch {
+  // Never fail npm install over telemetry preference write.
+}

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -12,6 +12,7 @@ import {
 import { readSlotRegistry } from '../../core/slot-registry';
 import {
   TELEMETRY_SIGNALS,
+  ensureDefaultTelemetryPreference,
   getTelemetryPreferencePath,
   getTelemetrySignals,
   isTelemetryEnabled,
@@ -73,10 +74,10 @@ async function handleStatus(argv: { json: boolean }): Promise<void> {
   printSignals();
 }
 
-async function handleOn(argv: { prompts?: boolean }): Promise<void> {
+async function handleOn(argv: { prompts: boolean }): Promise<void> {
   header('har telemetry on');
   const preference = writeTelemetryPreference(true, {
-    prompts: argv.prompts === true ? true : undefined,
+    prompts: argv.prompts,
     traces: true,
   });
   success('Telemetry enabled. Cursor / Claude / Codex export via opentelemetry-hooks → Mission Control.');
@@ -85,6 +86,8 @@ async function handleOn(argv: { prompts?: boolean }): Promise<void> {
   );
   if (preference.signals.prompts) {
     warn('Prompt text will leave the agent machine for local Mission Control (also used as session purpose).');
+  } else {
+    info('Prompt capture is off — enable with: har telemetry on --prompts');
   }
   printSignals();
 
@@ -190,9 +193,10 @@ function handlePrintEnv(argv: {
 
 async function handleInstallHooks(): Promise<void> {
   header('har telemetry install-hooks');
+  ensureDefaultTelemetryPreference();
   if (!isTelemetryEnabled()) {
     warn('Telemetry is off — enabling preference so hooks can export.');
-    writeTelemetryPreference(true, { traces: true });
+    writeTelemetryPreference(true, { traces: true, prompts: true });
   }
   const result = await ensureTelemetryInfrastructure({ startIfNeeded: true });
   if (result.message) success(result.message);
@@ -223,16 +227,23 @@ export const telemetryCommand = {
       )
       .command(
         'on',
-        'Enable telemetry, ensure Mission Control, install/configure opentelemetry-hooks',
+        'Enable full telemetry (incl. prompts), ensure Mission Control, install/configure opentelemetry-hooks',
         (y: Argv) =>
-          y.option('prompts', {
-            type: 'boolean',
-            default: false,
-            describe: 'Opt in to shipping user prompt text (also fills Mission Control purpose)',
-          }),
+          y
+            .option('prompts', {
+              type: 'boolean',
+              default: true,
+              describe: 'Ship user prompt text (also fills Mission Control purpose; default on)',
+            })
+            .option('no-prompts', {
+              type: 'boolean',
+              default: false,
+              describe: 'Disable prompt text capture (traces/logs/metrics still on)',
+            }),
         (argv) => {
+          const noPrompts = argv['no-prompts'] as boolean;
           void handleOn({
-            prompts: argv.prompts as boolean,
+            prompts: noPrompts ? false : (argv.prompts as boolean),
           });
         },
       )

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,7 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { getHarPackageVersion } from '../core/package-version';
+import { ensureDefaultTelemetryPreference } from '../core/telemetry-config';
 import { agentsCommand } from './commands/agents';
 import { envCommand } from './commands/env';
 import { controlCommand } from './commands/control';
@@ -11,6 +12,7 @@ import { telemetryCommand } from './commands/telemetry';
 import { HAR_ROOT_EPILOG } from './help-text';
 
 export async function runCli(): Promise<void> {
+  ensureDefaultTelemetryPreference();
   await yargs(hideBin(process.argv))
     .scriptName('har')
     .usage('$0 <command> [options]')

--- a/src/core/telemetry-config.ts
+++ b/src/core/telemetry-config.ts
@@ -18,7 +18,7 @@ export interface TelemetryPreference {
 const DEFAULT_SIGNALS_ON: TelemetrySignals = {
   metrics: true,
   logs: true,
-  prompts: false,
+  prompts: true,
   /** Hooks are traces-first; usage metrics are derived from span gen_ai.usage.* in Mission Control. */
   traces: true,
 };
@@ -53,7 +53,7 @@ function normalizeSignals(
   return {
     metrics: raw?.metrics !== false,
     logs: raw?.logs !== false,
-    prompts: raw?.prompts === true,
+    prompts: raw?.prompts !== false,
     traces: raw?.traces !== false,
   };
 }
@@ -98,6 +98,22 @@ export function writeTelemetryPreference(
   return preference;
 }
 
+/**
+ * Persist full default telemetry (including prompts) when no preference file exists.
+ * Does not overwrite an existing choice (e.g. prior `har telemetry off` or prompts=false).
+ * Skips writing when HAR_TELEMETRY explicitly disables telemetry.
+ */
+export function ensureDefaultTelemetryPreference(): TelemetryPreference {
+  const preferencePath = getPreferencePath();
+  if (fs.existsSync(preferencePath)) {
+    return readTelemetryPreference();
+  }
+  if (parseEnvOverride(process.env.HAR_TELEMETRY) === false) {
+    return { enabled: false, signals: { ...DEFAULT_SIGNALS_OFF } };
+  }
+  return writeTelemetryPreference(true, { ...DEFAULT_SIGNALS_ON });
+}
+
 /** Effective telemetry flag: HAR_TELEMETRY env wins over ~/.har/telemetry.json; default on. */
 export function isTelemetryEnabled(): boolean {
   const envOverride = parseEnvOverride(process.env.HAR_TELEMETRY);
@@ -119,6 +135,6 @@ export const TELEMETRY_SIGNALS = [
   'Traces (default): Cursor / Claude / Codex activity via opentelemetry-hooks → Mission Control',
   'Logs/events (default): hook lifecycle logs without prompt bodies',
   'Metrics (default): token usage derived from span gen_ai.usage.* attributes',
-  'Prompts (opt-in): user prompt text via IDE_OTEL_CAPTURE_TEXT — har telemetry on --prompts (also fills Mission Control purpose)',
+  'Prompts (default): user prompt text via IDE_OTEL_CAPTURE_TEXT (also fills Mission Control purpose); disable with har telemetry on --no-prompts',
   'Fallback: har control sync harvests local Claude/Codex session files when hooks telemetry is missing',
 ] as const;

--- a/src/core/telemetry-ensure.ts
+++ b/src/core/telemetry-ensure.ts
@@ -1,7 +1,7 @@
 import { getControlApiUrl, isControlEnabled } from './control-config';
 import { startMissionControl } from './control-lifecycle';
 import { isControlApiReachable, waitForControlApi } from './control-sync';
-import { isTelemetryEnabled } from './telemetry-config';
+import { ensureDefaultTelemetryPreference, isTelemetryEnabled } from './telemetry-config';
 
 export interface EnsureTelemetryResult {
   telemetryEnabled: boolean;
@@ -22,6 +22,7 @@ export async function ensureTelemetryInfrastructure(options?: {
   startIfNeeded?: boolean;
 }): Promise<EnsureTelemetryResult> {
   const apiUrl = getControlApiUrl();
+  ensureDefaultTelemetryPreference();
   const telemetryEnabled = isTelemetryEnabled();
   const controlEnabled = isControlEnabled();
   const startIfNeeded = options?.startIfNeeded !== false;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import { describeProject, initHarness } from '../core/harness';
 import { recordRepoForControlSync } from '../core/control-registry';
 import { startControlAndSync } from '../core/control-lifecycle';
 import { getHarPackageVersion } from '../core/package-version';
+import { ensureDefaultTelemetryPreference } from '../core/telemetry-config';
 import {
   completeEnvironment,
   getEnvironmentLogs,
@@ -494,6 +495,7 @@ export async function handleMcpToolCall(
 }
 
 export async function runHarMcpServer(defaultRepo = '.'): Promise<void> {
+  ensureDefaultTelemetryPreference();
   const server = new Server(
     { name: 'har', version: getHarPackageVersion() },
     { capabilities: { tools: {} } },

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -31,7 +31,7 @@ When a slot is occupied: prefer `complete` / `teardown` if the previous task is 
 - **Never** set `force`/`confirmReplace` without the user explicitly approving replacement.
 - **Commit early and often** in the session worktree — teardown keeps the branch, not uncommitted work.
 - **Gitignored paths are ephemeral** (`state/`, `runs/`, local clones) — they are lost when the worktree is removed.
-- With telemetry prompts enabled, Mission Control derives session purpose from the first captured user prompt.
+- With telemetry on (default, including prompts), Mission Control derives session purpose from the first captured user prompt.
 
 <!-- Monorepo: if this repository contains multiple .har harnesses, list them here
      and pick by the files you are changing. Example:

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  ensureDefaultTelemetryPreference,
   getTelemetryPreferencePath,
   isTelemetryEnabled,
   readTelemetryPreference,
@@ -38,26 +39,38 @@ describe('telemetry preference', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('defaults to enabled when preference file is missing', () => {
+  it('defaults to full telemetry (including prompts) when preference file is missing', () => {
     expect(readTelemetryPreference()).toEqual({
       enabled: true,
-      signals: { metrics: true, logs: true, prompts: false, traces: true },
+      signals: { metrics: true, logs: true, prompts: true, traces: true },
     });
     expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it('persists full defaults on first ensure without overwriting later', () => {
+    const first = ensureDefaultTelemetryPreference();
+    expect(first.enabled).toBe(true);
+    expect(first.signals.prompts).toBe(true);
+    expect(fs.existsSync(getTelemetryPreferencePath())).toBe(true);
+
+    writeTelemetryPreference(true, { prompts: false });
+    const second = ensureDefaultTelemetryPreference();
+    expect(second.signals.prompts).toBe(false);
   });
 
   it('persists on/off', () => {
     writeTelemetryPreference(false);
     expect(isTelemetryEnabled()).toBe(false);
     expect(fs.existsSync(getTelemetryPreferencePath())).toBe(true);
-    writeTelemetryPreference(true);
+    writeTelemetryPreference(true, { prompts: true, traces: true });
     expect(isTelemetryEnabled()).toBe(true);
+    expect(readTelemetryPreference().signals.prompts).toBe(true);
   });
 
-  it('persists prompt signal flags and defaults traces on', () => {
-    writeTelemetryPreference(true, { prompts: true });
+  it('persists prompt opt-out and defaults traces on', () => {
+    writeTelemetryPreference(true, { prompts: false });
     const preference = readTelemetryPreference();
-    expect(preference.signals.prompts).toBe(true);
+    expect(preference.signals.prompts).toBe(false);
     expect(preference.signals.traces).toBe(true);
     expect(preference.signals.metrics).toBe(true);
     expect(preference.signals.logs).toBe(true);
@@ -180,13 +193,19 @@ describe('otel hooks config', () => {
   });
 
   it('maps HAR signals to hook knobs with http/json endpoint', () => {
-    writeTelemetryPreference(true, { prompts: true });
+    writeTelemetryPreference(true);
     const config = buildOtelHooksConfig({ enabled: true, apiUrl: 'http://localhost:3847' });
     expect(config.OTEL_EXPORTER_OTLP_ENDPOINT).toBe('http://localhost:3847/api/otel/v1/traces');
     expect(config.OTEL_EXPORTER_OTLP_PROTOCOL).toBe('http/json');
     expect(config.IDE_OTEL_CAPTURE_TEXT).toBe('true');
     expect(config.IDE_OTEL_ENABLE_LOGS).toBe('true');
     expect(config.IDE_OTEL_BATCH_ON_STOP).toBe('true');
+  });
+
+  it('disables prompt capture when prompts signal is off', () => {
+    writeTelemetryPreference(true, { prompts: false });
+    const config = buildOtelHooksConfig({ enabled: true, apiUrl: 'http://localhost:3847' });
+    expect(config.IDE_OTEL_CAPTURE_TEXT).toBe('false');
   });
 
   it('nulls OTLP endpoint when telemetry disabled', () => {


### PR DESCRIPTION
## Summary
- Make full agent telemetry the default (traces, logs, metrics, **and prompts**) instead of treating prompts as opt-in.
- Persist `~/.har/telemetry.json` on npm install (`postinstall`) and on first `har` / MCP / launch when the file is missing; never overwrite an existing preference.
- Add `har telemetry on --no-prompts` to keep usage telemetry without shipping prompt text; update docs and Mission Control copy accordingly.

## Test plan
- [x] `./.har/verify.sh 1 --full` (pass) in session worktree
- [ ] Fresh install / missing `~/.har/telemetry.json` → file created with `prompts: true`
- [ ] Existing `telemetry.json` with `prompts: false` left unchanged until `har telemetry on`
- [ ] `har telemetry on --no-prompts` clears prompt capture in hooks config
- [ ] `har telemetry off` still disables export / MC auto-start


Made with [Cursor](https://cursor.com)