### PR TITLE
fix(harness): point stage SCRIPT_DIR at .har/ for slot registry

### DIFF
--- a/.har/STAGES.md
+++ b/.har/STAGES.md
@@ -57,7 +57,9 @@ then implement the TODO block in `.har/stages/db-integrity.sh`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`.
+1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
+   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
+   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
 2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
    args may follow.
 3. Load the slot env via `resolve_agent_env_file` and run checks from the

--- a/control/.har/stages/browser-e2e.sh
+++ b/control/.har/stages/browser-e2e.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
+# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
+SCRIPT_DIR="$HARNESS_DIR"
 
 # shellcheck source=/dev/null
 source "$HARNESS_DIR/harness.env"

--- a/control/.har/stages/docker-build.sh
+++ b/control/.har/stages/docker-build.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
+# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
+SCRIPT_DIR="$HARNESS_DIR"
 
 # shellcheck source=/dev/null
 source "$HARNESS_DIR/harness.env"

--- a/src/templates/har-boilerplate-cli/STAGES.md
+++ b/src/templates/har-boilerplate-cli/STAGES.md
@@ -57,7 +57,9 @@ then implement the TODO block in `.har/stages/db-integrity.sh`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`.
+1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
+   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
+   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
 2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
    args may follow.
 3. Load the slot env via `resolve_agent_env_file` and run checks from the

--- a/src/templates/har-boilerplate-ios/STAGES.md
+++ b/src/templates/har-boilerplate-ios/STAGES.md
@@ -57,7 +57,9 @@ then implement the TODO block in `.har/stages/db-integrity.sh`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`.
+1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
+   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
+   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
 2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
    args may follow.
 3. Load the slot env via `resolve_agent_env_file` and run checks from the

--- a/src/templates/har-boilerplate/STAGES.md
+++ b/src/templates/har-boilerplate/STAGES.md
@@ -57,7 +57,9 @@ then implement the TODO block in `.har/stages/db-integrity.sh`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`.
+1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
+   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
+   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
 2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
    args may follow.
 3. Load the slot env via `resolve_agent_env_file` and run checks from the

--- a/src/templates/plugins/custom-stage-skeleton.sh
+++ b/src/templates/plugins/custom-stage-skeleton.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
+# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
+SCRIPT_DIR="$HARNESS_DIR"
 
 # shellcheck source=/dev/null
 source "$HARNESS_DIR/harness.env"

--- a/src/templates/plugins/playwright/.har/stages/browser-e2e.sh
+++ b/src/templates/plugins/playwright/.har/stages/browser-e2e.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
+# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
+SCRIPT_DIR="$HARNESS_DIR"
 
 # shellcheck source=/dev/null
 source "$HARNESS_DIR/harness.env"

--- a/src/templates/plugins/rocketsim/.har/stages/rocketsim-flows.sh
+++ b/src/templates/plugins/rocketsim/.har/stages/rocketsim-flows.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
+# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
+SCRIPT_DIR="$HARNESS_DIR"
 
 # shellcheck source=/dev/null
 source "$HARNESS_DIR/harness.env"

--- a/tests/verify-shell-timing.test.ts
+++ b/tests/verify-shell-timing.test.ts
@@ -44,3 +44,21 @@ describe('verify.sh portable timing', () => {
     expect(script).not.toMatch(/^\s*mapfile/m);
   });
 });
+
+describe('stage scripts set SCRIPT_DIR to .har/', () => {
+  // Stages live under .har/stages/; agent-slot.sh resolves the slot registry via
+  // $SCRIPT_DIR/slots/..., so SCRIPT_DIR must be reassigned to HARNESS_DIR (.har/)
+  // or verify/e2e silently falls back to the main checkout.
+  const stagePaths = [
+    'src/templates/plugins/playwright/.har/stages/browser-e2e.sh',
+    'src/templates/plugins/rocketsim/.har/stages/rocketsim-flows.sh',
+    'src/templates/plugins/custom-stage-skeleton.sh',
+    'control/.har/stages/browser-e2e.sh',
+    'control/.har/stages/docker-build.sh',
+  ];
+
+  it.each(stagePaths)('%s reassigns SCRIPT_DIR to HARNESS_DIR', (relPath) => {
+    const script = fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8');
+    expect(script).toMatch(/HARNESS_DIR=.*\nREPO_ROOT=.*\n(?:#.*\n)*SCRIPT_DIR="\$HARNESS_DIR"/);
+  });
+});


### PR DESCRIPTION
## Summary
- Stage scripts under `.har/stages/` left `SCRIPT_DIR` as `stages/`, so `agent-slot.sh` looked for the slot registry in the wrong place and e2e/verify fell back to the main checkout (skipping worktree specs such as DEMO-1).
- Reassign `SCRIPT_DIR="$HARNESS_DIR"` in Playwright, RocketSim, custom-stage skeleton, and Mission Control stages; document the contract; add a regression test.

## Test plan
- [x] `har env verify 2 --full` (pass)
- [x] Confirm `browser-e2e` logs the session work dir (not the main checkout) after launch
- [x] Optional: run e2e against a slot that only has specs in the worktree


Made with [Cursor](https://cursor.com)