### PR TITLE
docs: require session handoff before complete, push, or PR

### DIFF
--- a/.cursor/rules/har-workflow.mdc
+++ b/.cursor/rules/har-workflow.mdc
@@ -55,8 +55,8 @@ Validate through the harness — do not skip verification or substitute ad-hoc n
 
 - `har_run_verification` with `agentId: 1` — fast loop (typecheck + unit tests)
 - `har_run_verification` with `agentId: 1, full: true` — required before declaring work done
-- `har_complete_environment` with `agentId: 1` — when the work is done: full verify + validation record + teardown, **keeping the session branch** so the user can push it / open a PR
-- `har_teardown_environment` with `agentId: 1` — plain cleanup (also keeps the branch; `deleteBranch: true` to drop it)
+- `har_complete_environment` with `agentId: 1` — **recommended finish** (full verify + validation record + teardown, branch kept). **Propose and wait for user approval** before invoking — never run autonomously
+- `har_teardown_environment` with `agentId: 1` — plain cleanup only (also keeps the branch; `deleteBranch: true` to drop it). Prefer `complete` when the work succeeded
 
 ### 2. HAR CLI (when `har` is installed)
 
@@ -88,8 +88,53 @@ When the Playwright stage is installed (`.har/stages/browser-e2e.sh` exists), ad
 - Full verification returns pass (`har env verify 1 --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh 1 --full`)
 - All edits live in the session worktree (main checkout untouched: `git status` clean there)
 - New behavior has automated test coverage
+- Changes committed in the session worktree
 - Show the user the slot preview URLs so they can test the app themselves
 - Do not declare work complete without running full verify
+- **Present session handoff and wait for the user's next instruction** — do not end the session without the handoff prompt
+
+## Session handoff (required)
+
+After full verify passes and changes are committed, **stop and hand off**. Never
+autonomously run `complete`, `teardown`, `git push`, or create a pull request.
+
+Present a handoff that includes:
+
+1. **Summary** of what changed
+2. **Session branch** name (from launch / `.har/slots/agent-<id>.json`)
+3. **Preview URLs** when the slot has a running app
+4. **Numbered next-step options** — then wait for the user
+
+Options to offer:
+
+1. **Complete the slot** (recommended) — `har env complete <id>` / MCP
+   `har_complete_environment`: full verify + validation record + worktree/runtime
+   teardown; **branch kept**. Prefer this over bare `teardown` when the work
+   succeeded.
+2. **Open a PR** — only if `gh` CLI or GitHub MCP is available. Create the PR
+   **only after explicit user approval**.
+3. **Keep the branch only** — if PR tooling is unavailable, report the session
+   branch and how to push manually. The branch already exists from launch.
+
+Canonical handoff shape:
+
+```markdown
+## Session handoff
+
+**Summary:** …
+**Branch:** `<session-branch>` (session worktree)
+**Preview:** … (if applicable)
+
+Next steps — tell me which you want:
+1. **Complete the slot** — I'll run `har env complete <id>` (full verify + validation record + teardown; branch kept)
+2. **Open a PR** — I can create one with `gh`/GitHub MCP (requires your approval)
+3. **Something else** — e.g. keep the slot running, more changes, or push only
+
+I'll wait for your instruction before running complete, teardown, push, or PR.
+```
+
+Omit option 2 when neither `gh` nor GitHub MCP is available; replace it with push
+instructions for the session branch.
 
 ## Commit gate
 

--- a/.har/CLAUDE.agent.md
+++ b/.har/CLAUDE.agent.md
@@ -29,7 +29,17 @@ For Mission Control (Next.js + Postgres), use `control/.har/` instead.
 - [ ] Full verify runs every registered stage in `stages.json` `verificationStages` (`docs-drift`)
 - [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message
-- [ ] Finish with `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — records the validation and tears down while **keeping the session branch** for the user to push / open a PR
+- [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
+- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+
+### Session handoff
+
+After full verify and commit, stop and propose next steps. Never autonomously run
+`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
+`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
+available (and only after explicit approval); otherwise report the session branch
+for a manual push. See `.cursor/rules/har-workflow.mdc` for the canonical handoff
+template.
 
 Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -28,7 +28,8 @@ After making changes, validate through the harness (not ad-hoc shell commands).
 - `har_launch_environment` with `agentId: 1` — once per session
 - `har_run_verification` with `agentId: 1` — typecheck + unit tests (fast)
 - `har_run_verification` with `agentId: 1, full: true` — + lint, docs check/build, docs-drift (before declaring done)
-- `har_teardown_environment` with `agentId: 1` — cleanup
+- `har_complete_environment` with `agentId: 1` — **recommended finish** (full verify + validation + teardown, branch kept); propose and wait for user approval
+- `har_teardown_environment` with `agentId: 1` — plain cleanup (prefer `complete` when the work succeeded)
 
 **CLI** (when `har` is installed):
 
@@ -36,7 +37,8 @@ After making changes, validate through the harness (not ad-hoc shell commands).
 har env launch 1
 har env verify 1
 har env verify 1 --full
-har env teardown 1
+har env complete 1      # done: verify + validate + teardown, branch kept for PR
+har env teardown 1      # plain cleanup (--delete-branch to drop the branch)
 ```
 
 **Shell fallback** (no CLI/MCP — scripts still work):
@@ -49,6 +51,10 @@ har env teardown 1
 ```
 
 Work happens in an isolated session worktree by default (`~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>`) recorded in `.har/slots/agent-<id>.json`. Use `har env launch 1 --no-worktree` or `./.har/launch.sh 1 --no-worktree` only when you must use the repo root checkout.
+
+### Session handoff
+
+After full verify and commit, present a handoff (summary, session branch, preview URLs, next-step options) and **wait for the user** before running `complete`, `teardown`, push, or opening a PR. Prefer `complete` over bare `teardown` when the work succeeded. Offer a PR only when `gh` or GitHub MCP is available. See [`.cursor/rules/har-workflow.mdc`](.cursor/rules/har-workflow.mdc) for the canonical template.
 
 See [`.har/README.md`](.har/README.md) for harness details.
 
@@ -216,8 +222,12 @@ For docs-only updates: branch `docs/<topic>`, title `docs: …`. For CI-only upd
 har env launch 1                # if not already launched this session
 har env verify 1                # typecheck + unit tests
 har env verify 1 --full         # + lint + build — required before declaring done
+# then: session handoff → wait for user → on approval:
+har env complete 1              # full verify + validation + teardown; branch kept
 ```
 
-Or use MCP `har_run_verification` (preferred in Cursor). Shell fallback: `./.har/verify.sh 1 --full`.
+Or use MCP `har_run_verification` / `har_complete_environment` (preferred in Cursor). Shell fallback: `./.har/verify.sh 1 --full` then `./.har/teardown.sh 1` (no validation record — prefer CLI/MCP `complete` when available).
+
+Do not end the session without a handoff prompt. Never autonomously run `complete`, push, or open a PR.
 
 If you changed `src/templates/`: `npm run build`, then `har env init --force --profile cli` on a fixture (or `--profile default` for web apps).

--- a/control/.har/CLAUDE.agent.md
+++ b/control/.har/CLAUDE.agent.md
@@ -31,7 +31,17 @@ A task is complete only when:
 - [ ] New or changed UI behavior has coverage in `tests/` (unit and/or Playwright as appropriate)
 - [ ] Changes are committed **in the session worktree** with a clear message
 - [ ] The user got the app URL (http://localhost:${FE_PORT}) to test themselves
-- [ ] Finish with `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — records the validation and tears down while **keeping the session branch** for the user to push / open a PR
+- [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
+- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+
+### Session handoff
+
+After full verify and commit, stop and propose next steps. Never autonomously run
+`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
+`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
+available (and only after explicit approval); otherwise report the session branch
+for a manual push. See `.cursor/rules/har-workflow.mdc` for the canonical handoff
+template.
 
 Quick check during development: `./.har/verify.sh ${AGENT_ID}` (stops before lint/e2e).
 

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -71,17 +71,37 @@ har env status --json
 2. Run full verification.
 3. Stage exactly the state that passed.
 4. Commit inside the session worktree.
-5. Complete the environment.
+5. Present a **session handoff** and wait for the user's next instruction.
+6. On user approval: complete the environment (and optionally open a PR).
 
 ```bash
 har env verify 2 --full
 git add -A
 git commit -m "feat: describe the change"
+# hand off → wait for user → on approval:
 har env complete 2
 ```
 
 Any edit after full verification changes the tree hash and requires another full
-verify. Completion keeps the branch, so the user can push it or open a pull request.
+verify.
+
+### What agents must propose
+
+After verify and commit, the agent should stop and offer numbered options — not
+silently finish the session:
+
+1. **Complete the slot** (recommended) — `har env complete <id>` / MCP
+   `har_complete_environment` runs full verification, records the validated tree
+   hash, tears down the worktree/runtime, and **keeps the session branch**. Prefer
+   this over bare `teardown` when the work succeeded.
+2. **Open a pull request** — only when `gh` or GitHub MCP is available, and only
+   after explicit user approval.
+3. **Keep the branch only** — if PR tooling is unavailable, report the session
+   branch name so the user can push manually.
+
+Never run `complete`, `teardown`, `git push`, or create a PR without user
+approval. The Cursor rule (`.cursor/rules/har-workflow.mdc`) includes the
+canonical handoff template.
 
 ## When to teardown
 
@@ -92,4 +112,5 @@ record a completion validation:
 har env teardown 2
 ```
 
-Branch deletion is a separate, explicit operation.
+Branch deletion is a separate, explicit operation. Prefer `complete` when the
+task succeeded and you want a validation record.

--- a/src/templates/AGENT.md.template
+++ b/src/templates/AGENT.md.template
@@ -25,8 +25,13 @@ Run `har env init` or `har env maintain` to create or refresh it.
 
 ## Harness workflow
 
-Prefer **HAR MCP tools** (Cursor) or **`har env launch/verify/teardown`** — they persist run history under `.har/runs/`.
+Prefer **HAR MCP tools** (Cursor) or **`har env launch/verify/complete`** — they persist run history under `.har/runs/`.
 Use `./.har/*.sh` only when the CLI is not installed.
+
+When the work is done: full verify, commit in the session worktree, then present a
+**session handoff** and wait for the user before `har env complete <id>` /
+`har_complete_environment` (recommended finish: validation + teardown, branch kept),
+push, or opening a PR. See `.cursor/rules/har-workflow.mdc` for the handoff template.
 
 ## Commit gate
 

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -55,8 +55,8 @@ Validate through the harness — do not skip verification or substitute ad-hoc n
 
 - `har_run_verification` with `agentId: 1` — fast loop (typecheck + unit tests)
 - `har_run_verification` with `agentId: 1, full: true` — required before declaring work done
-- `har_complete_environment` with `agentId: 1` — when the work is done: full verify + validation record + teardown, **keeping the session branch** so the user can push it / open a PR
-- `har_teardown_environment` with `agentId: 1` — plain cleanup (also keeps the branch; `deleteBranch: true` to drop it)
+- `har_complete_environment` with `agentId: 1` — **recommended finish** (full verify + validation record + teardown, branch kept). **Propose and wait for user approval** before invoking — never run autonomously
+- `har_teardown_environment` with `agentId: 1` — plain cleanup only (also keeps the branch; `deleteBranch: true` to drop it). Prefer `complete` when the work succeeded
 
 ### 2. HAR CLI (when `har` is installed)
 
@@ -88,8 +88,53 @@ When the Playwright stage is installed (`.har/stages/browser-e2e.sh` exists), ad
 - Full verification returns pass (`har env verify 1 --full`, MCP `har_run_verification` with `full: true`, or `./.har/verify.sh 1 --full`)
 - All edits live in the session worktree (main checkout untouched: `git status` clean there)
 - New behavior has automated test coverage
+- Changes committed in the session worktree
 - Show the user the slot preview URLs so they can test the app themselves
 - Do not declare work complete without running full verify
+- **Present session handoff and wait for the user's next instruction** — do not end the session without the handoff prompt
+
+## Session handoff (required)
+
+After full verify passes and changes are committed, **stop and hand off**. Never
+autonomously run `complete`, `teardown`, `git push`, or create a pull request.
+
+Present a handoff that includes:
+
+1. **Summary** of what changed
+2. **Session branch** name (from launch / `.har/slots/agent-<id>.json`)
+3. **Preview URLs** when the slot has a running app
+4. **Numbered next-step options** — then wait for the user
+
+Options to offer:
+
+1. **Complete the slot** (recommended) — `har env complete <id>` / MCP
+   `har_complete_environment`: full verify + validation record + worktree/runtime
+   teardown; **branch kept**. Prefer this over bare `teardown` when the work
+   succeeded.
+2. **Open a PR** — only if `gh` CLI or GitHub MCP is available. Create the PR
+   **only after explicit user approval**.
+3. **Keep the branch only** — if PR tooling is unavailable, report the session
+   branch and how to push manually. The branch already exists from launch.
+
+Canonical handoff shape:
+
+```markdown
+## Session handoff
+
+**Summary:** …
+**Branch:** `<session-branch>` (session worktree)
+**Preview:** … (if applicable)
+
+Next steps — tell me which you want:
+1. **Complete the slot** — I'll run `har env complete <id>` (full verify + validation record + teardown; branch kept)
+2. **Open a PR** — I can create one with `gh`/GitHub MCP (requires your approval)
+3. **Something else** — e.g. keep the slot running, more changes, or push only
+
+I'll wait for your instruction before running complete, teardown, push, or PR.
+```
+
+Omit option 2 when neither `gh` nor GitHub MCP is available; replace it with push
+instructions for the session branch.
 
 ## Commit gate
 

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -29,7 +29,17 @@ workflow, document the required credentials/default data and wire a smoke into
 - [ ] Full verify runs every registered stage in `stages.json` `verificationStages` (Playwright, custom checks, …) — when `stages/browser-e2e.sh` exists, adapt specs under `tests/` for UI changes
 - [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message
-- [ ] Finish with `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — records the validation and tears down while **keeping the session branch** for the user to push / open a PR
+- [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
+- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+
+### Session handoff
+
+After full verify and commit, stop and propose next steps. Never autonomously run
+`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
+`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
+available (and only after explicit approval); otherwise report the session branch
+for a manual push. See `.cursor/rules/har-workflow.mdc` for the canonical handoff
+template.
 
 Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
 

--- a/src/templates/har-boilerplate-ios/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-ios/CLAUDE.agent.md
@@ -31,7 +31,17 @@ seeded data, or a simulator flow, document it here and wire the smoke into
 - [ ] When `stages/rocketsim-flows.sh` exists, full verify includes user-flow validation — add or update flow scripts in `flows/` for UI changes
 - [ ] New behavior has automated test coverage (unit tests via XCTest)
 - [ ] Changes committed **in the session worktree** with a clear message
-- [ ] Finish with `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — records the validation and tears down while **keeping the session branch** for the user to push / open a PR
+- [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
+- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+
+### Session handoff
+
+After full verify and commit, stop and propose next steps. Never autonomously run
+`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
+`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
+available (and only after explicit approval); otherwise report the session branch
+for a manual push. See `.cursor/rules/har-workflow.mdc` for the canonical handoff
+template.
 
 Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
 

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -43,7 +43,17 @@ is alive; it does not automatically mean an agent can use the app.
 - [ ] New behavior has automated test coverage (unit and/or browser as appropriate)
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] The user got the preview URLs to test the app themselves
-- [ ] Finish with `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — records the validation and tears down while **keeping the session branch** for the user to push / open a PR
+- [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
+- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+
+### Session handoff
+
+After full verify and commit, stop and propose next steps. Never autonomously run
+`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
+`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
+available (and only after explicit approval); otherwise report the session branch
+for a manual push. See `.cursor/rules/har-workflow.mdc` for the canonical handoff
+template.
 
 Quick loop during development: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}` (smoke + health only; `--full` adds the registered verification stages).
 

--- a/tests/cursor-rule.test.ts
+++ b/tests/cursor-rule.test.ts
@@ -39,6 +39,11 @@ describe('cursor-rule', () => {
     expect(content).toContain('har env verify 1 --full');
     expect(content).toContain('har_run_verification');
     expect(content).toContain('HAR Harness Workflow');
+    expect(content).toContain('Session handoff');
+    expect(content).toContain('har_complete_environment');
+    expect(content).toContain('wait for the user');
+    expect(content).toContain('GitHub MCP');
+    expect(content).toContain('`gh`');
   });
 
   it('skips when not a Cursor workspace and no existing rule', async () => {


### PR DESCRIPTION
## Summary
- Add a required **session handoff** step to the Cursor rule and agent docs: after full verify, agents must summarize work, propose next steps, and wait for user approval before `complete`, teardown, push, or PR creation.
- Prefer `har env complete` / `har_complete_environment` (full verify + validation + teardown, branch kept) over bare teardown when the work succeeded; offer PR creation only when `gh` or GitHub MCP is available.
- Document the handoff in `AGENT.md`, boilerplate/dogfood `CLAUDE.agent.md` files, and the agent-workflow guide; extend cursor-rule tests for the new guidance.

## Test plan
- [x] `har env verify 3 --full` passes (typecheck, build, docs, unit tests, lint, docs-drift)
- [x] `tests/cursor-rule.test.ts` asserts Session handoff / `har_complete_environment` / GitHub MCP language
- [ ] Confirm `har env maintain --cursor-rule` refreshes consumer rules from the updated template


Made with [Cursor](https://cursor.com)