### PR TITLE
feat(control): har control sync incremental portal push via a per-(repo, portal) watermark

### DIFF
--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -105,6 +105,11 @@ export const controlCommand = {
               type: 'boolean',
               default: false,
               describe: 'Sync to HAR Cloud instead of local Mission Control',
+            })
+            .option('full', {
+              type: 'boolean',
+              default: false,
+              describe: 'Ignore the portal watermark and resend the complete payload',
             }),
         handleSync,
       )
@@ -318,6 +323,7 @@ async function handleSync(argv: {
   dryRun: boolean;
   json: boolean;
   cloud?: boolean;
+  full: boolean;
 }): Promise<void> {
   const isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
   const discovered = await discoverHarRepos({ apiUrl: argv.apiUrl, cwd: process.cwd() });
@@ -381,6 +387,7 @@ async function handleSync(argv: {
     apiUrl: argv.apiUrl,
     dryRun: argv.dryRun,
     cloud: argv.cloud,
+    full: argv.full,
   });
 
   if (argv.json) {

--- a/src/core/control-persisted-usage.ts
+++ b/src/core/control-persisted-usage.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import type { AgentSessionEvent, AgentSessionUsage, AgentTool, UsageSource } from '../harness/schema';
+import { selectSince } from './portal-watermark';
 
 const FETCH_TIMEOUT_MS = 3000;
 
@@ -22,6 +23,7 @@ interface PersistedUsageRow {
   sources?: unknown;
   firstSeenAt: string;
   lastSeenAt: string;
+  updatedAt?: string | null;
 }
 
 interface PersistedEventRow {
@@ -38,6 +40,7 @@ interface PersistedEventRow {
   source?: string | null;
   workUnitId?: string | null;
   attemptId?: string | null;
+  createdAt?: string | null;
 }
 
 async function getJson<T>(url: string): Promise<T | null> {
@@ -118,26 +121,44 @@ function normalizeEvent(row: PersistedEventRow): AgentSessionEvent {
   };
 }
 
+function maxTimestamp(a: string | null, b: string | null): string | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return a > b ? a : b;
+}
+
 /**
  * Best-effort read of persisted telemetry from a locally-reachable Mission
  * Control. Returns empty when the control API is unreachable or the repo is not
  * registered there, so a portal sync always falls back to the live-slot
  * harvest. Never throws.
+ *
+ * When `since` is set, only rows changed after it are returned — usage by its
+ * cumulative `updatedAt` (a live session that gained tokens re-syncs even
+ * though its event time looks old), events by their append-only `createdAt`.
+ * `maxSyncedAt` is the newest timestamp among the returned rows, for advancing
+ * the caller's watermark to the max actually sent.
  */
 export async function fetchPersistedPortalTelemetry(
   repoPath: string,
   apiUrl: string,
-): Promise<{ usage: AgentSessionUsage[]; events: AgentSessionEvent[] }> {
+  options?: { since?: string | null },
+): Promise<{ usage: AgentSessionUsage[]; events: AgentSessionEvent[]; maxSyncedAt: string | null }> {
   const repoId = await resolveControlRepoId(apiUrl, repoPath);
-  if (!repoId) return { usage: [], events: [] };
+  if (!repoId) return { usage: [], events: [], maxSyncedAt: null };
 
+  const since = options?.since ?? null;
   const [usageResponse, eventsResponse] = await Promise.all([
     getJson<{ usage: PersistedUsageRow[] }>(`${apiUrl}/api/repos/${repoId}/usage`),
     getJson<{ events: PersistedEventRow[] }>(`${apiUrl}/api/repos/${repoId}/events`),
   ]);
 
+  const usage = selectSince(usageResponse?.usage ?? [], since, (row) => row.updatedAt ?? row.lastSeenAt);
+  const events = selectSince(eventsResponse?.events ?? [], since, (row) => row.createdAt ?? row.timestamp);
+
   return {
-    usage: (usageResponse?.usage ?? []).map(normalizeUsage),
-    events: (eventsResponse?.events ?? []).map(normalizeEvent),
+    usage: usage.selected.map(normalizeUsage),
+    events: events.selected.map(normalizeEvent),
+    maxSyncedAt: maxTimestamp(usage.maxSyncedAt, events.maxSyncedAt),
   };
 }

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -36,6 +36,7 @@ import { harvestEventsForSlot, harvestUsageForSlot } from './usage-harvest';
 import { buildSessionKey } from './telemetry-env';
 import { fetchPersistedPortalTelemetry } from './control-persisted-usage';
 import { dedupePortalEvents, mergePortalUsage } from './portal-usage-merge';
+import { readPortalWatermark, writePortalWatermark } from './portal-watermark';
 import type { AgentSessionEvent, AgentSessionUsage } from '../harness/schema';
 
 export interface ControlSyncOptions {
@@ -45,6 +46,8 @@ export interface ControlSyncOptions {
   cloud?: boolean;
   /** Re-register even if the path was previously unregistered. */
   force?: boolean;
+  /** Ignore the portal watermark and resend the complete persisted payload. */
+  full?: boolean;
 }
 
 export interface ControlRegisterOptions extends ControlSyncOptions {
@@ -118,8 +121,13 @@ async function collectPortalTelemetry(
   repoPath: string,
   slots: EnvironmentStatus['slots'],
   controlApiUrl: string,
-): Promise<{ usage: Record<string, unknown>[]; events: Record<string, unknown>[] }> {
-  if (!isTelemetryEnabled()) return { usage: [], events: [] };
+  since: string | null,
+): Promise<{
+  usage: Record<string, unknown>[];
+  events: Record<string, unknown>[];
+  maxSyncedAt: string | null;
+}> {
+  if (!isTelemetryEnabled()) return { usage: [], events: [], maxSyncedAt: null };
   try {
     const userEmail = resolvePortalUserEmail();
     const liveUsage: AgentSessionUsage[] = slots.flatMap((slot) =>
@@ -162,7 +170,7 @@ async function collectPortalTelemetry(
       })),
     );
 
-    const persisted = await fetchPersistedPortalTelemetry(repoPath, controlApiUrl);
+    const persisted = await fetchPersistedPortalTelemetry(repoPath, controlApiUrl, { since });
 
     const usage = mergePortalUsage(liveUsage, persisted.usage).map((row) => {
       const models = modelsFromBreakdown(row.modelBreakdown as Record<string, unknown> | undefined);
@@ -177,18 +185,20 @@ async function collectPortalTelemetry(
       dropNullFields({ ...event }),
     );
 
-    return { usage, events };
+    return { usage, events, maxSyncedAt: persisted.maxSyncedAt };
   } catch {
-    return { usage: [], events: [] };
+    return { usage: [], events: [], maxSyncedAt: null };
   }
 }
 
 async function buildPortalPayload(
   repoPath: string,
   controlApiUrl: string,
+  since: string | null,
 ): Promise<{
   syncBody: Record<string, unknown>;
   events: Record<string, unknown>[];
+  maxSyncedAt: string | null;
 }> {
   const runs = listRuns(repoPath);
   const status = collectEnvironmentStatus(repoPath);
@@ -199,7 +209,12 @@ async function buildPortalPayload(
   const workUnits = listWorkUnits(harnessRoot);
   const attempts = listWorkAttempts(harnessRoot);
   const validationBindings = listValidationBindings(harnessRoot);
-  const { usage, events } = await collectPortalTelemetry(repoPath, status.slots, controlApiUrl);
+  const { usage, events, maxSyncedAt } = await collectPortalTelemetry(
+    repoPath,
+    status.slots,
+    controlApiUrl,
+    since,
+  );
 
   const syncBody: Record<string, unknown> = {
     path: repoPath,
@@ -215,7 +230,7 @@ async function buildPortalPayload(
     ...(usage.length > 0 ? { usage } : {}),
   };
 
-  return { syncBody, events };
+  return { syncBody, events, maxSyncedAt };
 }
 
 export async function isControlApiReachable(apiUrl = getControlApiUrl()): Promise<boolean> {
@@ -292,6 +307,7 @@ export async function syncReposWithControl(options: {
   apiUrl?: string;
   dryRun?: boolean;
   cloud?: boolean;
+  full?: boolean;
 }): Promise<{ synced: number; failed: number; results: SyncRepoResult[] }> {
   const apiUrl = options.apiUrl ?? getControlApiUrl();
   const results: SyncRepoResult[] = [];
@@ -301,7 +317,7 @@ export async function syncReposWithControl(options: {
   for (const repoPath of options.repoPaths) {
     try {
       await withTimeout(
-        syncRepoWithControl({ repoPath, apiUrl, dryRun: options.dryRun, cloud: options.cloud }),
+        syncRepoWithControl({ repoPath, apiUrl, dryRun: options.dryRun, cloud: options.cloud, full: options.full }),
         SYNC_TIMEOUT_MS,
         'control sync',
       );
@@ -407,7 +423,8 @@ export async function syncRepoWithControl(options: ControlSyncOptions): Promise<
 
   const portal = getPortalTarget();
   if (portal) {
-    const { syncBody, events } = await buildPortalPayload(repoPath, apiUrl);
+    const since = options.full ? null : readPortalWatermark(repoPath, portal.url);
+    const { syncBody, events, maxSyncedAt } = await buildPortalPayload(repoPath, apiUrl, since);
     await postPortal(portal, '/api/sync', syncBody, options.dryRun);
     if (events.length > 0) {
       await postPortal(
@@ -416,6 +433,9 @@ export async function syncRepoWithControl(options: ControlSyncOptions): Promise<
         { path: repoPath, events, spans: [] },
         options.dryRun,
       );
+    }
+    if (!options.dryRun && maxSyncedAt) {
+      writePortalWatermark(repoPath, portal.url, maxSyncedAt);
     }
     return;
   }

--- a/src/core/portal-watermark.ts
+++ b/src/core/portal-watermark.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { canonicalizeControlRepoPath } from './control-repo-path';
+
+interface PortalSyncStateEntry {
+  repoPath: string;
+  portalUrl: string;
+  lastSyncedAt: string;
+}
+
+interface PortalSyncState {
+  states: PortalSyncStateEntry[];
+}
+
+function getStatePath(): string {
+  if (process.env.HAR_PORTAL_SYNC_STATE_PATH) {
+    return path.resolve(process.env.HAR_PORTAL_SYNC_STATE_PATH);
+  }
+  return path.join(os.homedir(), '.har', 'portal-sync-state.json');
+}
+
+function readState(): PortalSyncState {
+  const statePath = getStatePath();
+  try {
+    if (!fs.existsSync(statePath)) return { states: [] };
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8')) as PortalSyncState;
+    return Array.isArray(parsed.states) ? parsed : { states: [] };
+  } catch {
+    return { states: [] };
+  }
+}
+
+function writeState(state: PortalSyncState): void {
+  const statePath = getStatePath();
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n');
+}
+
+/** Last-sync timestamp for a (repo, portal) pair, or null when never synced. */
+export function readPortalWatermark(repoPath: string, portalUrl: string): string | null {
+  const canonical = canonicalizeControlRepoPath(repoPath);
+  const entry = readState().states.find(
+    (state) => state.repoPath === canonical && state.portalUrl === portalUrl,
+  );
+  return entry?.lastSyncedAt ?? null;
+}
+
+export function writePortalWatermark(
+  repoPath: string,
+  portalUrl: string,
+  lastSyncedAt: string,
+): void {
+  const canonical = canonicalizeControlRepoPath(repoPath);
+  const state = readState();
+  const existing = state.states.find(
+    (entry) => entry.repoPath === canonical && entry.portalUrl === portalUrl,
+  );
+  if (existing) {
+    existing.lastSyncedAt = lastSyncedAt;
+  } else {
+    state.states.push({ repoPath: canonical, portalUrl, lastSyncedAt });
+  }
+  writeState(state);
+}
+
+export function getPortalWatermarkPath(): string {
+  return getStatePath();
+}
+
+/**
+ * Select rows newer than `since` and report the newest timestamp among them.
+ * Rows without a comparable timestamp are always included (can't tell → send;
+ * the portal upsert is idempotent). `since === null` selects everything.
+ */
+export function selectSince<T>(
+  rows: T[],
+  since: string | null,
+  getTimestamp: (row: T) => string | null | undefined,
+): { selected: T[]; maxSyncedAt: string | null } {
+  let maxSyncedAt: string | null = null;
+  const selected: T[] = [];
+
+  for (const row of rows) {
+    const ts = getTimestamp(row);
+    if (since && ts && ts <= since) continue;
+    selected.push(row);
+    if (ts && (maxSyncedAt === null || ts > maxSyncedAt)) maxSyncedAt = ts;
+  }
+
+  return { selected, maxSyncedAt };
+}

--- a/tests/control-persisted-usage.test.ts
+++ b/tests/control-persisted-usage.test.ts
@@ -28,7 +28,7 @@ describe('fetchPersistedPortalTelemetry', () => {
   it('returns empty when Mission Control does not know the repo', async () => {
     routedFetch({ '/api/repos': { status: 200, json: [{ id: 'r1', path: '/other/repo' }] } });
     const result = await fetchPersistedPortalTelemetry('/repo/x', API);
-    expect(result).toEqual({ usage: [], events: [] });
+    expect(result).toEqual({ usage: [], events: [], maxSyncedAt: null });
   });
 
   it('returns empty (never throws) when the control API is unreachable', async () => {
@@ -39,6 +39,7 @@ describe('fetchPersistedPortalTelemetry', () => {
     await expect(fetchPersistedPortalTelemetry('/repo/x', API)).resolves.toEqual({
       usage: [],
       events: [],
+      maxSyncedAt: null,
     });
   });
 
@@ -111,5 +112,93 @@ describe('fetchPersistedPortalTelemetry', () => {
     expect(result.events[0].sessionKey).toBe('feat/gone');
     expect(result.events[0].promptText).toBe('hello');
     expect(result.events[0].source).toBe('harvest');
+  });
+
+  function usageRow(sessionKey: string, updatedAt: string, lastSeenAt: string) {
+    return {
+      id: sessionKey,
+      repositoryId: 'repo-1',
+      sessionKey,
+      agentId: 1,
+      agentTool: 'claude_code',
+      tokensInput: 1,
+      tokensOutput: 1,
+      tokensCacheRead: 0,
+      tokensCacheCreation: 0,
+      tokensTotal: 2,
+      costUsd: null,
+      sources: ['harvest'],
+      firstSeenAt: '2026-01-01T00:00:00.000Z',
+      lastSeenAt,
+      updatedAt,
+    };
+  }
+
+  function eventRow(sessionKey: string, createdAt: string, timestamp: string) {
+    return {
+      id: sessionKey,
+      repositoryId: 'repo-1',
+      sessionKey,
+      agentId: 1,
+      agentTool: 'claude_code',
+      eventName: 'claude_code.user_prompt',
+      sequence: 1,
+      timestamp,
+      source: 'harvest',
+      createdAt,
+    };
+  }
+
+  it('forwards only rows changed after the watermark and reports the max sent', async () => {
+    routedFetch({
+      '/api/repos': { status: 200, json: [{ id: 'repo-1', path: '/repo/x' }] },
+      '/api/repos/repo-1/usage': {
+        status: 200,
+        json: {
+          usage: [
+            usageRow('old', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'),
+            usageRow('grew', '2026-01-05T00:00:00.000Z', '2026-01-01T00:00:00.000Z'),
+          ],
+        },
+      },
+      '/api/repos/repo-1/events': {
+        status: 200,
+        json: {
+          events: [
+            eventRow('old-ev', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'),
+            eventRow('new-ev', '2026-01-04T00:00:00.000Z', '2026-01-01T00:00:00.000Z'),
+          ],
+        },
+      },
+    });
+
+    const result = await fetchPersistedPortalTelemetry('/repo/x', API, {
+      since: '2026-01-02T00:00:00.000Z',
+    });
+
+    // The cumulative 'grew' session re-syncs on updatedAt even though its event
+    // time (lastSeenAt) predates the watermark; the stale 'old' row is dropped.
+    expect(result.usage.map((u) => u.sessionKey)).toEqual(['grew']);
+    expect(result.events.map((e) => e.sessionKey)).toEqual(['new-ev']);
+    expect(result.maxSyncedAt).toBe('2026-01-05T00:00:00.000Z');
+  });
+
+  it('sends nothing when no row changed since the watermark', async () => {
+    routedFetch({
+      '/api/repos': { status: 200, json: [{ id: 'repo-1', path: '/repo/x' }] },
+      '/api/repos/repo-1/usage': {
+        status: 200,
+        json: { usage: [usageRow('old', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z')] },
+      },
+      '/api/repos/repo-1/events': { status: 200, json: { events: [] } },
+    });
+
+    const result = await fetchPersistedPortalTelemetry('/repo/x', API, {
+      since: '2026-06-01T00:00:00.000Z',
+    });
+
+    expect(result.usage).toEqual([]);
+    expect(result.events).toEqual([]);
+    expect(result.maxSyncedAt).toBeNull();
   });
 });

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -27,7 +27,11 @@ jest.mock('../src/core/usage-harvest', () => ({
   harvestEventsForSlot: jest.fn(() => []),
 }));
 jest.mock('../src/core/control-persisted-usage', () => ({
-  fetchPersistedPortalTelemetry: jest.fn(async () => ({ usage: [], events: [] })),
+  fetchPersistedPortalTelemetry: jest.fn(async () => ({ usage: [], events: [], maxSyncedAt: null })),
+}));
+jest.mock('../src/core/portal-watermark', () => ({
+  readPortalWatermark: jest.fn(() => null),
+  writePortalWatermark: jest.fn(),
 }));
 jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => true }));
 jest.mock('../src/harness/manifest', () => ({
@@ -45,6 +49,7 @@ import {
 } from '../src/core/work-units';
 import { harvestUsageForSlot, harvestEventsForSlot } from '../src/core/usage-harvest';
 import { fetchPersistedPortalTelemetry } from '../src/core/control-persisted-usage';
+import { readPortalWatermark, writePortalWatermark } from '../src/core/portal-watermark';
 
 const collectEnvironmentStatusMock = collectEnvironmentStatus as jest.Mock;
 const readPortalCredentialsMock = readPortalCredentials as jest.Mock;
@@ -54,6 +59,8 @@ const listValidationBindingsMock = listValidationBindings as jest.Mock;
 const harvestUsageForSlotMock = harvestUsageForSlot as jest.Mock;
 const harvestEventsForSlotMock = harvestEventsForSlot as jest.Mock;
 const fetchPersistedPortalTelemetryMock = fetchPersistedPortalTelemetry as jest.Mock;
+const readPortalWatermarkMock = readPortalWatermark as jest.Mock;
+const writePortalWatermarkMock = writePortalWatermark as jest.Mock;
 
 function resetPayloadMocks(): void {
   collectEnvironmentStatusMock.mockReturnValue({
@@ -66,7 +73,10 @@ function resetPayloadMocks(): void {
   listValidationBindingsMock.mockReturnValue([]);
   harvestUsageForSlotMock.mockReturnValue([]);
   harvestEventsForSlotMock.mockReturnValue([]);
-  fetchPersistedPortalTelemetryMock.mockResolvedValue({ usage: [], events: [] });
+  fetchPersistedPortalTelemetryMock.mockResolvedValue({ usage: [], events: [], maxSyncedAt: null });
+  readPortalWatermarkMock.mockReset();
+  readPortalWatermarkMock.mockReturnValue(null);
+  writePortalWatermarkMock.mockReset();
 }
 
 const PORTAL_ENV = [
@@ -489,5 +499,85 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(otelBody.events).toHaveLength(1);
     expect(otelBody.events[0].promptText).toBe('persisted');
     expect('responseText' in otelBody.events[0]).toBe(false);
+  });
+});
+
+describe('syncRepoWithControl — portal watermark', () => {
+  const realFetch = global.fetch;
+  beforeEach(() => {
+    resetPayloadMocks();
+    clearPortalEnv();
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_x';
+  });
+  afterEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+  afterAll(clearPortalEnv);
+
+  it('passes the stored watermark as `since` and advances it to the max sent', async () => {
+    readPortalWatermarkMock.mockReturnValue('2026-01-02T00:00:00.000Z');
+    fetchPersistedPortalTelemetryMock.mockResolvedValue({
+      usage: [],
+      events: [],
+      maxSyncedAt: '2026-01-09T00:00:00.000Z',
+    });
+    mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(fetchPersistedPortalTelemetryMock).toHaveBeenCalledWith('/repo/x', expect.any(String), {
+      since: '2026-01-02T00:00:00.000Z',
+    });
+    expect(writePortalWatermarkMock).toHaveBeenCalledWith(
+      '/repo/x',
+      'https://portal.example.com',
+      '2026-01-09T00:00:00.000Z',
+    );
+  });
+
+  it('--full ignores the stored watermark (since=null) but still advances it', async () => {
+    readPortalWatermarkMock.mockReturnValue('2026-01-02T00:00:00.000Z');
+    fetchPersistedPortalTelemetryMock.mockResolvedValue({
+      usage: [],
+      events: [],
+      maxSyncedAt: '2026-01-09T00:00:00.000Z',
+    });
+    mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x', full: true });
+
+    expect(fetchPersistedPortalTelemetryMock).toHaveBeenCalledWith('/repo/x', expect.any(String), {
+      since: null,
+    });
+    expect(readPortalWatermarkMock).not.toHaveBeenCalled();
+    expect(writePortalWatermarkMock).toHaveBeenCalledWith(
+      '/repo/x',
+      'https://portal.example.com',
+      '2026-01-09T00:00:00.000Z',
+    );
+  });
+
+  it('does not advance the watermark when nothing new was sent', async () => {
+    readPortalWatermarkMock.mockReturnValue('2026-01-02T00:00:00.000Z');
+    fetchPersistedPortalTelemetryMock.mockResolvedValue({ usage: [], events: [], maxSyncedAt: null });
+    mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(writePortalWatermarkMock).not.toHaveBeenCalled();
+  });
+
+  it('does not advance the watermark on dry-run', async () => {
+    fetchPersistedPortalTelemetryMock.mockResolvedValue({
+      usage: [],
+      events: [],
+      maxSyncedAt: '2026-01-09T00:00:00.000Z',
+    });
+    mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x', dryRun: true });
+
+    expect(writePortalWatermarkMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/portal-watermark.test.ts
+++ b/tests/portal-watermark.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+
+import {
+  getPortalWatermarkPath,
+  readPortalWatermark,
+  selectSince,
+  writePortalWatermark,
+} from '../src/core/portal-watermark';
+
+describe('portal watermark store', () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'har-portal-watermark-'));
+    process.env.HAR_PORTAL_SYNC_STATE_PATH = path.join(tempHome, 'portal-sync-state.json');
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('returns null before any sync', () => {
+    expect(readPortalWatermark('/repo/a', 'https://portal.example.com')).toBeNull();
+  });
+
+  it('round-trips a watermark per (repo, portal)', () => {
+    writePortalWatermark('/repo/a', 'https://p1.example.com', '2026-01-02T00:00:00.000Z');
+    expect(fs.existsSync(getPortalWatermarkPath())).toBe(true);
+    expect(readPortalWatermark('/repo/a', 'https://p1.example.com')).toBe(
+      '2026-01-02T00:00:00.000Z',
+    );
+  });
+
+  it('keys independently by repo and by portal', () => {
+    writePortalWatermark('/repo/a', 'https://p1.example.com', '2026-01-01T00:00:00.000Z');
+    writePortalWatermark('/repo/a', 'https://p2.example.com', '2026-02-01T00:00:00.000Z');
+    writePortalWatermark('/repo/b', 'https://p1.example.com', '2026-03-01T00:00:00.000Z');
+
+    expect(readPortalWatermark('/repo/a', 'https://p1.example.com')).toBe('2026-01-01T00:00:00.000Z');
+    expect(readPortalWatermark('/repo/a', 'https://p2.example.com')).toBe('2026-02-01T00:00:00.000Z');
+    expect(readPortalWatermark('/repo/b', 'https://p1.example.com')).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('upserts the same (repo, portal) in place', () => {
+    writePortalWatermark('/repo/a', 'https://p1.example.com', '2026-01-01T00:00:00.000Z');
+    writePortalWatermark('/repo/a', 'https://p1.example.com', '2026-05-01T00:00:00.000Z');
+    expect(readPortalWatermark('/repo/a', 'https://p1.example.com')).toBe('2026-05-01T00:00:00.000Z');
+    const parsed = JSON.parse(fs.readFileSync(getPortalWatermarkPath(), 'utf8'));
+    expect(parsed.states).toHaveLength(1);
+  });
+});
+
+describe('selectSince', () => {
+  const rows = [
+    { key: 'a', ts: '2026-01-01T00:00:00.000Z' },
+    { key: 'b', ts: '2026-03-01T00:00:00.000Z' },
+    { key: 'c', ts: '2026-02-01T00:00:00.000Z' },
+  ];
+  const getTs = (r: { ts: string }) => r.ts;
+
+  it('selects everything and reports the max when since is null', () => {
+    const result = selectSince(rows, null, getTs);
+    expect(result.selected.map((r) => r.key)).toEqual(['a', 'b', 'c']);
+    expect(result.maxSyncedAt).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('selects only rows newer than since and advances to the max sent', () => {
+    const result = selectSince(rows, '2026-01-15T00:00:00.000Z', getTs);
+    expect(result.selected.map((r) => r.key)).toEqual(['b', 'c']);
+    expect(result.maxSyncedAt).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('selects nothing (max null) when all rows are at or before since', () => {
+    const result = selectSince(rows, '2026-06-01T00:00:00.000Z', getTs);
+    expect(result.selected).toEqual([]);
+    expect(result.maxSyncedAt).toBeNull();
+  });
+
+  it('always includes rows without a comparable timestamp', () => {
+    const mixed = [{ key: 'x', ts: undefined }, { key: 'y', ts: '2026-01-01T00:00:00.000Z' }];
+    const result = selectSince(mixed, '2026-05-01T00:00:00.000Z', (r) => r.ts);
+    expect(result.selected.map((r) => r.key)).toEqual(['x']);
+    expect(result.maxSyncedAt).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`har control sync` now forwards only the persisted usage/events **changed since the last push to a given portal**, instead of resending the full payload on every sync. Builds on the consolidated sync loop from #88.

- **Watermark**, host-side, per `(repo, portalUrl)` in `~/.har/portal-sync-state.json` (new `portal-watermark.ts`). Read as the `since` cutoff; advanced to the **max timestamp actually sent** (never `now()`), only after a successful push, never on dry-run.
- **Change-time filter** on the persisted read path: usage by its cumulative `updatedAt` (a session that gained tokens re-syncs even when its event time looks old), events by their append-only `createdAt`. `fetchPersistedPortalTelemetry(…, { since })` returns the filtered rows plus `maxSyncedAt`.
- **`--full`** flag ignores/resets the watermark and resends everything (recreated/wiped portal, schema change, backfill). Threads through `syncReposWithControl` → `syncRepoWithControl`.
- Portal upsert is unchanged, so a **deleted/absent watermark just triggers one idempotent full resend — no duplicates**.

Scope: the persisted usage + events read path only. `runs`/`slots` are rebuilt from local files each sync, not the persisted path, so they stay full each time.

## Test plan

- `typecheck` / `lint` (changed files) / `build` — green.
- Unit suites (50 tests): `portal-watermark` (store round-trip per repo+portal, `selectSince`), `control-persisted-usage` (since-filter incl. the cumulative-`updatedAt` re-send + nothing-new cases), `control-portal-sync` (since passthrough, advance-to-max on success, `--full` → `since=null` still advances, no-advance on dry-run / nothing-new). Existing sync suites still pass.
- **End-to-end against a live portal**: stood up an empty har-portal DB, synced real Mission Control data, and confirmed — first sync forwards the row + writes the watermark to the source max `updatedAt`; deleting the row then re-syncing incrementally leaves it gone (skipped); `--full` resends it. Idempotent throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)