### PR TITLE
fix(telemetry): register repos, parse otel-hook prompts, improve slot attribution

### DIFF
--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/control",
-  "version": "0.32.2",
+  "version": "0.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "0.32.2",
+      "version": "0.33.1",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -66,7 +66,7 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "0.32.2",
+      "version": "0.33.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/control/src/server/otel-ingest-session-context.test.ts
+++ b/control/src/server/otel-ingest-session-context.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { otelWorkspaceIdForPath } from './otel-workspace';
+
+interface FakeSlot {
+  repositoryId: string;
+  slotId: number;
+  workDir: string | null;
+  worktreePath: string | null;
+  branch: string | null;
+  suffix: string | null;
+  workUnitId: string | null;
+  attemptId: string | null;
+  active: boolean;
+  updatedAt: number;
+}
+
+const repos = [{ id: 'repo-1', path: '/home/user/project' }];
+let slots: FakeSlot[] = [];
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    repository: {
+      findMany: vi.fn(async () => repos),
+      findUnique: vi.fn(async ({ where }: { where: { path: string } }) =>
+        repos.find((r) => r.path === where.path) ?? null,
+      ),
+    },
+    agentSlot: {
+      findMany: vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+        if ('repositoryId' in where) {
+          return slots.filter(
+            (s) =>
+              s.repositoryId === where.repositoryId &&
+              (where.active === undefined || s.active === where.active),
+          );
+        }
+        // OR query used by resolveSlotByWorkspace / resolveRepositoryByWorkspaceId
+        return slots.filter((s) => s.workDir || s.worktreePath);
+      }),
+      findFirst: vi.fn(
+        async ({ where }: { where: { repositoryId: string; active: boolean } }) => {
+          const filtered = slots
+            .filter((s) => s.repositoryId === where.repositoryId && s.active === where.active)
+            .sort((a, b) => b.updatedAt - a.updatedAt);
+          return filtered[0] ?? null;
+        },
+      ),
+    },
+  },
+}));
+
+const { resolveSessionContext } = await import('./otel-ingest');
+
+function makeSlot(overrides: Partial<FakeSlot>): FakeSlot {
+  return {
+    repositoryId: 'repo-1',
+    slotId: 1,
+    workDir: null,
+    worktreePath: null,
+    branch: null,
+    suffix: null,
+    workUnitId: null,
+    attemptId: null,
+    active: true,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('resolveSessionContext — Cursor on the main checkout', () => {
+  beforeEach(() => {
+    slots = [];
+  });
+
+  it('attributes to the one active worktree when correlation is unambiguous', async () => {
+    slots = [
+      makeSlot({
+        slotId: 2,
+        workDir: '/home/user/worktrees/project-abcd-har-agent-2-xyz',
+        worktreePath: '/home/user/worktrees/project-abcd-har-agent-2-xyz',
+        branch: 'feat/x',
+        suffix: 'xyz',
+        workUnitId: 'WU-1',
+        attemptId: 'AT-1',
+        updatedAt: 1,
+      }),
+    ];
+
+    const { context } = await resolveSessionContext(
+      {},
+      { 'gen_ai.client.workspace': '/home/user/project' },
+    );
+
+    expect(context).toMatchObject({
+      repositoryId: 'repo-1',
+      agentId: 2,
+      workDir: '/home/user/worktrees/project-abcd-har-agent-2-xyz',
+      branch: 'feat/x',
+      suffix: 'xyz',
+      workUnitId: 'WU-1',
+      attemptId: 'AT-1',
+    });
+  });
+
+  it('falls back to the raw workspace path when two slots are active (ambiguous)', async () => {
+    slots = [
+      makeSlot({ slotId: 2, workDir: '/home/user/worktrees/project-a', updatedAt: 1 }),
+      makeSlot({ slotId: 3, workDir: '/home/user/worktrees/project-b', updatedAt: 2 }),
+    ];
+
+    const { context } = await resolveSessionContext(
+      {},
+      { 'gen_ai.client.workspace': '/home/user/project' },
+    );
+
+    expect(context).toMatchObject({
+      repositoryId: 'repo-1',
+      agentId: 3, // most recently updated active slot — same guess as before this fix
+      workDir: '/home/user/project',
+      branch: undefined,
+      workUnitId: undefined,
+      attemptId: undefined,
+    });
+  });
+
+  it('falls back to the raw workspace path when no slot is active', async () => {
+    slots = [];
+
+    const { context } = await resolveSessionContext(
+      {},
+      { 'gen_ai.client.workspace': '/home/user/project' },
+    );
+
+    expect(context).toMatchObject({
+      repositoryId: 'repo-1',
+      agentId: 1,
+      workDir: '/home/user/project',
+    });
+  });
+
+  it('applies the same unambiguous correlation via the opaque workspace id', async () => {
+    slots = [
+      makeSlot({
+        slotId: 5,
+        workDir: '/home/user/worktrees/project-abcd-har-agent-5-xyz',
+        worktreePath: '/home/user/worktrees/project-abcd-har-agent-5-xyz',
+        branch: 'fix/y',
+        workUnitId: 'WU-2',
+        updatedAt: 1,
+      }),
+    ];
+    const workspaceId = otelWorkspaceIdForPath('/home/user/project');
+
+    const { context } = await resolveSessionContext(
+      {},
+      { 'otelhook.workspace.id': workspaceId },
+    );
+
+    expect(context).toMatchObject({
+      repositoryId: 'repo-1',
+      agentId: 5,
+      workDir: '/home/user/worktrees/project-abcd-har-agent-5-xyz',
+      branch: 'fix/y',
+      workUnitId: 'WU-2',
+    });
+  });
+});

--- a/control/src/server/otel-ingest.test.ts
+++ b/control/src/server/otel-ingest.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { extractPromptText, type AttrMap } from './otel-ingest';
+
+describe('extractPromptText', () => {
+  it('reads gen_ai.prompt style attributes (existing behavior)', () => {
+    const attrs: AttrMap = { 'gen_ai.prompt.0.content': 'fix the bug' };
+    expect(extractPromptText(attrs)).toBe('fix the bug');
+  });
+
+  it('reads @osfactory/otel-hook prompt.submitted content facts from the log body', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'prompt.submitted',
+      'otelhook.content.kind': 'prompt',
+    };
+    expect(extractPromptText(attrs, 'otelhook.prompt.submitted', 'refactor the auth module')).toBe(
+      'refactor the auth module',
+    );
+  });
+
+  it('does not read the body when the content kind is not prompt', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'prompt.submitted',
+      'otelhook.content.kind': 'response',
+    };
+    expect(extractPromptText(attrs, 'otelhook.prompt.submitted', 'not a prompt')).toBeNull();
+  });
+
+  it('does not read the body for a different event type', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'generation.end',
+      'otelhook.content.kind': 'prompt',
+    };
+    expect(extractPromptText(attrs, 'otelhook.generation.end', 'irrelevant text')).toBeNull();
+  });
+
+  it('withholds the body when otelhook.content.withheld is set', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'prompt.submitted',
+      'otelhook.content.kind': 'prompt',
+      'otelhook.content.withheld': 'privacy-policy',
+    };
+    expect(extractPromptText(attrs, 'otelhook.prompt.submitted', 'should not appear')).toBeNull();
+  });
+
+  it('returns null when there is no body text at all', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'prompt.submitted',
+      'otelhook.content.kind': 'prompt',
+    };
+    expect(extractPromptText(attrs, 'otelhook.prompt.submitted', null)).toBeNull();
+  });
+
+  it('is case-insensitive on event type and content kind', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'Prompt.Submitted',
+      'otelhook.content.kind': 'Prompt',
+    };
+    expect(extractPromptText(attrs, undefined, 'hello there')).toBe('hello there');
+  });
+});

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -69,7 +69,7 @@ function decodeOtlpProtobufJson(
   }
 }
 
-interface AttrMap {
+export interface AttrMap {
   [key: string]: string | number | boolean;
 }
 
@@ -281,7 +281,7 @@ async function resolveSlotByWorkspace(workspace: string): Promise<{
   };
 }
 
-interface ResolvedSessionContext {
+export interface ResolvedSessionContext {
   repositoryId: string;
   sessionKey: string;
   agentId: number;
@@ -353,7 +353,54 @@ async function defaultAgentIdForRepo(repositoryId: string): Promise<number> {
   return active?.slotId ?? 1;
 }
 
-async function resolveSessionContext(
+interface ActiveSlotAttribution {
+  agentId: number;
+  workDir?: string;
+  branch?: string;
+  suffix?: string;
+  workUnitId?: string;
+  attemptId?: string;
+}
+
+/**
+ * The repo's one active slot, when there is exactly one.
+ *
+ * Cursor's OTEL workspace is the main checkout, not a HAR session worktree —
+ * `resolveSlotByWorkspace` only matches a slot's own workDir/worktreePath, so
+ * activity from Cursor running against the main checkout never correlates to
+ * the worktree an agent is actually working in. When a repo has exactly one
+ * active slot, that correlation is unambiguous; two or more active slots make
+ * a guess as likely wrong as right, so this returns null and callers keep
+ * attributing to the raw workspace path instead.
+ */
+async function resolveUnambiguousActiveSlot(
+  repositoryId: string,
+): Promise<ActiveSlotAttribution | null> {
+  const active = await prisma.agentSlot.findMany({
+    where: { repositoryId, active: true },
+    select: {
+      slotId: true,
+      workDir: true,
+      worktreePath: true,
+      branch: true,
+      suffix: true,
+      workUnitId: true,
+      attemptId: true,
+    },
+  });
+  if (active.length !== 1) return null;
+  const slot = active[0];
+  return {
+    agentId: slot.slotId,
+    workDir: slot.workDir ?? slot.worktreePath ?? undefined,
+    branch: slot.branch ?? undefined,
+    suffix: slot.suffix ?? undefined,
+    workUnitId: slot.workUnitId ?? undefined,
+    attemptId: slot.attemptId ?? undefined,
+  };
+}
+
+export async function resolveSessionContext(
   resource: AttrMap,
   attributes: AttrMap = {},
 ): Promise<{ context: ResolvedSessionContext | null; reason?: string }> {
@@ -392,22 +439,30 @@ async function resolveSessionContext(
 
     const byRepo = await resolveRepositoryByWorkspacePath(workspace);
     if (byRepo) {
+      const activeSlot = await resolveUnambiguousActiveSlot(byRepo.repositoryId);
       return {
         context: {
           repositoryId: byRepo.repositoryId,
           sessionKey:
             harSessionKey || providerSessionId || `ide:${normalizePath(byRepo.path)}`,
-          agentId: explicitAgentId ?? (await defaultAgentIdForRepo(byRepo.repositoryId)),
+          agentId:
+            explicitAgentId ??
+            activeSlot?.agentId ??
+            (await defaultAgentIdForRepo(byRepo.repositoryId)),
           agentTool: tool ?? 'cursor',
-          workDir: workspace,
-          branch: resource['har.branch'] ? String(resource['har.branch']) : undefined,
-          suffix: resource['har.suffix'] ? String(resource['har.suffix']) : undefined,
-          workUnitId: resource['har.work_unit_id']
-            ? String(resource['har.work_unit_id'])
-            : undefined,
-          attemptId: resource['har.attempt_id']
-            ? String(resource['har.attempt_id'])
-            : undefined,
+          workDir: activeSlot?.workDir ?? workspace,
+          branch:
+            activeSlot?.branch ??
+            (resource['har.branch'] ? String(resource['har.branch']) : undefined),
+          suffix:
+            activeSlot?.suffix ??
+            (resource['har.suffix'] ? String(resource['har.suffix']) : undefined),
+          workUnitId:
+            activeSlot?.workUnitId ??
+            (resource['har.work_unit_id'] ? String(resource['har.work_unit_id']) : undefined),
+          attemptId:
+            activeSlot?.attemptId ??
+            (resource['har.attempt_id'] ? String(resource['har.attempt_id']) : undefined),
         },
       };
     }
@@ -416,16 +471,26 @@ async function resolveSessionContext(
   if (workspaceId) {
     const byId = await resolveRepositoryByWorkspaceId(workspaceId);
     if (byId) {
+      const activeSlot = await resolveUnambiguousActiveSlot(byId.repositoryId);
       return {
         context: {
           repositoryId: byId.repositoryId,
           sessionKey:
             harSessionKey || providerSessionId || `ide:${normalizePath(byId.path)}`,
-          agentId: explicitAgentId ?? (await defaultAgentIdForRepo(byId.repositoryId)),
+          agentId:
+            explicitAgentId ??
+            activeSlot?.agentId ??
+            (await defaultAgentIdForRepo(byId.repositoryId)),
           agentTool: tool ?? 'cursor',
-          workDir: byId.matchedPath,
-          branch: resource['har.branch'] ? String(resource['har.branch']) : undefined,
-          suffix: resource['har.suffix'] ? String(resource['har.suffix']) : undefined,
+          workDir: activeSlot?.workDir ?? byId.matchedPath,
+          branch:
+            activeSlot?.branch ??
+            (resource['har.branch'] ? String(resource['har.branch']) : undefined),
+          suffix:
+            activeSlot?.suffix ??
+            (resource['har.suffix'] ? String(resource['har.suffix']) : undefined),
+          workUnitId: activeSlot?.workUnitId,
+          attemptId: activeSlot?.attemptId,
         },
       };
     }
@@ -507,7 +572,7 @@ function textFromGenAiMessages(raw: string): string | null {
   }
 }
 
-function extractPromptText(attributes: AttrMap, eventName?: string, bodyText?: string | null): string | null {
+export function extractPromptText(attributes: AttrMap, eventName?: string, bodyText?: string | null): string | null {
   const keys = [
     'gen_ai.client.prompt.text',
     'gen_ai.prompt.0.content',
@@ -529,6 +594,22 @@ function extractPromptText(attributes: AttrMap, eventName?: string, bodyText?: s
     (hookEvent.includes('userprompt') ||
       hookEvent.includes('beforesubmitprompt') ||
       hookEvent.includes('user_prompt')) &&
+    bodyText?.trim()
+  ) {
+    return bodyText.trim();
+  }
+  // @osfactory/otel-hook canonical log mapping: one record per content fact,
+  // `otelhook.event.type` names the canonical event and `otelhook.content.kind`
+  // names the fact. A withheld body (`otelhook.content.withheld` set) carries no
+  // `body` — the record states *why* rather than leaving an ambiguous absence, so
+  // it must not be read as an empty prompt.
+  const otelHookEventType = String(attributes['otelhook.event.type'] ?? '').toLowerCase();
+  const otelHookContentKind = String(attributes['otelhook.content.kind'] ?? '').toLowerCase();
+  const otelHookWithheld = attributes['otelhook.content.withheld'];
+  if (
+    otelHookEventType === 'prompt.submitted' &&
+    otelHookContentKind === 'prompt' &&
+    !otelHookWithheld &&
     bodyText?.trim()
   ) {
     return bodyText.trim();

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/schemas",
-  "version": "0.32.2",
+  "version": "0.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "0.32.2",
+      "version": "0.33.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import type { Argv } from 'yargs';
 import { getControlApiUrl } from '../../core/control-config';
-import { isControlApiReachable } from '../../core/control-sync';
+import { ensureRepoRegisteredWithControl, isControlApiReachable } from '../../core/control-sync';
 import { resolveHarnessRoot } from '../../harness/manifest';
 import {
   disableOtelHooksExport,
@@ -98,6 +98,7 @@ async function handleOn(argv: { prompts: boolean }): Promise<void> {
   if (hooks.message) success(hooks.message);
   if (hooks.warning) warn(hooks.warning);
   if (result.otelReady) {
+    await ensureRepoRegisteredWithControl(process.cwd(), result.apiUrl);
     info(`OTLP ingest: ${result.apiUrl.replace(/\/$/, '')}/api/otel`);
     info('Usage appears under Mission Control → Worktrees / Usage. Disable: har telemetry off');
   }
@@ -203,6 +204,9 @@ async function handleInstallHooks(): Promise<void> {
   const result = await ensureTelemetryInfrastructure({ startIfNeeded: true });
   if (result.message) success(result.message);
   if (result.warning) warn(result.warning);
+  if (result.otelReady) {
+    await ensureRepoRegisteredWithControl(process.cwd(), result.apiUrl);
+  }
   const hooks = ensureOtelHooks({ setupAgents: true });
   if (hooks.ok) {
     success(hooks.message ?? '@osfactory/otel-hook installed and agents registered');

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -19,7 +19,11 @@ import {
   isControlEnabled,
   PortalTarget,
 } from './control-config';
-import { listRegisteredRepos, removeRegisteredRepo } from './control-registry';
+import {
+  listRegisteredRepos,
+  recordRepoForControlSync,
+  removeRegisteredRepo,
+} from './control-registry';
 import { readPortalCredentials } from './portal-credentials';
 import { canonicalizeControlRepoPath } from './control-repo-path';
 import { collectEnvironmentStatus } from './slot-status';
@@ -388,6 +392,27 @@ export async function registerRepoWithControl(
   }
 
   return (await response.json()) as { id: string };
+}
+
+/**
+ * Best-effort: record the repo in the local registry and register it with
+ * Mission Control immediately, so OTLP ingest (otel-hook) can resolve
+ * workspace → repo/slot without waiting for the next `har control sync` or
+ * `har env launch`. Never throws — callers run this alongside telemetry
+ * enablement, which must not fail just because registration did.
+ */
+export async function ensureRepoRegisteredWithControl(
+  repoPath: string,
+  apiUrl?: string,
+): Promise<void> {
+  const canonical = canonicalizeControlRepoPath(repoPath);
+  recordRepoForControlSync(canonical);
+  try {
+    await registerRepoWithControl({ repoPath: canonical, apiUrl });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[har control] repo registration skipped: ${message}\n`);
+  }
 }
 
 async function syncRepoWithLocalControl(

--- a/src/core/onboarding.ts
+++ b/src/core/onboarding.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { addPlugin, initHarness } from './harness';
 import { startControlAndSync } from './control-lifecycle';
 import { getControlApiUrl } from './control-config';
-import { isControlApiReachable } from './control-sync';
+import { ensureRepoRegisteredWithControl, isControlApiReachable } from './control-sync';
 import { recordRepoForControlSync } from './control-registry';
 import {
   disableOtelHooksExport,
@@ -180,7 +180,7 @@ export async function applyOnboardingTelemetry(
   }
 }
 
-async function defaultEnsureControl(options: {
+export async function defaultEnsureControl(options: {
   startControl: boolean;
   telemetry: TelemetryChoice;
   cwd: string;
@@ -200,6 +200,9 @@ async function defaultEnsureControl(options: {
             'Telemetry is on but Mission Control is not running. Start later with: har control up',
         };
       }
+      // MC is already reachable — register now so OTLP ingest from otel-hook
+      // doesn't drop events waiting for the next sync.
+      await ensureRepoRegisteredWithControl(options.cwd, apiUrl);
     }
     return { started: false, apiUrl };
   }
@@ -208,6 +211,9 @@ async function defaultEnsureControl(options: {
     const ensured = await ensureTelemetryInfrastructure({ startIfNeeded: true });
     if (ensured.message) success(ensured.message);
     if (ensured.warning) warn(ensured.warning);
+    if (ensured.reachable) {
+      await ensureRepoRegisteredWithControl(options.cwd, ensured.apiUrl);
+    }
     return {
       started: ensured.started || ensured.reachable,
       apiUrl: ensured.apiUrl,

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -16,7 +16,7 @@ work around it with ad-hoc commands.
 ## Before making changes
 
 1. **On the main checkout, switch to the intended base** (usually `main`) — every launch creates a worktree from that HEAD. `--replace` does not select the base.
-2. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP) or `har env launch 1`. Launch always creates a **fresh session worktree** and returns its **work dir**.
+2. **Launch your slot FIRST — before editing any file.** Use `har_launch_environment` with `agentId: 1` (MCP) or `har env launch 1`. Launch always creates a **fresh session worktree** and returns its **work dir**. If the task binds to a durable external work item (a GitHub issue, a Linear ticket, a task from the user's tracker), pass `workUnitId` + `title` on launch (`har_launch_environment` `workUnitId`/`title`, or CLI `--work-id`/`--work-title`) so Mission Control attributes usage and events to that work item instead of leaving them session-only.
 3. **Make ALL file edits under the returned work dir — never in the main checkout.** The work dir looks like `~/worktrees/<base-branch>-<sha4>-har-agent-<id>-<rand4>` (recorded in `.har/slots/agent-<id>.json`). Edits there hot-reload in the running slot; use `har env restart <id>` or `./.har/agent-cli.sh <id> restart` if a change doesn't take.
 4. Read [AGENT.md](./AGENT.md) at the repo root
 5. Read [.har/README.md](./.har/README.md) and [.har/stages.json](./.har/stages.json)

--- a/tests/control-sync-register.test.ts
+++ b/tests/control-sync-register.test.ts
@@ -1,0 +1,73 @@
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => ({ profile: 'cli' }),
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
+
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ensureRepoRegisteredWithControl } from '../src/core/control-sync';
+import { listRegisteredRepos } from '../src/core/control-registry';
+
+const realFetch = global.fetch;
+
+describe('ensureRepoRegisteredWithControl', () => {
+  let registryPath: string;
+  let repoPath: string;
+
+  beforeEach(() => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-registry-'));
+    registryPath = path.join(tmpDir, 'repos.json');
+    repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-registry-repo-'));
+    process.env.HAR_CONTROL_REGISTRY_PATH = registryPath;
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_CONTROL_REGISTRY_PATH;
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+    fs.rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it('records the repo locally and registers it with Mission Control', async () => {
+    const posted: unknown[] = [];
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith('/api/repos') && init?.method === 'POST') {
+        posted.push(JSON.parse(String(init.body)));
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: async () => '',
+          json: async () => ({ id: 'repo-1' }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await ensureRepoRegisteredWithControl(repoPath, 'http://127.0.0.1:3847');
+
+    expect(listRegisteredRepos()).toEqual([repoPath]);
+    expect(posted).toEqual([expect.objectContaining({ path: repoPath })]);
+  });
+
+  it('does not throw when Mission Control registration fails', async () => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'boom',
+      json: async () => ({}),
+    }));
+
+    await expect(
+      ensureRepoRegisteredWithControl(repoPath, 'http://127.0.0.1:3847'),
+    ).resolves.toBeUndefined();
+
+    // Local registry write still happens even when the API call fails.
+    expect(listRegisteredRepos()).toEqual([repoPath]);
+  });
+});

--- a/tests/onboarding-ensure-control.test.ts
+++ b/tests/onboarding-ensure-control.test.ts
@@ -1,0 +1,78 @@
+const ensureTelemetryInfrastructure = jest.fn();
+const ensureRepoRegisteredWithControl = jest.fn();
+const isControlApiReachable = jest.fn();
+const startControlAndSync = jest.fn();
+
+jest.mock('../src/core/control-config', () => ({
+  getControlApiUrl: () => 'http://127.0.0.1:3847',
+}));
+jest.mock('../src/core/telemetry-ensure', () => ({
+  ensureTelemetryInfrastructure: (...args: unknown[]) => ensureTelemetryInfrastructure(...args),
+}));
+jest.mock('../src/core/control-sync', () => ({
+  isControlApiReachable: (...args: unknown[]) => isControlApiReachable(...args),
+  ensureRepoRegisteredWithControl: (...args: unknown[]) => ensureRepoRegisteredWithControl(...args),
+}));
+jest.mock('../src/core/control-lifecycle', () => ({
+  startControlAndSync: (...args: unknown[]) => startControlAndSync(...args),
+}));
+
+import { defaultEnsureControl } from '../src/core/onboarding';
+
+describe('defaultEnsureControl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers the repo with Mission Control once telemetry brings it up reachable', async () => {
+    ensureTelemetryInfrastructure.mockResolvedValue({
+      started: true,
+      reachable: true,
+      apiUrl: 'http://127.0.0.1:3847',
+    });
+
+    const result = await defaultEnsureControl({
+      startControl: true,
+      telemetry: 'on',
+      cwd: '/repos/demo',
+    });
+
+    expect(result.started).toBe(true);
+    expect(ensureRepoRegisteredWithControl).toHaveBeenCalledWith(
+      '/repos/demo',
+      'http://127.0.0.1:3847',
+    );
+  });
+
+  it('does not register when Mission Control never becomes reachable', async () => {
+    ensureTelemetryInfrastructure.mockResolvedValue({
+      started: false,
+      reachable: false,
+      apiUrl: 'http://127.0.0.1:3847',
+      warning: 'not reachable',
+    });
+
+    await defaultEnsureControl({ startControl: true, telemetry: 'on', cwd: '/repos/demo' });
+
+    expect(ensureRepoRegisteredWithControl).not.toHaveBeenCalled();
+  });
+
+  it('registers when Mission Control was already running and startControl is skipped', async () => {
+    ensureTelemetryInfrastructure.mockResolvedValue({ started: false, reachable: false });
+    isControlApiReachable.mockResolvedValue(true);
+
+    await defaultEnsureControl({ startControl: false, telemetry: 'on', cwd: '/repos/demo' });
+
+    expect(ensureRepoRegisteredWithControl).toHaveBeenCalledWith(
+      '/repos/demo',
+      'http://127.0.0.1:3847',
+    );
+  });
+
+  it('skips registration entirely when telemetry is off', async () => {
+    await defaultEnsureControl({ startControl: false, telemetry: 'off', cwd: '/repos/demo' });
+
+    expect(ensureTelemetryInfrastructure).not.toHaveBeenCalled();
+    expect(ensureRepoRegisteredWithControl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **#115** — Auto-register repositories with Mission Control when telemetry is enabled (`har telemetry on`, onboarding)
- **#113** — Extract prompt text from `@osfactory/otel-hook` `prompt.submitted` logs so Mission Control can derive slot `purpose`
- **#114** — Document `workUnitId` / `--work-id` binding in the Cursor rule template
- **#116** — Prefer attributing Cursor IDE OTEL on the main checkout to the sole active HAR worktree slot when unambiguous

Closes #113, #114, #115, #116.

## Test plan

- [x] `har env verify 3 --full` (commit gate passed)
- [x] New tests: `otel-ingest.test.ts`, `otel-ingest-session-context.test.ts`, `control-sync-register.test.ts`, `onboarding-ensure-control.test.ts`
- [x] Control vitest suite for otel-ingest modules

Made with [Cursor](https://cursor.com)