### PR TITLE
feat(onboard): ask how many agents to run in parallel

### DIFF
--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -8,7 +8,8 @@ All repository commands accept `--repo <path>`; the default is the current direc
 ## `har onboard`
 
 Interactive first-run guide: how HAR works, telemetry, Mission Control, plugins,
-then the adaptation prompt (clipboard + `.har/ADAPT-PROMPT.md`).
+parallel agent slot capacity, then the adaptation prompt (clipboard +
+`.har/ADAPT-PROMPT.md`).
 
 ```bash
 har onboard [--repo .] [--yes] [--skip-guide] [--skip-init]
@@ -16,6 +17,7 @@ har onboard [--repo .] [--yes] [--skip-guide] [--skip-init]
             [--telemetry on|on-no-prompts|off]
             [--control|--no-control]
             [--plugins playwright,rocketsim|--no-plugins]
+            [--agent-slots <n>]
             [--force]
             [--agents claude,cursor,codex] [--no-agents]
             [--cursor-rule|--no-cursor-rule]
@@ -26,6 +28,11 @@ har onboard [--repo .] [--yes] [--skip-guide] [--skip-init]
 `--yes` accepts defaults (telemetry on, start Mission Control, no plugins) without
 prompts. Prefer this over hand-rolling `preferences` + `env init` + `telemetry`
 + `control up` for new repositories.
+
+`--agent-slots <n>` sets how many agents may run in parallel (`1`–`10`), written to
+`.har/stages.json` as `agentSlots.max`. Interactive onboarding asks this when the
+flag is omitted (practical limit depends on machine resources and stack cost).
+With `--yes` and no `--agent-slots`, the profile template default is kept.
 
 ## `har env`
 

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -6,6 +6,11 @@ import { handleCursorRule } from '../../harness/cursor-rule';
 import { harnessExists } from '../../harness/parser';
 import type { HarnessProfile } from '../../harness/generator';
 import { PluginId } from '../../harness/plugins';
+import {
+  HAR_AGENT_SLOT_MIN,
+  HAR_AGENT_SLOT_ONBOARD_MAX,
+  getAgentSlotRange,
+} from '../../harness/stages';
 import { handleCommitGateOnboarding } from '../../core/commit-gate-onboarding';
 import {
   finalizeOnboardingAdaptation,
@@ -33,6 +38,8 @@ interface OnboardArgs {
   commitGate?: 'prompt' | 'always' | 'never';
   gateMode?: 'block' | 'warn';
   gateScope?: 'worktrees' | 'all';
+  /** Parallel agent slot max (1–10). */
+  agentSlots?: number;
 }
 
 function parsePluginsFlag(raw: string | false | undefined): PluginId[] | undefined {
@@ -46,6 +53,36 @@ function parsePluginsFlag(raw: string | false | undefined): PluginId[] | undefin
     throw new Error(`Unknown plugin(s): ${invalid.join(', ')}. Available: ${available.join(', ')}`);
   }
   return selected as PluginId[];
+}
+
+/** Template defaults for `agentSlots.max` by harness profile. */
+export function defaultAgentSlotMaxForProfile(profile: HarnessProfile): number {
+  return profile === 'default' ? 5 : 3;
+}
+
+export function parseAgentSlotsFlag(raw: number | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  if (!Number.isInteger(raw) || raw < HAR_AGENT_SLOT_MIN || raw > HAR_AGENT_SLOT_ONBOARD_MAX) {
+    throw new Error(
+      `--agent-slots must be an integer from ${HAR_AGENT_SLOT_MIN} to ${HAR_AGENT_SLOT_ONBOARD_MAX}`,
+    );
+  }
+  return raw;
+}
+
+function resolveDefaultAgentSlotsMax(
+  repoPath: string,
+  profile: HarnessProfile,
+  alreadyPresent: boolean,
+): number {
+  if (alreadyPresent) {
+    try {
+      return getAgentSlotRange(repoPath).max;
+    } catch {
+      // fall through to profile default
+    }
+  }
+  return defaultAgentSlotMaxForProfile(profile);
 }
 
 async function pauseForGuide(autoYes: boolean): Promise<void> {
@@ -64,7 +101,11 @@ async function promptChoices(args: OnboardArgs): Promise<{
   telemetry: TelemetryChoice;
   startControl: boolean;
   plugins: PluginId[];
+  agentSlotsMax?: number;
 }> {
+  const flaggedSlots = parseAgentSlotsFlag(args.agentSlots);
+  const shouldConfigureSlots = !args.skipInit;
+
   if (args.yes) {
     const telemetry = args.telemetry ?? 'on';
     return {
@@ -72,6 +113,7 @@ async function promptChoices(args: OnboardArgs): Promise<{
       telemetry,
       startControl: args.control ?? telemetry !== 'off',
       plugins: parsePluginsFlag(args.plugins) ?? [],
+      agentSlotsMax: shouldConfigureSlots ? flaggedSlots : undefined,
     };
   }
 
@@ -81,10 +123,11 @@ async function promptChoices(args: OnboardArgs): Promise<{
       args.telemetry === undefined &&
       args.control === undefined &&
       args.plugins === undefined &&
-      args.profile === undefined
+      args.profile === undefined &&
+      args.agentSlots === undefined
     ) {
       throw new Error(
-        'Interactive onboarding requires a TTY. Pass --yes or flags (--profile, --telemetry, --control/--no-control, --plugins).',
+        'Interactive onboarding requires a TTY. Pass --yes or flags (--profile, --telemetry, --control/--no-control, --plugins, --agent-slots).',
       );
     }
     const telemetry = args.telemetry ?? 'on';
@@ -93,18 +136,28 @@ async function promptChoices(args: OnboardArgs): Promise<{
       telemetry,
       startControl: args.control ?? telemetry !== 'off',
       plugins: parsePluginsFlag(args.plugins) ?? [],
+      agentSlotsMax: shouldConfigureSlots ? flaggedSlots : undefined,
     };
   }
 
   const pluginChoices = listPluginChoices();
-  const alreadyPresent = harnessExists(path.resolve(args.repo));
+  const repoPath = path.resolve(args.repo);
+  const alreadyPresent = harnessExists(repoPath);
   const needProfile = !alreadyPresent && !args.skipInit && args.profile === undefined;
+  const needAgentSlots = shouldConfigureSlots && flaggedSlots === undefined;
+
+  if (needAgentSlots) {
+    info(
+      'Each parallel slot runs an isolated copy of the stack. The practical limit depends on your machine resources (RAM/CPU) and how expensive the stack is to run (Docker services, databases, frontends, etc.). You can change this later in .har/stages.json.',
+    );
+  }
 
   const answers = await inquirer.prompt<{
     profile?: HarnessProfile;
     telemetry?: TelemetryChoice;
     startControl?: boolean;
     plugins?: PluginId[];
+    agentSlotsMax?: number;
   }>([
     {
       type: 'list',
@@ -148,14 +201,44 @@ async function promptChoices(args: OnboardArgs): Promise<{
         value: plugin.id,
       })),
     },
+    {
+      type: 'number',
+      name: 'agentSlotsMax',
+      message: `How many agents do you want to run in parallel? (${HAR_AGENT_SLOT_MIN}–${HAR_AGENT_SLOT_ONBOARD_MAX})`,
+      when: () => needAgentSlots,
+      default: (current: { profile?: HarnessProfile }) =>
+        resolveDefaultAgentSlotsMax(
+          repoPath,
+          args.profile ?? current.profile ?? 'default',
+          alreadyPresent,
+        ),
+      validate: (value: number | undefined) => {
+        if (
+          value === undefined ||
+          !Number.isInteger(value) ||
+          value < HAR_AGENT_SLOT_MIN ||
+          value > HAR_AGENT_SLOT_ONBOARD_MAX
+        ) {
+          return `Enter an integer from ${HAR_AGENT_SLOT_MIN} to ${HAR_AGENT_SLOT_ONBOARD_MAX}`;
+        }
+        return true;
+      },
+    },
   ]);
 
   const telemetry = args.telemetry ?? answers.telemetry ?? 'on';
+  const profile = args.profile ?? answers.profile ?? 'default';
+  let agentSlotsMax: number | undefined;
+  if (shouldConfigureSlots) {
+    agentSlotsMax = flaggedSlots ?? answers.agentSlotsMax;
+  }
+
   return {
-    profile: args.profile ?? answers.profile ?? 'default',
+    profile,
     telemetry,
     startControl: args.control ?? answers.startControl ?? telemetry !== 'off',
     plugins: parsePluginsFlag(args.plugins) ?? answers.plugins ?? [],
+    agentSlotsMax,
   };
 }
 
@@ -169,6 +252,7 @@ function printSummary(result: {
   pluginsApplied: PluginId[];
   adaptationPromptPath: string | null;
   adaptationPromptCopied: boolean;
+  agentSlots: { min: number; max: number } | null;
 }): void {
   divider();
   success('Onboarding complete');
@@ -195,6 +279,11 @@ function printSummary(result: {
       result.pluginsApplied.length > 0 ? result.pluginsApplied.join(', ') : 'none'
     }`,
   );
+  if (result.agentSlots) {
+    info(
+      `Agent slots:    ${result.agentSlots.min}–${result.agentSlots.max} parallel (see .har/stages.json)`,
+    );
+  }
   if (result.adaptationPromptPath) {
     info(`Adapt prompt:   ${result.adaptationPromptPath}`);
     info(
@@ -238,6 +327,7 @@ export async function handleOnboard(argv: OnboardArgs): Promise<void> {
       deferAdaptationPrompt: true,
       autoYes: argv.yes,
       forcePlugins: argv.force,
+      agentSlotsMax: choices.agentSlotsMax,
     });
 
     if (result.harnessInitialized || harnessExists(repoPath)) {
@@ -315,6 +405,10 @@ export const onboardCommand = {
         type: 'string',
         describe:
           'Comma-separated plugins to install (e.g. playwright); --no-plugins to skip; interactive checkbox when omitted',
+      })
+      .option('agent-slots', {
+        type: 'number',
+        describe: `Max parallel agent slots to configure in .har/stages.json (${HAR_AGENT_SLOT_MIN}–${HAR_AGENT_SLOT_ONBOARD_MAX})`,
       })
       .option('skip-guide', {
         type: 'boolean',

--- a/src/core/onboarding.ts
+++ b/src/core/onboarding.ts
@@ -26,6 +26,7 @@ import {
   PluginId,
   readPluginManifest,
 } from '../harness/plugins';
+import { applyAgentSlotMax, getAgentSlotRange } from '../harness/stages';
 import { divider, info, success, warn } from '../utils/logging';
 
 export type TelemetryChoice = 'on' | 'on-no-prompts' | 'off';
@@ -87,6 +88,8 @@ export interface OnboardOptions {
   autoYes?: boolean;
   /** Force overwrite when applying plugins. */
   forcePlugins?: boolean;
+  /** Parallel agent slot max to write into `.har/stages.json` after the harness exists. */
+  agentSlotsMax?: number;
 }
 
 export interface OnboardResult {
@@ -101,6 +104,8 @@ export interface OnboardResult {
   pluginWarnings: string[];
   adaptationPromptPath: string | null;
   adaptationPromptCopied: boolean;
+  /** Slot range after onboarding when a harness is present. */
+  agentSlots: { min: number; max: number } | null;
 }
 
 export interface OnboardingDeps {
@@ -282,6 +287,19 @@ export async function runOnboarding(
     success('Harness scaffolded');
   }
 
+  let agentSlots: { min: number; max: number } | null = null;
+  if (harnessExists(repoPath)) {
+    if (options.agentSlotsMax !== undefined) {
+      applyAgentSlotMax(repoPath, options.agentSlotsMax);
+      info(`Agent slots: 1–${options.agentSlotsMax} parallel (written to .har/stages.json)`);
+    }
+    try {
+      agentSlots = getAgentSlotRange(repoPath);
+    } catch {
+      agentSlots = null;
+    }
+  }
+
   const pluginsApplied: PluginId[] = [];
   const pluginWarnings: string[] = [];
 
@@ -335,6 +353,7 @@ export async function runOnboarding(
     pluginWarnings,
     adaptationPromptPath,
     adaptationPromptCopied,
+    agentSlots,
   };
 }
 

--- a/src/harness/stages.ts
+++ b/src/harness/stages.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
   HAR_AGENT_SLOT_MIN,
+  HarnessAgentSlotsSchema,
   HarnessStage,
   HarnessStageKind,
   HarnessStageRegistry,
@@ -11,7 +12,11 @@ import {
 import { parseHarnessEnvInt, readHarnessEnv } from './env';
 import { getHarnessDir } from './manifest';
 
+export { HAR_AGENT_SLOT_MIN };
 export const STAGE_REGISTRY_FILE = 'stages.json';
+
+/** Upper bound offered during `har onboard` for parallel agent slots. */
+export const HAR_AGENT_SLOT_ONBOARD_MAX = 10;
 
 const AGENT_REQUIRED_KINDS = new Set<HarnessStageKind>([
   'launch',
@@ -240,6 +245,17 @@ export function syncAgentSlotsToHarnessEnv(repoPath: string): boolean {
 
   fs.writeFileSync(envPath, content);
   return true;
+}
+
+/** Set `agentSlots.max` in stages.json and sync legacy harness.env exports. */
+export function applyAgentSlotMax(repoPath: string, max: number): void {
+  const slots = HarnessAgentSlotsSchema.parse({ min: HAR_AGENT_SLOT_MIN, max });
+  const registry = readStageRegistry(repoPath);
+  writeStageRegistry(repoPath, {
+    ...registry,
+    agentSlots: slots,
+  });
+  syncAgentSlotsToHarnessEnv(repoPath);
 }
 
 export function stageRequiresAgentId(stage: HarnessStage): boolean {

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -153,7 +153,7 @@ Document and configure ports in `.har/harness.env` and `.har/README.md`. Use the
 | Mailpit | `HARNESS_MAILPIT_*_PORT_DEFAULT` | Scan configured ranges |
 | Headless browser | `HARNESS_BROWSER_PORT_DEFAULT` | Scan configured ranges |
 
-Set slot limits in `.har/stages.json` (`agentSlots`) based on machine capacity. `har env maintain --finalize` syncs legacy `HARNESS_AGENT_SLOT_*` exports in `harness.env`.
+Onboarding may set an initial `agentSlots.max` in `.har/stages.json`. After you know the real stack cost, **re-tune** that limit for machine capacity (lighter stack → you can raise; heavy Docker/DB → lower). `har env maintain --finalize` syncs legacy `HARNESS_AGENT_SLOT_*` exports in `harness.env`.
 
 **Port / infra checklist:**
 

--- a/tests/agent-slots.test.ts
+++ b/tests/agent-slots.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  applyAgentSlotMax,
   detectAgentSlotEnvMismatch,
   getAgentSlotRange,
   syncAgentSlotsToHarnessEnv,
@@ -88,5 +89,27 @@ describe('agent slot limits', () => {
     expect(detectAgentSlotEnvMismatch(repoPath)).toBeNull();
     const env = fs.readFileSync(path.join(repoPath, '.har', 'harness.env'), 'utf8');
     expect(env).toContain('export HARNESS_AGENT_SLOT_MAX=10');
+  });
+
+  it('applyAgentSlotMax updates stages.json and syncs harness.env', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slots-apply-'));
+    fs.mkdirSync(path.join(repoPath, '.har'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoPath, '.har', 'stages.json'),
+      JSON.stringify({ version: '1', agentSlots: { min: 1, max: 5 }, stages: [] }),
+    );
+    fs.writeFileSync(
+      path.join(repoPath, '.har', 'harness.env'),
+      ['export HARNESS_AGENT_SLOT_MIN=1', 'export HARNESS_AGENT_SLOT_MAX=5', ''].join('\n'),
+    );
+
+    applyAgentSlotMax(repoPath, 2);
+
+    expect(getAgentSlotRange(repoPath)).toEqual({ min: 1, max: 2 });
+    const stages = JSON.parse(fs.readFileSync(path.join(repoPath, '.har', 'stages.json'), 'utf8'));
+    expect(stages.agentSlots).toEqual({ min: 1, max: 2 });
+    expect(detectAgentSlotEnvMismatch(repoPath)).toBeNull();
+    const env = fs.readFileSync(path.join(repoPath, '.har', 'harness.env'), 'utf8');
+    expect(env).toContain('export HARNESS_AGENT_SLOT_MAX=2');
   });
 });

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -9,6 +9,10 @@ import {
   runOnboarding,
 } from '../src/core/onboarding';
 import {
+  defaultAgentSlotMaxForProfile,
+  parseAgentSlotsFlag,
+} from '../src/cli/commands/onboard';
+import {
   isTelemetryEnabled,
   readTelemetryPreference,
 } from '../src/core/telemetry-config';
@@ -36,6 +40,23 @@ describe('onboarding guide', () => {
     expect(ids).toContain('playwright');
     expect(ids).toContain('rocketsim');
     expect(choices.every((c) => c.label.includes(c.id))).toBe(true);
+  });
+});
+
+describe('agent slot onboarding helpers', () => {
+  it('uses profile defaults for agentSlots.max', () => {
+    expect(defaultAgentSlotMaxForProfile('default')).toBe(5);
+    expect(defaultAgentSlotMaxForProfile('cli')).toBe(3);
+    expect(defaultAgentSlotMaxForProfile('ios')).toBe(3);
+  });
+
+  it('validates --agent-slots bounds', () => {
+    expect(parseAgentSlotsFlag(undefined)).toBeUndefined();
+    expect(parseAgentSlotsFlag(1)).toBe(1);
+    expect(parseAgentSlotsFlag(10)).toBe(10);
+    expect(() => parseAgentSlotsFlag(0)).toThrow(/1 to 10/);
+    expect(() => parseAgentSlotsFlag(11)).toThrow(/1 to 10/);
+    expect(() => parseAgentSlotsFlag(1.5)).toThrow(/1 to 10/);
   });
 });
 
@@ -115,6 +136,7 @@ describe('runOnboarding', () => {
 
     expect(result.harnessInitialized).toBe(true);
     expect(result.pluginsApplied).toEqual(['playwright']);
+    expect(result.agentSlots).toEqual({ min: 1, max: 3 });
     expect(fs.existsSync(path.join(tmpDir, '.har', 'verify.sh'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.har', 'stages', 'browser-e2e.sh'))).toBe(true);
     expect(result.adaptationPromptPath).toBe(
@@ -123,6 +145,36 @@ describe('runOnboarding', () => {
     expect(result.adaptationPromptCopied).toBe(true);
     expect(clipboardCalls).toHaveLength(1);
     expect(clipboardCalls[0]).toContain('AGENT.md');
+  });
+
+  it('applies agentSlotsMax to stages.json after scaffold', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'onboard-slots', version: '1.0.0' }, null, 2) + '\n',
+    );
+    const result = await runOnboarding(
+      {
+        repoPath: tmpDir,
+        profile: 'cli',
+        telemetry: 'off',
+        startControl: false,
+        plugins: [],
+        autoYes: true,
+        agentSlotsMax: 2,
+        deferAdaptationPrompt: true,
+      },
+      {
+        applyTelemetry: async () => {},
+        ensureControl: async () => ({ started: false, apiUrl: 'http://127.0.0.1:3847' }),
+      },
+    );
+
+    expect(result.harnessInitialized).toBe(true);
+    expect(result.agentSlots).toEqual({ min: 1, max: 2 });
+    const stages = JSON.parse(fs.readFileSync(path.join(tmpDir, '.har', 'stages.json'), 'utf8'));
+    expect(stages.agentSlots).toEqual({ min: 1, max: 2 });
+    const env = fs.readFileSync(path.join(tmpDir, '.har', 'harness.env'), 'utf8');
+    expect(env).toContain('export HARNESS_AGENT_SLOT_MAX=2');
   });
 
   it('skips init when harness already exists and still offers a maintain prompt', async () => {
@@ -183,6 +235,7 @@ describe('runOnboarding', () => {
     expect(result.harnessInitialized).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, '.har'))).toBe(false);
     expect(result.adaptationPromptPath).toBeNull();
+    expect(result.agentSlots).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Ask during `har onboard` how many agents to run in parallel (1–10), with guidance that the limit depends on machine resources and stack cost
- Persist the choice to `.har/stages.json` as `agentSlots.max` (and sync legacy `harness.env`); support `--agent-slots` for non-interactive / `--yes` flows
- Update adaptation prompt guidance and CLI docs; cover with unit and onboarding tests

## Test plan
- [x] `har onboard` interactively prompts for parallel agent count and writes `agentSlots.max`
- [x] `har onboard --yes --agent-slots 2` scaffolds with `max: 2` in `.har/stages.json`
- [x] `har onboard --yes` without `--agent-slots` keeps the profile template default
- [x] `har onboard --skip-init` does not prompt for or change agent slots
- [x] Full verify passes on this branch


Made with [Cursor](https://cursor.com)