### PR TITLE
feat(control): estimate and persist LLM costs via genai-prices

### DIFF
--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/control",
-  "version": "0.27.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "0.27.0",
+      "version": "0.30.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -66,9 +66,10 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "0.27.0",
+      "version": "0.30.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@pydantic/genai-prices": "^0.0.73",
         "zod": "^3.23.8"
       }
     },

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -7,7 +7,7 @@ import { SessionTimeline } from '@/components/session-timeline';
 import { ValidationPipeline } from '@/components/validation-pipeline';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
 import { eventModel } from '@/lib/session-event-detail';
-import { formatModelId, modelsFromBreakdown } from '@/lib/usage-models';
+import { formatModelId, formatCostUsd, modelTotalsFromBreakdown, modelsFromBreakdown, type UsageModelTotals } from '@/lib/usage-models';
 import { getRepository } from '@/server/repositories';
 import { listSessionEventsForSlot } from '@/server/session-events';
 import { listSessionUsageForSlot } from '@/server/usage';
@@ -150,7 +150,17 @@ export default async function SlotDetailPage({
             <p className="text-2xl font-bold tabular-nums">
               {totals.hasCost ? `$${totals.costUsd.toFixed(4)}` : '—'}
             </p>
-            <p className="text-xs text-muted-foreground">Claude reports USD; Codex may be token-only</p>
+            <p className="text-xs text-muted-foreground">
+              Agent-reported USD when available; otherwise estimated via{' '}
+              <a
+                href="https://github.com/pydantic/genai-prices"
+                className="underline underline-offset-2"
+                target="_blank"
+                rel="noreferrer"
+              >
+                genai-prices
+              </a>
+            </p>
           </CardContent>
         </Card>
         <Card>
@@ -243,8 +253,8 @@ export default async function SlotDetailPage({
         <CardHeader>
           <CardTitle>Usage by agent</CardTitle>
           <CardDescription>
-            Max-merged from OTEL ingest and sync harvest — model ids stored on modelBreakdown for
-            pricing
+            Max-merged from OTEL ingest and sync harvest — per-model token totals and USD estimates
+            (genai-prices) live on modelBreakdown for the portal
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -269,6 +279,7 @@ export default async function SlotDetailPage({
                 </thead>
                 <tbody>
                   {usageRows.map((row) => {
+                    const modelRows = modelTotalsFromBreakdown(row.modelBreakdown);
                     const models = resolveModels(row.sessionKey, row.agentTool, row.modelBreakdown);
                     return (
                       <tr key={row.id} className="border-b border-border/60">
@@ -279,19 +290,31 @@ export default async function SlotDetailPage({
                           <Badge variant="outline">{formatAgentToolLabel(row.agentTool)}</Badge>
                         </td>
                         <td className="py-2 pr-4">
-                          {models.length === 0 ? (
+                          {modelRows.length === 0 && models.length === 0 ? (
                             <span className="text-muted-foreground">—</span>
                           ) : (
-                            <div className="flex max-w-xs flex-wrap gap-1">
-                              {models.map((model) => (
-                                <Badge
-                                  key={model}
-                                  variant="secondary"
-                                  className="font-mono text-[10px]"
-                                  title={model}
-                                >
-                                  {formatModelId(model)}
-                                </Badge>
+                            <div className="flex max-w-md flex-col gap-1">
+                              {(modelRows.length > 0
+                                ? modelRows
+                                : models.map((model) => ({
+                                    model,
+                                    totals: {} as UsageModelTotals,
+                                  }))
+                              ).map(({ model, totals }) => (
+                                <div key={model} className="flex flex-wrap items-center gap-1">
+                                  <Badge
+                                    variant="secondary"
+                                    className="font-mono text-[10px]"
+                                    title={model}
+                                  >
+                                    {formatModelId(model)}
+                                  </Badge>
+                                  {totals.costUsd != null ? (
+                                    <span className="text-[10px] tabular-nums text-muted-foreground">
+                                      {formatCostUsd(totals.costUsd)}
+                                    </span>
+                                  ) : null}
+                                </div>
                               ))}
                             </div>
                           )}
@@ -300,7 +323,7 @@ export default async function SlotDetailPage({
                           {formatTokens(Number(row.tokensTotal))}
                         </td>
                         <td className="py-2 pr-4 tabular-nums">
-                          {row.costUsd == null ? '—' : `$${Number(row.costUsd).toFixed(4)}`}
+                          {formatCostUsd(row.costUsd == null ? null : Number(row.costUsd))}
                         </td>
                         <td className="py-2 pr-4">
                           <div className="flex flex-wrap gap-1">

--- a/control/src/app/usage/page.tsx
+++ b/control/src/app/usage/page.tsx
@@ -21,8 +21,18 @@ export default async function UsagePage() {
       <div>
         <h2 className="text-2xl font-semibold">Usage</h2>
         <p className="text-sm text-muted-foreground">
-          Cross-repo LLM token and cost rollup from OTEL ingest and harvest. Prompt bodies are
-          included by default (opt out: `har telemetry on --no-prompts`). Data stays in local SQLite.
+          Cross-repo LLM token and cost rollup from OTEL ingest and harvest. Costs use agent-reported
+          USD when available, otherwise{' '}
+          <a
+            href="https://github.com/pydantic/genai-prices"
+            className="underline underline-offset-2"
+            target="_blank"
+            rel="noreferrer"
+          >
+            genai-prices
+          </a>{' '}
+          estimates from modelBreakdown. Prompt bodies are included by default (opt out:
+          `har telemetry on --no-prompts`). Data stays in local SQLite.
         </p>
       </div>
 

--- a/control/src/lib/usage-models.test.ts
+++ b/control/src/lib/usage-models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatModelId, modelsFromBreakdown, modelTotalsFromBreakdown } from './usage-models';
+import { formatCostUsd, formatModelId, modelsFromBreakdown, modelTotalsFromBreakdown } from './usage-models';
 
 describe('usage-models', () => {
   it('lists model ids from breakdown', () => {
@@ -19,8 +19,15 @@ describe('usage-models', () => {
   it('returns totals entries', () => {
     expect(
       modelTotalsFromBreakdown({
-        'grok-4.5': { tokensInput: 5, tokensOutput: 1, tokensTotal: 6 },
+        'grok-4.5': { tokensInput: 5, tokensOutput: 1, tokensTotal: 6, costUsd: 0.0042 },
       }),
-    ).toEqual([{ model: 'grok-4.5', totals: { tokensInput: 5, tokensOutput: 1, tokensTotal: 6 } }]);
+    ).toEqual([
+      { model: 'grok-4.5', totals: { tokensInput: 5, tokensOutput: 1, tokensTotal: 6, costUsd: 0.0042 } },
+    ]);
+  });
+
+  it('formats cost values', () => {
+    expect(formatCostUsd(null)).toBe('—');
+    expect(formatCostUsd(0.1234)).toBe('$0.1234');
   });
 });

--- a/control/src/lib/usage-models.ts
+++ b/control/src/lib/usage-models.ts
@@ -6,6 +6,8 @@ export interface UsageModelTotals {
   tokensCacheRead?: number;
   tokensCacheCreation?: number;
   tokensTotal?: number;
+  /** USD cost for this model (agent-reported or genai-prices estimate). */
+  costUsd?: number;
 }
 
 export function modelsFromBreakdown(breakdown: unknown): string[] {
@@ -32,4 +34,9 @@ export function modelTotalsFromBreakdown(
 /** Format model id for badges (strip common cursor- prefix noise). */
 export function formatModelId(model: string): string {
   return model.replace(/^cursor-/, '');
+}
+
+export function formatCostUsd(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return '—';
+  return `$${value.toFixed(4)}`;
 }

--- a/control/src/server/usage.ts
+++ b/control/src/server/usage.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import type { AgentSessionUsage, UsageSource } from '@har/schemas';
+import { enrichUsageWithPricing } from '@har/schemas';
 import { prisma } from '@/lib/db';
 
 function toBigInt(n: number | bigint | undefined | null): bigint {
@@ -108,7 +109,6 @@ export async function upsertSessionUsage(repositoryId: string, input: UsageUpser
     toBigInt(existing?.tokensTotal),
     toBigInt(input.tokensTotal) || tokensInput + tokensOutput + tokensCacheRead + tokensCacheCreation,
   );
-  const costUsd = maxCost(existing?.costUsd, input.costUsd ?? null);
   const firstSeenAt = existing
     ? new Date(
         Math.min(existing.firstSeenAt.getTime(), new Date(input.firstSeenAt).getTime()),
@@ -117,6 +117,22 @@ export async function upsertSessionUsage(repositoryId: string, input: UsageUpser
   const lastSeenAt = existing
     ? new Date(Math.max(existing.lastSeenAt.getTime(), new Date(input.lastSeenAt).getTime()))
     : new Date(input.lastSeenAt);
+
+  const mergedModelBreakdown = mergeModelBreakdown(existing?.modelBreakdown, input.modelBreakdown);
+  const reportedCost = maxCost(existing?.costUsd, input.costUsd ?? null);
+
+  const priced = enrichUsageWithPricing({
+    agentTool: input.agentTool,
+    costUsd: reportedCost == null ? null : Number(reportedCost),
+    modelBreakdown: mergedModelBreakdown as AgentSessionUsage['modelBreakdown'],
+  });
+
+  const costUsd =
+    priced.costUsd == null
+      ? reportedCost
+      : new Prisma.Decimal(
+          Math.max(Number(reportedCost ?? 0), priced.costUsd) || priced.costUsd,
+        );
 
   const fields = {
     agentId: input.agentId,
@@ -131,7 +147,7 @@ export async function upsertSessionUsage(repositoryId: string, input: UsageUpser
     tokensCacheCreation,
     tokensTotal,
     costUsd,
-    modelBreakdown: mergeModelBreakdown(existing?.modelBreakdown, input.modelBreakdown),
+    modelBreakdown: (priced.modelBreakdown ?? mergedModelBreakdown) as Prisma.InputJsonValue | undefined,
     sources: mergeSources(existing?.sources, input.sources ?? []),
     firstSeenAt,
     lastSeenAt,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@pydantic/genai-prices": "^0.0.73",
         "chalk": "^5.3.0",
         "inquirer": "^10.1.2",
         "js-yaml": "^4.1.0",
@@ -2298,6 +2299,21 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@pydantic/genai-prices": {
+      "version": "0.0.73",
+      "resolved": "https://registry.npmjs.org/@pydantic/genai-prices/-/genai-prices-0.0.73.tgz",
+      "integrity": "sha512-eNrTE/C79FIdAHx1H/8XTWC/nVWIp8bZhOM9zqhhxXDQmmVZdG/fm8uPTh7Tw2WHitGph7qfTJPFJ28wm13v7A==",
+      "license": "MIT",
+      "dependencies": {
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "genai-prices": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@sec-ant/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.27.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@pydantic/genai-prices": "^0.0.73",
     "chalk": "^5.3.0",
     "inquirer": "^10.1.2",
     "js-yaml": "^4.1.0",

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,15 +1,208 @@
 {
   "name": "@har/schemas",
-  "version": "0.27.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "0.27.0",
+      "version": "0.30.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@pydantic/genai-prices": "^0.0.73",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@pydantic/genai-prices": {
+      "version": "0.0.73",
+      "resolved": "https://registry.npmjs.org/@pydantic/genai-prices/-/genai-prices-0.0.73.tgz",
+      "integrity": "sha512-eNrTE/C79FIdAHx1H/8XTWC/nVWIp8bZhOM9zqhhxXDQmmVZdG/fm8uPTh7Tw2WHitGph7qfTJPFJ28wm13v7A==",
+      "license": "MIT",
+      "dependencies": {
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "genai-prices": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -6,6 +6,7 @@
   "types": "src/index.ts",
   "license": "AGPL-3.0-only",
   "dependencies": {
+    "@pydantic/genai-prices": "^0.0.73",
     "zod": "^3.23.8"
   }
 }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,1 +1,2 @@
 export * from './schema';
+export * from './usage-pricing';

--- a/packages/schemas/src/usage-pricing.ts
+++ b/packages/schemas/src/usage-pricing.ts
@@ -1,0 +1,110 @@
+import { calcPrice } from '@pydantic/genai-prices';
+import type { AgentSessionUsage, AgentTool } from './schema';
+
+/** Per-model token and cost fields stored on AgentSessionUsage.modelBreakdown. */
+export interface ModelUsageTotals {
+  tokensInput?: number;
+  tokensOutput?: number;
+  tokensCacheRead?: number;
+  tokensCacheCreation?: number;
+  tokensTotal?: number;
+  /** USD cost for this model row (reported by the agent or estimated via genai-prices). */
+  costUsd?: number;
+}
+
+function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function resolveCostUsd(reported: number | null, computed: number | null): number | null {
+  if (reported == null && computed == null) return null;
+  if (reported == null) return computed;
+  if (computed == null) return reported;
+  return Math.max(reported, computed);
+}
+
+function providerHint(agentTool: AgentTool): string | undefined {
+  if (agentTool === 'claude_code') return 'anthropic';
+  if (agentTool === 'codex') return 'openai';
+  return undefined;
+}
+
+/** Cursor prefixes opaque slugs — try the stripped id against the catalog too. */
+export function pricingModelCandidates(modelId: string): string[] {
+  const out = [modelId];
+  if (modelId.startsWith('cursor-')) out.push(modelId.slice('cursor-'.length));
+  return [...new Set(out)];
+}
+
+/** Estimate USD for one model row using bundled genai-prices catalog data. */
+export function estimateModelCostUsd(
+  modelId: string,
+  totals: ModelUsageTotals,
+  agentTool: AgentTool,
+): number | null {
+  const usage = {
+    input_tokens: num(totals.tokensInput),
+    output_tokens: num(totals.tokensOutput),
+    cache_read_tokens: num(totals.tokensCacheRead),
+    cache_write_tokens: num(totals.tokensCacheCreation),
+  };
+  const tokenSum =
+    usage.input_tokens +
+    usage.output_tokens +
+    usage.cache_read_tokens +
+    usage.cache_write_tokens;
+  if (tokenSum <= 0) return null;
+
+  const providerId = providerHint(agentTool);
+  for (const candidate of pricingModelCandidates(modelId)) {
+    const result = calcPrice(usage, candidate, providerId ? { providerId } : undefined);
+    if (result) return result.total_price;
+  }
+  return null;
+}
+
+/**
+ * Attach per-model and session-level USD costs from genai-prices when modelBreakdown
+ * has token data. Preserves agent-reported costUsd when present (max with estimate).
+ */
+export function enrichUsageWithPricing<
+  T extends Pick<AgentSessionUsage, 'agentTool' | 'costUsd' | 'modelBreakdown'>,
+>(usage: T): T {
+  const breakdown = usage.modelBreakdown;
+  if (!breakdown || typeof breakdown !== 'object' || Array.isArray(breakdown)) {
+    return usage;
+  }
+
+  let computedTotal = 0;
+  let hasComputed = false;
+  const enriched: Record<string, ModelUsageTotals> = {};
+
+  for (const [modelId, raw] of Object.entries(breakdown as Record<string, unknown>)) {
+    if (!modelId) continue;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      continue;
+    }
+    const totals = raw as ModelUsageTotals;
+    const existingCost = totals.costUsd == null ? null : num(totals.costUsd);
+    const estimated =
+      existingCost ?? estimateModelCostUsd(modelId, totals, usage.agentTool);
+    if (estimated != null) {
+      computedTotal += estimated;
+      hasComputed = true;
+      enriched[modelId] = { ...totals, costUsd: estimated };
+    } else {
+      enriched[modelId] = totals;
+    }
+  }
+
+  if (!hasComputed) return usage;
+
+  const reported = usage.costUsd == null ? null : num(usage.costUsd);
+  const costUsd = resolveCostUsd(reported, computedTotal);
+
+  return {
+    ...usage,
+    modelBreakdown: enriched,
+    ...(costUsd != null ? { costUsd } : {}),
+  };
+}

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -36,6 +36,7 @@ import { harvestEventsForSlot, harvestUsageForSlot } from './usage-harvest';
 import { buildSessionKey } from './telemetry-env';
 import { fetchPersistedPortalTelemetry } from './control-persisted-usage';
 import { dedupePortalEvents, mergePortalUsage } from './portal-usage-merge';
+import { enrichUsageWithPricing } from '../harness/schema';
 import { readPortalWatermark, writePortalWatermark } from './portal-watermark';
 import type { AgentSessionEvent, AgentSessionUsage } from '../harness/schema';
 
@@ -173,9 +174,12 @@ async function collectPortalTelemetry(
     const persisted = await fetchPersistedPortalTelemetry(repoPath, controlApiUrl, { since });
 
     const usage = mergePortalUsage(liveUsage, persisted.usage).map((row) => {
-      const models = modelsFromBreakdown(row.modelBreakdown as Record<string, unknown> | undefined);
+      const priced = enrichUsageWithPricing(row);
+      const models = modelsFromBreakdown(
+        priced.modelBreakdown as Record<string, unknown> | undefined,
+      );
       return {
-        ...row,
+        ...priced,
         ...(userEmail ? { userEmail } : {}),
         ...(models.length > 0 ? { models } : {}),
       };

--- a/src/harness/schema.ts
+++ b/src/harness/schema.ts
@@ -1,2 +1,3 @@
 /** Canonical HAR Zod schemas — source of truth lives in @har/schemas. */
 export * from '../../packages/schemas/src/schema';
+export * from '../../packages/schemas/src/usage-pricing';

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -270,8 +270,15 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(body.usage[0].attemptId).toBe('AT-1');
     expect(body.usage[0].sessionKey).toBe('feat/x');
     expect(body.usage[0].models).toEqual([
-      { model: 'claude-opus-4-8', tokensInput: 60, tokensOutput: 40, tokensTotal: 100 },
+      {
+        model: 'claude-opus-4-8',
+        tokensInput: 60,
+        tokensOutput: 40,
+        tokensTotal: 100,
+        costUsd: 0.0013,
+      },
     ]);
+    expect(body.usage[0].costUsd).toBe(0.0013);
   });
 
   it('pushes harvested events to /api/otel with the same bearer token', async () => {
@@ -424,8 +431,15 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(body.usage[0].sessionKey).toBe('feat/gone');
     expect(body.usage[0].tokensTotal).toBe(4200);
     expect(body.usage[0].models).toEqual([
-      { model: 'claude-opus-4-8', tokensInput: 2000, tokensOutput: 2200, tokensTotal: 4200 },
+      {
+        model: 'claude-opus-4-8',
+        tokensInput: 2000,
+        tokensOutput: 2200,
+        tokensTotal: 4200,
+        costUsd: 0.065,
+      },
     ]);
+    expect(body.usage[0].costUsd).toBe(0.065);
   });
 
   it('dedupes an overlapping live + persisted session into one max-merged row', async () => {

--- a/tests/usage-pricing.test.ts
+++ b/tests/usage-pricing.test.ts
@@ -1,0 +1,93 @@
+import { enrichUsageWithPricing, estimateModelCostUsd, pricingModelCandidates } from '../packages/schemas/src/usage-pricing';
+import type { AgentSessionUsage } from '../packages/schemas/src/schema';
+
+function usage(overrides: Partial<AgentSessionUsage> = {}): AgentSessionUsage {
+  return {
+    sessionKey: 'feat/x',
+    agentId: 1,
+    agentTool: 'claude_code',
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreation: 0,
+    tokensTotal: 0,
+    sources: [],
+    firstSeenAt: '2026-01-01T00:00:00.000Z',
+    lastSeenAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('pricingModelCandidates', () => {
+  it('strips cursor- prefix as a fallback candidate', () => {
+    expect(pricingModelCandidates('cursor-grok-4.5-high-fast')).toEqual([
+      'cursor-grok-4.5-high-fast',
+      'grok-4.5-high-fast',
+    ]);
+  });
+});
+
+describe('estimateModelCostUsd', () => {
+  it('prices anthropic models from per-model token totals', () => {
+    const cost = estimateModelCostUsd(
+      'claude-opus-4-8',
+      {
+        tokensInput: 1000,
+        tokensOutput: 100,
+        tokensCacheRead: 200,
+        tokensCacheCreation: 50,
+      },
+      'claude_code',
+    );
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeGreaterThan(0);
+  });
+
+  it('returns null when a model is unknown to the catalog', () => {
+    expect(
+      estimateModelCostUsd(
+        'totally-unknown-model-slug',
+        { tokensInput: 1000, tokensOutput: 100 },
+        'cursor',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('enrichUsageWithPricing', () => {
+  it('adds per-model and session costUsd from modelBreakdown', () => {
+    const enriched = enrichUsageWithPricing(
+      usage({
+        costUsd: null,
+        modelBreakdown: {
+          'claude-opus-4-8': {
+            tokensInput: 1000,
+            tokensOutput: 100,
+            tokensTotal: 1100,
+          },
+        },
+      }),
+    );
+    expect(enriched.costUsd).not.toBeNull();
+    expect(enriched.costUsd!).toBeGreaterThan(0);
+    const breakdown = enriched.modelBreakdown as Record<string, { costUsd?: number }>;
+    expect(breakdown['claude-opus-4-8'].costUsd).toBeGreaterThan(0);
+  });
+
+  it('keeps agent-reported session cost when it exceeds the estimate', () => {
+    const enriched = enrichUsageWithPricing(
+      usage({
+        costUsd: 9.99,
+        modelBreakdown: {
+          'claude-opus-4-8': { tokensInput: 100, tokensOutput: 10, tokensTotal: 110 },
+        },
+      }),
+    );
+    expect(enriched.costUsd).toBe(9.99);
+  });
+
+  it('passes through rows without modelBreakdown', () => {
+    const row = usage({ costUsd: null });
+    expect(enrichUsageWithPricing(row)).toBe(row);
+  });
+});


### PR DESCRIPTION
## Summary

- Add shared `@pydantic/genai-prices` integration in `@har/schemas` to estimate USD from per-model token totals in `modelBreakdown` (input/output/cache read/write).
- Persist session-level and per-model `costUsd` on usage upsert (OTEL ingest + harvest sync), preferring agent-reported costs when higher.
- Enrich portal sync payloads with priced usage so the portal receives model-level cost fields.
- Surface per-model cost badges in Mission Control usage views (`/usage` and slot detail).

## Test plan

- [x] `npm test -- tests/usage-pricing.test.ts` (genai-prices enrichment + provider hints)
- [x] Control unit tests (`usage-models`, existing suite)
- [x] `har env verify 1 --full` in control harness (typecheck, unit tests, lint, browser-e2e, docker build)
- [x] Manual: enable telemetry, run an agent session with model breakdown, confirm `/usage` and slot detail show estimated costs


Made with [Cursor](https://cursor.com)