### PR TITLE
fix(control): sync to local Mission Control when portal is configured

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
+  setupFilesAfterEnv: ['<rootDir>/tests/jest-setup.ts'],
   moduleNameMapper: {
     '^chalk$': '<rootDir>/tests/__mocks__/chalk.ts',
   },

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -343,8 +343,7 @@ export async function syncAllKnownReposWithControl(options?: {
   if (!isControlEnabled()) return { synced: 0, failed: 0 };
 
   const apiUrl = options?.apiUrl ?? getControlApiUrl();
-  const portal = getPortalTarget();
-  if (!(await isControlApiReachable(portal ? portal.url : apiUrl))) {
+  if (!(await isControlApiReachable(apiUrl))) {
     return { synced: 0, failed: 0 };
   }
 
@@ -391,6 +390,52 @@ export async function registerRepoWithControl(
   return (await response.json()) as { id: string };
 }
 
+async function syncRepoWithLocalControl(
+  options: ControlSyncOptions & { repoPath: string },
+): Promise<void> {
+  const apiUrl = options.apiUrl ?? getControlApiUrl();
+  const { repoPath, dryRun } = options;
+
+  const registerResult = await registerRepoWithControl({ ...options, repoPath });
+  const repoId = registerResult?.id;
+
+  if (!repoId && !dryRun) {
+    const listResponse = await fetch(`${apiUrl}/api/repos`);
+    if (!listResponse.ok) throw new Error('Failed to list repos from Control API');
+    const repos = (await listResponse.json()) as { id: string; path: string }[];
+    const existing = repos.find((r) => path.resolve(r.path) === repoPath);
+    if (!existing) {
+      // Unregistered / blocked — nothing to sync locally.
+      return;
+    }
+    await syncRepoRunsAndSlots(apiUrl, existing.id, repoPath, dryRun);
+    return;
+  }
+
+  if (repoId) {
+    await syncRepoRunsAndSlots(apiUrl, repoId, repoPath, dryRun);
+  }
+}
+
+async function syncRepoWithPortal(
+  options: ControlSyncOptions & { repoPath: string },
+  controlApiUrl: string,
+): Promise<void> {
+  const portal = getPortalTarget();
+  if (!portal) return;
+
+  const { repoPath, dryRun, full } = options;
+  const since = full ? null : readPortalWatermark(repoPath, portal.url);
+  const { syncBody, events, maxSyncedAt } = await buildPortalPayload(repoPath, controlApiUrl, since);
+  await postPortal(portal, '/api/sync', syncBody, dryRun);
+  if (events.length > 0) {
+    await postPortal(portal, '/api/otel', { path: repoPath, events, spans: [] }, dryRun);
+  }
+  if (!dryRun && maxSyncedAt) {
+    writePortalWatermark(repoPath, portal.url, maxSyncedAt);
+  }
+}
+
 export async function syncRepoWithControl(options: ControlSyncOptions): Promise<void> {
   const repoPath = canonicalizeControlRepoPath(options.repoPath);
   const apiUrl = options.apiUrl ?? getControlApiUrl();
@@ -425,44 +470,8 @@ export async function syncRepoWithControl(options: ControlSyncOptions): Promise<
     return;
   }
 
-  const portal = getPortalTarget();
-  if (portal) {
-    const since = options.full ? null : readPortalWatermark(repoPath, portal.url);
-    const { syncBody, events, maxSyncedAt } = await buildPortalPayload(repoPath, apiUrl, since);
-    await postPortal(portal, '/api/sync', syncBody, options.dryRun);
-    if (events.length > 0) {
-      await postPortal(
-        portal,
-        '/api/otel',
-        { path: repoPath, events, spans: [] },
-        options.dryRun,
-      );
-    }
-    if (!options.dryRun && maxSyncedAt) {
-      writePortalWatermark(repoPath, portal.url, maxSyncedAt);
-    }
-    return;
-  }
-
-  const registerResult = await registerRepoWithControl({ ...options, repoPath });
-  const repoId = registerResult?.id;
-
-  if (!repoId && !options.dryRun) {
-    const listResponse = await fetch(`${apiUrl}/api/repos`);
-    if (!listResponse.ok) throw new Error('Failed to list repos from Control API');
-    const repos = (await listResponse.json()) as { id: string; path: string }[];
-    const existing = repos.find((r) => path.resolve(r.path) === repoPath);
-    if (!existing) {
-      // Unregistered / blocked — nothing to sync.
-      return;
-    }
-    await syncRepoRunsAndSlots(apiUrl, existing.id, repoPath, options.dryRun);
-    return;
-  }
-
-  if (repoId) {
-    await syncRepoRunsAndSlots(apiUrl, repoId, repoPath, options.dryRun);
-  }
+  await syncRepoWithLocalControl({ ...options, repoPath, apiUrl });
+  await syncRepoWithPortal({ ...options, repoPath }, apiUrl);
 }
 
 async function syncRepoRunsAndSlots(
@@ -587,11 +596,10 @@ export async function syncRepoWithControlAsync(repoPath: string): Promise<void> 
 
   const verbose = process.env.HAR_CONTROL_VERBOSE === 'true';
   try {
-    const portal = getPortalTarget();
-    const healthUrl = portal ? portal.url : getControlApiUrl();
-    if (!(await isControlApiReachable(healthUrl))) {
+    const apiUrl = getControlApiUrl();
+    if (!(await isControlApiReachable(apiUrl))) {
       if (verbose) {
-        process.stderr.write(`[har control] sync skipped: not reachable at ${healthUrl}\n`);
+        process.stderr.write(`[har control] sync skipped: not reachable at ${apiUrl}\n`);
       }
       return;
     }
@@ -609,42 +617,48 @@ export async function syncRepoWithControlAsync(repoPath: string): Promise<void> 
   }
 }
 
+async function syncRunWithLocalControl(
+  repoPath: string,
+  run: RunRecord,
+  apiUrl: string,
+): Promise<void> {
+  const registerResult = await registerRepoWithControl({ repoPath, apiUrl });
+  let repoId = registerResult?.id;
+
+  if (!repoId) {
+    const listResponse = await fetch(`${apiUrl}/api/repos`);
+    if (!listResponse.ok) return;
+    const repos = (await listResponse.json()) as { id: string; path: string }[];
+    repoId = repos.find((r) => path.resolve(r.path) === repoPath)?.id;
+  }
+
+  if (!repoId) return;
+
+  const runsBody = SyncRunsInputSchema.parse({ runs: [run] });
+  await postJson(`${apiUrl}/api/repos/${repoId}/runs`, runsBody);
+}
+
 export async function syncRunWithControlAsync(repoPath: string, run: RunRecord): Promise<void> {
   if (process.env.HAR_CONTROL_DISABLED === 'true') return;
 
-  const portal = getPortalTarget();
-  if (portal) {
-    try {
-      if (!(await isControlApiReachable(portal.url))) return;
-      const canonical = canonicalizeControlRepoPath(repoPath);
-      await postPortal(portal, '/api/sync', { path: canonical, runs: [run] });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[har control] run sync skipped: ${message}\n`);
+  const apiUrl = getControlApiUrl();
+  const canonical = canonicalizeControlRepoPath(repoPath);
+
+  try {
+    if (await isControlApiReachable(apiUrl)) {
+      await syncRunWithLocalControl(canonical, run, apiUrl);
     }
-    return;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[har control] run sync skipped: ${message}\n`);
   }
 
-  const apiUrl = getControlApiUrl();
+  const portal = getPortalTarget();
+  if (!portal) return;
+
   try {
-    const reachable = await isControlApiReachable(apiUrl);
-    if (!reachable) return;
-
-    const canonical = canonicalizeControlRepoPath(repoPath);
-    const registerResult = await registerRepoWithControl({ repoPath: canonical, apiUrl });
-    let repoId = registerResult?.id;
-
-    if (!repoId) {
-      const listResponse = await fetch(`${apiUrl}/api/repos`);
-      if (!listResponse.ok) return;
-      const repos = (await listResponse.json()) as { id: string; path: string }[];
-      repoId = repos.find((r) => path.resolve(r.path) === canonical)?.id;
-    }
-
-    if (!repoId) return;
-
-    const runsBody = SyncRunsInputSchema.parse({ runs: [run] });
-    await postJson(`${apiUrl}/api/repos/${repoId}/runs`, runsBody);
+    if (!(await isControlApiReachable(portal.url))) return;
+    await postPortal(portal, '/api/sync', { path: canonical, runs: [run] });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`[har control] run sync skipped: ${message}\n`);

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -92,13 +92,68 @@ function clearPortalEnv(): void {
 
 type FetchResult = { status: number; body?: string };
 
+function portalSlot(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agentId: 1,
+    active: true,
+    harnessUsage: 'cli',
+    ...overrides,
+  };
+}
+
+function portalCalls(fetchMock: jest.Mock): [string, RequestInit][] {
+  return fetchMock.mock.calls.filter(([url]) =>
+    String(url).includes('portal.example.com'),
+  ) as [string, RequestInit][];
+}
+
+function portalSyncCall(fetchMock: jest.Mock): [string, RequestInit] {
+  const call = portalCalls(fetchMock).find(([url]) => url.endsWith('/api/sync'));
+  if (!call) throw new Error('expected a portal /api/sync call');
+  return call;
+}
+
+function portalOtelCall(fetchMock: jest.Mock): [string, RequestInit] {
+  const call = portalCalls(fetchMock).find(([url]) => url.endsWith('/api/otel'));
+  if (!call) throw new Error('expected a portal /api/otel call');
+  return call;
+}
+
 function mockFetch(result: FetchResult): jest.Mock {
-  const fn = jest.fn(async () => ({
-    ok: result.status >= 200 && result.status < 300,
-    status: result.status,
-    text: async () => result.body ?? '',
-    json: async () => ({}),
-  }));
+  const fn = jest.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    if (String(url).includes('portal.example.com')) {
+      return {
+        ok: result.status >= 200 && result.status < 300,
+        status: result.status,
+        text: async () => result.body ?? '',
+        json: async () => ({}),
+      };
+    }
+    // Local Mission Control — keep sync tests deterministic.
+    if (String(url).endsWith('/api/repos') && method === 'POST') {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({ id: 'local-repo-1' }),
+      };
+    }
+    if (String(url).endsWith('/api/repos') && method === 'GET') {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => [],
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({}),
+    };
+  });
   (global as unknown as { fetch: unknown }).fetch = fn;
   return fn;
 }
@@ -157,8 +212,9 @@ describe('syncRepoWithControl — portal push', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const portal = portalCalls(fetchMock);
+    expect(portal).toHaveLength(1);
+    const [url, init] = portal[0];
     expect(url).toBe('https://portal.example.com/api/sync');
     expect(init.method).toBe('POST');
     expect((init.headers as Record<string, string>).Authorization).toBe(
@@ -169,6 +225,25 @@ describe('syncRepoWithControl — portal push', () => {
     expect(Array.isArray(body.runs)).toBe(true);
     expect(Array.isArray(body.slots)).toBe(true);
     expect(body.generatedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('syncs to local Mission Control before pushing to the portal', async () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_secret';
+    const fetchMock = mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const urls = fetchMock.mock.calls.map(([url]) => String(url));
+    const localRegisterIdx = urls.findIndex(
+      (url) => url.endsWith('/api/repos') && !url.includes('portal.example.com'),
+    );
+    const portalSyncIdx = urls.findIndex((url) => url.includes('/api/sync'));
+    expect(localRegisterIdx).toBeGreaterThanOrEqual(0);
+    expect(portalSyncIdx).toBeGreaterThan(localRegisterIdx);
+    expect(
+      urls.some((url) => url.includes('/api/repos/local-repo-1/runs')),
+    ).toBe(true);
   });
 
   it('raises a token error on 401 (bad/revoked token)', async () => {
@@ -223,22 +298,45 @@ describe('syncRepoWithControl — portal full payload', () => {
   it('forwards usage (with userEmail + models), work identity to /api/sync', async () => {
     collectEnvironmentStatusMock.mockReturnValue({
       slots: [
-        {
-          agentId: 1,
+        portalSlot({
           workDir: '/repo/x/wt-1',
           worktreePath: '/repo/x/wt-1',
           branch: 'feat/x',
           suffix: 'a',
           sessionCreatedAt: '2026-01-01T00:00:00.000Z',
-          workUnitId: 'WU-1',
-          attemptId: 'AT-1',
-        },
+          workUnitId: 'github:acme/widget#123',
+          attemptId: '00000000-0000-4000-8000-000000000002',
+        }),
       ],
       generatedAt: '2026-01-01T00:00:00.000Z',
     });
-    listWorkUnitsMock.mockReturnValue([{ workUnitId: 'WU-1', title: 't' }]);
-    listWorkAttemptsMock.mockReturnValue([{ attemptId: 'AT-1', workUnitId: 'WU-1' }]);
-    listValidationBindingsMock.mockReturnValue([{ bindingId: 'B-1' }]);
+    listWorkUnitsMock.mockReturnValue([
+      {
+        workUnitId: 'github:acme/widget#123',
+        source: 'github',
+        title: 't',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    listWorkAttemptsMock.mockReturnValue([
+      {
+        attemptId: '00000000-0000-4000-8000-000000000002',
+        workUnitId: 'github:acme/widget#123',
+        agentId: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    listValidationBindingsMock.mockReturnValue([
+      {
+        bindingId: '00000000-0000-4000-8000-000000000004',
+        workUnitId: 'github:acme/widget#123',
+        attemptId: '00000000-0000-4000-8000-000000000002',
+        validationId: '00000000-0000-4000-8000-000000000003',
+        treeHash: 'a'.repeat(40),
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
     harvestUsageForSlotMock.mockReturnValue([
       {
         sessionKey: '',
@@ -257,8 +355,9 @@ describe('syncRepoWithControl — portal full payload', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const portal = portalCalls(fetchMock);
+    expect(portal).toHaveLength(1);
+    const [url, init] = portal[0];
     expect(url).toBe('https://portal.example.com/api/sync');
     const body = JSON.parse(init.body as string);
     expect(body.workUnits).toHaveLength(1);
@@ -266,8 +365,8 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(body.validationBindings).toHaveLength(1);
     expect(body.usage).toHaveLength(1);
     expect('userEmail' in body.usage[0]).toBe(false);
-    expect(body.usage[0].workUnitId).toBe('WU-1');
-    expect(body.usage[0].attemptId).toBe('AT-1');
+    expect(body.usage[0].workUnitId).toBe('github:acme/widget#123');
+    expect(body.usage[0].attemptId).toBe('00000000-0000-4000-8000-000000000002');
     expect(body.usage[0].sessionKey).toBe('feat/x');
     expect(body.usage[0].models).toEqual([
       {
@@ -284,14 +383,13 @@ describe('syncRepoWithControl — portal full payload', () => {
   it('pushes harvested events to /api/otel with the same bearer token', async () => {
     collectEnvironmentStatusMock.mockReturnValue({
       slots: [
-        {
-          agentId: 1,
+        portalSlot({
           workDir: '/repo/x/wt-1',
           worktreePath: '/repo/x/wt-1',
           branch: 'feat/x',
-          workUnitId: 'WU-1',
-          attemptId: 'AT-1',
-        },
+          workUnitId: 'github:acme/widget#123',
+          attemptId: '00000000-0000-4000-8000-000000000002',
+        }),
       ],
       generatedAt: '2026-01-01T00:00:00.000Z',
     });
@@ -313,9 +411,9 @@ describe('syncRepoWithControl — portal full payload', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const [syncUrl] = fetchMock.mock.calls[0] as [string, RequestInit];
-    const [otelUrl, otelInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(portalCalls(fetchMock)).toHaveLength(2);
+    const [syncUrl] = portalSyncCall(fetchMock);
+    const [otelUrl, otelInit] = portalOtelCall(fetchMock);
     expect(syncUrl).toBe('https://portal.example.com/api/sync');
     expect(otelUrl).toBe('https://portal.example.com/api/otel');
     expect((otelInit.headers as Record<string, string>).Authorization).toBe(
@@ -324,7 +422,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     const otelBody = JSON.parse(otelInit.body as string);
     expect(otelBody.path).toBe('/repo/x');
     expect(otelBody.events).toHaveLength(1);
-    expect(otelBody.events[0].workUnitId).toBe('WU-1');
+    expect(otelBody.events[0].workUnitId).toBe('github:acme/widget#123');
     expect(otelBody.events[0].promptText).toBe('hi');
     expect('responseText' in otelBody.events[0]).toBe(false);
     expect('rawTruncated' in otelBody.events[0]).toBe(false);
@@ -334,10 +432,8 @@ describe('syncRepoWithControl — portal full payload', () => {
   it('does not call /api/otel when there are no events', async () => {
     const fetchMock = mockFetch({ status: 200 });
     await syncRepoWithControl({ repoPath: '/repo/x' });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect((fetchMock.mock.calls[0] as [string])[0]).toBe(
-      'https://portal.example.com/api/sync',
-    );
+    expect(portalCalls(fetchMock)).toHaveLength(1);
+    expect(portalSyncCall(fetchMock)[0]).toBe('https://portal.example.com/api/sync');
   });
 
   it('attributes usage to the authenticated login email from credentials', async () => {
@@ -348,7 +444,7 @@ describe('syncRepoWithControl — portal full payload', () => {
       createdAt: '2026-01-01T00:00:00.000Z',
     });
     collectEnvironmentStatusMock.mockReturnValue({
-      slots: [{ agentId: 1, branch: 'feat/x' }],
+      slots: [portalSlot({ branch: 'feat/x' })],
       generatedAt: '2026-01-01T00:00:00.000Z',
     });
     harvestUsageForSlotMock.mockReturnValue([
@@ -366,7 +462,7 @@ describe('syncRepoWithControl — portal full payload', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = portalSyncCall(fetchMock);
     const body = JSON.parse(init.body as string);
     expect(body.usage[0].userEmail).toBe('login@haulieros.io');
   });
@@ -378,7 +474,7 @@ describe('syncRepoWithControl — portal full payload', () => {
       createdAt: '2026-01-01T00:00:00.000Z',
     });
     collectEnvironmentStatusMock.mockReturnValue({
-      slots: [{ agentId: 1, branch: 'feat/x' }],
+      slots: [portalSlot({ branch: 'feat/x' })],
       generatedAt: '2026-01-01T00:00:00.000Z',
     });
     harvestUsageForSlotMock.mockReturnValue([
@@ -396,7 +492,7 @@ describe('syncRepoWithControl — portal full payload', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = portalSyncCall(fetchMock);
     const body = JSON.parse(init.body as string);
     expect('userEmail' in body.usage[0]).toBe(false);
   });
@@ -424,7 +520,7 @@ describe('syncRepoWithControl — portal full payload', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = portalSyncCall(fetchMock);
     expect(url).toBe('https://portal.example.com/api/sync');
     const body = JSON.parse(init.body as string);
     expect(body.usage).toHaveLength(1);
@@ -444,7 +540,7 @@ describe('syncRepoWithControl — portal full payload', () => {
 
   it('dedupes an overlapping live + persisted session into one max-merged row', async () => {
     collectEnvironmentStatusMock.mockReturnValue({
-      slots: [{ agentId: 1, branch: 'feat/x' }],
+      slots: [portalSlot({ branch: 'feat/x' })],
       generatedAt: '2026-01-01T00:00:00.000Z',
     });
     harvestUsageForSlotMock.mockReturnValue([
@@ -476,7 +572,7 @@ describe('syncRepoWithControl — portal full payload', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = portalSyncCall(fetchMock);
     const body = JSON.parse(init.body as string);
     expect(body.usage).toHaveLength(1);
     expect(body.usage[0].tokensTotal).toBe(250);
@@ -506,8 +602,8 @@ describe('syncRepoWithControl — portal full payload', () => {
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const [otelUrl, otelInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(portalCalls(fetchMock)).toHaveLength(2);
+    const [otelUrl, otelInit] = portalOtelCall(fetchMock);
     expect(otelUrl).toBe('https://portal.example.com/api/otel');
     const otelBody = JSON.parse(otelInit.body as string);
     expect(otelBody.events).toHaveLength(1);

--- a/tests/control-sync-repos.test.ts
+++ b/tests/control-sync-repos.test.ts
@@ -40,16 +40,48 @@ function clearPortalEnv(): void {
   delete process.env.HAR_PORTAL_TOKEN;
 }
 
-// Any repo whose path includes "fail" gets an HTTP 500 from the portal.
+// Portal failures are keyed off repo path; local Mission Control always succeeds.
 function mockFetchByRepo(): void {
-  (global as unknown as { fetch: unknown }).fetch = jest.fn(async (_url: string, init?: RequestInit) => {
+  (global as unknown as { fetch: unknown }).fetch = jest.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
     const body = init?.body ? (JSON.parse(String(init.body)) as { path?: string }) : {};
     const failed = typeof body.path === 'string' && body.path.includes('fail');
+
+    if (String(url).includes('portal.example.com')) {
+      return {
+        ok: !failed,
+        status: failed ? 500 : 200,
+        statusText: failed ? 'Internal Server Error' : 'OK',
+        text: async () => (failed ? 'boom' : ''),
+        json: async () => ({}),
+      };
+    }
+
+    if (String(url).endsWith('/api/repos') && method === 'POST') {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => '',
+        json: async () => ({ id: 'local-repo-1' }),
+      };
+    }
+
+    if (String(url).endsWith('/api/repos') && method === 'GET') {
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => '',
+        json: async () => [],
+      };
+    }
+
     return {
-      ok: !failed,
-      status: failed ? 500 : 200,
-      statusText: failed ? 'Internal Server Error' : 'OK',
-      text: async () => (failed ? 'boom' : ''),
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '',
       json: async () => ({}),
     };
   });

--- a/tests/env-init-flags.test.ts
+++ b/tests/env-init-flags.test.ts
@@ -35,7 +35,10 @@ function runInit(dir: string, extraArgs: string[]): { status: number | null; com
   const result = spawnSync(
     process.execPath,
     [cli, 'env', 'init', '--repo', dir, '--yes', '--profile', 'cli', ...extraArgs],
-    { encoding: 'utf8' },
+    {
+      encoding: 'utf8',
+      env: process.env,
+    },
   );
   return {
     status: result.status,
@@ -61,9 +64,17 @@ describe('har env init --no-agents / --no-cursor-rule (CLI)', () => {
   const cli = path.resolve(__dirname, '..', 'dist', 'index.js');
   const hasBuild = fs.existsSync(cli);
   const maybeIt = hasBuild ? it : it.skip;
+  const fixtureDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of fixtureDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   maybeIt('exits 0 and skips skills + cursor rule when both --no-* flags are set', () => {
     const dir = initFixtureRepo();
+    fixtureDirs.push(dir);
     // Seed dirs so auto-detect would otherwise want to scaffold
     fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
     fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
@@ -82,6 +93,7 @@ describe('har env init --no-agents / --no-cursor-rule (CLI)', () => {
 
   maybeIt('still writes the cursor rule when --yes without --no-cursor-rule', () => {
     const dir = initFixtureRepo();
+    fixtureDirs.push(dir);
     fs.mkdirSync(path.join(dir, '.cursor'), { recursive: true });
 
     const { status, combined } = runInit(dir, ['--no-agents']);

--- a/tests/jest-setup.ts
+++ b/tests/jest-setup.ts
@@ -1,0 +1,15 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Keep unit tests from writing to the developer's real ~/.har/repos.json.
+ * Spawned CLI subprocesses inherit this via process.env.
+ */
+const harHome = fs.mkdtempSync(path.join(os.tmpdir(), 'har-jest-home-'));
+process.env.HAR_CONTROL_REGISTRY_PATH = path.join(harHome, 'repos.json');
+
+afterAll(() => {
+  fs.rmSync(harHome, { recursive: true, force: true });
+  delete process.env.HAR_CONTROL_REGISTRY_PATH;
+});


### PR DESCRIPTION
## Summary

- **Dual sync:** `har control sync` and background sync after harness operations now always push to local Mission Control first, then additionally forward to the portal when credentials are configured. Previously, portal login redirected all sync traffic to the hosted portal, leaving local MC empty after a reset.
- **Health checks:** Auto-sync startup checks local MC reachability instead of the portal URL when logged in.
- **Test isolation:** Jest sets `HAR_CONTROL_REGISTRY_PATH` to a temp file so unit tests (including spawned `har env init` CLI tests) no longer pollute `~/.har/repos.json`. CLI init fixtures are cleaned up after each test.

## Test plan

- [x] `npm test` (371 tests)
- [x] `har env verify 1 --full` in session worktree
- [x] Manual: `har control sync` with portal credentials repopulates local MC (`repoCount > 0`) while portal continues to receive data


Made with [Cursor](https://cursor.com)