### PR TITLE
fix(telemetry): stop parent cwd sessions matching child worktree slots

### DIFF
--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -4,6 +4,7 @@ import type { AgentSessionUsage, AgentTool } from '@har/schemas';
 import { prisma } from '@/lib/db';
 import { upsertSessionUsage } from '@/server/usage';
 import {
+  isWorkspaceUnderPath,
   normalizeOtelPath,
   pickBestRepoPathMatch,
   pickPathForWorkspaceId,
@@ -260,12 +261,7 @@ async function resolveSlotByWorkspace(workspace: string): Promise<{
     const candidates = [slot.workDir, slot.worktreePath]
       .filter((p): p is string => Boolean(p))
       .map(normalizePath);
-    return candidates.some(
-      (path) =>
-        path === normalized ||
-        normalized.startsWith(`${path}/`) ||
-        path.startsWith(`${normalized}/`),
-    );
+    return candidates.some((slotPath) => isWorkspaceUnderPath(normalized, slotPath));
   });
   if (!match) return null;
 

--- a/control/src/server/otel-workspace.test.ts
+++ b/control/src/server/otel-workspace.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isWorkspaceUnderPath,
   otelWorkspaceIdForPath,
   pickBestRepoPathMatch,
   pickPathForWorkspaceId,
@@ -34,6 +35,15 @@ describe('pickBestRepoPathMatch', () => {
 
   it('returns null when nothing matches', () => {
     expect(pickBestRepoPathMatch('/tmp/x', ['/home/me/proj'])).toBeNull();
+  });
+});
+
+describe('isWorkspaceUnderPath', () => {
+  it('matches equal paths and child workspaces only', () => {
+    const worktree = '/home/antoine/worktrees/main-abcd-har-agent-2-xy12';
+    expect(isWorkspaceUnderPath(worktree, worktree)).toBe(true);
+    expect(isWorkspaceUnderPath(`${worktree}/src`, worktree)).toBe(true);
+    expect(isWorkspaceUnderPath('/home/antoine', worktree)).toBe(false);
   });
 });
 

--- a/control/src/server/otel-workspace.ts
+++ b/control/src/server/otel-workspace.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import * as path from 'node:path';
 
 /**
  * Match @osfactory/otel-hook's default privacy hash (empty salt):
@@ -21,6 +22,14 @@ export function otelWorkspaceIdForPath(absolutePath: string, hashSalt = ''): str
 
 export function normalizeOtelPath(value: string): string {
   return value.replace(/[/\\]+$/, '');
+}
+
+/** True when `workspace` equals `basePath` or is a subdirectory of it (not the reverse). */
+export function isWorkspaceUnderPath(workspace: string, basePath: string): boolean {
+  const workspaceNorm = normalizeOtelPath(path.resolve(workspace));
+  const baseNorm = normalizeOtelPath(path.resolve(basePath));
+  if (!workspaceNorm || !baseNorm) return false;
+  return workspaceNorm === baseNorm || workspaceNorm.startsWith(`${baseNorm}${path.sep}`);
 }
 
 /** Longest registered path that equals or is a parent of `workspace`. */

--- a/src/core/usage-harvest/claude.ts
+++ b/src/core/usage-harvest/claude.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import type { AgentSessionEvent, AgentSessionUsage } from '../../harness/schema';
 import { getTelemetrySignals } from '../telemetry-config';
 import { buildSessionKey } from '../telemetry-env';
+import { workspaceMatchesTarget } from '../workspace-path-match';
 
 export interface HarvestSlotContext {
   agentId: number;
@@ -13,14 +14,6 @@ export interface HarvestSlotContext {
   suffix?: string;
   sessionCreatedAt?: string;
   repoPath: string;
-}
-
-function pathsMatch(candidate: string, targets: string[]): boolean {
-  const norm = path.resolve(candidate);
-  return targets.some((t) => {
-    const target = path.resolve(t);
-    return norm === target || norm.startsWith(target + path.sep) || target.startsWith(norm + path.sep);
-  });
 }
 
 function claudeProjectsRoot(): string {
@@ -134,7 +127,7 @@ function findMatchingClaudeTranscripts(slot: HarvestSlotContext): Array<{ filePa
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const projectDir = path.join(root, entry.name);
-    const encodedHit = targets.some((t) => entry.name.includes(encodeClaudeProjectDir(t).slice(0, 40)));
+    const encodedHit = targets.some((t) => entry.name === encodeClaudeProjectDir(t));
 
     for (const file of fs.readdirSync(projectDir)) {
       if (!file.endsWith('.jsonl')) continue;
@@ -145,7 +138,7 @@ function findMatchingClaudeTranscripts(slot: HarvestSlotContext): Array<{ filePa
       for (const record of records) {
         if (!record || typeof record !== 'object') continue;
         const cwd = String((record as { cwd?: string }).cwd ?? '');
-        if (cwd && pathsMatch(cwd, targets)) {
+        if (cwd && workspaceMatchesTarget(cwd, targets)) {
           cwdHit = true;
           break;
         }

--- a/src/core/usage-harvest/codex.ts
+++ b/src/core/usage-harvest/codex.ts
@@ -4,14 +4,7 @@ import * as path from 'path';
 import type { AgentSessionUsage } from '../../harness/schema';
 import { buildSessionKey } from '../telemetry-env';
 import type { HarvestSlotContext } from './claude';
-
-function pathsMatch(candidate: string, targets: string[]): boolean {
-  const norm = path.resolve(candidate);
-  return targets.some((t) => {
-    const target = path.resolve(t);
-    return norm === target || norm.startsWith(target + path.sep) || target.startsWith(norm + path.sep);
-  });
-}
+import { workspaceMatchesTarget } from '../workspace-path-match';
 
 function codexSessionsRoot(): string {
   return process.env.HAR_CODEX_SESSIONS_DIR
@@ -116,7 +109,7 @@ export function harvestCodexUsage(slot: HarvestSlotContext): AgentSessionUsage |
   for (const file of files) {
     const records = readJsonl(file);
     const extracted = extractCodexTokens(records);
-    if (!extracted.cwd || !pathsMatch(extracted.cwd, targets)) continue;
+    if (!extracted.cwd || !workspaceMatchesTarget(extracted.cwd, targets)) continue;
     if (extracted.tokensInput + extracted.tokensOutput + extracted.tokensCacheRead === 0) continue;
     const mtime = fs.statSync(file).mtimeMs;
     if (mtime >= bestMtime) {

--- a/src/core/workspace-path-match.ts
+++ b/src/core/workspace-path-match.ts
@@ -1,0 +1,17 @@
+import * as path from 'path';
+
+function stripTrailingSeparators(value: string): string {
+  return value.replace(/[/\\]+$/, '');
+}
+
+/** True when `workspace` equals `basePath` or is a subdirectory of it (not the reverse). */
+export function isWorkspaceUnderPath(workspace: string, basePath: string): boolean {
+  const workspaceNorm = stripTrailingSeparators(path.resolve(workspace));
+  const baseNorm = stripTrailingSeparators(path.resolve(basePath));
+  if (!workspaceNorm || !baseNorm) return false;
+  return workspaceNorm === baseNorm || workspaceNorm.startsWith(`${baseNorm}${path.sep}`);
+}
+
+export function workspaceMatchesTarget(workspace: string, targets: string[]): boolean {
+  return targets.some((target) => isWorkspaceUnderPath(workspace, target));
+}

--- a/tests/usage-harvest.test.ts
+++ b/tests/usage-harvest.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { harvestClaudeUsage, encodeClaudeProjectDir } from '../src/core/usage-harvest/claude';
 import { harvestCodexUsage } from '../src/core/usage-harvest/codex';
+import { isWorkspaceUnderPath } from '../src/core/workspace-path-match';
 
 describe('usage harvest claude', () => {
   let tmp: string;
@@ -100,6 +101,43 @@ describe('usage harvest claude', () => {
         tokensTotal: 44,
       },
     });
+  });
+
+  it('does not harvest a parent cwd session into a child worktree slot', () => {
+    const homeDir = '/home/antoine';
+    const workDir = '/home/antoine/worktrees/main-abcd-har-agent-2-xy12';
+    const homeProject = path.join(tmp, encodeClaudeProjectDir(homeDir));
+    fs.mkdirSync(homeProject, { recursive: true });
+    fs.writeFileSync(
+      path.join(homeProject, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: homeDir, message: { role: 'user', content: 'hi' } }),
+        JSON.stringify({
+          type: 'result',
+          usage: { input_tokens: 10, output_tokens: 5 },
+          total_cost_usd: 0.01,
+        }),
+      ].join('\n') + '\n',
+    );
+
+    expect(
+      harvestClaudeUsage({
+        agentId: 2,
+        workDir,
+        branch: 'main-abcd-har-agent-2-xy12',
+        suffix: 'xy12',
+        repoPath: '/home/antoine/Documents/osfactory/har-project',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('workspace path match', () => {
+  it('matches equal paths and child workspaces only', () => {
+    const worktree = '/home/antoine/worktrees/main-abcd-har-agent-2-xy12';
+    expect(isWorkspaceUnderPath(worktree, worktree)).toBe(true);
+    expect(isWorkspaceUnderPath(`${worktree}/src`, worktree)).toBe(true);
+    expect(isWorkspaceUnderPath('/home/antoine', worktree)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Tighten Claude/Codex harvest matching so a session cwd must equal or be inside the slot worktree (not the reverse)
- Require exact Claude project folder names instead of fuzzy encoded-path substring checks
- Apply the same one-way workspace rule to Mission Control OTEL slot resolution

Fixes the case where running Claude Code from `~` caused the same prompts to appear on every active HAR worktree slot during `har control sync`.

## Test plan
- [x] `npm test -- tests/usage-harvest.test.ts`
- [x] Regression: parent cwd (`/home/antoine`) does not harvest into child worktree slot
- [x] `control/src/server/otel-workspace.test.ts` — `isWorkspaceUnderPath` child-only matching


Made with [Cursor](https://cursor.com)