### PR TITLE
fix(control): normalize HAR token buckets for genai-prices

### DIFF
--- a/packages/schemas/src/usage-pricing.ts
+++ b/packages/schemas/src/usage-pricing.ts
@@ -29,6 +29,30 @@ function providerHint(agentTool: AgentTool): string | undefined {
   return undefined;
 }
 
+/**
+ * Map HAR token buckets to genai-prices semantics.
+ * genai-prices treats `input_tokens` as the inclusive parent; cache read/write are subsets.
+ * Claude harvest reports disjoint buckets (uncached input vs cache creation).
+ */
+export function toGenaiPricesUsage(totals: ModelUsageTotals): {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+} {
+  const rawInput = num(totals.tokensInput);
+  const cacheRead = num(totals.tokensCacheRead);
+  const cacheWrite = num(totals.tokensCacheCreation);
+  const uncached = rawInput >= cacheRead ? rawInput - cacheRead : rawInput;
+  const inclusiveInput = uncached + cacheRead + cacheWrite;
+  return {
+    input_tokens: inclusiveInput,
+    output_tokens: num(totals.tokensOutput),
+    cache_read_tokens: cacheRead,
+    cache_write_tokens: cacheWrite,
+  };
+}
+
 /** Cursor prefixes opaque slugs — try the stripped id against the catalog too. */
 export function pricingModelCandidates(modelId: string): string[] {
   const out = [modelId];
@@ -42,23 +66,18 @@ export function estimateModelCostUsd(
   totals: ModelUsageTotals,
   agentTool: AgentTool,
 ): number | null {
-  const usage = {
-    input_tokens: num(totals.tokensInput),
-    output_tokens: num(totals.tokensOutput),
-    cache_read_tokens: num(totals.tokensCacheRead),
-    cache_write_tokens: num(totals.tokensCacheCreation),
-  };
-  const tokenSum =
-    usage.input_tokens +
-    usage.output_tokens +
-    usage.cache_read_tokens +
-    usage.cache_write_tokens;
+  const usage = toGenaiPricesUsage(totals);
+  const tokenSum = usage.input_tokens + usage.output_tokens;
   if (tokenSum <= 0) return null;
 
   const providerId = providerHint(agentTool);
   for (const candidate of pricingModelCandidates(modelId)) {
-    const result = calcPrice(usage, candidate, providerId ? { providerId } : undefined);
-    if (result) return result.total_price;
+    try {
+      const result = calcPrice(usage, candidate, providerId ? { providerId } : undefined);
+      if (result) return result.total_price;
+    } catch {
+      continue;
+    }
   }
   return null;
 }

--- a/tests/usage-pricing.test.ts
+++ b/tests/usage-pricing.test.ts
@@ -1,4 +1,9 @@
-import { enrichUsageWithPricing, estimateModelCostUsd, pricingModelCandidates } from '../packages/schemas/src/usage-pricing';
+import {
+  enrichUsageWithPricing,
+  estimateModelCostUsd,
+  pricingModelCandidates,
+  toGenaiPricesUsage,
+} from '../packages/schemas/src/usage-pricing';
 import type { AgentSessionUsage } from '../packages/schemas/src/schema';
 
 function usage(overrides: Partial<AgentSessionUsage> = {}): AgentSessionUsage {
@@ -27,6 +32,37 @@ describe('pricingModelCandidates', () => {
   });
 });
 
+describe('toGenaiPricesUsage', () => {
+  it('builds inclusive input_tokens for Claude-style disjoint buckets', () => {
+    expect(
+      toGenaiPricesUsage({
+        tokensInput: 2,
+        tokensCacheCreation: 26207,
+      }),
+    ).toEqual({
+      input_tokens: 26209,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 26207,
+    });
+  });
+
+  it('does not double-count cache read when input already includes it', () => {
+    expect(
+      toGenaiPricesUsage({
+        tokensInput: 1200,
+        tokensCacheRead: 1000,
+        tokensCacheCreation: 50,
+      }),
+    ).toEqual({
+      input_tokens: 1250,
+      output_tokens: 0,
+      cache_read_tokens: 1000,
+      cache_write_tokens: 50,
+    });
+  });
+});
+
 describe('estimateModelCostUsd', () => {
   it('prices anthropic models from per-model token totals', () => {
     const cost = estimateModelCostUsd(
@@ -36,6 +72,19 @@ describe('estimateModelCostUsd', () => {
         tokensOutput: 100,
         tokensCacheRead: 200,
         tokensCacheCreation: 50,
+      },
+      'claude_code',
+    );
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeGreaterThan(0);
+  });
+
+  it('prices Claude cache_creation rows without validation errors', () => {
+    const cost = estimateModelCostUsd(
+      'claude-opus-4-8',
+      {
+        tokensInput: 2,
+        tokensCacheCreation: 26207,
       },
       'claude_code',
     );


### PR DESCRIPTION
## Summary
- Add `toGenaiPricesUsage` to map HAR's disjoint Claude token buckets to genai-prices inclusive `input_tokens` semantics (uncached + cache read + cache write).
- Wrap `calcPrice` in try/catch so pricing validation errors never block usage harvest sync.

Fixes usage harvest failures like:
`Invalid usage data: cache_write_tokens (26207) cannot exceed input_tokens(2)`

## Test plan
- [x] `npm test -- tests/usage-pricing.test.ts`
- [ ] `har control sync` no longer logs usage harvest skipped for genai-prices validation errors on Claude sessions with large cache creation


Made with [Cursor](https://cursor.com)