### PR TITLE
feat(control): carry session-usage userEmail and verify coverage through portal sync

### DIFF
--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -176,6 +176,7 @@ export const HarnessVerificationResultSchema = z.object({
   status: z.enum(['pass', 'fail']),
   agent_id: z.number().int().min(HAR_AGENT_SLOT_MIN),
   total_ms: z.number().optional(),
+  coverage: z.number().min(0).max(100).optional(),
   stages: z.array(HarnessVerificationStepSchema),
 });
 
@@ -660,6 +661,7 @@ export const AgentSessionUsageSchema = z.object({
   sessionKey: z.string().min(1),
   agentId: z.number().int().min(HAR_AGENT_SLOT_MIN),
   agentTool: AgentToolSchema,
+  userEmail: z.string().email().optional(),
   workDir: z.string().optional(),
   branch: z.string().optional(),
   suffix: z.string().optional(),

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -492,6 +492,7 @@ async function syncRepoRunsAndSlots(
 
   if (isTelemetryEnabled() && process.env.NODE_ENV !== 'test') {
     try {
+      const userEmail = resolvePortalUserEmail();
       const usage = status.slots.flatMap((slot) =>
         harvestUsageForSlot({
           agentId: slot.agentId,
@@ -513,6 +514,7 @@ async function syncRepoRunsAndSlots(
               suffix: slot.suffix,
               createdAt: slot.sessionCreatedAt,
             }),
+          ...(userEmail ? { userEmail } : {}),
         })),
       );
       if (usage.length > 0) {

--- a/tests/core-results.test.ts
+++ b/tests/core-results.test.ts
@@ -22,6 +22,17 @@ describe('parseVerificationResult', () => {
     });
   });
 
+  it('retains a coverage figure emitted by verify.sh', () => {
+    const stdout = `${JSON.stringify({
+      status: 'pass',
+      agent_id: 1,
+      coverage: 87.5,
+      stages: [{ name: 'unit-tests', pass: true }],
+    })}\n`;
+
+    expect(parseVerificationResult(stdout)?.coverage).toBe(87.5);
+  });
+
   it('returns null for invalid output', () => {
     expect(parseVerificationResult('not json')).toBeNull();
   });

--- a/tests/session-usage-schema.test.ts
+++ b/tests/session-usage-schema.test.ts
@@ -1,0 +1,30 @@
+import { AgentSessionUsageSchema, SyncUsageInputSchema } from '../src/harness/schema';
+
+const baseRow = {
+  sessionKey: 'branch:1',
+  agentId: 1,
+  agentTool: 'claude_code',
+  firstSeenAt: '2026-07-29T00:00:00.000Z',
+  lastSeenAt: '2026-07-29T00:00:00.000Z',
+};
+
+describe('AgentSessionUsageSchema userEmail', () => {
+  it('retains a member-matching userEmail (does not strip it)', () => {
+    const parsed = AgentSessionUsageSchema.parse({
+      ...baseRow,
+      userEmail: 'diogo.ribeiro@kerno.io',
+    });
+    expect(parsed.userEmail).toBe('diogo.ribeiro@kerno.io');
+  });
+
+  it('survives the SyncUsageInput envelope used by the /usage push path', () => {
+    const body = SyncUsageInputSchema.parse({
+      usage: [{ ...baseRow, userEmail: 'diogo.ribeiro@kerno.io' }],
+    });
+    expect(body.usage[0].userEmail).toBe('diogo.ribeiro@kerno.io');
+  });
+
+  it('stays optional — a row without an email parses fine', () => {
+    expect(AgentSessionUsageSchema.parse(baseRow).userEmail).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Two portal-facing fields were silently dropped before reaching the control API because their canonical Zod schemas declared neither the field nor `.passthrough()`:

- **`AgentSessionUsageSchema` gains an optional `userEmail`.** Per-session usage rows are how a downstream portal attributes a session to a workspace member; without the field, `SyncUsageInputSchema.parse()` stripped it on the `/api/repos/:id/usage` push path. `control-sync` now also attaches the resolved portal-user email on that path (the main sync-body path already did). Attribution stays keyed to the logged-in portal user's credentials — no git-identity guessing.
- **`HarnessVerificationResultSchema` gains an optional `coverage` (0–100).** A coverage figure emitted by a repo's verify pipeline now survives `parseVerificationResult` instead of being discarded, landing at `result.data.verification.coverage` for downstream consumers.

Both additions are optional and additive; existing payloads are unaffected.

## Test plan
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — new `tests/session-usage-schema.test.ts` (userEmail survives the `SyncUsageInput` envelope; stays optional) and a coverage-retention case in `tests/core-results.test.ts`; pre-existing tmpdir/husky env failures are unrelated.