### PR TITLE
fix(control): attribute IDE OTEL by workspace, not last launch

### DIFF
--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/control",
-  "version": "0.30.0",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "0.30.0",
+      "version": "0.32.2",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -66,7 +66,7 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "0.30.0",
+      "version": "0.32.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -3,6 +3,12 @@ import type { Prisma } from '@prisma/client';
 import type { AgentSessionUsage, AgentTool } from '@har/schemas';
 import { prisma } from '@/lib/db';
 import { upsertSessionUsage } from '@/server/usage';
+import {
+  normalizeOtelPath,
+  pickBestRepoPathMatch,
+  pickPathForWorkspaceId,
+  shouldPersistOtelUsage,
+} from '@/server/otel-workspace';
 
 const nodeRequire = createRequire(__filename);
 
@@ -182,14 +188,16 @@ function detectAgentTool(resource: AttrMap, serviceName?: string): AgentTool | n
 }
 
 function normalizePath(value: string): string {
-  return value.replace(/\/$/, '');
+  return normalizeOtelPath(value);
 }
 
 function workspaceFromAttrs(...maps: AttrMap[]): string {
   for (const map of maps) {
     for (const key of [
       'gen_ai.client.workspace',
+      'gen_ai.client.repository_root',
       'har.work_dir',
+      'har.repo_path',
       'code.filepath',
       'cwd',
       'process.cwd',
@@ -197,6 +205,22 @@ function workspaceFromAttrs(...maps: AttrMap[]): string {
       const raw = map[key];
       if (typeof raw === 'string' && raw.trim()) return raw.trim();
     }
+  }
+  return '';
+}
+
+function workspaceIdFromAttrs(...maps: AttrMap[]): string {
+  for (const map of maps) {
+    const raw = map['otelhook.workspace.id'];
+    if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  }
+  return '';
+}
+
+function sessionIdFromAttrs(...maps: AttrMap[]): string {
+  for (const map of maps) {
+    const raw = map['session.id'];
+    if (typeof raw === 'string' && raw.trim()) return raw.trim();
   }
   return '';
 }
@@ -269,33 +293,161 @@ interface ResolvedSessionContext {
   attemptId?: string;
 }
 
+async function resolveRepositoryByWorkspacePath(
+  workspace: string,
+): Promise<{ repositoryId: string; path: string } | null> {
+  const repos = await prisma.repository.findMany({ select: { id: true, path: true } });
+  const best = pickBestRepoPathMatch(
+    workspace,
+    repos.map((r) => r.path),
+  );
+  if (!best) return null;
+  const match = repos.find((r) => normalizePath(r.path) === best);
+  return match ? { repositoryId: match.id, path: match.path } : null;
+}
+
+async function resolveRepositoryByWorkspaceId(
+  workspaceId: string,
+): Promise<{ repositoryId: string; path: string; matchedPath: string } | null> {
+  const [repos, slots] = await Promise.all([
+    prisma.repository.findMany({ select: { id: true, path: true } }),
+    prisma.agentSlot.findMany({
+      where: {
+        OR: [{ workDir: { not: null } }, { worktreePath: { not: null } }],
+      },
+      select: { repositoryId: true, workDir: true, worktreePath: true },
+    }),
+  ]);
+
+  const candidates: Array<{ repositoryId: string; path: string; candidate: string }> = [];
+  for (const repo of repos) {
+    candidates.push({ repositoryId: repo.id, path: repo.path, candidate: repo.path });
+  }
+  for (const slot of slots) {
+    const repo = repos.find((r) => r.id === slot.repositoryId);
+    if (!repo) continue;
+    for (const candidate of [slot.workDir, slot.worktreePath]) {
+      if (candidate) {
+        candidates.push({ repositoryId: repo.id, path: repo.path, candidate });
+      }
+    }
+  }
+
+  const matchedPath = pickPathForWorkspaceId(
+    workspaceId,
+    candidates.map((c) => c.candidate),
+  );
+  if (!matchedPath) return null;
+  const hit = candidates.find((c) => normalizePath(c.candidate) === matchedPath);
+  return hit
+    ? { repositoryId: hit.repositoryId, path: hit.path, matchedPath }
+    : null;
+}
+
+async function defaultAgentIdForRepo(repositoryId: string): Promise<number> {
+  const active = await prisma.agentSlot.findFirst({
+    where: { repositoryId, active: true },
+    orderBy: { updatedAt: 'desc' },
+    select: { slotId: true },
+  });
+  return active?.slotId ?? 1;
+}
+
 async function resolveSessionContext(
   resource: AttrMap,
   attributes: AttrMap = {},
 ): Promise<{ context: ResolvedSessionContext | null; reason?: string }> {
   const tool =
     detectAgentTool(attributes) ?? detectAgentTool(resource) ?? null;
-  const sessionKey = String(
+  const harSessionKey = String(
     resource['har.session_key'] ?? attributes['har.session_key'] ?? '',
   );
   const repoPath = String(resource['har.repo_path'] ?? attributes['har.repo_path'] ?? '');
   const agentIdRaw = Number(resource['har.agent_id'] ?? attributes['har.agent_id'] ?? 0);
   const workspace = workspaceFromAttrs(attributes, resource);
+  const workspaceId = workspaceIdFromAttrs(attributes, resource);
+  const providerSessionId = sessionIdFromAttrs(attributes, resource);
+  const explicitAgentId =
+    Number.isFinite(agentIdRaw) && agentIdRaw > 0 ? agentIdRaw : undefined;
 
-  if (sessionKey) {
+  // Prefer live workspace/slot matching over stale global har.session_key
+  // resource attributes left behind by the last `har env launch`.
+  if (workspace) {
+    const byWs = await resolveSlotByWorkspace(workspace);
+    if (byWs) {
+      return {
+        context: {
+          repositoryId: byWs.repositoryId,
+          sessionKey: harSessionKey || byWs.sessionKey || providerSessionId,
+          agentId: explicitAgentId ?? byWs.agentId,
+          agentTool: tool ?? 'cursor',
+          workDir: byWs.workDir ?? workspace,
+          branch: byWs.branch,
+          suffix: byWs.suffix,
+          workUnitId: byWs.workUnitId,
+          attemptId: byWs.attemptId,
+        },
+      };
+    }
+
+    const byRepo = await resolveRepositoryByWorkspacePath(workspace);
+    if (byRepo) {
+      return {
+        context: {
+          repositoryId: byRepo.repositoryId,
+          sessionKey:
+            harSessionKey || providerSessionId || `ide:${normalizePath(byRepo.path)}`,
+          agentId: explicitAgentId ?? (await defaultAgentIdForRepo(byRepo.repositoryId)),
+          agentTool: tool ?? 'cursor',
+          workDir: workspace,
+          branch: resource['har.branch'] ? String(resource['har.branch']) : undefined,
+          suffix: resource['har.suffix'] ? String(resource['har.suffix']) : undefined,
+          workUnitId: resource['har.work_unit_id']
+            ? String(resource['har.work_unit_id'])
+            : undefined,
+          attemptId: resource['har.attempt_id']
+            ? String(resource['har.attempt_id'])
+            : undefined,
+        },
+      };
+    }
+  }
+
+  if (workspaceId) {
+    const byId = await resolveRepositoryByWorkspaceId(workspaceId);
+    if (byId) {
+      return {
+        context: {
+          repositoryId: byId.repositoryId,
+          sessionKey:
+            harSessionKey || providerSessionId || `ide:${normalizePath(byId.path)}`,
+          agentId: explicitAgentId ?? (await defaultAgentIdForRepo(byId.repositoryId)),
+          agentTool: tool ?? 'cursor',
+          workDir: byId.matchedPath,
+          branch: resource['har.branch'] ? String(resource['har.branch']) : undefined,
+          suffix: resource['har.suffix'] ? String(resource['har.suffix']) : undefined,
+        },
+      };
+    }
+  }
+
+  if (harSessionKey) {
     let repositoryId = await resolveRepositoryId(repoPath || undefined);
     if (!repositoryId && workspace) {
       const byWs = await resolveSlotByWorkspace(workspace);
       repositoryId = byWs?.repositoryId ?? null;
     }
     if (!repositoryId) {
-      return { context: null, reason: `unknown repository for ${repoPath || workspace || '(empty)'}` };
+      return {
+        context: null,
+        reason: `unknown repository for ${repoPath || workspace || workspaceId || '(empty)'}`,
+      };
     }
     return {
       context: {
         repositoryId,
-        sessionKey,
-        agentId: Number.isFinite(agentIdRaw) && agentIdRaw > 0 ? agentIdRaw : 1,
+        sessionKey: harSessionKey,
+        agentId: explicitAgentId ?? 1,
         agentTool: tool ?? 'claude_code',
         workDir: resource['har.work_dir']
           ? String(resource['har.work_dir'])
@@ -312,27 +464,10 @@ async function resolveSessionContext(
     };
   }
 
-  if (workspace) {
-    const byWs = await resolveSlotByWorkspace(workspace);
-    if (byWs) {
-      return {
-        context: {
-          repositoryId: byWs.repositoryId,
-          sessionKey: byWs.sessionKey,
-          agentId: byWs.agentId,
-          agentTool: tool ?? 'cursor',
-          workDir: byWs.workDir ?? workspace,
-          branch: byWs.branch,
-          suffix: byWs.suffix,
-          workUnitId: byWs.workUnitId,
-          attemptId: byWs.attemptId,
-        },
-      };
-    }
-    return { context: null, reason: `no slot matched workspace ${workspace}` };
-  }
-
-  return { context: null, reason: 'missing har.session_key and workspace' };
+  return {
+    context: null,
+    reason: `no repository matched workspace ${workspace || workspaceId || '(empty)'}`,
+  };
 }
 
 const PURPOSE_MAX_CHARS = 160;
@@ -449,8 +584,8 @@ async function maybeSetDerivedPurpose(
 }
 
 function shouldPersistUsage(usage: AgentSessionUsage): boolean {
-  if (usage.tokensTotal > 0) return true;
-  return Boolean(usage.modelBreakdown && Object.keys(usage.modelBreakdown).length > 0);
+  // Model-only / zero-token rows are not real usage — keep events/spans, skip usage table.
+  return shouldPersistOtelUsage(usage);
 }
 
 function applyHooksUsageFromAttrs(usage: AgentSessionUsage, attributes: AttrMap): void {

--- a/control/src/server/otel-workspace.test.ts
+++ b/control/src/server/otel-workspace.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  otelWorkspaceIdForPath,
+  pickBestRepoPathMatch,
+  pickPathForWorkspaceId,
+  shouldPersistOtelUsage,
+} from './otel-workspace';
+
+describe('otelWorkspaceIdForPath', () => {
+  it('matches @osfactory/otel-hook empty-salt working-directory ids', () => {
+    // Precomputed: sha256("\0" + "workspace/working-directory\0" + path)
+    expect(otelWorkspaceIdForPath('/home/antoine/Documents/osfactory/har-project')).toBe(
+      'sha256:4b1253011b011d9f17508e9f9e5c155d008c44260939891982d966704abb06a8',
+    );
+  });
+
+  it('strips trailing slashes before hashing', () => {
+    const a = otelWorkspaceIdForPath('/repo/foo');
+    const b = otelWorkspaceIdForPath('/repo/foo/');
+    expect(a).toBe(b);
+  });
+});
+
+describe('pickBestRepoPathMatch', () => {
+  it('prefers the longest registered prefix', () => {
+    expect(
+      pickBestRepoPathMatch('/home/me/proj/control/src', [
+        '/home/me/proj',
+        '/home/me/proj/control',
+        '/home/other',
+      ]),
+    ).toBe('/home/me/proj/control');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(pickBestRepoPathMatch('/tmp/x', ['/home/me/proj'])).toBeNull();
+  });
+});
+
+describe('pickPathForWorkspaceId', () => {
+  it('recovers a registered path from an opaque workspace id', () => {
+    const path = '/home/antoine/Documents/osfactory/har-project';
+    const id = otelWorkspaceIdForPath(path);
+    expect(
+      pickPathForWorkspaceId(id, [
+        '/home/antoine/Documents/osfactory/examples/webapp-nextjs',
+        path,
+        `${path}/control`,
+      ]),
+    ).toBe(path);
+  });
+
+  it('prefers longer candidate paths when both hash-match (worktree over root)', () => {
+    // Distinct paths produce distinct ids — verify longest-first scan order by
+    // ensuring the matched candidate is the one whose id we queried.
+    const worktree = '/home/antoine/worktrees/main-abcd-har-agent-1-xy12';
+    const id = otelWorkspaceIdForPath(worktree);
+    expect(
+      pickPathForWorkspaceId(id, [
+        '/home/antoine/Documents/osfactory/har-project',
+        worktree,
+      ]),
+    ).toBe(worktree);
+  });
+});
+
+describe('shouldPersistOtelUsage', () => {
+  it('requires tokens or a positive cost', () => {
+    expect(shouldPersistOtelUsage({ tokensTotal: 0, costUsd: null })).toBe(false);
+    expect(shouldPersistOtelUsage({ tokensTotal: 0, costUsd: 0 })).toBe(false);
+    expect(shouldPersistOtelUsage({ tokensTotal: 12, costUsd: null })).toBe(true);
+    expect(shouldPersistOtelUsage({ tokensTotal: 0, costUsd: 0.01 })).toBe(true);
+  });
+});

--- a/control/src/server/otel-workspace.ts
+++ b/control/src/server/otel-workspace.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Match @osfactory/otel-hook's default privacy hash (empty salt):
+ *   sha256(salt + "\0" + `${namespace}\0${value}`)
+ * with namespace `workspace/working-directory` and value = absolute path
+ * (trailing slashes stripped). Used to map opaque `otelhook.workspace.id`
+ * back to a registered repository path without storing filesystem paths in
+ * OTLP payloads.
+ */
+export function otelWorkspaceIdForPath(absolutePath: string, hashSalt = ''): string {
+  const material = absolutePath.replace(/[/\\]+$/, '');
+  if (!material) return 'unknown:0000000000000000';
+  const digest = createHash('sha256')
+    .update(hashSalt)
+    .update('\0')
+    .update(`workspace/working-directory\0${material}`, 'utf8')
+    .digest('hex');
+  return `sha256:${digest}`;
+}
+
+export function normalizeOtelPath(value: string): string {
+  return value.replace(/[/\\]+$/, '');
+}
+
+/** Longest registered path that equals or is a parent of `workspace`. */
+export function pickBestRepoPathMatch(
+  workspace: string,
+  repoPaths: string[],
+): string | null {
+  const normalized = normalizeOtelPath(workspace);
+  if (!normalized) return null;
+  const matches = repoPaths
+    .map(normalizeOtelPath)
+    .filter(
+      (path) =>
+        path.length > 0 &&
+        (normalized === path || normalized.startsWith(`${path}/`)),
+    )
+    .sort((a, b) => b.length - a.length);
+  return matches[0] ?? null;
+}
+
+/** First path (longest preferred) whose opaque workspace id equals `workspaceId`. */
+export function pickPathForWorkspaceId(
+  workspaceId: string,
+  candidatePaths: string[],
+  hashSalt = '',
+): string | null {
+  if (!workspaceId || workspaceId === 'unknown:0000000000000000') return null;
+  const unique = [...new Set(candidatePaths.map(normalizeOtelPath).filter(Boolean))];
+  // Prefer longer paths so worktree dirs win over the parent checkout.
+  unique.sort((a, b) => b.length - a.length);
+  for (const path of unique) {
+    if (otelWorkspaceIdForPath(path, hashSalt) === workspaceId) return path;
+  }
+  return null;
+}
+
+export function shouldPersistOtelUsage(usage: {
+  tokensTotal: number;
+  costUsd?: number | null;
+}): boolean {
+  if (usage.tokensTotal > 0) return true;
+  return typeof usage.costUsd === 'number' && Number.isFinite(usage.costUsd) && usage.costUsd > 0;
+}

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/schemas",
-  "version": "0.30.0",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "0.30.0",
+      "version": "0.32.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -21,7 +21,6 @@ import {
 } from '../../core/telemetry-config';
 import {
   appendTelemetryEnvToFile,
-  buildOtelResourceAttributes,
   buildSessionKey,
   buildTelemetryEnvBlock,
 } from '../../core/telemetry-env';
@@ -155,11 +154,14 @@ async function handleWriteEnv(argv: {
 
   appendTelemetryEnvToFile(envFile, attrs);
 
+  // Do not write per-session har.* resource attributes into the global
+  // ~/.har/otel-hooks/otel_config.json — that file is shared by every Cursor /
+  // Claude / Codex hook invocation. Stale har.session_key / har.repo_path from
+  // the last launch made Mission Control drop or mis-attribute IDE activity.
+  // Session attribution for OTEL ingest uses workspace / otelhook.workspace.id
+  // matching against registered repos and active slots instead.
   if (isTelemetryEnabled()) {
-    ensureOtelHooks({
-      setupAgents: false,
-      resourceAttributes: buildOtelResourceAttributes(attrs),
-    });
+    ensureOtelHooks({ setupAgents: false });
   }
 
   success(`Wrote session attribution to ${envFile}`);

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -6,7 +6,7 @@ import { createRun, finishRun, resolveAgentWorkDir } from './runs';
 import { listSlotRegistryEntries, readSlotRegistry } from './slot-registry';
 import { checkLaunchGuard } from './slot-launch-guard';
 import { formatPreflightReport, inspectSlotReadiness } from './slot-preflight';
-import { recordValidation } from './validations';
+import { recordValidation, resolveValidationCheckoutDir } from './validations';
 import {
   bindValidationToAttempt,
   createWorkAttempt,
@@ -359,7 +359,12 @@ export class RunService {
     if (verification) {
       try {
         const harnessRoot = resolveHarnessRoot(options.repoPath);
-        const checkoutDir = resolveAgentWorkDir(harnessRoot, options.agentId) ?? harnessRoot;
+        const session = readSlotRegistry(harnessRoot, options.agentId);
+        const checkoutDir = resolveValidationCheckoutDir({
+          worktreePath: session?.worktreePath,
+          workDir: resolveAgentWorkDir(harnessRoot, options.agentId),
+          harnessRoot,
+        });
         const runId =
           typeof result.data === 'object' && result.data !== null && !Array.isArray(result.data)
             ? (result.data as { runId?: string }).runId
@@ -372,7 +377,6 @@ export class RunService {
           runId,
           agentId: options.agentId,
         });
-        const session = readSlotRegistry(harnessRoot, options.agentId);
         if (session?.workUnitId && session.attemptId) {
           bindValidationToAttempt(harnessRoot, {
             workUnitId: session.workUnitId,

--- a/src/core/validations.ts
+++ b/src/core/validations.ts
@@ -6,6 +6,22 @@ import { computeWorktreeSnapshot, isCheckoutRoot } from './change-batch';
 
 export const VALIDATIONS_DIR = 'validations';
 
+/**
+ * Pick the git checkout root to snapshot for a validation record.
+ * Nested harnesses (e.g. `control/`) often set workDir to a subdirectory;
+ * prefer the linked worktree root when present.
+ */
+export function resolveValidationCheckoutDir(input: {
+  worktreePath?: string;
+  workDir?: string;
+  harnessRoot: string;
+}): string {
+  const candidates = [input.worktreePath, input.workDir, input.harnessRoot].filter(
+    (value): value is string => Boolean(value),
+  );
+  return candidates.find(isCheckoutRoot) ?? candidates[0] ?? input.harnessRoot;
+}
+
 function getValidationsDir(checkoutDir: string): string {
   return path.join(checkoutDir, '.har', VALIDATIONS_DIR);
 }

--- a/tests/otel-mapping.test.ts
+++ b/tests/otel-mapping.test.ts
@@ -226,6 +226,17 @@ describe('hooks agent tool + usage mapping', () => {
     });
   });
 
+  it('does not treat model-only zero-token rows as persistable usage', () => {
+    const usage = applyHooksUsageFromAttrs({
+      'gen_ai.request.model': 'gpt-test',
+    });
+    const tokensTotal =
+      usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead + usage.tokensCacheCreation;
+    expect(tokensTotal).toBe(0);
+    // Mission Control only persists usage when tokensTotal > 0 or costUsd > 0.
+    expect(tokensTotal > 0).toBe(false);
+  });
+
   it('derives truncated purpose from first prompt content', () => {
     const prompt = extractPromptText({
       'gen_ai.client.hook.event': 'UserPromptSubmit',

--- a/tests/validations.test.ts
+++ b/tests/validations.test.ts
@@ -8,6 +8,7 @@ import {
   findValidation,
   listValidations,
   recordValidation,
+  resolveValidationCheckoutDir,
 } from '../src/core/validations';
 
 function sh(cwd: string, command: string): string {
@@ -117,5 +118,19 @@ describe('validation store', () => {
     fs.mkdirSync(path.join(dir, '.har', 'validations'), { recursive: true });
     fs.writeFileSync(path.join(dir, '.har', 'validations', 'garbage.json'), 'not json');
     expect(listValidations(dir)).toEqual([]);
+  });
+
+  it('prefers the worktree root over a nested harness workDir', () => {
+    const dir = initRepo();
+    const nested = path.join(dir, 'control');
+    fs.mkdirSync(nested, { recursive: true });
+
+    expect(
+      resolveValidationCheckoutDir({
+        worktreePath: dir,
+        workDir: nested,
+        harnessRoot: nested,
+      }),
+    ).toBe(dir);
   });
 });


### PR DESCRIPTION
## Summary
- Attribute Mission Control OTEL ingest to registered repos via filesystem path or opaque `otelhook.workspace.id`, instead of requiring a live slot `workDir` match or trusting stale global `har.session_key` from the last launch.
- Stop writing per-session `har.*` resource attributes into the shared `otel_config.json` on `telemetry write-env`, which was poisoning Cursor/Claude IDE sessions.
- Persist usage rows only when tokens or cost are non-zero (no phantom `tokensTotal: 0` success rows).
- Record commit-gate validations against the git worktree root for nested harnesses (e.g. `control/`), so full verify can unlock commits.

## Test plan
- [x] Control slot full verify (`har env verify 3 --full`)
- [x] Root unit tests: `validations`, `otel-mapping`, `telemetry`
- [x] After merge/install: `har telemetry install-hooks` to clear poisoned global resource attrs
- [x] Confirm Cursor IDE activity on a registered checkout appears under that repo in Mission Control
- [x] Confirm usage rows appear only when generation spans include real token counts


Made with [Cursor](https://cursor.com)