### PR TITLE
feat(telemetry): replace Python hooks with TypeScript package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ Top-level command groups (see `har <cmd> --help`):
 | `har hooks …` | Commit gate and Claude worktree guard |
 | `har mcp` | MCP stdio server |
 | `har preferences …` | User onboarding defaults (`~/.har/preferences.json`) |
-| `har telemetry …` | Agent usage telemetry via opentelemetry-hooks |
+| `har telemetry …` | Agent usage telemetry via `@osfactory/otel-hook` |
 
 ## Testing on a project
 

--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -112,7 +112,7 @@ lives at `/repos`; cross-repo usage rollup at `/usage`.
 ## Agent usage telemetry (Cursor / Claude / Codex)
 
 HAR attributes Cursor, Claude Code, and Codex activity to each worktree/session via
-[opentelemetry-hooks](https://github.com/o11y-dev/opentelemetry-hooks) and shows it in
+[`@osfactory/otel-hook`](https://www.npmjs.com/package/@osfactory/otel-hook) and shows it in
 Mission Control. Preference shape:
 
 ```json
@@ -126,7 +126,7 @@ the Mission Control **purpose** column from the first captured user prompt.
 
 ```bash
 har telemetry status
-har telemetry on              # full telemetry + Mission Control + opentelemetry-hooks
+har telemetry on              # full telemetry + Mission Control + @osfactory/otel-hook
 har telemetry on --no-prompts # keep traces/logs/metrics; disable prompt text capture
 har telemetry install-hooks   # re-run Cursor / Claude / Codex hook registration
 har telemetry off             # clear hooks OTLP export + stop MC auto-start; keeps historical rows
@@ -134,12 +134,26 @@ har telemetry off             # clear hooks OTLP export + stop MC auto-start; ke
 
 Preference is stored in `~/.har/telemetry.json`. Override with `HAR_TELEMETRY=0|1`.
 Hooks config lives at `~/.har/otel-hooks/otel_config.json` (`HAR_OTEL_HOOKS_HOME` to override).
+The package itself is installed under `~/.har/otel-hooks/node_modules` (pinned
+`@osfactory/otel-hook`).
+
+### Upgrading from the Python hook
+
+Run `har telemetry install-hooks` after upgrading HAR. HAR installs the TypeScript
+package in its managed hooks directory, replaces existing HAR hook registrations,
+and then removes the legacy `opentelemetry-hooks` tool when it was installed with
+`uv` or `pipx`. The command name remains `otel-hook`, but HAR registrations use
+`~/.har/otel-hooks/run-otel-hook.sh`; the old Python executable does not need to
+remain on `PATH`. Python is no longer required for HAR telemetry.
+
+For a standalone, user-wide `otel-hook` command outside HAR, install it separately
+with `npm install -g @osfactory/otel-hook`.
 
 When telemetry is on:
 
 1. `har env launch` auto-starts Mission Control if it is not reachable (`har control up`).
-2. `har telemetry on` (and launch) install `opentelemetry-hooks` and register Cursor / Claude / Codex hooks
-   to export OTLP `http/json` to `{HAR_CONTROL_API_URL}/api/otel`.
+2. `har telemetry on` (and launch) install `@osfactory/otel-hook` and register Cursor / Claude / Codex hooks
+   to export OTLP `http/protobuf` to `{HAR_CONTROL_API_URL}/api/otel`.
 3. Launch writes session attribution into `.env.agent.<id>` (`HAR_SESSION_KEY`, resource attrs).
    Mission Control matches sessions by `har.session_key` or by workspace/cwd → slot work dir.
 4. Token usage is derived from span `gen_ai.usage.*` attributes. `har control sync` also

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -169,7 +169,7 @@ har telemetry write-env --agent-id <n> [--repo .] [--env-file path]
 har telemetry print-env --agent-id <n>
 ```
 
-Controls agent usage telemetry (Cursor / Claude / Codex via opentelemetry-hooks → Mission Control).
+Controls agent usage telemetry (Cursor / Claude / Codex via `@osfactory/otel-hook` → Mission Control).
 **Default: full on** (traces, logs, metrics, prompts). Install and the first `har` invocation
 persist `~/.har/telemetry.json` when missing. `on` ensures Mission Control is running and
 installs/configures hooks. Use `--no-prompts` to keep telemetry without prompt text.

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -80,7 +80,7 @@ async function handleOn(argv: { prompts: boolean }): Promise<void> {
     prompts: argv.prompts,
     traces: true,
   });
-  success('Telemetry enabled. Cursor / Claude / Codex export via opentelemetry-hooks → Mission Control.');
+  success('Telemetry enabled. Cursor / Claude / Codex export via @osfactory/otel-hook → Mission Control.');
   info(
     `Signals: metrics=${preference.signals.metrics} logs=${preference.signals.logs} prompts=${preference.signals.prompts} traces=${preference.signals.traces}`,
   );
@@ -203,18 +203,18 @@ async function handleInstallHooks(): Promise<void> {
   if (result.warning) warn(result.warning);
   const hooks = ensureOtelHooks({ setupAgents: true });
   if (hooks.ok) {
-    success(hooks.message ?? 'opentelemetry-hooks installed and agents registered');
+    success(hooks.message ?? '@osfactory/otel-hook installed and agents registered');
     info(`Config: ${hooks.configPath}`);
     info(`Wrapper: ${hooks.wrapperPath}`);
   } else {
-    error(hooks.warning ?? 'Failed to install opentelemetry-hooks');
+    error(hooks.warning ?? 'Failed to install @osfactory/otel-hook');
     process.exitCode = 1;
   }
 }
 
 export const telemetryCommand = {
   command: 'telemetry <subcommand>',
-  describe: 'Agent usage telemetry (Cursor / Claude / Codex via opentelemetry-hooks → Mission Control)',
+  describe: 'Agent usage telemetry (Cursor / Claude / Codex via @osfactory/otel-hook → Mission Control)',
   builder: (yargs: Argv) =>
     yargs
       .command(
@@ -227,7 +227,7 @@ export const telemetryCommand = {
       )
       .command(
         'on',
-        'Enable full telemetry (incl. prompts), ensure Mission Control, install/configure opentelemetry-hooks',
+        'Enable full telemetry (incl. prompts), ensure Mission Control, install/configure @osfactory/otel-hook',
         (y: Argv) =>
           y
             .option('prompts', {
@@ -257,7 +257,7 @@ export const telemetryCommand = {
       )
       .command(
         'install-hooks',
-        'Install opentelemetry-hooks and register Cursor / Claude / Codex',
+        'Install @osfactory/otel-hook and register Cursor / Claude / Codex',
         () => {},
         () => {
           void handleInstallHooks().catch((err) => {

--- a/src/core/otel-hooks.ts
+++ b/src/core/otel-hooks.ts
@@ -5,22 +5,43 @@ import * as path from 'path';
 import { getControlApiUrl } from './control-config';
 import { getTelemetrySignals, isTelemetryEnabled } from './telemetry-config';
 
-/** Pinned PyPI release for reproducible installs. */
-export const OTEL_HOOKS_PACKAGE = 'opentelemetry-hooks==0.14.0';
+/** Pinned npm package for reproducible installs (replaces Python opentelemetry-hooks). */
+export const OTEL_HOOKS_PACKAGE = '@osfactory/otel-hook@0.1.1';
 
+/** Providers HAR registers with `otel-hook setup --provider`. */
+export const OTEL_HOOKS_PROVIDERS = [
+  { id: 'cursor', label: 'cursor' },
+  { id: 'claude-code', label: 'claude' },
+  { id: 'codex', label: 'codex' },
+] as const;
+
+export type OtelHooksProviderId = (typeof OTEL_HOOKS_PROVIDERS)[number]['id'];
+
+/** @deprecated Use OTEL_HOOKS_PROVIDERS — kept for callers that still say "agents". */
 export const OTEL_HOOKS_AGENTS = ['cursor', 'claude', 'codex'] as const;
 export type OtelHooksAgent = (typeof OTEL_HOOKS_AGENTS)[number];
 
+/**
+ * HAR-managed `@osfactory/otel-hook` config file (`--config-file`).
+ * Shape matches the package's `OtelHookConfigPatch` (not the old Python IDE_OTEL_* keys).
+ */
 export interface OtelHooksConfig {
-  OTEL_EXPORTER_OTLP_ENDPOINT: string | null;
-  OTEL_EXPORTER_OTLP_PROTOCOL: string;
-  OTEL_SERVICE_NAME: string;
-  IDE_OTEL_BATCH_ON_STOP: string;
-  IDE_OTEL_ENABLE_LOGS: string;
-  IDE_OTEL_LOG_ALL_EVENTS: string;
-  IDE_OTEL_CAPTURE_TEXT: string;
-  IDE_OTEL_MASK_PROMPTS: string;
-  OTEL_RESOURCE_ATTRIBUTES?: string | null;
+  exporter: {
+    enabled: boolean;
+    endpoint?: string;
+    protocol: 'http/protobuf';
+    serviceName: string;
+    resourceAttributes?: Record<string, string | number | boolean>;
+    logs: {
+      enabled: boolean;
+      endpoint?: string;
+      includeContent: boolean;
+    };
+  };
+  privacy: {
+    contentMode: 'omit' | 'raw';
+    allowRawContent: boolean;
+  };
 }
 
 export interface EnsureOtelHooksResult {
@@ -32,6 +53,7 @@ export interface EnsureOtelHooksResult {
   message?: string;
   warning?: string;
   agentsSetup: OtelHooksAgent[];
+  providersSetup: OtelHooksProviderId[];
   errors: string[];
 }
 
@@ -50,6 +72,55 @@ export function getOtelHooksWrapperPath(hooksHome = getOtelHooksHome()): string 
   return path.join(hooksHome, 'run-otel-hook.sh');
 }
 
+export function getOtelHooksStateDir(hooksHome = getOtelHooksHome()): string {
+  return path.join(hooksHome, 'state');
+}
+
+function localOtelHookBin(hooksHome: string): string {
+  return path.join(hooksHome, 'node_modules', '.bin', 'otel-hook');
+}
+
+function installedPackageVersion(hooksHome: string): string | null {
+  try {
+    const pkgPath = path.join(
+      hooksHome,
+      'node_modules',
+      '@osfactory',
+      'otel-hook',
+      'package.json',
+    );
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function pinnedVersion(): string {
+  const at = OTEL_HOOKS_PACKAGE.lastIndexOf('@');
+  // package name is @osfactory/otel-hook@version — split on the last @
+  return at > 0 ? OTEL_HOOKS_PACKAGE.slice(at + 1) : OTEL_HOOKS_PACKAGE;
+}
+
+/** Parse `OTEL_RESOURCE_ATTRIBUTES` / HAR session attrs into a config object. */
+export function parseResourceAttributesString(
+  raw: string | null | undefined,
+): Record<string, string> {
+  if (!raw?.trim()) return {};
+  const out: Record<string, string> = {};
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (!key || key === 'service.name' || key === 'service.namespace') continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 /** Build HAR-managed otel-hook config from current telemetry signals. */
 export function buildOtelHooksConfig(options?: {
   enabled?: boolean;
@@ -59,17 +130,26 @@ export function buildOtelHooksConfig(options?: {
   const enabled = options?.enabled ?? isTelemetryEnabled();
   const signals = getTelemetrySignals();
   const apiUrl = (options?.apiUrl ?? getControlApiUrl()).replace(/\/$/, '');
+  const resourceAttributes = parseResourceAttributesString(options?.resourceAttributes);
+  const capturePrompts = enabled && signals.prompts;
 
   return {
-    OTEL_EXPORTER_OTLP_ENDPOINT: enabled ? `${apiUrl}/api/otel/v1/traces` : null,
-    OTEL_EXPORTER_OTLP_PROTOCOL: 'http/json',
-    OTEL_SERVICE_NAME: 'har-ide-agent',
-    IDE_OTEL_BATCH_ON_STOP: 'true',
-    IDE_OTEL_ENABLE_LOGS: enabled && signals.logs ? 'true' : 'false',
-    IDE_OTEL_LOG_ALL_EVENTS: enabled && signals.logs ? 'true' : 'false',
-    IDE_OTEL_CAPTURE_TEXT: enabled && signals.prompts ? 'true' : 'false',
-    IDE_OTEL_MASK_PROMPTS: 'false',
-    OTEL_RESOURCE_ATTRIBUTES: options?.resourceAttributes ?? null,
+    exporter: {
+      enabled,
+      ...(enabled ? { endpoint: `${apiUrl}/api/otel/v1/traces` } : {}),
+      protocol: 'http/protobuf',
+      serviceName: 'har-ide-agent',
+      ...(Object.keys(resourceAttributes).length > 0 ? { resourceAttributes } : {}),
+      logs: {
+        enabled: enabled && signals.logs,
+        ...(enabled && signals.logs ? { endpoint: `${apiUrl}/api/otel/v1/logs` } : {}),
+        includeContent: capturePrompts,
+      },
+    },
+    privacy: {
+      contentMode: capturePrompts ? 'raw' : 'omit',
+      allowRawContent: capturePrompts,
+    },
   };
 }
 
@@ -92,12 +172,17 @@ export function writeOtelHooksWrapper(
   hooksHome = getOtelHooksHome(),
 ): string {
   fs.mkdirSync(hooksHome, { recursive: true });
+  fs.mkdirSync(getOtelHooksStateDir(hooksHome), { recursive: true });
   const wrapperPath = getOtelHooksWrapperPath(hooksHome);
+  const configPath = getOtelHooksConfigPath(hooksHome);
+  const stateDir = getOtelHooksStateDir(hooksHome);
   const script = `#!/usr/bin/env bash
-# Managed by har telemetry — invokes opentelemetry-hooks with HAR config home.
+# Managed by har telemetry — invokes @osfactory/otel-hook with HAR config.
 set -euo pipefail
-export IDE_OTEL_HOOK_HOME="${hooksHome}"
-exec "${otelHookCommand}" "$@"
+exec "${otelHookCommand}" run \\
+  --config-file "${configPath}" \\
+  --state-dir "${stateDir}" \\
+  "$@"
 `;
   fs.writeFileSync(wrapperPath, script, { mode: 0o755 });
   try {
@@ -115,88 +200,83 @@ function commandExists(command: string): boolean {
   return result.status === 0 && Boolean(result.stdout?.trim());
 }
 
-function resolveOtelHookCommand(): string | null {
-  if (commandExists('otel-hook')) {
-    const which = spawnSync('sh', ['-c', 'command -v otel-hook'], { encoding: 'utf8' });
-    return which.stdout?.trim() || 'otel-hook';
-  }
+function resolveOtelHookCommand(hooksHome: string): string | null {
+  const local = localOtelHookBin(hooksHome);
+  if (fs.existsSync(local)) return local;
   return null;
 }
 
-function tryInstallPackage(): { ok: boolean; detail: string } {
-  if (commandExists('uv')) {
-    const result = spawnSync(
-      'uv',
-      ['tool', 'install', '--force', OTEL_HOOKS_PACKAGE],
-      { encoding: 'utf8', timeout: 180_000 },
-    );
-    if (result.status === 0) {
-      return { ok: true, detail: `uv tool install ${OTEL_HOOKS_PACKAGE}` };
-    }
-  }
-
-  if (commandExists('pipx')) {
-    const result = spawnSync('pipx', ['install', '--force', OTEL_HOOKS_PACKAGE], {
-      encoding: 'utf8',
-      timeout: 180_000,
-    });
-    if (result.status === 0) {
-      return { ok: true, detail: `pipx install ${OTEL_HOOKS_PACKAGE}` };
-    }
+function tryInstallPackage(hooksHome: string): { ok: boolean; detail: string } {
+  fs.mkdirSync(hooksHome, { recursive: true });
+  if (!commandExists('npm')) {
     return {
       ok: false,
-      detail: `pipx install failed: ${(result.stderr || result.stdout || '').trim().slice(0, 400)}`,
+      detail: 'npm not found; install Node.js to use @osfactory/otel-hook',
     };
   }
-
-  if (commandExists('pip3') || commandExists('pip')) {
-    const pip = commandExists('pip3') ? 'pip3' : 'pip';
-    const result = spawnSync(
-      pip,
-      ['install', '--user', OTEL_HOOKS_PACKAGE],
-      { encoding: 'utf8', timeout: 180_000 },
-    );
-    if (result.status === 0) {
-      return { ok: true, detail: `${pip} install --user ${OTEL_HOOKS_PACKAGE}` };
-    }
-    return {
-      ok: false,
-      detail: `${pip} install failed: ${(result.stderr || result.stdout || '').trim().slice(0, 400)}`,
-    };
+  const result = spawnSync(
+    'npm',
+    ['install', '--prefix', hooksHome, '--no-fund', '--no-audit', OTEL_HOOKS_PACKAGE],
+    { encoding: 'utf8', timeout: 180_000 },
+  );
+  if (result.status === 0 && fs.existsSync(localOtelHookBin(hooksHome))) {
+    return { ok: true, detail: `npm install --prefix ${hooksHome} ${OTEL_HOOKS_PACKAGE}` };
   }
-
   return {
     ok: false,
-    detail:
-      'Neither uv, pipx, nor pip3/pip found; install Python tooling to use opentelemetry-hooks',
+    detail: `npm install ${OTEL_HOOKS_PACKAGE} failed: ${(result.stderr || result.stdout || '').trim().slice(0, 400)}`,
   };
 }
 
-function runSetupAgent(
-  agent: OtelHooksAgent,
+/** Best-effort removal of the legacy Python package so only the TS CLI remains. */
+function uninstallLegacyPythonHooks(): void {
+  const attempts: Array<[string, string[]]> = [
+    ['uv', ['tool', 'uninstall', 'opentelemetry-hooks']],
+    ['pipx', ['uninstall', 'opentelemetry-hooks']],
+  ];
+  for (const [cmd, args] of attempts) {
+    if (!commandExists(cmd)) continue;
+    try {
+      spawnSync(cmd, args, { encoding: 'utf8', timeout: 60_000 });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function runSetupProvider(
+  providerId: OtelHooksProviderId,
   otelHookCommand: string,
-  hooksHome: string,
+  wrapperPath: string,
 ): { ok: boolean; detail: string } {
-  const result = spawnSync(otelHookCommand, ['setup', '--agent', agent], {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      IDE_OTEL_HOOK_HOME: hooksHome,
-    },
-    timeout: 60_000,
-  });
+  const hookCommand = `${wrapperPath} --provider ${providerId}`;
+  const result = spawnSync(
+    otelHookCommand,
+    [
+      'setup',
+      '--provider',
+      providerId,
+      '--scope',
+      'global',
+      '--hook-command',
+      hookCommand,
+      '--managed-marker',
+      'otel-hook',
+    ],
+    { encoding: 'utf8', timeout: 60_000 },
+  );
   if (result.status === 0) {
-    return { ok: true, detail: `setup --agent ${agent}` };
+    return { ok: true, detail: `setup --provider ${providerId}` };
   }
   return {
     ok: false,
-    detail: `setup --agent ${agent} failed: ${(result.stderr || result.stdout || '').trim().slice(0, 400)}`,
+    detail: `setup --provider ${providerId} failed: ${(result.stderr || result.stdout || '').trim().slice(0, 400)}`,
   };
 }
 
 /**
  * Rewrite hook command entries that invoke otel-hook so they use the HAR wrapper
- * (ensures IDE_OTEL_HOOK_HOME points at ~/.har/otel-hooks).
+ * (ensures --config-file / --state-dir point at ~/.har/otel-hooks).
  */
 export function rewriteHookCommandsToWrapper(
   filePath: string,
@@ -217,15 +297,28 @@ export function rewriteHookCommandsToWrapper(
   }
   if (!parsed || typeof parsed !== 'object') return false;
 
-  const quoted = JSON.stringify(wrapperPath);
   const rewriteCommand = (command: string): string => {
-    if (!command.includes('otel-hook') && !command.includes('otel_hook.py')) return command;
+    if (
+      !command.includes('otel-hook') &&
+      !command.includes('otel_hook.py') &&
+      !command.includes('opentelemetry-hooks')
+    ) {
+      return command;
+    }
     if (command.includes(wrapperPath)) return command;
-    // Preserve trailing args if any; replace the executable portion.
-    return command.replace(
-      /(?:^|[;&|]\s*)(?:env\s+[^=\s]+=\S+\s+)*(?:python3?\s+)?(?:\S*otel[_-]hook\S*)/,
-      (match) => match.replace(/(?:python3?\s+)?(?:\S*otel[_-]hook\S*)/, quoted.slice(1, -1)),
+    // Preserve current CLI args while translating legacy Python source flags.
+    const rewritten = command.replace(
+      /(?:^|[;&|]\s*)(?:env\s+[^=\s]+=\S+\s+)*(?:python3?\s+)?(?:npx\s+)?(?:\S*otel[_-]hook\S*|\S*opentelemetry-hooks\S*)/,
+      (match) =>
+        match.replace(
+          /(?:python3?\s+)?(?:npx\s+)?(?:\S*otel[_-]hook\S*|\S*opentelemetry-hooks\S*)/,
+          wrapperPath,
+        ),
     );
+    return rewritten
+      .replace(/(^|\s)--cursor(?=\s|$)/g, '$1--provider cursor')
+      .replace(/(^|\s)--claude(?=\s|$)/g, '$1--provider claude-code')
+      .replace(/(^|\s)--codex(?=\s|$)/g, '$1--provider codex');
   };
 
   const walk = (node: unknown): boolean => {
@@ -268,8 +361,15 @@ function rewriteKnownHookRegistrations(wrapperPath: string): void {
   }
 }
 
+function providerLabel(id: OtelHooksProviderId): OtelHooksAgent {
+  if (id === 'claude-code') return 'claude';
+  if (id === 'cursor') return 'cursor';
+  return 'codex';
+}
+
 /**
- * Install opentelemetry-hooks (if needed), write HAR config, register Cursor/Claude/Codex.
+ * Install @osfactory/otel-hook (if needed), write HAR config, register Cursor/Claude/Codex.
+ * Replaces the legacy Python opentelemetry-hooks install path.
  */
 export function ensureOtelHooks(options?: {
   setupAgents?: boolean;
@@ -277,13 +377,16 @@ export function ensureOtelHooks(options?: {
 }): EnsureOtelHooksResult {
   const hooksHome = getOtelHooksHome();
   const errors: string[] = [];
-  const agentsSetup: OtelHooksAgent[] = [];
+  const providersSetup: OtelHooksProviderId[] = [];
 
   fs.mkdirSync(hooksHome, { recursive: true });
 
-  let otelHookCommand = resolveOtelHookCommand();
-  if (!otelHookCommand) {
-    const installed = tryInstallPackage();
+  let otelHookCommand = resolveOtelHookCommand(hooksHome);
+  const needsInstall =
+    !otelHookCommand || installedPackageVersion(hooksHome) !== pinnedVersion();
+  if (needsInstall) {
+    // Prefer a prefix-local install so HAR pins the version under ~/.har/otel-hooks.
+    const installed = tryInstallPackage(hooksHome);
     if (!installed.ok) {
       errors.push(installed.detail);
       const configPath = writeOtelHooksConfig(
@@ -297,13 +400,14 @@ export function ensureOtelHooks(options?: {
         wrapperPath: getOtelHooksWrapperPath(hooksHome),
         otelHookCommand: null,
         warning: installed.detail,
-        agentsSetup,
+        agentsSetup: [],
+        providersSetup,
         errors,
       };
     }
-    otelHookCommand = resolveOtelHookCommand();
+    otelHookCommand = resolveOtelHookCommand(hooksHome);
     if (!otelHookCommand) {
-      errors.push('opentelemetry-hooks installed but otel-hook is not on PATH');
+      errors.push('@osfactory/otel-hook installed but otel-hook binary is missing');
       const configPath = writeOtelHooksConfig(
         buildOtelHooksConfig({ resourceAttributes: options?.resourceAttributes }),
         hooksHome,
@@ -315,44 +419,70 @@ export function ensureOtelHooks(options?: {
         wrapperPath: getOtelHooksWrapperPath(hooksHome),
         otelHookCommand: null,
         warning: errors[errors.length - 1],
-        agentsSetup,
+        agentsSetup: [],
+        providersSetup,
         errors,
       };
     }
+  }
+
+  const resolvedCommand = otelHookCommand;
+  if (!resolvedCommand) {
+    errors.push('@osfactory/otel-hook binary is missing');
+    const configPath = writeOtelHooksConfig(
+      buildOtelHooksConfig({ resourceAttributes: options?.resourceAttributes }),
+      hooksHome,
+    );
+    return {
+      ok: false,
+      hooksHome,
+      configPath,
+      wrapperPath: getOtelHooksWrapperPath(hooksHome),
+      otelHookCommand: null,
+      warning: errors[errors.length - 1],
+      agentsSetup: [],
+      providersSetup,
+      errors,
+    };
   }
 
   const configPath = writeOtelHooksConfig(
     buildOtelHooksConfig({ resourceAttributes: options?.resourceAttributes }),
     hooksHome,
   );
-  const wrapperPath = writeOtelHooksWrapper(otelHookCommand, hooksHome);
+  const wrapperPath = writeOtelHooksWrapper(resolvedCommand, hooksHome);
+  // Remove the old Python tool only after the npm replacement and wrapper are
+  // ready. If npm installation fails, an existing HAR hook remains usable.
+  uninstallLegacyPythonHooks();
 
   if (options?.setupAgents !== false && isTelemetryEnabled()) {
-    for (const agent of OTEL_HOOKS_AGENTS) {
-      const setup = runSetupAgent(agent, otelHookCommand, hooksHome);
-      if (setup.ok) agentsSetup.push(agent);
+    for (const provider of OTEL_HOOKS_PROVIDERS) {
+      const setup = runSetupProvider(provider.id, resolvedCommand, wrapperPath);
+      if (setup.ok) providersSetup.push(provider.id);
       else errors.push(setup.detail);
     }
     rewriteKnownHookRegistrations(wrapperPath);
   }
 
+  const agentsSetup = providersSetup.map(providerLabel);
   const ok = errors.length === 0;
   return {
     ok,
     hooksHome,
     configPath,
     wrapperPath,
-    otelHookCommand,
+    otelHookCommand: resolvedCommand,
     message: ok
-      ? `opentelemetry-hooks ready (${agentsSetup.join(', ') || 'config only'}) → ${configPath}`
+      ? `@osfactory/otel-hook ready (${agentsSetup.join(', ') || 'config only'}) → ${configPath}`
       : undefined,
     warning: errors.length ? errors.join('; ') : undefined,
     agentsSetup,
+    providersSetup,
     errors,
   };
 }
 
-/** Refresh config for telemetry off (null endpoint) without uninstalling hooks. */
+/** Refresh config for telemetry off (exporter disabled) without uninstalling hooks. */
 export function disableOtelHooksExport(): string {
   return writeOtelHooksConfig(buildOtelHooksConfig({ enabled: false }));
 }

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -199,7 +199,7 @@ export class RunService {
     if (isTelemetryEnabled() && process.env.NODE_ENV !== 'test') {
       const ensured = await ensureTelemetryInfrastructure({ startIfNeeded: true });
       if (ensured.message) {
-        telemetryBanner += `${ensured.message}\nUsage from Cursor / Claude / Codex (opentelemetry-hooks) will appear under Worktrees. Disable: har telemetry off\n`;
+        telemetryBanner += `${ensured.message}\nUsage from Cursor / Claude / Codex (@osfactory/otel-hook) will appear under Worktrees. Disable: har telemetry off\n`;
       }
       if (ensured.warning) {
         telemetryBanner += `${ensured.warning}\n`;
@@ -210,7 +210,7 @@ export class RunService {
         if (hooks.message) telemetryBanner += `${hooks.message}\n`;
         if (hooks.warning) telemetryBanner += `${hooks.warning}\n`;
       } catch (err) {
-        telemetryBanner += `opentelemetry-hooks setup skipped: ${err instanceof Error ? err.message : String(err)}\n`;
+        telemetryBanner += `@osfactory/otel-hook setup skipped: ${err instanceof Error ? err.message : String(err)}\n`;
       }
     }
 

--- a/src/core/telemetry-config.ts
+++ b/src/core/telemetry-config.ts
@@ -132,9 +132,9 @@ export function getTelemetryPreferencePath(): string {
 }
 
 export const TELEMETRY_SIGNALS = [
-  'Traces (default): Cursor / Claude / Codex activity via opentelemetry-hooks → Mission Control',
+  'Traces (default): Cursor / Claude / Codex activity via @osfactory/otel-hook → Mission Control',
   'Logs/events (default): hook lifecycle logs without prompt bodies',
   'Metrics (default): token usage derived from span gen_ai.usage.* attributes',
-  'Prompts (default): user prompt text via IDE_OTEL_CAPTURE_TEXT (also fills Mission Control purpose); disable with har telemetry on --no-prompts',
+  'Prompts (default): user prompt text via otel-hook contentMode=raw (also fills Mission Control purpose); disable with har telemetry on --no-prompts',
   'Fallback: har control sync harvests local Claude/Codex session files when hooks telemetry is missing',
 ] as const;

--- a/src/core/telemetry-env.ts
+++ b/src/core/telemetry-env.ts
@@ -46,7 +46,7 @@ export function buildSessionKey(input: {
 
 /**
  * Session attribution for .env.agent.<id>.
- * Agent OTEL export is owned by opentelemetry-hooks (har telemetry on) — not Claude/Codex native exporters.
+ * Agent OTEL export is owned by @osfactory/otel-hook (har telemetry on) — not Claude/Codex native exporters.
  */
 export function buildTelemetryEnvBlock(attrs: TelemetrySessionAttrs): string {
   const apiUrl = getControlApiUrl().replace(/\/$/, '');
@@ -58,7 +58,7 @@ export function buildTelemetryEnvBlock(attrs: TelemetrySessionAttrs): string {
     ...(attrs.attemptId ? [`HAR_ATTEMPT_ID=${attrs.attemptId}`] : []),
     `HAR_CONTROL_API_URL=${apiUrl}`,
     `OTEL_RESOURCE_ATTRIBUTES=${buildOtelResourceAttributes(attrs)}`,
-    '# Agent telemetry: opentelemetry-hooks → Mission Control (har telemetry on|off)',
+    '# Agent telemetry: @osfactory/otel-hook → Mission Control (har telemetry on|off)',
   ];
   return lines.join('\n') + '\n';
 }

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -18,6 +18,7 @@ import {
   buildOtelHooksConfig,
   rewriteHookCommandsToWrapper,
   writeOtelHooksConfig,
+  writeOtelHooksWrapper,
 } from '../src/core/otel-hooks';
 
 describe('telemetry preference', () => {
@@ -139,7 +140,7 @@ describe('telemetry env', () => {
     });
     expect(block).toContain('HAR_SESSION_KEY=s1');
     expect(block).toContain('OTEL_RESOURCE_ATTRIBUTES=');
-    expect(block).toContain('opentelemetry-hooks');
+    expect(block).toContain('@osfactory/otel-hook');
     expect(block).not.toContain('CLAUDE_CODE_ENABLE_TELEMETRY');
     expect(block).not.toContain('OTEL_METRICS_EXPORTER');
     expect(block).not.toContain('OTEL_LOGS_EXPORTER');
@@ -192,26 +193,31 @@ describe('otel hooks config', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('maps HAR signals to hook knobs with http/json endpoint', () => {
+  it('maps HAR signals to @osfactory/otel-hook config with protobuf endpoint', () => {
     writeTelemetryPreference(true);
     const config = buildOtelHooksConfig({ enabled: true, apiUrl: 'http://localhost:3847' });
-    expect(config.OTEL_EXPORTER_OTLP_ENDPOINT).toBe('http://localhost:3847/api/otel/v1/traces');
-    expect(config.OTEL_EXPORTER_OTLP_PROTOCOL).toBe('http/json');
-    expect(config.IDE_OTEL_CAPTURE_TEXT).toBe('true');
-    expect(config.IDE_OTEL_ENABLE_LOGS).toBe('true');
-    expect(config.IDE_OTEL_BATCH_ON_STOP).toBe('true');
+    expect(config.exporter.endpoint).toBe('http://localhost:3847/api/otel/v1/traces');
+    expect(config.exporter.protocol).toBe('http/protobuf');
+    expect(config.exporter.enabled).toBe(true);
+    expect(config.exporter.logs.enabled).toBe(true);
+    expect(config.exporter.logs.includeContent).toBe(true);
+    expect(config.privacy.contentMode).toBe('raw');
+    expect(config.privacy.allowRawContent).toBe(true);
   });
 
   it('disables prompt capture when prompts signal is off', () => {
     writeTelemetryPreference(true, { prompts: false });
     const config = buildOtelHooksConfig({ enabled: true, apiUrl: 'http://localhost:3847' });
-    expect(config.IDE_OTEL_CAPTURE_TEXT).toBe('false');
+    expect(config.privacy.contentMode).toBe('omit');
+    expect(config.privacy.allowRawContent).toBe(false);
+    expect(config.exporter.logs.includeContent).toBe(false);
   });
 
-  it('nulls OTLP endpoint when telemetry disabled', () => {
+  it('disables exporter when telemetry is off', () => {
     const config = buildOtelHooksConfig({ enabled: false, apiUrl: 'http://localhost:3847' });
-    expect(config.OTEL_EXPORTER_OTLP_ENDPOINT).toBeNull();
-    expect(config.IDE_OTEL_CAPTURE_TEXT).toBe('false');
+    expect(config.exporter.enabled).toBe(false);
+    expect(config.exporter.endpoint).toBeUndefined();
+    expect(config.privacy.contentMode).toBe('omit');
   });
 
   it('writes config JSON under hooks home', () => {
@@ -222,9 +228,9 @@ describe('otel hooks config', () => {
     );
     expect(configPath).toBe(path.join(hooksHome, 'otel_config.json'));
     const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
-      OTEL_EXPORTER_OTLP_PROTOCOL: string;
+      exporter: { protocol: string };
     };
-    expect(parsed.OTEL_EXPORTER_OTLP_PROTOCOL).toBe('http/json');
+    expect(parsed.exporter.protocol).toBe('http/protobuf');
   });
 
   it('rewrites hooks.json commands to the HAR wrapper', () => {
@@ -244,5 +250,41 @@ describe('otel hooks config', () => {
       hooks: { sessionStart: Array<{ command: string }> };
     };
     expect(parsed.hooks.sessionStart[0].command).toBe(wrapper);
+  });
+
+  it('upgrades a copied Python hook command to the HAR wrapper', () => {
+    const hooksFile = path.join(tmpDir, 'legacy-hooks.json');
+    fs.writeFileSync(
+      hooksFile,
+      JSON.stringify({
+        version: 1,
+        hooks: {
+          sessionStart: [
+            {
+              command:
+                'python3 /repo/.cursor/hooks/opentelemetry-hook/otel_hook.py --cursor',
+            },
+          ],
+        },
+      }),
+    );
+    const wrapper = '/tmp/har-run-otel-hook.sh';
+    expect(rewriteHookCommandsToWrapper(hooksFile, wrapper)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(hooksFile, 'utf8')) as {
+      hooks: { sessionStart: Array<{ command: string }> };
+    };
+    expect(parsed.hooks.sessionStart[0].command).toBe(`${wrapper} --provider cursor`);
+  });
+
+  it('writes a wrapper that invokes the TypeScript CLI with HAR paths', () => {
+    const hooksHome = path.join(tmpDir, 'hooks');
+    const binary = path.join(hooksHome, 'node_modules', '.bin', 'otel-hook');
+    const wrapper = writeOtelHooksWrapper(binary, hooksHome);
+    const script = fs.readFileSync(wrapper, 'utf8');
+    expect(script).toContain(`exec "${binary}" run`);
+    expect(script).toContain(`--config-file "${path.join(hooksHome, 'otel_config.json')}"`);
+    expect(script).toContain(`--state-dir "${path.join(hooksHome, 'state')}"`);
+    expect(script).not.toContain('python');
+    expect(fs.statSync(wrapper).mode & 0o111).not.toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- replace the Python `opentelemetry-hooks` installer and configuration with pinned `@osfactory/otel-hook@0.1.1`
- migrate Cursor, Claude Code, and Codex registrations to a HAR-managed TypeScript wrapper and remove legacy uv/pipx tools only after the replacement is ready
- update telemetry configuration, upgrade documentation, and automated migration coverage

## Test plan
- [x] `har env verify 1 --full`
- [x] run `har telemetry install-hooks` against an existing Python-hook installation
- [x] verify `@osfactory/otel-hook` 0.1.1 registration diagnostics for Cursor, Claude Code, and Codex
- [x] verify the legacy `opentelemetry-hooks` uv tool is removed

Made with [Cursor](https://cursor.com)