### PR TITLE
chore(telemetry): pin @osfactory/otel-hook to 0.1.2

### DIFF
--- a/src/core/otel-hooks.ts
+++ b/src/core/otel-hooks.ts
@@ -6,7 +6,7 @@ import { getControlApiUrl } from './control-config';
 import { getTelemetrySignals, isTelemetryEnabled } from './telemetry-config';
 
 /** Pinned npm package for reproducible installs (replaces Python opentelemetry-hooks). */
-export const OTEL_HOOKS_PACKAGE = '@osfactory/otel-hook@0.1.1';
+export const OTEL_HOOKS_PACKAGE = '@osfactory/otel-hook@0.1.2';
 
 /** Providers HAR registers with `otel-hook setup --provider`. */
 export const OTEL_HOOKS_PROVIDERS = [


### PR DESCRIPTION
## Summary

Bump the HAR-managed `@osfactory/otel-hook` install pin from `0.1.1` to `0.1.2`, which includes the Cursor `beforeSubmitPrompt` `session_id` fallback fix (os-factory/otel-hook#33).

## Test plan

- [x] `har env verify 3 --full`
- [x] `npm test -- --testPathPattern=telemetry`

Made with [Cursor](https://cursor.com)