### PR TITLE
feat(control): refresh expired portal ingest token on 401 instead of failing sync

### DIFF
--- a/src/core/control-config.ts
+++ b/src/core/control-config.ts
@@ -14,6 +14,7 @@ export function isControlEnabled(): boolean {
 export interface PortalTarget {
   url: string;
   token: string;
+  refreshToken?: string;
 }
 
 function normalizeUrl(url: string): string {
@@ -30,7 +31,11 @@ export function getPortalTarget(): PortalTarget | null {
 
   const stored = readPortalCredentials();
   if (stored) {
-    return { url: normalizeUrl(stored.portalUrl), token: stored.token };
+    return {
+      url: normalizeUrl(stored.portalUrl),
+      token: stored.token,
+      refreshToken: stored.refreshToken,
+    };
   }
 
   if (process.env.HAR_CLOUD_API_URL && process.env.HAR_CLOUD_API_KEY) {

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -24,7 +24,7 @@ import {
   recordRepoForControlSync,
   removeRegisteredRepo,
 } from './control-registry';
-import { readPortalCredentials } from './portal-credentials';
+import { readPortalCredentials, writePortalCredentials } from './portal-credentials';
 import { canonicalizeControlRepoPath } from './control-repo-path';
 import { collectEnvironmentStatus } from './slot-status';
 import { listRuns } from './runs';
@@ -76,6 +76,52 @@ async function postJson<T>(url: string, body: unknown, dryRun?: boolean): Promis
   return (await response.json()) as T;
 }
 
+function postPortalOnce(
+  target: PortalTarget,
+  endpoint: string,
+  body: unknown,
+): Promise<Response> {
+  return fetch(`${target.url}${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${target.token}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// Rotate an expired ingest token via the stored refresh token: on success
+// mutates target.token and persists the rotated credential, else returns false
+// so the caller surfaces the original 401.
+async function refreshPortalToken(target: PortalTarget): Promise<boolean> {
+  if (!target.refreshToken) return false;
+
+  let response: Response;
+  try {
+    response = await fetch(`${target.url}/api/cli/refresh`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${target.refreshToken}` },
+    });
+  } catch {
+    return false;
+  }
+  if (!response.ok) return false;
+
+  const data = (await response.json().catch(() => null)) as {
+    token?: string;
+    expiresAt?: string;
+  } | null;
+  if (!data?.token) return false;
+
+  target.token = data.token;
+  const stored = readPortalCredentials();
+  if (stored) {
+    writePortalCredentials({ ...stored, token: data.token, expiresAt: data.expiresAt });
+  }
+  return true;
+}
+
 async function postPortal(
   target: PortalTarget,
   endpoint: string,
@@ -84,19 +130,19 @@ async function postPortal(
 ): Promise<void> {
   if (dryRun) return;
 
-  const response = await fetch(`${target.url}${endpoint}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${target.token}`,
-    },
-    body: JSON.stringify(body),
-  });
+  let response = await postPortalOnce(target, endpoint, body);
+
+  if (
+    (response.status === 401 || response.status === 403) &&
+    (await refreshPortalToken(target))
+  ) {
+    response = await postPortalOnce(target, endpoint, body);
+  }
 
   if (!response.ok) {
     if (response.status === 401 || response.status === 403) {
       throw new Error(
-        `har-portal rejected the ingest token (HTTP ${response.status}) — check HAR_PORTAL_TOKEN.`,
+        `har-portal rejected the ingest token (HTTP ${response.status}) — run \`har control login\` (or check HAR_PORTAL_TOKEN).`,
       );
     }
     const text = await response.text().catch(() => '');

--- a/src/core/portal-credentials.ts
+++ b/src/core/portal-credentials.ts
@@ -9,6 +9,8 @@ export interface PortalCredentials {
   workspace?: string;
   email?: string;
   createdAt: string;
+  refreshToken?: string;
+  expiresAt?: string;
 }
 
 export function portalCredentialsPath(): string {
@@ -29,6 +31,8 @@ export function readPortalCredentials(): PortalCredentials | null {
       workspace: parsed.workspace,
       email: parsed.email,
       createdAt: parsed.createdAt ?? '',
+      refreshToken: parsed.refreshToken,
+      expiresAt: parsed.expiresAt,
     };
   } catch {
     return null;

--- a/src/core/portal-login.ts
+++ b/src/core/portal-login.ts
@@ -44,6 +44,8 @@ export async function loginViaBrowser(
       const returnedState = requestUrl.searchParams.get('state');
       const workspace = requestUrl.searchParams.get('workspace') ?? undefined;
       const email = requestUrl.searchParams.get('email') ?? undefined;
+      const refreshToken = requestUrl.searchParams.get('refreshToken') ?? undefined;
+      const expiresAt = requestUrl.searchParams.get('expiresAt') ?? undefined;
 
       if (returnedState !== state || !token) {
         res.writeHead(400, { 'Content-Type': 'text/html' });
@@ -56,7 +58,15 @@ export async function loginViaBrowser(
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end('<h1>Logged in</h1><p>You can close this tab and return to the terminal.</p>');
       cleanup();
-      resolve({ portalUrl, token, workspace, email, createdAt: new Date().toISOString() });
+      resolve({
+        portalUrl,
+        token,
+        workspace,
+        email,
+        refreshToken,
+        expiresAt,
+        createdAt: new Date().toISOString(),
+      });
     });
 
     const cleanup = () => {

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -5,7 +5,10 @@ import { syncRepoWithControl } from '../src/core/control-sync';
 // collectors are exercised by their own suites — here we only care that the
 // portal push targets the right URL, sends the bearer token, and shapes the
 // omnibus body from whatever the collectors return.
-jest.mock('../src/core/portal-credentials', () => ({ readPortalCredentials: jest.fn(() => null) }));
+jest.mock('../src/core/portal-credentials', () => ({
+  readPortalCredentials: jest.fn(() => null),
+  writePortalCredentials: jest.fn(),
+}));
 jest.mock('../src/core/control-repo-path', () => ({
   canonicalizeControlRepoPath: (p: string) => p,
 }));
@@ -41,7 +44,10 @@ jest.mock('../src/harness/manifest', () => ({
 jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
 
 import { collectEnvironmentStatus } from '../src/core/slot-status';
-import { readPortalCredentials } from '../src/core/portal-credentials';
+import {
+  readPortalCredentials,
+  writePortalCredentials,
+} from '../src/core/portal-credentials';
 import {
   listWorkUnits,
   listWorkAttempts,
@@ -53,6 +59,7 @@ import { readPortalWatermark, writePortalWatermark } from '../src/core/portal-wa
 
 const collectEnvironmentStatusMock = collectEnvironmentStatus as jest.Mock;
 const readPortalCredentialsMock = readPortalCredentials as jest.Mock;
+const writePortalCredentialsMock = writePortalCredentials as jest.Mock;
 const listWorkUnitsMock = listWorkUnits as jest.Mock;
 const listWorkAttemptsMock = listWorkAttempts as jest.Mock;
 const listValidationBindingsMock = listValidationBindings as jest.Mock;
@@ -689,5 +696,128 @@ describe('syncRepoWithControl — portal watermark', () => {
     await syncRepoWithControl({ repoPath: '/repo/x', dryRun: true });
 
     expect(writePortalWatermarkMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncRepoWithControl — token refresh on 401', () => {
+  const realFetch = global.fetch;
+  beforeEach(() => {
+    resetPayloadMocks();
+    clearPortalEnv();
+    writePortalCredentialsMock.mockReset();
+  });
+  afterEach(() => {
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+  afterAll(clearPortalEnv);
+
+  function storedCreds(overrides: Record<string, unknown> = {}): void {
+    readPortalCredentialsMock.mockReturnValue({
+      portalUrl: 'https://portal.example.com',
+      token: 'har_ingest_old',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      refreshToken: 'har_refresh_ok',
+      ...overrides,
+    });
+  }
+
+  function refreshFetch(opts: {
+    syncStatuses: number[];
+    refreshStatus: number;
+    refreshBody?: Record<string, unknown>;
+  }): jest.Mock {
+    let syncCall = 0;
+    const fn = jest.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? 'GET';
+      if (u.endsWith('/api/cli/refresh')) {
+        const ok = opts.refreshStatus >= 200 && opts.refreshStatus < 300;
+        return {
+          ok,
+          status: opts.refreshStatus,
+          text: async () => '',
+          json: async () => opts.refreshBody ?? {},
+        };
+      }
+      if (u.includes('portal.example.com') && u.endsWith('/api/sync')) {
+        const status = opts.syncStatuses[Math.min(syncCall, opts.syncStatuses.length - 1)];
+        syncCall++;
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          text: async () => '',
+          json: async () => ({}),
+        };
+      }
+      if (u.endsWith('/api/repos') && method === 'POST') {
+        return { ok: true, status: 200, text: async () => '', json: async () => ({ id: 'local-repo-1' }) };
+      }
+      return { ok: true, status: 200, text: async () => '', json: async () => ({}) };
+    });
+    (global as unknown as { fetch: unknown }).fetch = fn;
+    return fn;
+  }
+
+  function callsTo(fetchMock: jest.Mock, endpoint: string): [string, RequestInit][] {
+    return fetchMock.mock.calls.filter(([url]) =>
+      String(url).endsWith(endpoint),
+    ) as [string, RequestInit][];
+  }
+
+  it('rotates the ingest token on 401 and retries the sync with it', async () => {
+    storedCreds();
+    const fetchMock = refreshFetch({
+      syncStatuses: [401, 200],
+      refreshStatus: 200,
+      refreshBody: { token: 'har_ingest_new', expiresAt: '2026-02-01T00:00:00.000Z' },
+    });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const refreshCalls = callsTo(fetchMock, '/api/cli/refresh');
+    expect(refreshCalls).toHaveLength(1);
+    expect((refreshCalls[0][1].headers as Record<string, string>).Authorization).toBe(
+      'Bearer har_refresh_ok',
+    );
+
+    const syncCalls = callsTo(fetchMock, '/api/sync');
+    expect(syncCalls).toHaveLength(2);
+    expect((syncCalls[0][1].headers as Record<string, string>).Authorization).toBe(
+      'Bearer har_ingest_old',
+    );
+    expect((syncCalls[1][1].headers as Record<string, string>).Authorization).toBe(
+      'Bearer har_ingest_new',
+    );
+
+    expect(writePortalCredentialsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'har_ingest_new',
+        expiresAt: '2026-02-01T00:00:00.000Z',
+        refreshToken: 'har_refresh_ok',
+      }),
+    );
+  });
+
+  it('surfaces the 401 without refreshing when there is no refresh token', async () => {
+    storedCreds({ refreshToken: undefined });
+    const fetchMock = refreshFetch({ syncStatuses: [401], refreshStatus: 200 });
+
+    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).rejects.toThrow(
+      /rejected the ingest token/,
+    );
+    expect(callsTo(fetchMock, '/api/cli/refresh')).toHaveLength(0);
+    expect(writePortalCredentialsMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the original 401 when the refresh itself is rejected', async () => {
+    storedCreds();
+    const fetchMock = refreshFetch({ syncStatuses: [401], refreshStatus: 401 });
+
+    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).rejects.toThrow(
+      /rejected the ingest token/,
+    );
+    expect(callsTo(fetchMock, '/api/cli/refresh')).toHaveLength(1);
+    expect(callsTo(fetchMock, '/api/sync')).toHaveLength(1);
+    expect(writePortalCredentialsMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/portal-credentials.test.ts
+++ b/tests/portal-credentials.test.ts
@@ -58,6 +58,19 @@ describe('portal credentials store', () => {
     expect(readPortalCredentials()?.email).toBe('login@haulieros.io');
   });
 
+  it('round-trips the refresh token and ingest-token expiry', () => {
+    writePortalCredentials({
+      portalUrl: 'https://portal.example.com',
+      token: 'har_ingest_x',
+      refreshToken: 'har_refresh_y',
+      expiresAt: '2026-02-01T00:00:00.000Z',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const creds = readPortalCredentials();
+    expect(creds?.refreshToken).toBe('har_refresh_y');
+    expect(creds?.expiresAt).toBe('2026-02-01T00:00:00.000Z');
+  });
+
   it('returns null when the file is missing or incomplete', () => {
     expect(readPortalCredentials()).toBeNull();
     fs.writeFileSync(tmpFile, JSON.stringify({ portalUrl: 'https://x' }));

--- a/tests/portal-login.test.ts
+++ b/tests/portal-login.test.ts
@@ -4,7 +4,14 @@ import { loginViaBrowser } from '../src/core/portal-login';
 
 function hitCallback(
   loginUrl: string,
-  opts: { token?: string; state?: string; workspace?: string; email?: string },
+  opts: {
+    token?: string;
+    state?: string;
+    workspace?: string;
+    email?: string;
+    refreshToken?: string;
+    expiresAt?: string;
+  },
 ): void {
   const url = new URL(loginUrl);
   const callback = url.searchParams.get('callback') as string;
@@ -13,6 +20,8 @@ function hitCallback(
   params.set('state', opts.state ?? (url.searchParams.get('state') as string));
   if (opts.workspace) params.set('workspace', opts.workspace);
   if (opts.email) params.set('email', opts.email);
+  if (opts.refreshToken) params.set('refreshToken', opts.refreshToken);
+  if (opts.expiresAt) params.set('expiresAt', opts.expiresAt);
   http.get(`${callback}?${params.toString()}`, (res) => res.resume());
 }
 
@@ -33,6 +42,18 @@ describe('loginViaBrowser', () => {
       hitCallback(url, { token: 'har_ingest_abc', email: 'login@haulieros.io' }),
     );
     expect(creds.email).toBe('login@haulieros.io');
+  });
+
+  it('captures the refresh token and ingest-token expiry from the callback', async () => {
+    const creds = await loginViaBrowser('https://portal.example.com', (url) =>
+      hitCallback(url, {
+        token: 'har_ingest_abc',
+        refreshToken: 'har_refresh_xyz',
+        expiresAt: '2026-02-01T00:00:00.000Z',
+      }),
+    );
+    expect(creds.refreshToken).toBe('har_refresh_xyz');
+    expect(creds.expiresAt).toBe('2026-02-01T00:00:00.000Z');
   });
 
   it('rejects on state mismatch', async () => {


### PR DESCRIPTION
## What

Portal sync authenticates with a single static ingest Bearer token in `~/.har/credentials.json`. When it expires or is revoked the portal returns 401/403 and `postPortal` throws — on the auto-sync path that throw is swallowed best-effort, so every activity edge silently no-ops until the user manually re-runs `har control login`.

This adds a seamless refresh flow:

- `PortalCredentials` gains `refreshToken` + `expiresAt` (`portal-credentials.ts`), parsed from the login callback (`portal-login.ts`).
- `PortalTarget` carries `refreshToken` — only when the token came from stored credentials; a raw `HAR_PORTAL_TOKEN` / cloud key has no refresh path (`control-config.ts`).
- `postPortal`: on 401/403 with a refresh token, POST the portal's `/api/cli/refresh`, persist the rotated credential, and retry once. Otherwise it throws the (now more actionable) re-login error. Best-effort semantics are unchanged — a dead token never breaks `env verify` / `launch` / commit.

The portal side (the `/api/cli/refresh` endpoint + refresh-capable login mint) ships separately. Backward-compatible in both directions: an old portal that returns no refresh fields leaves today's behavior intact, and an old CLI ignores the new fields.

## Tests

`control-portal-sync.test.ts` covers refresh-on-401 (rotate + retry + persist), no-refresh-token (surface the 401), and refresh-rejected (surface the 401). `portal-credentials.test.ts` / `portal-login.test.ts` round-trip the new fields. `typecheck` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)