### PR TITLE
feat: add interactive har onboard first-run wizard

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -124,6 +124,7 @@ These are non-negotiable. Do not introduce imports that violate them.
 | Manifest / stages.json I/O | `src/harness/manifest.ts`, `stages.ts` |
 | Scaffold copy, boilerplate wiring | `src/harness/generator.ts` |
 | Init / maintain / describe orchestration | `src/core/harness.ts` |
+| Guided first-run onboarding (`har onboard`) | `src/core/onboarding.ts`, `src/cli/commands/onboard.ts` |
 | Run orchestration (launch, verify, teardown) | `src/core/run-service.ts` |
 | Local bash/script execution | `src/core/local-executor.ts` |
 | Run history (`.har/runs/`) | `src/core/runs.ts` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,7 @@ Top-level command groups (see `har <cmd> --help`):
 
 | Command | Purpose |
 |---------|---------|
+| `har onboard` | Guided first-run setup (telemetry, Mission Control, plugins, adapt prompt) |
 | `har env …` | Harness lifecycle (init, maintain, launch, verify, complete, …) |
 | `har agents …` | Scaffold/remove agent skills (`/setup-har`, `/har-wt`, `/har-maintain`) |
 | `har control …` | Local Mission Control dashboard |
@@ -200,7 +201,8 @@ Top-level command groups (see `har <cmd> --help`):
 
 ```bash
 cd /path/to/your-project
-har env init
+har onboard --yes --no-control --no-plugins
+# or: har env init
 ```
 
 For CLI/library repos:

--- a/FAQ.md
+++ b/FAQ.md
@@ -84,11 +84,18 @@ The repo-owned `.har/` directory remains the runtime contract. HAR should make i
 </details>
 
 <details>
+<summary><strong>Q: How do I set up HAR in a new repository?</strong></summary>
+
+**A:** Run `har onboard` for the guided first-run flow (how HAR works, telemetry, Mission Control, optional plugins, then the adaptation prompt on the clipboard). For a non-interactive scaffold only, use `har env init` (or `har onboard --yes --no-control --no-plugins`).
+
+</details>
+
+<details>
 <summary><strong>Q: What does `har env init` create?</strong></summary>
 
 **A:** It creates a `.har/` directory with scripts, docs, metadata, environment templates, and optional stage definitions for the current repo.
 
-By default, `har env init` scaffolds boilerplate and prints a copy-paste prompt for your coding agent to adapt the harness and repo-root `AGENT.md`. In a TTY it also offers to copy that prompt to the clipboard (or copies automatically with `--yes`). Pass `--auto` to run built-in Claude adaptation instead (requires `ANTHROPIC_API_KEY`).
+By default, `har env init` scaffolds boilerplate and prints a copy-paste prompt for your coding agent to adapt the harness and repo-root `AGENT.md`. In a TTY it also offers to copy that prompt to the clipboard (or copies automatically with `--yes`). Pass `--auto` to run built-in Claude adaptation instead (requires `ANTHROPIC_API_KEY`). Prefer `har onboard` when you also want telemetry / Mission Control / plugin choices in one pass.
 
 A typical harness includes scripts such as:
 

--- a/docs/src/content/docs/docs/getting-started/installation.md
+++ b/docs/src/content/docs/docs/getting-started/installation.md
@@ -24,7 +24,8 @@ in the same `@osfactory/har` package.
 Install activates **full agent telemetry by default** (traces, logs, metrics, and
 prompts → local Mission Control). Preference is written to `~/.har/telemetry.json`
 when missing. Disable with `har telemetry off`, or keep usage without prompt text
-via `har telemetry on --no-prompts`.
+via `har telemetry on --no-prompts`. For a guided first-run in a repository
+(including telemetry and Mission Control choices), use `har onboard`.
 
 ## Install from source
 

--- a/docs/src/content/docs/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/docs/getting-started/quick-start.md
@@ -3,9 +3,31 @@ title: Quick start
 description: Initialize a harness and complete the first isolated agent session.
 ---
 
-## 1. Initialize the repository
+## 1. Onboard (recommended)
 
 From your project root:
+
+```bash
+har onboard
+```
+
+The guided wizard walks through how HAR works, then lets you:
+
+- choose agent telemetry (`on` / `on-no-prompts` / `off`)
+- start Mission Control
+- pick optional plugins (for example Playwright)
+- scaffold `.har/` for a profile (`default`, `cli`, or `ios`)
+
+It finishes by writing `.har/ADAPT-PROMPT.md` and offering to copy that prompt
+to the clipboard so you can paste it into your coding agent.
+
+Non-interactive defaults:
+
+```bash
+har onboard --yes --profile cli --no-control --no-plugins
+```
+
+### Manual init (equivalent pieces)
 
 ```bash
 har preferences configure
@@ -18,12 +40,6 @@ init/maintain should install the commit gate. Explicit command flags still win.
 
 The default profile targets web applications. Use `--profile cli` for libraries
 and command-line tools or `--profile ios` for an Xcode project.
-
-HAR copies an editable `.har/` scaffold, validates it, and writes an adaptation
-prompt to `.har/ADAPT-PROMPT.md`. In an interactive terminal it offers to copy
-that prompt to the clipboard (macOS / Linux / Windows, with OSC 52 fallback)
-so you can paste it into your coding agent. The agent can also read the file
-directly.
 
 To let HAR perform the Claude-based adaptation:
 

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -5,6 +5,28 @@ description: Commands and important options exposed by the HAR executable.
 
 All repository commands accept `--repo <path>`; the default is the current directory.
 
+## `har onboard`
+
+Interactive first-run guide: how HAR works, telemetry, Mission Control, plugins,
+then the adaptation prompt (clipboard + `.har/ADAPT-PROMPT.md`).
+
+```bash
+har onboard [--repo .] [--yes] [--skip-guide] [--skip-init]
+            [--profile default|cli|ios]
+            [--telemetry on|on-no-prompts|off]
+            [--control|--no-control]
+            [--plugins playwright,rocketsim|--no-plugins]
+            [--force]
+            [--agents claude,cursor,codex] [--no-agents]
+            [--cursor-rule|--no-cursor-rule]
+            [--commit-gate prompt|always|never]
+            [--gate-mode block|warn] [--gate-scope worktrees|all]
+```
+
+`--yes` accepts defaults (telemetry on, start Mission Control, no plugins) without
+prompts. Prefer this over hand-rolling `preferences` + `env init` + `telemetry`
++ `control up` for new repositories.
+
 ## `har env`
 
 | Command | Purpose |

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -1,0 +1,357 @@
+import * as path from 'path';
+import inquirer from 'inquirer';
+import type { Argv } from 'yargs';
+import { handleAgentSkills } from '../../harness/agent-skills';
+import { handleCursorRule } from '../../harness/cursor-rule';
+import { harnessExists } from '../../harness/parser';
+import type { HarnessProfile } from '../../harness/generator';
+import { PluginId } from '../../harness/plugins';
+import { handleCommitGateOnboarding } from '../../core/commit-gate-onboarding';
+import {
+  finalizeOnboardingAdaptation,
+  listPluginChoices,
+  ONBOARDING_GUIDE_STEPS,
+  printOnboardingGuide,
+  runOnboarding,
+  TelemetryChoice,
+} from '../../core/onboarding';
+import { divider, error, header, info, success, warn } from '../../utils/logging';
+import { resolveOnboardingOptions } from './env';
+
+interface OnboardArgs {
+  repo: string;
+  yes: boolean;
+  profile?: HarnessProfile;
+  telemetry?: TelemetryChoice;
+  control?: boolean;
+  plugins?: string | false;
+  skipGuide: boolean;
+  skipInit: boolean;
+  force: boolean;
+  cursorRule?: boolean;
+  agents?: string | false;
+  commitGate?: 'prompt' | 'always' | 'never';
+  gateMode?: 'block' | 'warn';
+  gateScope?: 'worktrees' | 'all';
+}
+
+function parsePluginsFlag(raw: string | false | undefined): PluginId[] | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === false) return [];
+  const available = listPluginChoices().map((p) => p.id);
+  if (raw.trim() === '' || raw === 'none') return [];
+  const selected = raw.split(',').map((value) => value.trim()).filter(Boolean);
+  const invalid = selected.filter((id) => !available.includes(id as PluginId));
+  if (invalid.length > 0) {
+    throw new Error(`Unknown plugin(s): ${invalid.join(', ')}. Available: ${available.join(', ')}`);
+  }
+  return selected as PluginId[];
+}
+
+async function pauseForGuide(autoYes: boolean): Promise<void> {
+  if (autoYes || !process.stdin.isTTY || !process.stdout.isTTY) return;
+  await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'continue',
+      message: 'Press Enter to continue',
+    },
+  ]);
+}
+
+async function promptChoices(args: OnboardArgs): Promise<{
+  profile: HarnessProfile;
+  telemetry: TelemetryChoice;
+  startControl: boolean;
+  plugins: PluginId[];
+}> {
+  if (args.yes) {
+    const telemetry = args.telemetry ?? 'on';
+    return {
+      profile: args.profile ?? 'default',
+      telemetry,
+      startControl: args.control ?? telemetry !== 'off',
+      plugins: parsePluginsFlag(args.plugins) ?? [],
+    };
+  }
+
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!interactive) {
+    if (
+      args.telemetry === undefined &&
+      args.control === undefined &&
+      args.plugins === undefined &&
+      args.profile === undefined
+    ) {
+      throw new Error(
+        'Interactive onboarding requires a TTY. Pass --yes or flags (--profile, --telemetry, --control/--no-control, --plugins).',
+      );
+    }
+    const telemetry = args.telemetry ?? 'on';
+    return {
+      profile: args.profile ?? 'default',
+      telemetry,
+      startControl: args.control ?? telemetry !== 'off',
+      plugins: parsePluginsFlag(args.plugins) ?? [],
+    };
+  }
+
+  const pluginChoices = listPluginChoices();
+  const alreadyPresent = harnessExists(path.resolve(args.repo));
+  const needProfile = !alreadyPresent && !args.skipInit && args.profile === undefined;
+
+  const answers = await inquirer.prompt<{
+    profile?: HarnessProfile;
+    telemetry?: TelemetryChoice;
+    startControl?: boolean;
+    plugins?: PluginId[];
+  }>([
+    {
+      type: 'list',
+      name: 'profile',
+      message: 'Harness profile',
+      when: () => needProfile,
+      choices: [
+        { name: 'default — web / full-stack apps', value: 'default' },
+        { name: 'cli — libraries and CLI tools (no PM2)', value: 'cli' },
+        { name: 'ios — Xcode / iOS Simulator', value: 'ios' },
+      ],
+      default: 'default',
+    },
+    {
+      type: 'list',
+      name: 'telemetry',
+      message: 'Agent usage telemetry (Cursor / Claude / Codex → Mission Control)',
+      when: () => args.telemetry === undefined,
+      choices: [
+        { name: 'Full on (traces, logs, metrics, prompts) — recommended', value: 'on' },
+        { name: 'On without prompt text', value: 'on-no-prompts' },
+        { name: 'Off', value: 'off' },
+      ],
+      default: 'on',
+    },
+    {
+      type: 'confirm',
+      name: 'startControl',
+      message: 'Start Mission Control now?',
+      when: () => args.control === undefined,
+      default: (current: { telemetry?: TelemetryChoice }) =>
+        (args.telemetry ?? current.telemetry ?? 'on') !== 'off',
+    },
+    {
+      type: 'checkbox',
+      name: 'plugins',
+      message: 'Optional plugins to install (space to toggle, enter to confirm)',
+      when: () => args.plugins === undefined,
+      choices: pluginChoices.map((plugin) => ({
+        name: plugin.label,
+        value: plugin.id,
+      })),
+    },
+  ]);
+
+  const telemetry = args.telemetry ?? answers.telemetry ?? 'on';
+  return {
+    profile: args.profile ?? answers.profile ?? 'default',
+    telemetry,
+    startControl: args.control ?? answers.startControl ?? telemetry !== 'off',
+    plugins: parsePluginsFlag(args.plugins) ?? answers.plugins ?? [],
+  };
+}
+
+function printSummary(result: {
+  repoPath: string;
+  harnessInitialized: boolean;
+  harnessAlreadyPresent: boolean;
+  telemetry: TelemetryChoice;
+  controlStarted: boolean;
+  controlApiUrl: string;
+  pluginsApplied: PluginId[];
+  adaptationPromptPath: string | null;
+  adaptationPromptCopied: boolean;
+}): void {
+  divider();
+  success('Onboarding complete');
+  info(`Repository:     ${result.repoPath}`);
+  info(
+    `Harness:        ${
+      result.harnessInitialized
+        ? 'scaffolded'
+        : result.harnessAlreadyPresent
+          ? 'already present'
+          : 'skipped'
+    }`,
+  );
+  info(`Telemetry:      ${result.telemetry}`);
+  info(
+    `Mission Control:${
+      result.controlStarted
+        ? ` started (${result.controlApiUrl})`
+        : ` not started (${result.controlApiUrl})`
+    }`,
+  );
+  info(
+    `Plugins:        ${
+      result.pluginsApplied.length > 0 ? result.pluginsApplied.join(', ') : 'none'
+    }`,
+  );
+  if (result.adaptationPromptPath) {
+    info(`Adapt prompt:   ${result.adaptationPromptPath}`);
+    info(
+      result.adaptationPromptCopied
+        ? 'Clipboard:      copied — paste into your coding agent'
+        : 'Clipboard:      open .har/ADAPT-PROMPT.md and paste into your coding agent',
+    );
+  }
+  console.error('');
+  console.error('  Next:');
+  console.error('    Adapt:   paste the prompt into your coding agent');
+  console.error('    Launch:  har env launch 1');
+  console.error('    Verify:  har env verify 1 --full');
+  console.error('    Control: har control up   # if you skipped Mission Control');
+  console.error('');
+}
+
+export async function handleOnboard(argv: OnboardArgs): Promise<void> {
+  const repoPath = path.resolve(argv.repo);
+  header('har onboard');
+  info(`Repository: ${repoPath}`);
+
+  try {
+    if (!argv.skipGuide) {
+      printOnboardingGuide();
+      await pauseForGuide(argv.yes);
+    } else {
+      info(`Skipped guide (${ONBOARDING_GUIDE_STEPS.length} steps available without --skip-guide)`);
+    }
+
+    const choices = await promptChoices(argv);
+    const onboarding = resolveOnboardingOptions(argv);
+
+    const result = await runOnboarding({
+      repoPath,
+      profile: choices.profile,
+      telemetry: choices.telemetry,
+      startControl: choices.startControl,
+      plugins: choices.plugins,
+      skipInit: argv.skipInit,
+      deferAdaptationPrompt: true,
+      autoYes: argv.yes,
+      forcePlugins: argv.force,
+    });
+
+    if (result.harnessInitialized || harnessExists(repoPath)) {
+      await handleCommitGateOnboarding({
+        repoPath,
+        ...onboarding.commitGate,
+        autoYes: argv.yes,
+      });
+      await handleCursorRule({
+        repoPath,
+        cursorRule: onboarding.cursorRule,
+        autoYes: argv.yes,
+        mode: result.harnessInitialized ? 'init' : 'maintain',
+      });
+      await handleAgentSkills({
+        repoPath,
+        ...onboarding.agentSkills,
+        autoYes: argv.yes,
+        force: argv.force,
+        mode: result.harnessInitialized ? 'init' : 'maintain',
+      });
+    }
+
+    if (harnessExists(repoPath)) {
+      const finalized = await finalizeOnboardingAdaptation({
+        repoPath,
+        profile: result.profile,
+        harnessInitialized: result.harnessInitialized,
+        autoYes: argv.yes,
+      });
+      result.adaptationPromptPath = finalized.path;
+      result.adaptationPromptCopied = finalized.copied;
+    }
+
+    for (const warning of result.pluginWarnings) {
+      warn(warning);
+    }
+
+    printSummary(result);
+  } catch (err: unknown) {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+export const onboardCommand = {
+  command: 'onboard',
+  describe:
+    'Interactive first-run guide: how HAR works, telemetry, Mission Control, plugins, adapt prompt',
+  builder: (yargs: Argv) =>
+    yargs
+      .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+      .option('yes', {
+        alias: 'y',
+        type: 'boolean',
+        default: false,
+        describe:
+          'Accept defaults without prompting (telemetry on, start Mission Control, no plugins)',
+      })
+      .option('profile', {
+        type: 'string',
+        choices: ['default', 'cli', 'ios'] as const,
+        describe: 'Harness profile when scaffolding (default: default)',
+      })
+      .option('telemetry', {
+        type: 'string',
+        choices: ['on', 'on-no-prompts', 'off'] as const,
+        describe: 'Telemetry preference',
+      })
+      .option('control', {
+        type: 'boolean',
+        describe: 'Start Mission Control (use --no-control to skip)',
+      })
+      .option('plugins', {
+        type: 'string',
+        describe:
+          'Comma-separated plugins to install (e.g. playwright); --no-plugins to skip; interactive checkbox when omitted',
+      })
+      .option('skip-guide', {
+        type: 'boolean',
+        default: false,
+        describe: 'Skip the how-HAR-works introduction',
+      })
+      .option('skip-init', {
+        type: 'boolean',
+        default: false,
+        describe: 'Do not scaffold .har/ even when missing',
+      })
+      .option('force', {
+        type: 'boolean',
+        default: false,
+        describe: 'Overwrite existing plugin files when installing',
+      })
+      .option('cursor-rule', {
+        type: 'boolean',
+        describe:
+          'Create .cursor/rules/har-workflow.mdc without prompting (use --no-cursor-rule to skip)',
+      })
+      .option('agents', {
+        type: 'string',
+        describe:
+          'Scaffold agent skills for these targets (comma-separated: claude,cursor,codex); --no-agents to skip',
+      })
+      .option('commit-gate', {
+        choices: ['prompt', 'always', 'never'] as const,
+        describe: 'Install commit hooks during onboarding (defaults to user preferences)',
+      })
+      .option('gate-mode', {
+        choices: ['block', 'warn'] as const,
+        describe: 'Policy for commits without a passing full verification',
+      })
+      .option('gate-scope', {
+        choices: ['worktrees', 'all'] as const,
+        describe: 'Apply the commit policy to HAR worktrees or every checkout',
+      }),
+  handler: (argv: OnboardArgs) => handleOnboard(argv),
+};

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -1,6 +1,9 @@
 /** Shared CLI epilog / launch copy for `har --help` and `har env` help. */
 
-export const HAR_ROOT_EPILOG = `Typical agent workflow:
+export const HAR_ROOT_EPILOG = `First time in a repo:
+  har onboard                    # guided setup → adaptation prompt on clipboard
+
+Typical agent workflow:
   har env status                 # see which slots are free / occupied
   har env launch <id>            # new session from the main checkout's HEAD
   # …edit only under the printed work dir…

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { envCommand } from './commands/env';
 import { controlCommand } from './commands/control';
 import { hooksCommand } from './commands/hooks';
 import { mcpCommand } from './commands/mcp';
+import { onboardCommand } from './commands/onboard';
 import { preferencesCommand } from './commands/preferences';
 import { telemetryCommand } from './commands/telemetry';
 import { HAR_ROOT_EPILOG } from './help-text';
@@ -16,6 +17,7 @@ export async function runCli(): Promise<void> {
   await yargs(hideBin(process.argv))
     .scriptName('har')
     .usage('$0 <command> [options]')
+    .command(onboardCommand)
     .command(envCommand)
     .command(agentsCommand)
     .command(controlCommand)
@@ -23,7 +25,7 @@ export async function runCli(): Promise<void> {
     .command(mcpCommand)
     .command(preferencesCommand)
     .command(telemetryCommand)
-    .demandCommand(1, 'Please specify a command. Try: har env --help')
+    .demandCommand(1, 'Please specify a command. Try: har onboard   or   har env --help')
     .epilog(HAR_ROOT_EPILOG)
     .strict()
     .help()

--- a/src/core/onboarding.ts
+++ b/src/core/onboarding.ts
@@ -1,0 +1,361 @@
+import * as path from 'path';
+import { addPlugin, initHarness } from './harness';
+import { startControlAndSync } from './control-lifecycle';
+import { getControlApiUrl } from './control-config';
+import { isControlApiReachable } from './control-sync';
+import { recordRepoForControlSync } from './control-registry';
+import {
+  disableOtelHooksExport,
+  ensureOtelHooks,
+} from './otel-hooks';
+import {
+  writeTelemetryPreference,
+} from './telemetry-config';
+import { ensureTelemetryInfrastructure } from './telemetry-ensure';
+import {
+  buildInitAdaptationPrompt,
+  buildMaintainAdaptationPrompt,
+  offerAdaptationPromptClipboard,
+  printAdaptationPrompt,
+  writeAdaptationPrompt,
+} from '../harness/adaptation-prompt';
+import type { HarnessProfile } from '../harness/generator';
+import { harnessExists } from '../harness/parser';
+import {
+  listPluginIds,
+  PluginId,
+  readPluginManifest,
+} from '../harness/plugins';
+import { divider, info, success, warn } from '../utils/logging';
+
+export type TelemetryChoice = 'on' | 'on-no-prompts' | 'off';
+
+export interface PluginChoice {
+  id: PluginId;
+  label: string;
+  description: string;
+}
+
+/** Short guided tour shown at the start of `har onboard`. */
+export const ONBOARDING_GUIDE_STEPS: readonly { title: string; body: string }[] = [
+  {
+    title: 'What HAR is',
+    body: [
+      'HAR (Harness) gives coding agents a reproducible environment for your repo:',
+      'an editable `.har/` scaffold, isolated git worktree sessions, and a verify → complete loop.',
+      'You adapt the scaffold once to your stack; agents then use the same launch/verify/teardown contract.',
+    ].join('\n'),
+  },
+  {
+    title: 'Sessions and slots',
+    body: [
+      'Each `har env launch <id>` creates a fresh session worktree from your main checkout HEAD.',
+      'Edit only under the printed work dir — never the main checkout while a slot is active.',
+      'Use separate slot ids for parallel tasks. Prefer `complete` / `teardown` before starting unrelated work.',
+    ].join('\n'),
+  },
+  {
+    title: 'Verify and finish',
+    body: [
+      'Quick:  har env verify <id>',
+      'Done:   har env verify <id> --full   then   har env complete <id>',
+      '`complete` records a validation, frees the slot, and keeps the session branch for a PR.',
+    ].join('\n'),
+  },
+  {
+    title: 'Mission Control and plugins',
+    body: [
+      'Mission Control is a local dashboard for slots, runs, and (optional) agent usage telemetry.',
+      'Plugins (`har env add-plugin`) add optional verification stages such as Playwright browser-e2e.',
+      'After setup, paste the adaptation prompt into your coding agent to tailor `.har/` to this repo.',
+    ].join('\n'),
+  },
+];
+
+export interface OnboardOptions {
+  repoPath: string;
+  profile: HarnessProfile;
+  telemetry: TelemetryChoice;
+  startControl: boolean;
+  plugins: PluginId[];
+  /** Do not scaffold `.har/` (even when missing). */
+  skipInit?: boolean;
+  /** Skip scaffolding when `.har/` already exists (default: true). */
+  skipInitIfPresent?: boolean;
+  /** Defer writing/copying the adaptation prompt to the caller (default: false). */
+  deferAdaptationPrompt?: boolean;
+  autoYes?: boolean;
+  /** Force overwrite when applying plugins. */
+  forcePlugins?: boolean;
+}
+
+export interface OnboardResult {
+  repoPath: string;
+  profile: HarnessProfile;
+  harnessInitialized: boolean;
+  harnessAlreadyPresent: boolean;
+  telemetry: TelemetryChoice;
+  controlStarted: boolean;
+  controlApiUrl: string;
+  pluginsApplied: PluginId[];
+  pluginWarnings: string[];
+  adaptationPromptPath: string | null;
+  adaptationPromptCopied: boolean;
+}
+
+export interface OnboardingDeps {
+  applyTelemetry?: (choice: TelemetryChoice) => Promise<void>;
+  ensureControl?: (options: {
+    startControl: boolean;
+    telemetry: TelemetryChoice;
+    cwd: string;
+  }) => Promise<{ started: boolean; apiUrl: string; warning?: string }>;
+  initHarness?: typeof initHarness;
+  addPlugin?: typeof addPlugin;
+  offerClipboard?: typeof offerAdaptationPromptClipboard;
+}
+
+export function listPluginChoices(): PluginChoice[] {
+  return listPluginIds().map((id) => {
+    try {
+      const manifest = readPluginManifest(id);
+      const description =
+        typeof manifest.stage.description === 'string'
+          ? manifest.stage.description
+          : `Adds stage ${manifest.stageId}`;
+      return {
+        id,
+        label: `${id} — ${description}`,
+        description,
+      };
+    } catch {
+      return { id, label: id, description: id };
+    }
+  });
+}
+
+export function printOnboardingGuide(): void {
+  divider();
+  info('How HAR works');
+  divider();
+  for (const [index, step] of ONBOARDING_GUIDE_STEPS.entries()) {
+    info(`${index + 1}. ${step.title}`);
+    for (const line of step.body.split('\n')) {
+      info(`   ${line}`);
+    }
+    info('');
+  }
+}
+
+export async function applyOnboardingTelemetry(
+  choice: TelemetryChoice,
+  options: { setupHooks?: boolean } = {},
+): Promise<void> {
+  const setupHooks = options.setupHooks !== false;
+
+  if (choice === 'off') {
+    writeTelemetryPreference(false);
+    if (setupHooks) {
+      try {
+        disableOtelHooksExport();
+      } catch (err) {
+        warn(`Could not refresh hooks config: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    success('Telemetry disabled');
+    return;
+  }
+
+  const prompts = choice === 'on';
+  writeTelemetryPreference(true, { prompts, traces: true });
+  success(
+    prompts
+      ? 'Telemetry enabled (including prompts) → Mission Control via @osfactory/otel-hook'
+      : 'Telemetry enabled without prompt capture',
+  );
+  if (setupHooks) {
+    const hooks = ensureOtelHooks({ setupAgents: true });
+    if (hooks.message) success(hooks.message);
+    if (hooks.warning) warn(hooks.warning);
+  }
+}
+
+async function defaultEnsureControl(options: {
+  startControl: boolean;
+  telemetry: TelemetryChoice;
+  cwd: string;
+}): Promise<{ started: boolean; apiUrl: string; warning?: string }> {
+  const apiUrl = getControlApiUrl();
+
+  if (!options.startControl) {
+    if (options.telemetry !== 'off') {
+      // Keep hooks/preference wired, but do not auto-start Mission Control.
+      await ensureTelemetryInfrastructure({ startIfNeeded: false });
+      const reachable = await isControlApiReachable(apiUrl);
+      if (!reachable) {
+        return {
+          started: false,
+          apiUrl,
+          warning:
+            'Telemetry is on but Mission Control is not running. Start later with: har control up',
+        };
+      }
+    }
+    return { started: false, apiUrl };
+  }
+
+  if (options.telemetry !== 'off') {
+    const ensured = await ensureTelemetryInfrastructure({ startIfNeeded: true });
+    if (ensured.message) success(ensured.message);
+    if (ensured.warning) warn(ensured.warning);
+    return {
+      started: ensured.started || ensured.reachable,
+      apiUrl: ensured.apiUrl,
+      warning: ensured.warning,
+    };
+  }
+
+  const result = await startControlAndSync({ detach: true, cwd: options.cwd });
+  if (result.code !== 0) {
+    return {
+      started: false,
+      apiUrl: result.apiUrl,
+      warning: 'Failed to start Mission Control (is Docker available?)',
+    };
+  }
+  success(`Mission Control started at ${result.apiUrl}`);
+  return { started: true, apiUrl: result.apiUrl };
+}
+
+/**
+ * Run the non-interactive parts of onboarding after the CLI has collected choices.
+ */
+export async function runOnboarding(
+  options: OnboardOptions,
+  deps: OnboardingDeps = {},
+): Promise<OnboardResult> {
+  const repoPath = path.resolve(options.repoPath);
+  const applyTelemetry = deps.applyTelemetry ?? applyOnboardingTelemetry;
+  const ensureControl = deps.ensureControl ?? defaultEnsureControl;
+  const init = deps.initHarness ?? initHarness;
+  const applyPlugin = deps.addPlugin ?? addPlugin;
+  const offerClipboard = deps.offerClipboard ?? offerAdaptationPromptClipboard;
+
+  await applyTelemetry(options.telemetry);
+
+  const control = await ensureControl({
+    startControl: options.startControl,
+    telemetry: options.telemetry,
+    cwd: repoPath,
+  });
+  if (control.warning) warn(control.warning);
+
+  const alreadyPresent = harnessExists(repoPath);
+  let harnessInitialized = false;
+  const shouldInit =
+    !options.skipInit && !(alreadyPresent && options.skipInitIfPresent !== false);
+
+  if (options.skipInit) {
+    info('Skipping harness scaffold (--skip-init)');
+  } else if (alreadyPresent && options.skipInitIfPresent !== false) {
+    info('Harness already present — skipping scaffold');
+  } else if (shouldInit) {
+    divider();
+    info(`Scaffolding .har/ (profile: ${options.profile})...`);
+    const result = await init({
+      repoPath,
+      profile: options.profile,
+      force: alreadyPresent,
+      auto: false,
+    });
+    if (!result.validation.pass) {
+      warn('Harness has validation errors — review .har/ after adaptation.');
+    }
+    harnessInitialized = true;
+    recordRepoForControlSync(repoPath);
+    success('Harness scaffolded');
+  }
+
+  const pluginsApplied: PluginId[] = [];
+  const pluginWarnings: string[] = [];
+
+  if (options.plugins.length > 0) {
+    if (!harnessExists(repoPath)) {
+      warn('Cannot install plugins without a harness — skipping');
+    } else {
+      divider();
+      info(`Installing plugins: ${options.plugins.join(', ')}`);
+      for (const pluginId of options.plugins) {
+        try {
+          const result = applyPlugin(repoPath, pluginId, {
+            force: options.forcePlugins === true,
+          });
+          pluginsApplied.push(pluginId);
+          success(`Plugin ${pluginId} → stage ${result.stageId}`);
+          for (const w of result.warnings) pluginWarnings.push(w);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          pluginWarnings.push(`${pluginId}: ${message}`);
+          warn(`Plugin ${pluginId} failed: ${message}`);
+        }
+      }
+    }
+  }
+
+  let adaptationPromptPath: string | null = null;
+  let adaptationPromptCopied = false;
+
+  if (!options.deferAdaptationPrompt && harnessExists(repoPath)) {
+    const finalized = await finalizeOnboardingAdaptation({
+      repoPath,
+      profile: options.profile,
+      harnessInitialized,
+      autoYes: options.autoYes,
+      offerClipboard,
+    });
+    adaptationPromptPath = finalized.path;
+    adaptationPromptCopied = finalized.copied;
+  }
+
+  return {
+    repoPath,
+    profile: options.profile,
+    harnessInitialized,
+    harnessAlreadyPresent: alreadyPresent,
+    telemetry: options.telemetry,
+    controlStarted: control.started,
+    controlApiUrl: control.apiUrl,
+    pluginsApplied,
+    pluginWarnings,
+    adaptationPromptPath,
+    adaptationPromptCopied,
+  };
+}
+
+/** Write, print, and optionally copy the adaptation prompt (final onboarding step). */
+export async function finalizeOnboardingAdaptation(options: {
+  repoPath: string;
+  profile: HarnessProfile;
+  harnessInitialized: boolean;
+  autoYes?: boolean;
+  offerClipboard?: typeof offerAdaptationPromptClipboard;
+}): Promise<{ path: string; copied: boolean }> {
+  const offerClipboard = options.offerClipboard ?? offerAdaptationPromptClipboard;
+  const mode = options.harnessInitialized ? 'init' : 'maintain';
+  const prompt =
+    mode === 'init'
+      ? buildInitAdaptationPrompt(options.repoPath, options.profile)
+      : buildMaintainAdaptationPrompt(options.repoPath);
+  const filePath = writeAdaptationPrompt(options.repoPath, prompt);
+
+  divider();
+  info(
+    mode === 'init'
+      ? 'Adapt the harness with your coding agent (final step):'
+      : 'Optional: paste this maintenance prompt into your coding agent:',
+  );
+  info('  Also saved to .har/ADAPT-PROMPT.md');
+  printAdaptationPrompt(prompt);
+  const copied = await offerClipboard(prompt, { autoYes: options.autoYes });
+  return { path: filePath, copied };
+}

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -1,0 +1,206 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  applyOnboardingTelemetry,
+  finalizeOnboardingAdaptation,
+  listPluginChoices,
+  ONBOARDING_GUIDE_STEPS,
+  runOnboarding,
+} from '../src/core/onboarding';
+import {
+  isTelemetryEnabled,
+  readTelemetryPreference,
+} from '../src/core/telemetry-config';
+import { ADAPTATION_PROMPT_FILE } from '../src/harness/adaptation-prompt';
+
+describe('onboarding guide', () => {
+  it('covers the core HAR concepts', () => {
+    const titles = ONBOARDING_GUIDE_STEPS.map((step) => step.title);
+    expect(titles).toEqual([
+      'What HAR is',
+      'Sessions and slots',
+      'Verify and finish',
+      'Mission Control and plugins',
+    ]);
+    const body = ONBOARDING_GUIDE_STEPS.map((step) => step.body).join('\n');
+    expect(body).toContain('har env launch');
+    expect(body).toContain('complete');
+    expect(body).toContain('Mission Control');
+    expect(body).toContain('add-plugin');
+  });
+
+  it('lists shipped plugins with descriptions', () => {
+    const choices = listPluginChoices();
+    const ids = choices.map((c) => c.id);
+    expect(ids).toContain('playwright');
+    expect(ids).toContain('rocketsim');
+    expect(choices.every((c) => c.label.includes(c.id))).toBe(true);
+  });
+});
+
+describe('applyOnboardingTelemetry', () => {
+  const originalEnv = process.env.HAR_TELEMETRY;
+  const originalPath = process.env.HAR_TELEMETRY_CONFIG_PATH;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-onboard-tel-'));
+    process.env.HAR_TELEMETRY_CONFIG_PATH = path.join(tmpDir, 'telemetry.json');
+    delete process.env.HAR_TELEMETRY;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.HAR_TELEMETRY;
+    else process.env.HAR_TELEMETRY = originalEnv;
+    if (originalPath === undefined) delete process.env.HAR_TELEMETRY_CONFIG_PATH;
+    else process.env.HAR_TELEMETRY_CONFIG_PATH = originalPath;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('enables full telemetry including prompts', async () => {
+    await applyOnboardingTelemetry('on', { setupHooks: false });
+    expect(isTelemetryEnabled()).toBe(true);
+    expect(readTelemetryPreference().signals.prompts).toBe(true);
+  });
+
+  it('enables telemetry without prompts', async () => {
+    await applyOnboardingTelemetry('on-no-prompts', { setupHooks: false });
+    expect(isTelemetryEnabled()).toBe(true);
+    expect(readTelemetryPreference().signals.prompts).toBe(false);
+  });
+
+  it('disables telemetry', async () => {
+    await applyOnboardingTelemetry('on', { setupHooks: false });
+    await applyOnboardingTelemetry('off', { setupHooks: false });
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+});
+
+describe('runOnboarding', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-onboard-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('scaffolds a harness, applies plugins, and finishes with an adapt prompt', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'onboard-fixture', version: '1.0.0' }, null, 2) + '\n',
+    );
+    const clipboardCalls: string[] = [];
+    const result = await runOnboarding(
+      {
+        repoPath: tmpDir,
+        profile: 'cli',
+        telemetry: 'off',
+        startControl: false,
+        plugins: ['playwright'],
+        autoYes: true,
+      },
+      {
+        applyTelemetry: async () => {},
+        ensureControl: async () => ({ started: false, apiUrl: 'http://127.0.0.1:3847' }),
+        offerClipboard: async (content) => {
+          clipboardCalls.push(content);
+          return true;
+        },
+      },
+    );
+
+    expect(result.harnessInitialized).toBe(true);
+    expect(result.pluginsApplied).toEqual(['playwright']);
+    expect(fs.existsSync(path.join(tmpDir, '.har', 'verify.sh'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.har', 'stages', 'browser-e2e.sh'))).toBe(true);
+    expect(result.adaptationPromptPath).toBe(
+      path.join(tmpDir, '.har', ADAPTATION_PROMPT_FILE),
+    );
+    expect(result.adaptationPromptCopied).toBe(true);
+    expect(clipboardCalls).toHaveLength(1);
+    expect(clipboardCalls[0]).toContain('AGENT.md');
+  });
+
+  it('skips init when harness already exists and still offers a maintain prompt', async () => {
+    await runOnboarding(
+      {
+        repoPath: tmpDir,
+        profile: 'cli',
+        telemetry: 'off',
+        startControl: false,
+        plugins: [],
+        autoYes: true,
+        deferAdaptationPrompt: true,
+      },
+      {
+        applyTelemetry: async () => {},
+        ensureControl: async () => ({ started: false, apiUrl: 'http://127.0.0.1:3847' }),
+      },
+    );
+
+    const second = await runOnboarding(
+      {
+        repoPath: tmpDir,
+        profile: 'cli',
+        telemetry: 'off',
+        startControl: false,
+        plugins: [],
+        autoYes: true,
+      },
+      {
+        applyTelemetry: async () => {},
+        ensureControl: async () => ({ started: false, apiUrl: 'http://127.0.0.1:3847' }),
+        offerClipboard: async () => false,
+      },
+    );
+
+    expect(second.harnessInitialized).toBe(false);
+    expect(second.harnessAlreadyPresent).toBe(true);
+    expect(fs.readFileSync(second.adaptationPromptPath!, 'utf8')).toContain('already exists');
+  });
+
+  it('honors skipInit', async () => {
+    const result = await runOnboarding(
+      {
+        repoPath: tmpDir,
+        profile: 'cli',
+        telemetry: 'off',
+        startControl: false,
+        plugins: [],
+        skipInit: true,
+        autoYes: true,
+      },
+      {
+        applyTelemetry: async () => {},
+        ensureControl: async () => ({ started: false, apiUrl: 'http://127.0.0.1:3847' }),
+      },
+    );
+
+    expect(result.harnessInitialized).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.har'))).toBe(false);
+    expect(result.adaptationPromptPath).toBeNull();
+  });
+});
+
+describe('finalizeOnboardingAdaptation', () => {
+  it('writes the init prompt after a fresh scaffold', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-onboard-final-'));
+    fs.mkdirSync(path.join(tmpDir, '.har'), { recursive: true });
+
+    const finalized = await finalizeOnboardingAdaptation({
+      repoPath: tmpDir,
+      profile: 'default',
+      harnessInitialized: true,
+      autoYes: true,
+      offerClipboard: async () => true,
+    });
+
+    expect(finalized.copied).toBe(true);
+    expect(fs.readFileSync(finalized.path, 'utf8')).toContain('Profile: default');
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION

<img width="1083" height="734" alt="image" src="https://github.com/user-attachments/assets/d3d54eeb-6749-4fcf-9a81-91ba4ee8b227" />
## Summary
- Add `har onboard`, a guided first-run CLI that explains how HAR works, then configures telemetry, optionally starts Mission Control, scaffolds `.har/`, and installs selected plugins
- Finish onboarding by writing `.har/ADAPT-PROMPT.md` and offering clipboard copy for the adaptation prompt
- Document the flow in quick-start, CLI reference, FAQ, and CONTRIBUTING

## Test plan
- [ ] `har onboard --help` shows the new command and flags
- [ ] Interactive: `har onboard` walks through guide → telemetry → Mission Control → profile/plugins → adapt prompt
- [ ] Non-interactive: `har onboard --yes --profile cli --no-control --no-plugins` scaffolds without prompts
- [ ] `har onboard --yes --plugins playwright` installs the Playwright plugin when `package.json` exists
- [ ] Full verify passes on the PR branch


Made with [Cursor](https://cursor.com)