### PR TITLE
fix(telemetry): prevent cross-slot harvest and unsafe OTEL attribution (#84)

### DIFF
--- a/control/src/server/otel-ingest-session-context.test.ts
+++ b/control/src/server/otel-ingest-session-context.test.ts
@@ -164,4 +164,17 @@ describe('resolveSessionContext — Cursor on the main checkout', () => {
       workUnitId: 'WU-2',
     });
   });
+
+  it('refuses harSessionKey-only attribution when agent tool is unknown', async () => {
+    const { context, reason } = await resolveSessionContext(
+      {
+        'har.session_key': 'main-abcd-har-agent-1-xy12',
+        'har.repo_path': '/home/user/project',
+      },
+      { 'gen_ai.client.workspace': '/tmp/unrelated-workspace' },
+    );
+
+    expect(context).toBeNull();
+    expect(reason).toMatch(/unknown agent tool/i);
+  });
 });

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -504,12 +504,18 @@ export async function resolveSessionContext(
         reason: `unknown repository for ${repoPath || workspace || workspaceId || '(empty)'}`,
       };
     }
+    if (!tool) {
+      return {
+        context: null,
+        reason: `unknown agent tool for session key ${harSessionKey}`,
+      };
+    }
     return {
       context: {
         repositoryId,
         sessionKey: harSessionKey,
         agentId: explicitAgentId ?? 1,
-        agentTool: tool ?? 'claude_code',
+        agentTool: tool,
         workDir: resource['har.work_dir']
           ? String(resource['har.work_dir'])
           : workspace || undefined,

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -36,7 +36,7 @@ import {
 } from './work-units';
 import { createRemoteExecutor } from './cloud-executor';
 import { isTelemetryEnabled } from './telemetry-config';
-import { harvestEventsForSlot, harvestUsageForSlot } from './usage-harvest';
+import { harvestEventsForSlot, harvestUsageForSlot, omitHarvestEventsWhenOtelPresent, omitHarvestWhenOtelPresent } from './usage-harvest';
 import { buildSessionKey } from './telemetry-env';
 import { fetchPersistedPortalTelemetry } from './control-persisted-usage';
 import { dedupePortalEvents, mergePortalUsage } from './portal-usage-merge';
@@ -177,7 +177,10 @@ async function collectPortalTelemetry(
 
     const persisted = await fetchPersistedPortalTelemetry(repoPath, controlApiUrl, { since });
 
-    const usage = mergePortalUsage(liveUsage, persisted.usage).map((row) => {
+    const harvestedUsage = omitHarvestWhenOtelPresent(liveUsage, persisted.usage);
+    const harvestedEvents = omitHarvestEventsWhenOtelPresent(liveEvents, persisted.events);
+
+    const usage = mergePortalUsage(harvestedUsage, persisted.usage).map((row) => {
       const priced = enrichUsageWithPricing(row);
       const models = modelsFromBreakdown(
         priced.modelBreakdown as Record<string, unknown> | undefined,
@@ -189,7 +192,7 @@ async function collectPortalTelemetry(
       };
     });
 
-    const events = dedupePortalEvents(liveEvents, persisted.events).map((event) =>
+    const events = dedupePortalEvents(harvestedEvents, persisted.events).map((event) =>
       dropNullFields({ ...event }),
     );
 

--- a/src/core/usage-harvest/index.ts
+++ b/src/core/usage-harvest/index.ts
@@ -6,6 +6,40 @@ import {
 } from './claude';
 import { harvestCodexUsage } from './codex';
 
+function sessionToolKey(sessionKey: string, agentTool: string): string {
+  return `${sessionKey}\0${agentTool}`;
+}
+
+/** Skip harvest rows when Mission Control already has OTLP usage for that session/tool. */
+export function omitHarvestWhenOtelPresent(
+  harvested: AgentSessionUsage[],
+  existing: AgentSessionUsage[],
+): AgentSessionUsage[] {
+  const otelKeys = new Set(
+    existing
+      .filter((row) => (row.sources ?? []).includes('otel'))
+      .map((row) => sessionToolKey(row.sessionKey, row.agentTool)),
+  );
+  if (otelKeys.size === 0) return harvested;
+  return harvested.filter((row) => !otelKeys.has(sessionToolKey(row.sessionKey, row.agentTool)));
+}
+
+/** Skip harvested prompt events when OTLP events already exist for that session/tool. */
+export function omitHarvestEventsWhenOtelPresent(
+  harvested: AgentSessionEvent[],
+  existing: AgentSessionEvent[],
+): AgentSessionEvent[] {
+  const otelKeys = new Set(
+    existing
+      .filter((event) => event.source === 'otel')
+      .map((event) => sessionToolKey(event.sessionKey, event.agentTool)),
+  );
+  if (otelKeys.size === 0) return harvested;
+  return harvested.filter(
+    (event) => !otelKeys.has(sessionToolKey(event.sessionKey, event.agentTool)),
+  );
+}
+
 export function harvestUsageForSlot(slot: HarvestSlotContext): AgentSessionUsage[] {
   const out: AgentSessionUsage[] = [];
   const claude = harvestClaudeUsage(slot);

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -22,10 +22,14 @@ jest.mock('../src/core/work-units', () => ({
   listWorkAttempts: jest.fn(() => []),
   listValidationBindings: jest.fn(() => []),
 }));
-jest.mock('../src/core/usage-harvest', () => ({
-  harvestUsageForSlot: jest.fn(() => []),
-  harvestEventsForSlot: jest.fn(() => []),
-}));
+jest.mock('../src/core/usage-harvest', () => {
+  const actual = jest.requireActual('../src/core/usage-harvest') as typeof import('../src/core/usage-harvest');
+  return {
+    ...actual,
+    harvestUsageForSlot: jest.fn(() => []),
+    harvestEventsForSlot: jest.fn(() => []),
+  };
+});
 jest.mock('../src/core/control-persisted-usage', () => ({
   fetchPersistedPortalTelemetry: jest.fn(async () => ({ usage: [], events: [], maxSyncedAt: null })),
 }));
@@ -538,7 +542,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(body.usage[0].costUsd).toBe(0.065);
   });
 
-  it('dedupes an overlapping live + persisted session into one max-merged row', async () => {
+  it('prefers persisted otel usage over live harvest for the same session/tool', async () => {
     collectEnvironmentStatusMock.mockReturnValue({
       slots: [portalSlot({ branch: 'feat/x' })],
       generatedAt: '2026-01-01T00:00:00.000Z',
@@ -576,7 +580,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     const body = JSON.parse(init.body as string);
     expect(body.usage).toHaveLength(1);
     expect(body.usage[0].tokensTotal).toBe(250);
-    expect(body.usage[0].sources.sort()).toEqual(['harvest', 'otel']);
+    expect(body.usage[0].sources).toEqual(['otel']);
     expect(body.usage[0].lastSeenAt).toBe('2026-01-03T00:00:00.000Z');
   });
 

--- a/tests/control-sync-repos.test.ts
+++ b/tests/control-sync-repos.test.ts
@@ -15,10 +15,14 @@ jest.mock('../src/core/work-units', () => ({
   listWorkAttempts: () => [],
   listValidationBindings: () => [],
 }));
-jest.mock('../src/core/usage-harvest', () => ({
-  harvestUsageForSlot: () => [],
-  harvestEventsForSlot: () => [],
-}));
+jest.mock('../src/core/usage-harvest', () => {
+  const actual = jest.requireActual('../src/core/usage-harvest') as typeof import('../src/core/usage-harvest');
+  return {
+    ...actual,
+    harvestUsageForSlot: () => [],
+    harvestEventsForSlot: () => [],
+  };
+});
 jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => false }));
 jest.mock('../src/harness/manifest', () => ({
   readManifest: () => null,

--- a/tests/usage-harvest.test.ts
+++ b/tests/usage-harvest.test.ts
@@ -3,6 +3,10 @@ import * as os from 'os';
 import * as path from 'path';
 import { harvestClaudeUsage, encodeClaudeProjectDir } from '../src/core/usage-harvest/claude';
 import { harvestCodexUsage } from '../src/core/usage-harvest/codex';
+import {
+  omitHarvestEventsWhenOtelPresent,
+  omitHarvestWhenOtelPresent,
+} from '../src/core/usage-harvest';
 import { isWorkspaceUnderPath } from '../src/core/workspace-path-match';
 
 describe('usage harvest claude', () => {
@@ -130,6 +134,57 @@ describe('usage harvest claude', () => {
       }),
     ).toBeNull();
   });
+
+  it('harvests only the slot whose worktree matches among parallel slots', () => {
+    const homeDir = '/home/alice';
+    const slot1Dir = '/home/alice/worktrees/main-abcd-har-agent-1-aa11';
+    const slot2Dir = '/home/alice/worktrees/main-abcd-har-agent-2-bb22';
+    const slot3Dir = '/home/alice/worktrees/main-abcd-har-agent-3-cc33';
+    const repoPath = '/home/alice/project';
+
+    const homeProject = path.join(tmp, encodeClaudeProjectDir(homeDir));
+    fs.mkdirSync(homeProject, { recursive: true });
+    fs.writeFileSync(
+      path.join(homeProject, 'parent-session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: homeDir }),
+        JSON.stringify({
+          type: 'result',
+          usage: { input_tokens: 99, output_tokens: 99 },
+          total_cost_usd: 9.99,
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const slot2Project = path.join(tmp, encodeClaudeProjectDir(slot2Dir));
+    fs.mkdirSync(slot2Project, { recursive: true });
+    fs.writeFileSync(
+      path.join(slot2Project, 'slot2-session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: slot2Dir }),
+        JSON.stringify({
+          type: 'result',
+          usage: { input_tokens: 20, output_tokens: 10 },
+          total_cost_usd: 0.2,
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const slots = [
+      { agentId: 1, workDir: slot1Dir, branch: 'main-abcd-har-agent-1-aa11', suffix: 'aa11' },
+      { agentId: 2, workDir: slot2Dir, branch: 'main-abcd-har-agent-2-bb22', suffix: 'bb22' },
+      { agentId: 3, workDir: slot3Dir, branch: 'main-abcd-har-agent-3-cc33', suffix: 'cc33' },
+    ];
+
+    const harvested = slots.map((slot) =>
+      harvestClaudeUsage({ ...slot, repoPath }),
+    );
+
+    expect(harvested[0]).toBeNull();
+    expect(harvested[1]?.tokensOutput).toBe(10);
+    expect(harvested[1]?.costUsd).toBe(0.2);
+    expect(harvested[2]).toBeNull();
+  });
 });
 
 describe('workspace path match', () => {
@@ -183,5 +238,81 @@ describe('usage harvest codex', () => {
     expect(usage!.tokensInput).toBe(10);
     expect(usage!.tokensOutput).toBe(5);
     expect(usage!.costUsd).toBeNull();
+  });
+
+  it('does not harvest a parent cwd session into a child worktree slot', () => {
+    const homeDir = '/home/alice';
+    const workDir = '/home/alice/worktrees/main-abcd-har-agent-2-bb22';
+    const sessionDir = path.join(tmp, '2026');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, 'parent.jsonl'),
+      [
+        JSON.stringify({ cwd: homeDir }),
+        JSON.stringify({
+          usage: { input_tokens: 50, output_tokens: 25 },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    expect(
+      harvestCodexUsage({
+        agentId: 2,
+        workDir,
+        branch: 'main-abcd-har-agent-2-bb22',
+        suffix: 'bb22',
+        repoPath: '/home/alice/project',
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('omit harvest when otel present', () => {
+  it('drops harvested usage when otel already attributed the session/tool', () => {
+    const harvested = [
+      {
+        sessionKey: 'main-abcd-har-agent-2-bb22',
+        agentId: 2,
+        agentTool: 'claude_code' as const,
+        tokensInput: 10,
+        tokensOutput: 5,
+        tokensCacheRead: 0,
+        tokensCacheCreation: 0,
+        tokensTotal: 15,
+        sources: ['harvest' as const],
+        firstSeenAt: '2026-01-01T00:00:00.000Z',
+        lastSeenAt: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+    const existing = [
+      {
+        ...harvested[0],
+        sources: ['otel' as const],
+      },
+    ];
+
+    expect(omitHarvestWhenOtelPresent(harvested, existing)).toEqual([]);
+  });
+
+  it('drops harvested events when otel events already exist for the session/tool', () => {
+    const harvested = [
+      {
+        sessionKey: 'main-abcd-har-agent-2-bb22',
+        agentId: 2,
+        agentTool: 'claude_code' as const,
+        eventName: 'claude_code.user_prompt',
+        sequence: 1,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        source: 'harvest' as const,
+      },
+    ];
+    const existing = [
+      {
+        ...harvested[0],
+        source: 'otel' as const,
+      },
+    ];
+
+    expect(omitHarvestEventsWhenOtelPresent(harvested, existing)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Skip Claude/Codex harvest during portal sync when Mission Control already has OTLP usage/events for the same session and tool, avoiding duplicate attribution from stale transcripts.
- Refuse OTEL ingest on the `harSessionKey` fallback path when the agent tool cannot be detected (no silent `claude_code` default).
- Add regression tests for parallel-slot harvest isolation, parent-cwd false positives, and otel-over-harvest preference.

Builds on earlier fixes for #84: strict harvest path matching (#124) and workspace-based OTEL attribution (#102).

## Test plan
- [x] `har env verify 1 --full` (commit gate + complete)
- [x] `tests/usage-harvest.test.ts` — 3-slot parallel harvest, parent cwd rejection, omit-when-otel helpers
- [x] `control/src/server/otel-ingest-session-context.test.ts` — unknown tool rejected on harSessionKey fallback
- [x] `tests/control-portal-sync.test.ts` — persisted OTLP preferred over live harvest

Closes #84

Made with [Cursor](https://cursor.com)