### PR TITLE
feat(maintain): detect drift for installed verification plugins

### DIFF
--- a/docs/src/content/docs/docs/guides/plugins.md
+++ b/docs/src/content/docs/docs/guides/plugins.md
@@ -36,6 +36,25 @@ This adds:
 Adapt selectors and URLs after installation. Full verification runs the stage when
 it is listed in `verificationStages` (the plugin updates that list for you).
 
+## Upgrading installed plugins
+
+`har env maintain` now compares **installed plugins** (detected via registered
+stage ids in `stages.json`) against the bundled plugin templates shipped with
+your HAR version.
+
+When plugin files drift:
+
+1. Run `har env maintain`
+2. Review `.har/maintain/plugins/<plugin-id>/` (templates, installed copies, diffs)
+3. Merge the diffs into your repo **or** refresh everything with:
+
+```bash
+har env add-plugin playwright --force
+```
+
+Use `--force` only when you are OK overwriting plugin-owned paths listed in the
+plugin manifest (config, stage scripts, scaffold specs, merged `package.json` keys).
+
 ## RocketSim
 
 ```bash

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -1148,9 +1148,16 @@ function printDrift(drift: HarnessDriftResult): void {
 function printMaintainBundleSummary(report: MaintainBundleReport): void {
   const missing = report.actions.filter((a) => a.kind === 'missing').length;
   const drifted = report.actions.filter((a) => a.kind === 'drift').length;
+  const pluginMissing = report.pluginActions.filter((a) => a.kind === 'missing').length;
+  const pluginDrifted = report.pluginActions.filter((a) => a.kind === 'drift').length;
   const stale = report.stale.length;
   info(`Maintenance bundle: .har/maintain/`);
-  info(`  ${missing} missing, ${drifted} drifted, ${stale} stale`);
+  info(`  Harness: ${missing} missing, ${drifted} drifted, ${stale} stale`);
+  if (report.pluginDrift.length > 0) {
+    info(
+      `  Plugins (${report.pluginDrift.map((p) => p.pluginId).join(', ')}): ${pluginMissing} missing, ${pluginDrifted} drifted`,
+    );
+  }
   if (!report.validation.pass) {
     warn(`  Validation: ${report.validation.errors.length} error(s) — blocks --finalize`);
   }

--- a/src/harness/maintain-bundle.ts
+++ b/src/harness/maintain-bundle.ts
@@ -8,6 +8,14 @@ import type { HarnessDriftResult } from './drift';
 import { templateFileForHarness } from './gitignore-template';
 import { getHarnessDir, readManifest } from './manifest';
 import { resolveTemplatesDir } from '../utils/paths';
+import {
+  buildPluginDriftActions,
+  compareInstalledPluginsToTemplate,
+  readInstalledPluginFile,
+  readTemplatePluginFile,
+  type PluginDriftAction,
+  type PluginDriftResult,
+} from './plugin-drift';
 import type { ValidationIssue, ValidationResult } from './validator';
 
 export const MAINTAIN_DIR = 'maintain';
@@ -39,6 +47,8 @@ export interface MaintainBundleReport {
   generatorVersion: HarnessDriftResult['generatorVersion'];
   profile: HarnessProfile;
   actions: MaintainAction[];
+  pluginDrift: PluginDriftResult[];
+  pluginActions: PluginDriftAction[];
   stale: MaintainStaleFile[];
   missingPortVars: string[];
   agentSlotMismatch: HarnessDriftResult['agentSlotMismatch'];
@@ -197,7 +207,7 @@ function buildReadme(report: MaintainBundleReport): string {
   lines.push('', '## Drift actions', '');
 
   if (report.actions.length === 0) {
-    lines.push('No missing or drifted template files.');
+    lines.push('No missing or drifted harness template files.');
   } else {
     lines.push('| File | Status | Reference |');
     lines.push('|------|--------|-----------|');
@@ -208,6 +218,27 @@ function buildReadme(report: MaintainBundleReport): string {
           : `diffs/${action.file}.diff`;
       lines.push(`| ${action.file} | ${action.kind} | ${ref} |`);
     }
+  }
+
+  lines.push('', '## Plugin drift (installed verification plugins)', '');
+
+  if (report.pluginActions.length === 0) {
+    lines.push('No installed plugins detected, or all plugin files match bundled templates.');
+  } else {
+    lines.push('| Plugin | File | Status | Reference |');
+    lines.push('|--------|------|--------|-----------|');
+    for (const action of report.pluginActions) {
+      const ref =
+        action.kind === 'missing'
+          ? `plugins/${action.pluginId}/templates/${action.file}`
+          : `plugins/${action.pluginId}/diffs/${action.file}.diff`;
+      lines.push(`| ${action.pluginId} | ${action.file} | ${action.kind} | ${ref} |`);
+    }
+    lines.push(
+      '',
+      'To refresh all plugin files: `har env add-plugin <id> --force` (overwrites plugin-owned paths).',
+      '',
+    );
   }
 
   if (report.missingPortVars.length > 0) {
@@ -244,10 +275,11 @@ function buildReadme(report: MaintainBundleReport): string {
     '',
     '## Next steps',
     '',
-    '1. Resolve each drift action (merge diffs; keep repo-specific customizations).',
-    '2. Review stale files — delete or merge superseded scripts.',
-    '3. Re-run `har env maintain` until validation passes and drift is clear.',
-    '4. `har env maintain --finalize --summary "<what changed>"`',
+    '1. Resolve each harness drift action (merge diffs; keep repo-specific customizations).',
+    '2. Merge plugin drift under `maintain/plugins/` or run `har env add-plugin <id> --force`.',
+    '3. Review stale files — delete or merge superseded scripts.',
+    '4. Re-run `har env maintain` until validation passes and drift is clear.',
+    '5. `har env maintain --finalize --summary "<what changed>"`',
     '',
   );
 
@@ -321,6 +353,52 @@ function writeBundleArtifacts(
   return bundleDir;
 }
 
+function ensureParentDir(filePath: string): void {
+  const parent = path.dirname(filePath);
+  if (!fs.existsSync(parent)) {
+    fs.mkdirSync(parent, { recursive: true });
+  }
+}
+
+function writePluginBundleArtifacts(repoPath: string, bundleDir: string, report: MaintainBundleReport): void {
+  if (report.pluginActions.length === 0) return;
+
+  for (const action of report.pluginActions) {
+    const pluginRoot = path.join(bundleDir, 'plugins', action.pluginId);
+    const templatesDir = path.join(pluginRoot, 'templates');
+    const installedDir = path.join(pluginRoot, 'installed');
+    const diffsDir = path.join(pluginRoot, 'diffs');
+    for (const dir of [templatesDir, installedDir, diffsDir]) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    const templateContent = readTemplatePluginFile(action.pluginId, action.file);
+    if (templateContent === null) continue;
+
+    const templatePath = path.join(templatesDir, action.file);
+    ensureParentDir(templatePath);
+    writeFileSafe(templatePath, templateContent);
+
+    const installedContent = readInstalledPluginFile(repoPath, action.pluginId, action.file);
+    if (installedContent !== null) {
+      const installedPath = path.join(installedDir, action.file);
+      ensureParentDir(installedPath);
+      writeFileSafe(installedPath, installedContent);
+      const diff = createUnifiedDiff(
+        installedContent,
+        templateContent,
+        `installed/${action.file}`,
+        `templates/${action.file}`,
+      );
+      if (diff) {
+        const diffPath = path.join(diffsDir, `${action.file}.diff`);
+        ensureParentDir(diffPath);
+        writeFileSafe(diffPath, diff);
+      }
+    }
+  }
+}
+
 export function buildMaintainBundle(
   repoPath: string,
   validation: ValidationResult,
@@ -330,12 +408,16 @@ export function buildMaintainBundle(
   const profile: HarnessProfile = manifest?.profile ?? 'default';
   const errors = validation.issues.filter((i) => i.severity === 'error');
   const warnings = validation.issues.filter((i) => i.severity === 'warning');
+  const pluginDrift = compareInstalledPluginsToTemplate(repoPath);
+  const pluginActions = buildPluginDriftActions(repoPath, pluginDrift);
 
   const report: MaintainBundleReport = {
     generatedAt: new Date().toISOString(),
     generatorVersion: drift.generatorVersion,
     profile,
     actions: buildActions(repoPath, profile, drift),
+    pluginDrift,
+    pluginActions,
     stale: buildStale(drift),
     missingPortVars: drift.missingPortVars,
     agentSlotMismatch: drift.agentSlotMismatch,
@@ -347,6 +429,7 @@ export function buildMaintainBundle(
   };
 
   const bundleDir = writeBundleArtifacts(repoPath, profile, drift, report);
+  writePluginBundleArtifacts(repoPath, bundleDir, report);
   return { bundleDir, report };
 }
 
@@ -362,7 +445,8 @@ export function formatMaintainBundlePromptSection(report: MaintainBundleReport):
     '## Step 0 — Read the maintenance bundle',
     '',
     'Open `.har/maintain/README.md` and `.har/maintain/drift-report.json`.',
-    'All reference templates are under `.har/maintain/templates/`.',
+    'Harness reference templates: `.har/maintain/templates/`.',
+    'Plugin reference templates: `.har/maintain/plugins/<plugin-id>/`.',
     'Do **not** read files from the globally installed har package.',
     '',
   ];
@@ -383,6 +467,23 @@ export function formatMaintainBundlePromptSection(report: MaintainBundleReport):
           ? `maintain/templates/${action.file}`
           : `maintain/diffs/${action.file}.diff`;
       lines.push(`| ${action.file} | ${action.kind} | ${ref} |`);
+    }
+    lines.push('');
+  }
+
+  if (report.pluginActions.length > 0) {
+    lines.push(
+      '### Plugin drift',
+      '',
+      '| Plugin | File | Status | Reference |',
+      '|--------|------|--------|-----------|',
+    );
+    for (const action of report.pluginActions) {
+      const ref =
+        action.kind === 'missing'
+          ? `maintain/plugins/${action.pluginId}/templates/${action.file}`
+          : `maintain/plugins/${action.pluginId}/diffs/${action.file}.diff`;
+      lines.push(`| ${action.pluginId} | ${action.file} | ${action.kind} | ${ref} |`);
     }
     lines.push('');
   }
@@ -417,6 +518,7 @@ export function formatMaintainBundlePromptSection(report: MaintainBundleReport):
 
   if (
     report.actions.length === 0 &&
+    report.pluginActions.length === 0 &&
     report.stale.length === 0 &&
     report.missingPortVars.length === 0 &&
     !report.agentSlotMismatch &&

--- a/src/harness/plugin-drift.ts
+++ b/src/harness/plugin-drift.ts
@@ -1,0 +1,250 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { computeFileChecksum } from './manifest';
+import { PLUGIN_IDS, PluginId, readPluginManifest } from './plugins';
+import { readStageRegistry } from './stages';
+import { resolveTemplatesDir } from '../utils/paths';
+
+export interface PluginDriftResult {
+  pluginId: PluginId;
+  stageId: string;
+  missing: string[];
+  checksumMismatch: string[];
+  unchanged: string[];
+}
+
+export interface PluginDriftAction {
+  pluginId: PluginId;
+  file: string;
+  kind: 'missing' | 'drift';
+  template: string;
+  installed?: string;
+  diff?: string;
+  hint: string;
+}
+
+const PACKAGE_SECTIONS = ['scripts', 'devDependencies'] as const;
+
+/** Detect shipped plugins whose stage id is registered in stages.json. */
+export function detectInstalledPlugins(repoPath: string): PluginId[] {
+  const resolved = path.resolve(repoPath);
+  const registryPath = path.join(resolved, '.har', 'stages.json');
+  if (!fs.existsSync(registryPath)) return [];
+
+  const registry = readStageRegistry(resolved);
+  const stageIds = new Set(registry.stages.map((stage) => stage.id));
+  const installed: PluginId[] = [];
+
+  for (const pluginId of PLUGIN_IDS) {
+    const manifest = readPluginManifest(pluginId);
+    if (stageIds.has(manifest.stageId)) {
+      installed.push(pluginId);
+    }
+  }
+
+  return installed;
+}
+
+function pluginTemplatePath(pluginId: PluginId, srcRel: string): string {
+  return path.join(resolveTemplatesDir(), 'plugins', pluginId, srcRel);
+}
+
+function readBundledPluginFile(pluginId: PluginId, srcRel: string): string {
+  return fs.readFileSync(pluginTemplatePath(pluginId, srcRel), 'utf8');
+}
+
+function listPluginDestPaths(pluginId: PluginId, repoPath: string): string[] {
+  const manifest = readPluginManifest(pluginId);
+  const paths = manifest.files.map((file) => file.dest);
+
+  if (manifest.optionalFiles) {
+    for (const file of manifest.optionalFiles) {
+      if (fs.existsSync(path.join(repoPath, file.dest))) {
+        paths.push(file.dest);
+      }
+    }
+  }
+
+  if (manifest.merge) {
+    for (const dest of Object.keys(manifest.merge)) {
+      if (!paths.includes(dest)) paths.push(dest);
+    }
+  }
+
+  return paths.sort();
+}
+
+function manifestEntryForDest(pluginId: PluginId, dest: string) {
+  const manifest = readPluginManifest(pluginId);
+  return [...manifest.files, ...(manifest.optionalFiles ?? [])].find((file) => file.dest === dest);
+}
+
+function extractPackageFragment(pkgContent: string, fragmentContent: string): string {
+  const pkg = JSON.parse(pkgContent) as Record<string, Record<string, string>>;
+  const fragment = JSON.parse(fragmentContent) as Record<string, Record<string, string>>;
+  const extracted: Record<string, Record<string, string>> = {};
+
+  for (const section of PACKAGE_SECTIONS) {
+    const incoming = fragment[section] ?? {};
+    const existing = pkg[section] ?? {};
+    const picked: Record<string, string> = {};
+    for (const key of Object.keys(incoming)) {
+      if (existing[key] !== undefined) picked[key] = existing[key];
+    }
+    if (Object.keys(picked).length > 0) extracted[section] = picked;
+  }
+
+  return `${JSON.stringify(extracted, null, 2)}\n`;
+}
+
+function pluginKeysMatch(installedContent: string, fragmentContent: string): boolean {
+  const pkg = JSON.parse(installedContent) as Record<string, Record<string, string>>;
+  const fragment = JSON.parse(fragmentContent) as Record<string, Record<string, string>>;
+
+  for (const section of PACKAGE_SECTIONS) {
+    const incoming = fragment[section] ?? {};
+    const existing = pkg[section] ?? {};
+    for (const [key, value] of Object.entries(incoming)) {
+      if (existing[key] !== value) return false;
+    }
+  }
+
+  return true;
+}
+
+export function readTemplatePluginFile(pluginId: PluginId, dest: string): string | null {
+  const entry = manifestEntryForDest(pluginId, dest);
+  if (entry) {
+    return readBundledPluginFile(pluginId, entry.src);
+  }
+
+  const manifest = readPluginManifest(pluginId);
+  const fragmentRel = manifest.merge?.[dest];
+  if (fragmentRel) {
+    const fragment = JSON.parse(readBundledPluginFile(pluginId, fragmentRel)) as Record<
+      string,
+      unknown
+    >;
+    return `${JSON.stringify(fragment, null, 2)}\n`;
+  }
+
+  return null;
+}
+
+export function readInstalledPluginFile(repoPath: string, pluginId: PluginId, dest: string): string | null {
+  const installedPath = path.join(path.resolve(repoPath), dest);
+  if (!fs.existsSync(installedPath)) return null;
+
+  const content = fs.readFileSync(installedPath, 'utf8');
+  const manifest = readPluginManifest(pluginId);
+  const fragmentRel = manifest.merge?.[dest];
+  if (fragmentRel) {
+    return extractPackageFragment(content, readBundledPluginFile(pluginId, fragmentRel));
+  }
+
+  return content;
+}
+
+function pluginActionHint(pluginId: PluginId, dest: string, kind: 'missing' | 'drift'): string {
+  if (kind === 'missing') {
+    return `Copy/adapt from maintain/plugins/${pluginId}/templates/${dest} or run: har env add-plugin ${pluginId} --force`;
+  }
+  if (dest === 'package.json') {
+    return `Merge plugin script/devDependency keys from maintain/plugins/${pluginId}/diffs/${dest}.diff or run: har env add-plugin ${pluginId} --force`;
+  }
+  return `Merge maintain/plugins/${pluginId}/diffs/${dest}.diff or run: har env add-plugin ${pluginId} --force`;
+}
+
+export function comparePluginToTemplate(repoPath: string, pluginId: PluginId): PluginDriftResult {
+  const manifest = readPluginManifest(pluginId);
+  const resolved = path.resolve(repoPath);
+  const destPaths = listPluginDestPaths(pluginId, resolved);
+
+  const missing: string[] = [];
+  const checksumMismatch: string[] = [];
+  const unchanged: string[] = [];
+
+  for (const dest of destPaths) {
+    const templateContent = readTemplatePluginFile(pluginId, dest);
+    if (templateContent === null) continue;
+
+    const installedContent = readInstalledPluginFile(resolved, pluginId, dest);
+    if (installedContent === null) {
+      missing.push(dest);
+      continue;
+    }
+
+    if (dest === 'package.json') {
+      const fragmentRel = manifest.merge?.[dest];
+      const installedPath = path.join(resolved, dest);
+      const installedRaw = fs.readFileSync(installedPath, 'utf8');
+      if (
+        fragmentRel &&
+        pluginKeysMatch(installedRaw, readBundledPluginFile(pluginId, fragmentRel))
+      ) {
+        unchanged.push(dest);
+      } else if (
+        computeFileChecksum(installedContent) === computeFileChecksum(templateContent)
+      ) {
+        unchanged.push(dest);
+      } else {
+        checksumMismatch.push(dest);
+      }
+      continue;
+    }
+
+    if (computeFileChecksum(installedContent) === computeFileChecksum(templateContent)) {
+      unchanged.push(dest);
+    } else {
+      checksumMismatch.push(dest);
+    }
+  }
+
+  return {
+    pluginId,
+    stageId: manifest.stageId,
+    missing,
+    checksumMismatch,
+    unchanged,
+  };
+}
+
+export function compareInstalledPluginsToTemplate(repoPath: string): PluginDriftResult[] {
+  return detectInstalledPlugins(repoPath).map((pluginId) =>
+    comparePluginToTemplate(repoPath, pluginId),
+  );
+}
+
+export function buildPluginDriftActions(
+  repoPath: string,
+  pluginDrift: PluginDriftResult[],
+): PluginDriftAction[] {
+  const actions: PluginDriftAction[] = [];
+
+  for (const drift of pluginDrift) {
+    for (const file of drift.missing) {
+      actions.push({
+        pluginId: drift.pluginId,
+        file,
+        kind: 'missing',
+        template: `maintain/plugins/${drift.pluginId}/templates/${file}`,
+        hint: pluginActionHint(drift.pluginId, file, 'missing'),
+      });
+    }
+    for (const file of drift.checksumMismatch) {
+      actions.push({
+        pluginId: drift.pluginId,
+        file,
+        kind: 'drift',
+        template: `maintain/plugins/${drift.pluginId}/templates/${file}`,
+        installed: `maintain/plugins/${drift.pluginId}/installed/${file}`,
+        diff: `maintain/plugins/${drift.pluginId}/diffs/${file}.diff`,
+        hint: pluginActionHint(drift.pluginId, file, 'drift'),
+      });
+    }
+  }
+
+  return actions.sort(
+    (a, b) => a.pluginId.localeCompare(b.pluginId) || a.file.localeCompare(b.file),
+  );
+}

--- a/src/templates/plugins/playwright/.har/stages/PLAYWRIGHT.md
+++ b/src/templates/plugins/playwright/.har/stages/PLAYWRIGHT.md
@@ -18,4 +18,25 @@ After `./.har/launch.sh <id>`:
 ./.har/verify.sh <id> --full
 ```
 
-Replace TODO selectors and paths in the scaffold specs during harness adaptation.
+Adapt selectors and paths in the scaffold specs during harness adaptation.
+
+## New UI features
+
+Add or update Playwright specs so `browser-e2e` covers the change. Prefer one file per feature under `tests/frontend/<feature>.spec.js`. Full verification (`verify --full`) must pass before done.
+
+See the header comment in `playwright.config.js` for harness env vars, artifact paths, and the quick vs full verify contract.
+
+## Plugin updates
+
+When HAR ships a new plugin template version, merge drift from:
+
+```bash
+har env maintain
+# review .har/maintain/plugins/playwright/
+```
+
+Or refresh all plugin-owned files:
+
+```bash
+har env add-plugin playwright --force
+```

--- a/tests/maintain-bundle.test.ts
+++ b/tests/maintain-bundle.test.ts
@@ -130,6 +130,8 @@ describe('adaptation prompts with maintain bundle', () => {
           hint: 'Add this file.',
         },
       ],
+      pluginDrift: [],
+      pluginActions: [],
       stale: [{ file: 'legacy.sh', hint: 'Delete after merge.' }],
       missingPortVars: ['HARNESS_DB_PORT_DEFAULT'],
       agentSlotMismatch: null,

--- a/tests/plugin-drift.test.ts
+++ b/tests/plugin-drift.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { scaffoldHarnessBoilerplate } from '../src/harness/generator';
+import { buildMaintainBundle } from '../src/harness/maintain-bundle';
+import { applyPlugin } from '../src/harness/plugins';
+import {
+  compareInstalledPluginsToTemplate,
+  comparePluginToTemplate,
+  detectInstalledPlugins,
+} from '../src/harness/plugin-drift';
+import { validateHarness } from '../src/harness/validator';
+import { compareHarnessToTemplate } from '../src/harness/drift';
+
+function makeTempRepo(name: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+}
+
+function scaffoldRepoWithPlugin(name: string): string {
+  const repoPath = makeTempRepo(name);
+  fs.writeFileSync(
+    path.join(repoPath, 'package.json'),
+    JSON.stringify({ name: 'test-app', version: '1.0.0' }, null, 2) + '\n',
+  );
+  scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'default' });
+  applyPlugin(repoPath, 'playwright', { skipCi: true });
+  return repoPath;
+}
+
+describe('plugin drift', () => {
+  it('detects playwright after add-plugin', () => {
+    const repoPath = scaffoldRepoWithPlugin('har-plugin-detect');
+
+    expect(detectInstalledPlugins(repoPath)).toEqual(['playwright']);
+  });
+
+  it('reports no drift when plugin files match bundled templates', () => {
+    const repoPath = scaffoldRepoWithPlugin('har-plugin-fresh');
+
+    const drift = comparePluginToTemplate(repoPath, 'playwright');
+    expect(drift.missing).toEqual([]);
+    expect(drift.checksumMismatch).toEqual([]);
+    expect(drift.unchanged.length).toBeGreaterThan(0);
+  });
+
+  it('reports drift when a plugin file was customized', () => {
+    const repoPath = scaffoldRepoWithPlugin('har-plugin-drift');
+
+    const configPath = path.join(repoPath, 'playwright.config.js');
+    fs.writeFileSync(configPath, `${fs.readFileSync(configPath, 'utf8')}\n// customized\n`);
+
+    const drift = comparePluginToTemplate(repoPath, 'playwright');
+    expect(drift.checksumMismatch).toContain('playwright.config.js');
+  });
+
+  it('includes plugin drift in maintain bundle artifacts', () => {
+    const repoPath = scaffoldRepoWithPlugin('har-plugin-bundle');
+
+    const configPath = path.join(repoPath, 'playwright.config.js');
+    fs.writeFileSync(configPath, `${fs.readFileSync(configPath, 'utf8')}\n// customized\n`);
+
+    const drift = compareHarnessToTemplate(repoPath);
+    const validation = validateHarness(repoPath);
+    const { bundleDir, report } = buildMaintainBundle(repoPath, validation, drift);
+
+    expect(report.pluginDrift.some((entry) => entry.pluginId === 'playwright')).toBe(true);
+    expect(report.pluginActions.some((action) => action.file === 'playwright.config.js')).toBe(true);
+    expect(
+      fs.existsSync(path.join(bundleDir, 'plugins', 'playwright', 'diffs', 'playwright.config.js.diff')),
+    ).toBe(true);
+    expect(fs.readFileSync(path.join(bundleDir, 'README.md'), 'utf8')).toContain('Plugin drift');
+  });
+
+  it('compareInstalledPluginsToTemplate skips plugins that are not installed', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-plugin-none-'));
+    scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'default' });
+
+    expect(compareInstalledPluginsToTemplate(repoPath)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Detect installed plugins during `har env maintain` by matching registered stage ids (`browser-e2e` → playwright, `rocketsim-flows` → rocketsim).
- Compare plugin-owned files against bundled templates and write per-plugin templates/diffs under `.har/maintain/plugins/<id>/`.
- Surface plugin drift in the maintain bundle report, adaptation prompt, CLI summary, and plugins guide.

## Test plan
- [x] `tests/plugin-drift.test.ts` — detection, unchanged, drift, bundle artifacts
- [x] `tests/maintain-bundle.test.ts` — updated report shape
- [x] `har env verify 2 --full` passes

## Related
- Complements #107 (Playwright plugin config documentation)


Made with [Cursor](https://cursor.com)