### PR TITLE
feat(harness): improve invalid slot errors and raise max slots to 5

### DIFF
--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -53,12 +53,18 @@ validate_agent_id() {
   fi
 
   if [[ -z "$id" ]] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
-    echo "Error: agent-id must be a positive integer between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id:-"(missing)"}" >&2
+    echo "  Must be an integer between ${min} and ${max} (see .har/stages.json → agentSlots)" >&2
     exit 1
   fi
 
   if (( id < min || id > max )); then
-    echo "Error: agent-id must be between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id}" >&2
+    echo "  Valid slots: ${min}–${max} (configured in .har/stages.json → agentSlots)" >&2
+    echo "  Run: har env status   # see which slots are in use" >&2
+    if (( id > max )); then
+      echo "  To allow slot ${id}, raise agentSlots.max in .har/stages.json." >&2
+    fi
     exit 1
   fi
 }

--- a/.har/harness.env
+++ b/.har/harness.env
@@ -15,7 +15,7 @@ export HARNESS_DB_PORT_SCAN_START=15432
 export HARNESS_DB_PORT_SCAN_END=15499
 
 export HARNESS_AGENT_SLOT_MIN=1
-export HARNESS_AGENT_SLOT_MAX=3
+export HARNESS_AGENT_SLOT_MAX=5
 
 # Toolchain provisioning — launch writes resolved paths into .env.agent.<id>
 # Ecosystem: auto (detect from manifests) | node | python | go | rust | java | ruby | none

--- a/.har/stages.json
+++ b/.har/stages.json
@@ -2,7 +2,7 @@
   "version": "1",
   "agentSlots": {
     "min": 1,
-    "max": 3
+    "max": 5
   },
   "verificationStages": [
     "docs-drift"

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -53,12 +53,18 @@ validate_agent_id() {
   fi
 
   if [[ -z "$id" ]] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
-    echo "Error: agent-id must be a positive integer between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id:-"(missing)"}" >&2
+    echo "  Must be an integer between ${min} and ${max} (see .har/stages.json → agentSlots)" >&2
     exit 1
   fi
 
   if (( id < min || id > max )); then
-    echo "Error: agent-id must be between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id}" >&2
+    echo "  Valid slots: ${min}–${max} (configured in .har/stages.json → agentSlots)" >&2
+    echo "  Run: har env status   # see which slots are in use" >&2
+    if (( id > max )); then
+      echo "  To allow slot ${id}, raise agentSlots.max in .har/stages.json." >&2
+    fi
     exit 1
   fi
 }

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -53,12 +53,18 @@ validate_agent_id() {
   fi
 
   if [[ -z "$id" ]] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
-    echo "Error: agent-id must be a positive integer between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id:-"(missing)"}" >&2
+    echo "  Must be an integer between ${min} and ${max} (see .har/stages.json → agentSlots)" >&2
     exit 1
   fi
 
   if (( id < min || id > max )); then
-    echo "Error: agent-id must be between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id}" >&2
+    echo "  Valid slots: ${min}–${max} (configured in .har/stages.json → agentSlots)" >&2
+    echo "  Run: har env status   # see which slots are in use" >&2
+    if (( id > max )); then
+      echo "  To allow slot ${id}, raise agentSlots.max in .har/stages.json." >&2
+    fi
     exit 1
   fi
 }

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -53,12 +53,18 @@ validate_agent_id() {
   fi
 
   if [[ -z "$id" ]] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
-    echo "Error: agent-id must be a positive integer between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id:-"(missing)"}" >&2
+    echo "  Must be an integer between ${min} and ${max} (see .har/stages.json → agentSlots)" >&2
     exit 1
   fi
 
   if (( id < min || id > max )); then
-    echo "Error: agent-id must be between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id}" >&2
+    echo "  Valid slots: ${min}–${max} (configured in .har/stages.json → agentSlots)" >&2
+    echo "  Run: har env status   # see which slots are in use" >&2
+    if (( id > max )); then
+      echo "  To allow slot ${id}, raise agentSlots.max in .har/stages.json." >&2
+    fi
     exit 1
   fi
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -24,11 +24,33 @@ export function requireHarnessDir(repoPath: string): string {
   return harnessDir;
 }
 
+export function formatInvalidAgentIdError(
+  id: unknown,
+  range: { min: number; max: number },
+): string {
+  const idLabel =
+    id === undefined || id === null || id === ''
+      ? '(missing)'
+      : typeof id === 'string'
+        ? id
+        : String(id);
+  const lines = [
+    `Invalid agent slot id: ${idLabel}`,
+    `Valid slots: ${range.min}–${range.max} (configured in .har/stages.json → agentSlots)`,
+    'Run `har env status` to see which slots are in use.',
+  ];
+  const num = Number(id);
+  if (Number.isInteger(num) && num > range.max) {
+    lines.push(`To allow slot ${num}, raise agentSlots.max in .har/stages.json.`);
+  }
+  return lines.join('\n');
+}
+
 export function validateAgentId(id: unknown, repoPath: string): number {
   const num = Number(id);
   const range = getAgentSlotRange(repoPath);
   if (!Number.isInteger(num) || num < range.min || num > range.max) {
-    throw new Error(`agent-id must be a number between ${range.min} and ${range.max}`);
+    throw new Error(formatInvalidAgentIdError(id, range));
   }
   return num;
 }

--- a/tests/agent-slots.test.ts
+++ b/tests/agent-slots.test.ts
@@ -6,10 +6,19 @@ import {
   getAgentSlotRange,
   syncAgentSlotsToHarnessEnv,
 } from '../src/harness/stages';
-import { validateAgentId } from '../src/utils/validation';
+import { formatInvalidAgentIdError, validateAgentId } from '../src/utils/validation';
 import { compareHarnessToTemplate } from '../src/harness/drift';
 
 describe('agent slot limits', () => {
+  it('formatInvalidAgentIdError explains out-of-range slots', () => {
+    const msg = formatInvalidAgentIdError(4, { min: 1, max: 3 });
+    expect(msg).toContain('Invalid agent slot id: 4');
+    expect(msg).toContain('Valid slots: 1–3');
+    expect(msg).toContain('agentSlots');
+    expect(msg).toContain('har env status');
+    expect(msg).toContain('raise agentSlots.max');
+  });
+
   it('uses agentSlots from stages.json', () => {
     const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slots-'));
     fs.mkdirSync(path.join(repoPath, '.har'), { recursive: true });
@@ -20,7 +29,9 @@ describe('agent slot limits', () => {
 
     expect(getAgentSlotRange(repoPath)).toEqual({ min: 1, max: 12 });
     expect(validateAgentId(12, repoPath)).toBe(12);
-    expect(() => validateAgentId(13, repoPath)).toThrow('agent-id must be a number between 1 and 12');
+    expect(() => validateAgentId(13, repoPath)).toThrow(
+      formatInvalidAgentIdError(13, { min: 1, max: 12 }),
+    );
   });
 
   it('falls back to harness.env when stages.json has no agentSlots', () => {
@@ -34,7 +45,9 @@ describe('agent slot limits', () => {
 
     expect(getAgentSlotRange(repoPath)).toEqual({ min: 2, max: 8 });
     expect(validateAgentId(2, repoPath)).toBe(2);
-    expect(() => validateAgentId(1, repoPath)).toThrow('agent-id must be a number between 2 and 8');
+    expect(() => validateAgentId(1, repoPath)).toThrow(
+      formatInvalidAgentIdError(1, { min: 2, max: 8 }),
+    );
   });
 
   it('detects mismatch between stages.json and harness.env', () => {

--- a/tests/fixtures/minimal-harness/.har/agent-slot.sh
+++ b/tests/fixtures/minimal-harness/.har/agent-slot.sh
@@ -34,12 +34,18 @@ validate_agent_id() {
   fi
 
   if [[ -z "$id" ]] || ! [[ "$id" =~ ^[0-9]+$ ]]; then
-    echo "Error: agent-id must be a positive integer between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id:-"(missing)"}" >&2
+    echo "  Must be an integer between ${min} and ${max} (see .har/stages.json → agentSlots)" >&2
     exit 1
   fi
 
   if (( id < min || id > max )); then
-    echo "Error: agent-id must be between ${min} and ${max}" >&2
+    echo "Error: invalid agent slot id: ${id}" >&2
+    echo "  Valid slots: ${min}–${max} (configured in .har/stages.json → agentSlots)" >&2
+    echo "  Run: har env status   # see which slots are in use" >&2
+    if (( id > max )); then
+      echo "  To allow slot ${id}, raise agentSlots.max in .har/stages.json." >&2
+    fi
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary
- Replace the terse `agent-id must be a number between X and Y` error with actionable guidance: shows the invalid id, valid range, how to check slot status, and how to raise `agentSlots.max`
- Apply the same messaging to bash fallbacks (`agent-slot.sh`) in this repo and boilerplate templates
- Increase this repository's agent slot limit from 3 to 5 (`.har/stages.json` + synced `harness.env`)

## Test plan
- [x] `har env verify 2 --full` passes
- [x] `tests/agent-slots.test.ts` covers `formatInvalidAgentIdError`
- [x] `har env status` shows slots 4–5 as available
- [ ] `har env launch 4` succeeds after merge


Made with [Cursor](https://cursor.com)