### PR TITLE
feat(plugin): document HAR harness contract in playwright plugin config 

### DIFF
--- a/src/templates/plugins/playwright/.har/stages/PLAYWRIGHT.md
+++ b/src/templates/plugins/playwright/.har/stages/PLAYWRIGHT.md
@@ -19,3 +19,17 @@ After `./.har/launch.sh <id>`:
 ```
 
 Replace TODO selectors and paths in the scaffold specs during harness adaptation.
+
+## New UI features
+
+Add or update Playwright specs so `browser-e2e` covers the change. Prefer one file per feature under `tests/frontend/<feature>.spec.js`. Full verification (`verify --full`) must pass before done.
+
+See the header comment in `playwright.config.js` for harness env vars, artifact paths, and the quick vs full verify contract.
+
+## Plugin updates
+
+When HAR ships a new plugin template version, refresh installed files with:
+
+```bash
+har env add-plugin playwright --force
+```

--- a/src/templates/plugins/playwright/playwright.config.js
+++ b/src/templates/plugins/playwright/playwright.config.js
@@ -1,8 +1,48 @@
-// Playwright config tuned for HAR agent slots and CI.
+// Playwright config for the HAR `browser-e2e` verification stage.
+//
+// Harness integration
+// -------------------
+// - Stage id: `browser-e2e` (`.har/stages/browser-e2e.sh`, registered in `stages.json`).
+// - Runs automatically on FULL verify only — not on quick verify:
+//     ./.har/verify.sh <id> --full
+//     har env verify <id> --full
+//     har env complete <id>          # always full; required before declaring done
+// - Quick verify (`verify.sh <id>`) stops at typecheck / unit tests / api-health.
+//
+// Prerequisites
+// -------------
+// 1. Launch a slot first:     ./.har/launch.sh <id>
+// 2. Install browsers once:     npx playwright install chromium
+//
+// Environment (injected by browser-e2e.sh — never hardcode slot ports in specs)
+// ------------------------------------------------------------------------------
+// BASE_URL       Frontend origin for page.goto('/') and UI specs
+// API_URL        API origin for tests/api (defaults to BASE_URL when FE/API share a port)
+// PW_SCREENSHOT  Playwright screenshot mode (default: on)
+// CI             Set in CI for retries, worker cap, and forbidOnly
+//
+// Test layout — agents must add or update specs for every UI change
+// ------------------------------------------------------------------
+// tests/frontend/<feature>.spec.js   UI flows (prefer one file per feature)
+// tests/api/                         HTTP checks via the request fixture
+// tests/a11y/                        axe-core on key routes
+//
+// Full verify only proves existing specs pass. New UI behavior needs new or
+// updated specs here — the harness does not auto-generate flows per feature.
+//
+// Artifacts (gitignored under .har/artifacts/)
+// --------------------------------------------
+// browser-e2e/playwright-report/   HTML report after full verify
+// browser-e2e/test-results/        traces, screenshots, videos on failure
+//
+// Local-only (without browser-e2e.sh):  npm run test:e2e
+// Set BASE_URL (and API_URL if split) when the app is not on the default below.
 const { defineConfig, devices } = require('@playwright/test');
 
+const baseURL = process.env.BASE_URL || 'http://localhost:3000';
+const apiURL = process.env.API_URL || baseURL;
+
 module.exports = defineConfig({
-  testDir: './tests',
   timeout: 30 * 1000,
   expect: { timeout: 5000 },
   fullyParallel: true,
@@ -15,15 +55,26 @@ module.exports = defineConfig({
   ],
   outputDir: '.har/artifacts/browser-e2e/test-results',
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL,
     headless: true,
-    screenshot: 'only-on-failure',
+    screenshot: process.env.PW_SCREENSHOT || 'on',
     video: 'retain-on-failure',
     trace: 'on-first-retry',
   },
   projects: [
     {
-      name: 'chromium',
+      name: 'frontend',
+      testDir: './tests/frontend',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'api',
+      testDir: './tests/api',
+      use: { baseURL: apiURL },
+    },
+    {
+      name: 'a11y',
+      testDir: './tests/a11y',
       use: { ...devices['Desktop Chrome'] },
     },
   ],


### PR DESCRIPTION
## Summary
- Embed harness integration guidance directly in the Playwright plugin `playwright.config.js` (full vs quick verify, env vars, test layout, artifacts).
- Split Playwright projects into `frontend`, `api`, and `a11y` so API specs can use `API_URL` when FE/API ports differ.
- Extend plugin `PLAYWRIGHT.md` with new-feature and plugin-update guidance.

## Test plan
- [x] `har env verify 1 --full` passes on the session worktree
- [ ] After merge, `har env add-plugin playwright` on a fresh harness picks up the new config


Made with [Cursor](https://cursor.com)