### PR TITLE
feat(control): detect repos from the registry only and auto-register on any command

### DIFF
--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -34,7 +34,6 @@ import { collectEnvironmentStatus } from '../../core/slot-status';
 import { handleCommitGateOnboarding } from '../../core/commit-gate-onboarding';
 import { readOnboardingPreferences } from '../../core/onboarding-preferences';
 import { EnvironmentStatusSchema, SlotReadinessSchema } from '../../harness/schema';
-import { recordRepoForControlSync } from '../../core/control-registry';
 import { writeFileSafe } from '../../utils/file-ops';
 import { requireApiKey, validateAgentId } from '../../utils/validation';
 import { info, success, error, header, divider, warn } from '../../utils/logging';
@@ -469,7 +468,6 @@ export async function handleInit(argv: {
 
     divider();
     success('Harness initialized!');
-    recordRepoForControlSync(repoPath);
     await handleCommitGateOnboarding({
       repoPath,
       ...onboarding.commitGate,

--- a/src/core/control-registry.ts
+++ b/src/core/control-registry.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { readManifest } from '../harness/manifest';
-import { canonicalizeControlRepoPath } from './control-repo-path';
+import { canonicalizeControlRepoPath, resolveMainWorkingTree } from './control-repo-path';
 
 interface ControlRegistry {
   repos: string[];
@@ -41,6 +41,7 @@ export function recordRepoForControlSync(repoPath: string): void {
   if (process.env.HAR_CONTROL_DISABLED === 'true') return;
 
   const resolved = canonicalizeControlRepoPath(repoPath);
+  if (!resolveMainWorkingTree(resolved)) return;
   if (!readManifest(resolved)) return;
 
   const registry = readRegistry();

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -273,34 +273,21 @@ export interface SyncRepoResult {
 }
 
 /**
- * Every har repo Mission Control knows about: the local registry, an optional
- * cwd, and whatever the portal/control API already tracks — all manifest-gated
- * and canonicalized. Shared by the all-repos auto-sync and the interactive
- * `har control sync` selection.
+ * Every har repo known locally: the control registry (`~/.har/repos.json`) plus
+ * an optional cwd — both manifest-gated and canonicalized. Detection is registry
+ * only; it neither scans the filesystem nor depends on portal/control API state.
+ * Shared by the all-repos auto-sync and the interactive `har control sync`
+ * selection.
  */
 export async function discoverHarRepos(options?: {
   apiUrl?: string;
   cwd?: string;
 }): Promise<string[]> {
-  const apiUrl = options?.apiUrl ?? getControlApiUrl();
   const repoPaths = new Set<string>(listRegisteredRepos());
 
   if (options?.cwd) {
     const cwd = canonicalizeControlRepoPath(options.cwd);
     if (readManifest(cwd)) repoPaths.add(cwd);
-  }
-
-  try {
-    const listResponse = await fetch(`${apiUrl}/api/repos`);
-    if (listResponse.ok) {
-      const repos = (await listResponse.json()) as { path: string }[];
-      for (const repo of repos) {
-        const resolved = canonicalizeControlRepoPath(repo.path);
-        if (readManifest(resolved)) repoPaths.add(resolved);
-      }
-    }
-  } catch {
-    // Best-effort — registry + cwd repos are enough for first sync.
   }
 
   return [...repoPaths];
@@ -621,6 +608,8 @@ export async function syncRepoWithControlAsync(repoPath: string): Promise<void> 
 
   const verbose = process.env.HAR_CONTROL_VERBOSE === 'true';
   try {
+    recordRepoForControlSync(repoPath);
+
     const apiUrl = getControlApiUrl();
     if (!(await isControlApiReachable(apiUrl))) {
       if (verbose) {

--- a/src/core/onboarding.ts
+++ b/src/core/onboarding.ts
@@ -3,7 +3,6 @@ import { addPlugin, initHarness } from './harness';
 import { startControlAndSync } from './control-lifecycle';
 import { getControlApiUrl } from './control-config';
 import { ensureRepoRegisteredWithControl, isControlApiReachable } from './control-sync';
-import { recordRepoForControlSync } from './control-registry';
 import {
   disableOtelHooksExport,
   ensureOtelHooks,
@@ -278,7 +277,6 @@ export async function runOnboarding(
       warn('Harness has validation errors — review .har/ after adaptation.');
     }
     harnessInitialized = true;
-    recordRepoForControlSync(repoPath);
     success('Harness scaffolded');
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,7 +7,6 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { describeProject, initHarness } from '../core/harness';
-import { recordRepoForControlSync } from '../core/control-registry';
 import { startControlAndSync } from '../core/control-lifecycle';
 import { getHarPackageVersion } from '../core/package-version';
 import { ensureDefaultTelemetryPreference } from '../core/telemetry-config';
@@ -285,7 +284,6 @@ export async function handleMcpToolCall(
         smoke: input.smoke,
         profile: input.profile,
       });
-      recordRepoForControlSync(repo);
       return jsonContent({
         harnessDir: result.harnessDir,
         validation: result.validation,

--- a/tests/control-discover-repos.test.ts
+++ b/tests/control-discover-repos.test.ts
@@ -1,0 +1,38 @@
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+  resolveMainWorkingTree: (p: string) => p,
+}));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => ({ version: '1' }),
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/core/control-registry', () => ({
+  listRegisteredRepos: jest.fn(() => ['/repos/a', '/repos/b']),
+  recordRepoForControlSync: jest.fn(),
+  removeRegisteredRepo: jest.fn(),
+}));
+
+import { discoverHarRepos } from '../src/core/control-sync';
+
+const realFetch = global.fetch;
+
+describe('discoverHarRepos', () => {
+  beforeEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn();
+  });
+  afterEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  it('returns the registry entries without any network call', async () => {
+    const repos = await discoverHarRepos();
+    expect(repos).toEqual(['/repos/a', '/repos/b']);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('adds the optional cwd when it has a manifest, still without a network call', async () => {
+    const repos = await discoverHarRepos({ cwd: '/repos/c' });
+    expect(repos).toEqual(['/repos/a', '/repos/b', '/repos/c']);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/control-registry.test.ts
+++ b/tests/control-registry.test.ts
@@ -46,6 +46,21 @@ describe('control registry', () => {
     expect(listRegisteredRepos()).toEqual([]);
   });
 
+  it('ignores a manifest that is not inside a git repo', () => {
+    const nonGit = fs.mkdtempSync(path.join(os.tmpdir(), 'har-non-git-'));
+    fs.mkdirSync(path.join(nonGit, '.har'), { recursive: true });
+    fs.copyFileSync(
+      path.join(FIXTURE, '.har', 'manifest.json'),
+      path.join(nonGit, '.har', 'manifest.json'),
+    );
+    try {
+      recordRepoForControlSync(nonGit);
+      expect(listRegisteredRepos()).toEqual([]);
+    } finally {
+      fs.rmSync(nonGit, { recursive: true, force: true });
+    }
+  });
+
   it('does not write when HAR_CONTROL_DISABLED is set', () => {
     process.env.HAR_CONTROL_DISABLED = 'true';
     recordRepoForControlSync(FIXTURE);

--- a/tests/control-sync-register.test.ts
+++ b/tests/control-sync-register.test.ts
@@ -1,5 +1,6 @@
 jest.mock('../src/core/control-repo-path', () => ({
   canonicalizeControlRepoPath: (p: string) => p,
+  resolveMainWorkingTree: (p: string) => p,
 }));
 jest.mock('../src/harness/manifest', () => ({
   readManifest: () => ({ profile: 'cli' }),


### PR DESCRIPTION
## What

Make the set of known local har projects derive from the control registry (`~/.har/repos.json`) alone, and register repos automatically as har commands run — no explicit register step, no machine scan, no dependence on server state.

- **Detection = registry only.** `discoverHarRepos()` now resolves projects from the registry plus an optional `cwd` (both manifest-gated + canonicalized). Dropped the `/api/repos` merge, so "which projects exist locally" no longer depends on portal/control server state.
- **Auto-register on any command.** Registration piggybacks on the per-repo auto-sync hook (`syncRepoWithControlAsync`) — placed before the reachability check, so a command run in a manifest-gated git repo registers the repo even when Mission Control is offline. Removed the init-time `recordRepoForControlSync` calls previously wired into individual commands (`env init`, onboarding scaffold, MCP `init_harness`); the explicit `har control register` stays.
- **Git gate.** `recordRepoForControlSync` now requires a git repo (via `resolveMainWorkingTree`) in addition to the existing manifest guard, so a manifest sitting outside a git repo is never registered.

## Why

Detection pulled from three sources (registry + cwd + `/api/repos`) and registration only fired from three commands, so a repo you only ever `verify` in was never known, while server-tracked repos leaked into local detection. Init-time registration also accumulated stale temp-dir entries in the registry.

## Test plan

- `npm run typecheck` ✓ · `npm run lint` ✓
- `npm test` — added specs pass: registry-only discovery makes no network call; a manifest outside a git repo is not registered. (Pre-existing `/private`-symlink flakes in `control-repo-path`/`hooks`/`slot-registry` are unrelated and also red on `main`.)
- Verified live: running `env verify` in a real repo auto-registers it; `control sync` lists/derives from the registry only and prunes vanished entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)