### PR TITLE
fix(telemetry): stop writing unknown _comment into otel-hook config

### DIFF
--- a/src/core/otel-hooks.ts
+++ b/src/core/otel-hooks.ts
@@ -159,11 +159,9 @@ export function writeOtelHooksConfig(
 ): string {
   fs.mkdirSync(hooksHome, { recursive: true });
   const configPath = getOtelHooksConfigPath(hooksHome);
-  const payload = {
-    _comment: 'Managed by har telemetry — do not edit by hand; use: har telemetry on|off',
-    ...config,
-  };
-  fs.writeFileSync(configPath, `${JSON.stringify(payload, null, 2)}\n`);
+  // Write schema-only JSON — @osfactory/otel-hook rejects unknown keys (e.g. `_comment`)
+  // and falls back to defaults with OTLP export disabled.
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
   return configPath;
 }
 

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -223,15 +223,19 @@ describe('otel hooks config', () => {
 
   it('writes config JSON under hooks home', () => {
     const hooksHome = path.join(tmpDir, 'hooks');
-    const configPath = writeOtelHooksConfig(
-      buildOtelHooksConfig({ enabled: true, apiUrl: 'http://localhost:3847' }),
-      hooksHome,
-    );
+    const config = buildOtelHooksConfig({ enabled: true, apiUrl: 'http://localhost:3847' });
+    const configPath = writeOtelHooksConfig(config, hooksHome);
     expect(configPath).toBe(path.join(hooksHome, 'otel_config.json'));
     const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
-      exporter: { protocol: string };
+      exporter: { protocol: string; endpoint?: string };
+      privacy: { contentMode: string };
+      _comment?: string;
     };
     expect(parsed.exporter.protocol).toBe('http/protobuf');
+    expect(parsed.exporter.endpoint).toBe('http://localhost:3847/api/otel/v1/traces');
+    // otel-hook rejects unknown keys and disables OTLP; keep the file schema-clean.
+    expect(parsed).not.toHaveProperty('_comment');
+    expect(Object.keys(parsed).sort()).toEqual(['exporter', 'privacy']);
   });
 
   it('rewrites hooks.json commands to the HAR wrapper', () => {


### PR DESCRIPTION
## Summary
- `@osfactory/otel-hook` rejects unrecognized config keys and falls back to defaults with OTLP export disabled
- HAR was writing a `_comment` field into `~/.har/otel-hooks/otel_config.json`, which silently broke Mission Control usage ingest
- Write schema-only JSON (`exporter` / `privacy`) and assert that in unit tests

## Test plan
- [x] `har env verify 1 --full` (typecheck, build, docs, unit tests)
- [ ] After merge/install: `har telemetry install-hooks` (rewrites local `otel_config.json`)
- [ ] Confirm hook no longer logs `Unrecognized key: "_comment"` / `otlp sink disabled`
- [ ] Open Mission Control → Worktrees / Usage and confirm new Cursor activity appears


Made with [Cursor](https://cursor.com)