### PR TITLE
feat(control): batch + incrementally sync runs so large histories don't fail

### DIFF
--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -41,7 +41,13 @@ import { buildSessionKey } from './telemetry-env';
 import { fetchPersistedPortalTelemetry } from './control-persisted-usage';
 import { dedupePortalEvents, mergePortalUsage } from './portal-usage-merge';
 import { enrichUsageWithPricing } from '../harness/schema';
-import { readPortalWatermark, writePortalWatermark } from './portal-watermark';
+import {
+  readPortalWatermark,
+  writePortalWatermark,
+  readRunsWatermarkEntry,
+  writeRunsWatermark,
+  selectSince,
+} from './portal-watermark';
 import type { AgentSessionEvent, AgentSessionUsage } from '../harness/schema';
 
 export interface ControlSyncOptions {
@@ -59,14 +65,117 @@ export interface ControlRegisterOptions extends ControlSyncOptions {
   gitRemote?: string;
 }
 
+/** Per-request byte cap: a single POST of a large run history gets the connection
+ * dropped (undici UND_ERR_SOCKET), so unbounded collections chunk under this. */
+const DEFAULT_MAX_BATCH_BYTES = 4 * 1024 * 1024;
+
+function maxSyncBatchBytes(): number {
+  const raw = Number(process.env.HAR_SYNC_MAX_BATCH_BYTES);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_MAX_BATCH_BYTES;
+}
+
+export function chunkBySerializedSize<T>(items: T[], maxBytes: number): T[][] {
+  const batches: T[][] = [];
+  let current: T[] = [];
+  let currentBytes = 0;
+
+  for (const item of items) {
+    const itemBytes = Buffer.byteLength(JSON.stringify(item), 'utf8');
+    if (current.length > 0 && currentBytes + itemBytes > maxBytes) {
+      batches.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(item);
+    currentBytes += itemBytes;
+  }
+  if (current.length > 0) batches.push(current);
+
+  return batches;
+}
+
+function runTimestamp(run: RunRecord): string {
+  return run.finishedAt ?? run.startedAt;
+}
+
+// Re-send a small window past the watermark so a same-ms sibling or a backward
+// clock step isn't dropped (the resend is an idempotent upsert).
+const DEFAULT_SYNC_OVERLAP_MS = 60_000;
+
+function rewindSince(since: string | null): string | null {
+  if (!since) return null;
+  const raw = Number(process.env.HAR_SYNC_OVERLAP_MS);
+  const overlap = Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_SYNC_OVERLAP_MS;
+  return new Date(new Date(since).getTime() - overlap).toISOString();
+}
+
+function runsWatermarkTarget(target: string): string {
+  return `runs:${target}`;
+}
+
+/** Send run batches oldest-first, advancing the watermark (with the server repo
+ * id) after each lands — so a sync killed mid-flight resumes, and a wiped repo
+ * invalidates it. */
+async function syncRunBatches(
+  newRuns: RunRecord[],
+  repoPath: string,
+  runsTarget: string,
+  getRepoId: () => string | undefined,
+  dryRun: boolean | undefined,
+  send: (batch: RunRecord[], index: number) => Promise<void>,
+): Promise<void> {
+  const ordered = [...newRuns].sort((a, b) => runTimestamp(a).localeCompare(runTimestamp(b)));
+  const batches = chunkBySerializedSize(ordered, maxSyncBatchBytes());
+  const toSend = batches.length > 0 ? batches : [[]];
+  for (let i = 0; i < toSend.length; i++) {
+    const batch = toSend[i];
+    await send(batch, i);
+    if (!dryRun && batch.length > 0) {
+      writeRunsWatermark(repoPath, runsTarget, getRepoId(), runTimestamp(batch[batch.length - 1]));
+    }
+  }
+}
+
+function describeFetchFailure(url: string, bodyBytes: number, err: unknown): string {
+  const base = err instanceof Error ? err.message : String(err);
+  const cause = (err as { cause?: { code?: string; message?: string } }).cause;
+  const code = cause?.code ? ` [${cause.code}]` : '';
+  const detail = cause?.message && cause.message !== base ? `: ${cause.message}` : '';
+  const size = bodyBytes > 0 ? ` (request body ${(bodyBytes / 1024 / 1024).toFixed(2)} MB)` : '';
+  return `${base}${code}${detail}${size} — POST ${url}`;
+}
+
+const MAX_FETCH_ATTEMPTS = 3;
+
+async function postForResponse(
+  url: string,
+  headers: Record<string, string>,
+  payload: string,
+): Promise<Response> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    try {
+      return await fetch(url, { method: 'POST', headers, body: payload });
+    } catch (err) {
+      // Retry network throws (e.g. a keep-alive socket dropped after a big batch)
+      // — every sync POST is an idempotent upsert, so a fresh connection is safe.
+      lastErr = err;
+      if (attempt < MAX_FETCH_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 100));
+      }
+    }
+  }
+  throw new Error(describeFetchFailure(url, Buffer.byteLength(payload, 'utf8'), lastErr));
+}
+
 async function postJson<T>(url: string, body: unknown, dryRun?: boolean): Promise<T | null> {
   if (dryRun) return null;
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
+  const response = await postForResponse(
+    url,
+    { 'Content-Type': 'application/json' },
+    JSON.stringify(body),
+  );
 
   if (!response.ok) {
     const text = await response.text().catch(() => '');
@@ -81,14 +190,14 @@ function postPortalOnce(
   endpoint: string,
   body: unknown,
 ): Promise<Response> {
-  return fetch(`${target.url}${endpoint}`, {
-    method: 'POST',
-    headers: {
+  return postForResponse(
+    `${target.url}${endpoint}`,
+    {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${target.token}`,
     },
-    body: JSON.stringify(body),
-  });
+    JSON.stringify(body),
+  );
 }
 
 // Rotate an expired ingest token via the stored refresh token: on success
@@ -127,8 +236,8 @@ async function postPortal(
   endpoint: string,
   body: unknown,
   dryRun?: boolean,
-): Promise<void> {
-  if (dryRun) return;
+): Promise<Record<string, unknown> | null> {
+  if (dryRun) return null;
 
   let response = await postPortalOnce(target, endpoint, body);
 
@@ -148,6 +257,8 @@ async function postPortal(
     const text = await response.text().catch(() => '');
     throw new Error(`har-portal sync failed: HTTP ${response.status}${text ? ` — ${text}` : ''}`);
   }
+
+  return (await response.json().catch(() => null)) as Record<string, unknown> | null;
 }
 
 function resolvePortalUserEmail(): string | undefined {
@@ -254,6 +365,7 @@ async function buildPortalPayload(
   since: string | null,
 ): Promise<{
   syncBody: Record<string, unknown>;
+  runs: RunRecord[];
   events: Record<string, unknown>[];
   maxSyncedAt: string | null;
 }> {
@@ -277,7 +389,6 @@ async function buildPortalPayload(
     path: repoPath,
     ...(manifest ? { manifest } : {}),
     ...(stagesRegistry ? { stagesRegistry } : {}),
-    runs,
     slots: status.slots,
     generatedAt: status.generatedAt,
     ...(validations.length > 0 ? { validations } : {}),
@@ -287,7 +398,7 @@ async function buildPortalPayload(
     ...(usage.length > 0 ? { usage } : {}),
   };
 
-  return { syncBody, events, maxSyncedAt };
+  return { syncBody, runs, events, maxSyncedAt };
 }
 
 export async function isControlApiReachable(apiUrl = getControlApiUrl()): Promise<boolean> {
@@ -362,7 +473,7 @@ export async function syncReposWithControl(options: {
     try {
       await withTimeout(
         syncRepoWithControl({ repoPath, apiUrl, dryRun: options.dryRun, cloud: options.cloud, full: options.full }),
-        SYNC_TIMEOUT_MS,
+        EXPLICIT_SYNC_TIMEOUT_MS,
         'control sync',
       );
       synced++;
@@ -455,7 +566,7 @@ async function syncRepoWithLocalControl(
   options: ControlSyncOptions & { repoPath: string },
 ): Promise<void> {
   const apiUrl = options.apiUrl ?? getControlApiUrl();
-  const { repoPath, dryRun } = options;
+  const { repoPath, dryRun, full } = options;
 
   const registerResult = await registerRepoWithControl({ ...options, repoPath });
   const repoId = registerResult?.id;
@@ -469,12 +580,12 @@ async function syncRepoWithLocalControl(
       // Unregistered / blocked — nothing to sync locally.
       return;
     }
-    await syncRepoRunsAndSlots(apiUrl, existing.id, repoPath, dryRun);
+    await syncRepoRunsAndSlots(apiUrl, existing.id, repoPath, dryRun, full);
     return;
   }
 
   if (repoId) {
-    await syncRepoRunsAndSlots(apiUrl, repoId, repoPath, dryRun);
+    await syncRepoRunsAndSlots(apiUrl, repoId, repoPath, dryRun, full);
   }
 }
 
@@ -487,10 +598,33 @@ async function syncRepoWithPortal(
 
   const { repoPath, dryRun, full } = options;
   const since = full ? null : readPortalWatermark(repoPath, portal.url);
-  const { syncBody, events, maxSyncedAt } = await buildPortalPayload(repoPath, controlApiUrl, since);
-  await postPortal(portal, '/api/sync', syncBody, dryRun);
-  if (events.length > 0) {
-    await postPortal(portal, '/api/otel', { path: repoPath, events, spans: [] }, dryRun);
+
+  const runsTarget = runsWatermarkTarget(portal.url);
+  const stored = full ? null : readRunsWatermarkEntry(repoPath, runsTarget);
+  const runsSince = rewindSince(stored?.lastSyncedAt ?? null);
+  const { syncBody, runs, events, maxSyncedAt } = await buildPortalPayload(
+    repoPath,
+    controlApiUrl,
+    since,
+  );
+  const { selected: newRuns } = selectSince(runs, runsSince, runTimestamp);
+
+  let repoId: string | undefined;
+  await syncRunBatches(newRuns, repoPath, runsTarget, () => repoId, dryRun, async (batch, i) => {
+    const body = i === 0 ? { ...syncBody, runs: batch } : { path: repoPath, runs: batch };
+    const res = await postPortal(portal, '/api/sync', body, dryRun);
+    if (i === 0 && typeof res?.repositoryId === 'string') repoId = res.repositoryId;
+  });
+
+  // Repo id changed → the portal repo was wiped; resend the whole history.
+  if (!full && !dryRun && stored?.repoId && repoId && stored.repoId !== repoId) {
+    await syncRunBatches(listRuns(repoPath), repoPath, runsTarget, () => repoId, dryRun, async (batch) => {
+      await postPortal(portal, '/api/sync', { path: repoPath, runs: batch }, dryRun);
+    });
+  }
+
+  for (const batch of chunkBySerializedSize(events, maxSyncBatchBytes())) {
+    await postPortal(portal, '/api/otel', { path: repoPath, events: batch, spans: [] }, dryRun);
   }
   if (!dryRun && maxSyncedAt) {
     writePortalWatermark(repoPath, portal.url, maxSyncedAt);
@@ -540,10 +674,17 @@ async function syncRepoRunsAndSlots(
   repoId: string,
   repoPath: string,
   dryRun?: boolean,
+  full?: boolean,
 ): Promise<void> {
+  const runsTarget = runsWatermarkTarget(apiUrl);
+  const stored = full ? null : readRunsWatermarkEntry(repoPath, runsTarget);
+  const runsSince = rewindSince(stored?.repoId === repoId ? (stored?.lastSyncedAt ?? null) : null);
   const runs = listRuns(repoPath);
-  const runsBody = SyncRunsInputSchema.parse({ runs });
-  await postJson(`${apiUrl}/api/repos/${repoId}/runs`, runsBody, dryRun);
+  const { selected: newRuns } = selectSince(runs, runsSince, runTimestamp);
+
+  await syncRunBatches(newRuns, repoPath, runsTarget, () => repoId, dryRun, async (batch) => {
+    await postJson(`${apiUrl}/api/repos/${repoId}/runs`, SyncRunsInputSchema.parse({ runs: batch }), dryRun);
+  });
 
   const status: EnvironmentStatus = collectEnvironmentStatus(repoPath);
   const slotsBody = SyncSlotsInputSchema.parse({
@@ -636,6 +777,7 @@ async function syncRepoRunsAndSlots(
 }
 
 const SYNC_TIMEOUT_MS = 15_000;
+const EXPLICIT_SYNC_TIMEOUT_MS = 120_000;
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: NodeJS.Timeout;

--- a/src/core/portal-watermark.ts
+++ b/src/core/portal-watermark.ts
@@ -7,6 +7,13 @@ interface PortalSyncStateEntry {
   repoPath: string;
   portalUrl: string;
   lastSyncedAt: string;
+  /** Server repo id at last sync; a change means the repo was wiped/recreated. */
+  repoId?: string;
+}
+
+export interface RunsWatermark {
+  lastSyncedAt: string;
+  repoId?: string;
 }
 
 interface PortalSyncState {
@@ -66,6 +73,34 @@ export function writePortalWatermark(
 
 export function getPortalWatermarkPath(): string {
   return getStatePath();
+}
+
+export function readRunsWatermarkEntry(repoPath: string, target: string): RunsWatermark | null {
+  const canonical = canonicalizeControlRepoPath(repoPath);
+  const entry = readState().states.find(
+    (state) => state.repoPath === canonical && state.portalUrl === target,
+  );
+  return entry ? { lastSyncedAt: entry.lastSyncedAt, repoId: entry.repoId } : null;
+}
+
+export function writeRunsWatermark(
+  repoPath: string,
+  target: string,
+  repoId: string | undefined,
+  lastSyncedAt: string,
+): void {
+  const canonical = canonicalizeControlRepoPath(repoPath);
+  const state = readState();
+  const existing = state.states.find(
+    (entry) => entry.repoPath === canonical && entry.portalUrl === target,
+  );
+  if (existing) {
+    existing.lastSyncedAt = lastSyncedAt;
+    existing.repoId = repoId;
+  } else {
+    state.states.push({ repoPath: canonical, portalUrl: target, lastSyncedAt, repoId });
+  }
+  writeState(state);
 }
 
 /**

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -37,8 +37,11 @@ jest.mock('../src/core/control-persisted-usage', () => ({
   fetchPersistedPortalTelemetry: jest.fn(async () => ({ usage: [], events: [], maxSyncedAt: null })),
 }));
 jest.mock('../src/core/portal-watermark', () => ({
+  ...jest.requireActual('../src/core/portal-watermark'),
   readPortalWatermark: jest.fn(() => null),
   writePortalWatermark: jest.fn(),
+  readRunsWatermarkEntry: jest.fn(() => null),
+  writeRunsWatermark: jest.fn(),
 }));
 jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => true }));
 jest.mock('../src/harness/manifest', () => ({

--- a/tests/control-sync-batching.test.ts
+++ b/tests/control-sync-batching.test.ts
@@ -1,0 +1,453 @@
+// Bounding the sync payload: a large run history must be chunked under a size
+// cap (no single oversized request), land with no loss/reorder, and — when a
+// request does fail at the socket level — surface the real cause, not a bare
+// `fetch failed`. Collectors are mocked (covered by their own suites); we drive
+// listRuns + fetch to exercise the batching and error-surfacing seams.
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+jest.mock('../src/core/portal-credentials', () => ({ readPortalCredentials: jest.fn(() => null) }));
+jest.mock('../src/core/runs', () => ({ listRuns: jest.fn(() => []) }));
+jest.mock('../src/core/slot-status', () => ({
+  collectEnvironmentStatus: () => ({ slots: [], generatedAt: '2026-01-01T00:00:00.000Z' }),
+}));
+jest.mock('../src/core/validations', () => ({ listValidations: () => [] }));
+jest.mock('../src/core/work-units', () => ({
+  listWorkUnits: () => [],
+  listWorkAttempts: () => [],
+  listValidationBindings: () => [],
+}));
+jest.mock('../src/core/usage-harvest', () => ({
+  harvestUsageForSlot: () => [],
+  harvestEventsForSlot: () => [],
+}));
+jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => false }));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => null,
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { chunkBySerializedSize, syncReposWithControl } from '../src/core/control-sync';
+import { listRuns } from '../src/core/runs';
+import type { RunRecord } from '../src/harness/schema';
+
+const realFetch = global.fetch;
+const mockedListRuns = listRuns as jest.MockedFunction<typeof listRuns>;
+
+function makeRuns(count: number, bytesEach: number): RunRecord[] {
+  return Array.from({ length: count }, (_, i) => ({
+    runId: `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,
+    repoPath: '/repos/big',
+    stageId: 'verify',
+    status: 'unknown' as const,
+    startedAt: `2026-01-01T00:00:${String(i).padStart(2, '0')}.000Z`,
+    trigger: 'cli' as const,
+    blob: 'x'.repeat(bytesEach),
+  }));
+}
+
+describe('chunkBySerializedSize', () => {
+  it('returns [] for empty input', () => {
+    expect(chunkBySerializedSize([], 1000)).toEqual([]);
+  });
+
+  it('keeps everything in one batch when it fits under the cap', () => {
+    const items = [{ a: 1 }, { b: 2 }, { c: 3 }];
+    expect(chunkBySerializedSize(items, 1_000)).toEqual([items]);
+  });
+
+  it('splits under the cap while preserving order and losing nothing', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ i, pad: 'y'.repeat(80) }));
+    const batches = chunkBySerializedSize(items, 200);
+
+    expect(batches.length).toBeGreaterThan(1);
+    expect(batches.flat()).toEqual(items); // order preserved, no loss
+    for (const batch of batches) {
+      // Every batch of >1 item stays under the cap.
+      if (batch.length > 1) {
+        expect(Buffer.byteLength(JSON.stringify(batch), 'utf8')).toBeLessThanOrEqual(200 + 2);
+      }
+    }
+  });
+
+  it('isolates a single item larger than the cap into its own batch', () => {
+    const items = [{ small: 1 }, { big: 'z'.repeat(500) }, { small: 2 }];
+    const batches = chunkBySerializedSize(items, 100);
+    expect(batches.flat()).toEqual(items);
+    // The oversized item is alone in a batch — it cannot be split further.
+    const bigBatch = batches.find((b) => b.some((x) => 'big' in x));
+    expect(bigBatch).toHaveLength(1);
+  });
+});
+
+describe('sync payload batching', () => {
+  const calls: { url: string; body: Record<string, unknown> }[] = [];
+  let stateDir: string;
+
+  beforeEach(() => {
+    calls.length = 0;
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-sync-state-'));
+    process.env.HAR_PORTAL_SYNC_STATE_PATH = path.join(stateDir, 'state.json');
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_test';
+    process.env.HAR_SYNC_MAX_BATCH_BYTES = '2000';
+
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(
+      async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (method === 'POST') calls.push({ url: String(url), body });
+
+        if (String(url).endsWith('/api/repos') && method === 'POST') {
+          return jsonResponse({ id: 'local-repo-1' });
+        }
+        if (String(url).endsWith('/api/repos') && method === 'GET') {
+          return jsonResponse([]);
+        }
+        return jsonResponse({});
+      }
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.HAR_PORTAL_URL;
+    delete process.env.HAR_PORTAL_TOKEN;
+    delete process.env.HAR_SYNC_MAX_BATCH_BYTES;
+    mockedListRuns.mockReturnValue([]);
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  it('splits a large run history into multiple bounded requests on both targets', async () => {
+    const runs = makeRuns(12, 500);
+    mockedListRuns.mockReturnValue(runs);
+
+    const result = await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(result.failed).toBe(0);
+
+    const runIds = runs.map((r) => r.runId);
+
+    // Local Mission Control: POST /api/repos/{id}/runs, chunked, reassembles whole.
+    const localRunCalls = calls.filter((c) => c.url.endsWith('/api/repos/local-repo-1/runs'));
+    expect(localRunCalls.length).toBeGreaterThan(1);
+    expect(localRunCalls.flatMap((c) => (c.body.runs as RunRecord[]).map((r) => r.runId))).toEqual(
+      runIds
+    );
+
+    // Portal: POST /api/sync, first request carries metadata + first runs batch,
+    // follow-ups are runs-only. All runs reassemble in order.
+    const syncCalls = calls.filter((c) => c.url === 'https://portal.example.com/api/sync');
+    expect(syncCalls.length).toBeGreaterThan(1);
+    expect(syncCalls[0].body).toHaveProperty('slots'); // metadata rides the first
+    expect(syncCalls.slice(1).every((c) => Object.keys(c.body).sort().join() === 'path,runs')).toBe(
+      true
+    );
+    expect(syncCalls.flatMap((c) => (c.body.runs as RunRecord[]).map((r) => r.runId))).toEqual(
+      runIds
+    );
+
+    // No runs-only request exceeds the cap.
+    for (const c of syncCalls.slice(1)) {
+      expect(Buffer.byteLength(JSON.stringify(c.body), 'utf8')).toBeLessThanOrEqual(2000 + 200);
+    }
+  });
+
+  it('sends a small history in a single request per target', async () => {
+    mockedListRuns.mockReturnValue(makeRuns(2, 100));
+
+    await syncReposWithControl({ repoPaths: ['/repos/small'] });
+
+    expect(calls.filter((c) => c.url.endsWith('/api/repos/local-repo-1/runs'))).toHaveLength(1);
+    expect(calls.filter((c) => c.url === 'https://portal.example.com/api/sync')).toHaveLength(1);
+  });
+});
+
+describe('incremental runs sync', () => {
+  const calls: { url: string; body: Record<string, unknown> }[] = [];
+  let stateDir: string;
+
+  const localRunIdsSince = (from: number): string[] =>
+    calls
+      .slice(from)
+      .filter((c) => c.url.endsWith('/api/repos/local-repo-1/runs'))
+      .flatMap((c) => (c.body.runs as RunRecord[]).map((r) => r.runId));
+
+  beforeEach(() => {
+    calls.length = 0;
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-sync-state-'));
+    process.env.HAR_PORTAL_SYNC_STATE_PATH = path.join(stateDir, 'state.json');
+    process.env.HAR_SYNC_OVERLAP_MS = '0'; // test pure watermark semantics
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(
+      async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (method === 'POST') calls.push({ url: String(url), body });
+        if (String(url).endsWith('/api/repos') && method === 'POST') {
+          return jsonResponse({ id: 'local-repo-1' });
+        }
+        if (String(url).endsWith('/api/repos') && method === 'GET') return jsonResponse([]);
+        return jsonResponse({});
+      }
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+    delete process.env.HAR_SYNC_MAX_BATCH_BYTES;
+    delete process.env.HAR_SYNC_OVERLAP_MS;
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    mockedListRuns.mockReturnValue([]);
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  it('resumes from the last landed batch when a sync is cut short mid-history', async () => {
+    process.env.HAR_SYNC_MAX_BATCH_BYTES = '400'; // ~2 runs/batch
+    const runs = makeRuns(9, 100); // ascending startedAt 00:00:00 … 00:00:08
+    mockedListRuns.mockReturnValue(runs);
+
+    // The batch carrying run #4 always throws (every retry), so the two batches
+    // before it land and the rest abort — a cut-short sync.
+    let failMidBatch = true;
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(
+      async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (String(url).endsWith('/api/repos') && method === 'POST') {
+          return jsonResponse({ id: 'local-repo-1' });
+        }
+        if (String(url).endsWith('/api/repos') && method === 'GET') return jsonResponse([]);
+        if (String(url).endsWith('/local-repo-1/runs') && method === 'POST') {
+          const ids = (body.runs as RunRecord[]).map((r) => r.runId);
+          if (failMidBatch && ids.some((id) => id.endsWith('000000000004'))) {
+            throw Object.assign(new TypeError('fetch failed'), {
+              cause: { code: 'UND_ERR_SOCKET', message: 'other side closed' },
+            });
+          }
+          calls.push({ url: String(url), body });
+        }
+        return jsonResponse({});
+      }
+    );
+
+    const first = await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(first.failed).toBe(1);
+    expect(localRunIdsSince(0)).toEqual([
+      runs[0].runId,
+      runs[1].runId,
+      runs[2].runId,
+      runs[3].runId,
+    ]); // only the batches before the failure landed
+
+    failMidBatch = false;
+    const mark = calls.length;
+    const second = await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(second.failed).toBe(0);
+    expect(localRunIdsSince(mark)).toEqual([
+      runs[4].runId,
+      runs[5].runId,
+      runs[6].runId,
+      runs[7].runId,
+      runs[8].runId,
+    ]); // resumes at the watermark — no re-send of 0–3
+  });
+
+  it('sends everything first, then nothing new when the history is unchanged', async () => {
+    const runs = makeRuns(4, 100);
+    mockedListRuns.mockReturnValue(runs);
+
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(localRunIdsSince(0)).toEqual(runs.map((r) => r.runId)); // first sync: all
+
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(localRunIdsSince(mark)).toEqual([]); // second sync: nothing re-sent
+  });
+
+  it('sends only runs newer than the watermark on a later sync', async () => {
+    const runs = makeRuns(4, 100);
+    mockedListRuns.mockReturnValue(runs);
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+
+    const newer: RunRecord = {
+      runId: '00000000-0000-4000-8000-000000000099',
+      repoPath: '/repos/big',
+      stageId: 'verify',
+      status: 'pass',
+      startedAt: '2026-02-01T00:00:00.000Z',
+      finishedAt: '2026-02-01T00:00:05.000Z',
+      trigger: 'cli',
+    };
+    mockedListRuns.mockReturnValue([...runs, newer]);
+
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(localRunIdsSince(mark)).toEqual([newer.runId]); // only the new run
+  });
+
+  it('--full resends the whole history despite the watermark', async () => {
+    const runs = makeRuns(4, 100);
+    mockedListRuns.mockReturnValue(runs);
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'], full: true });
+    expect(localRunIdsSince(mark)).toEqual(runs.map((r) => r.runId));
+  });
+
+  it('re-sends a recent window (overlap) so a boundary run is not dropped', async () => {
+    process.env.HAR_SYNC_OVERLAP_MS = '600000'; // 10-minute window
+    const run = (id: string, startedAt: string): RunRecord => ({
+      runId: `00000000-0000-4000-8000-${id}`,
+      repoPath: '/repos/big',
+      stageId: 'verify',
+      status: 'unknown',
+      startedAt,
+      trigger: 'cli',
+    });
+    const old = run('000000000001', '2020-01-01T00:00:00.000Z');
+    const r0 = run('000000000002', '2026-01-01T00:00:00.000Z');
+    const r1 = run('000000000003', '2026-01-01T00:05:00.000Z'); // within 10 min of the watermark
+    mockedListRuns.mockReturnValue([old, r0, r1]);
+
+    await syncReposWithControl({ repoPaths: ['/repos/big'] }); // watermark → r1
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    // The overlap re-sends the last 10 min (r0, r1) but not the old run.
+    expect(localRunIdsSince(mark)).toEqual([r0.runId, r1.runId]);
+  });
+});
+
+describe('self-heals on a server wipe (repo id change)', () => {
+  const calls: { url: string; body: Record<string, unknown> }[] = [];
+  let stateDir: string;
+  let localRepoId: string;
+  let portalRepoId: string;
+
+  const runIdsSince = (from: number, urlSuffix: string): string[] =>
+    calls
+      .slice(from)
+      .filter((c) => c.url.endsWith(urlSuffix))
+      .flatMap((c) => ((c.body.runs as RunRecord[]) ?? []).map((r) => r.runId));
+
+  beforeEach(() => {
+    calls.length = 0;
+    localRepoId = 'repo-A';
+    portalRepoId = 'p-A';
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-sync-state-'));
+    process.env.HAR_PORTAL_SYNC_STATE_PATH = path.join(stateDir, 'state.json');
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_test';
+    process.env.HAR_SYNC_OVERLAP_MS = '0';
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(
+      async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (method === 'POST') calls.push({ url: String(url), body });
+        if (String(url).includes('portal.example.com')) {
+          return jsonResponse({ repositoryId: portalRepoId });
+        }
+        if (String(url).endsWith('/api/repos') && method === 'POST') {
+          return jsonResponse({ id: localRepoId });
+        }
+        if (String(url).endsWith('/api/repos') && method === 'GET') return jsonResponse([]);
+        return jsonResponse({});
+      }
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+    delete process.env.HAR_PORTAL_URL;
+    delete process.env.HAR_PORTAL_TOKEN;
+    delete process.env.HAR_SYNC_OVERLAP_MS;
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    mockedListRuns.mockReturnValue([]);
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  it('local: resends the whole history after Mission Control is reset', async () => {
+    const runs = makeRuns(4, 100);
+    mockedListRuns.mockReturnValue(runs);
+
+    await syncReposWithControl({ repoPaths: ['/repos/big'] }); // id repo-A → all
+    const settled = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] }); // same id → nothing new
+    expect(runIdsSince(settled, '/api/repos/repo-A/runs')).toEqual([]);
+
+    localRepoId = 'repo-B'; // Mission Control reset → new repo id
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(runIdsSince(mark, '/api/repos/repo-B/runs')).toEqual(runs.map((r) => r.runId));
+  });
+
+  it('portal: resends the whole history after the portal repo is recreated', async () => {
+    const runs = makeRuns(4, 100);
+    mockedListRuns.mockReturnValue(runs);
+
+    await syncReposWithControl({ repoPaths: ['/repos/big'] }); // portal p-A → all
+    const settled = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] }); // same id → nothing new
+    expect(runIdsSince(settled, '/api/sync')).toEqual([]);
+
+    portalRepoId = 'p-B'; // portal repo wiped → new id in the sync response
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(new Set(runIdsSince(mark, '/api/sync'))).toEqual(new Set(runs.map((r) => r.runId)));
+  });
+});
+
+describe('sync error surfacing', () => {
+  beforeEach(() => {
+    mockedListRuns.mockReturnValue([]);
+    delete process.env.HAR_PORTAL_URL;
+    delete process.env.HAR_PORTAL_TOKEN;
+  });
+
+  afterEach(() => {
+    mockedListRuns.mockReturnValue([]);
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  it('reports the underlying undici cause instead of a bare "fetch failed"', async () => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(
+      async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        if (String(url).endsWith('/api/repos') && method === 'POST') {
+          return jsonResponse({ id: 'local-repo-1' });
+        }
+        if (String(url).endsWith('/runs') && method === 'POST') {
+          // Mirror undici: a bare TypeError whose real reason hides in `cause`.
+          const err = new TypeError('fetch failed');
+          (err as { cause?: unknown }).cause = {
+            code: 'UND_ERR_SOCKET',
+            message: 'other side closed',
+          };
+          throw err;
+        }
+        return jsonResponse({});
+      }
+    );
+
+    const result = await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(result.failed).toBe(1);
+    const error = result.results[0].error ?? '';
+    expect(error).toContain('UND_ERR_SOCKET');
+    expect(error).toContain('other side closed');
+    expect(error).toContain('/runs');
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => '',
+    json: async () => body,
+  } as unknown as Response;
+}

--- a/tests/control-sync-repos.test.ts
+++ b/tests/control-sync-repos.test.ts
@@ -30,9 +30,13 @@ jest.mock('../src/harness/manifest', () => ({
 }));
 jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
 
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { syncReposWithControl } from '../src/core/control-sync';
 
 const realFetch = global.fetch;
+let stateDir: string;
 
 function setPortalEnv(): void {
   process.env.HAR_PORTAL_URL = 'https://portal.example.com';
@@ -93,10 +97,14 @@ function mockFetchByRepo(): void {
 
 describe('syncReposWithControl', () => {
   beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-sync-state-'));
+    process.env.HAR_PORTAL_SYNC_STATE_PATH = path.join(stateDir, 'state.json');
     setPortalEnv();
     mockFetchByRepo();
   });
   afterEach(() => {
+    delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+    fs.rmSync(stateDir, { recursive: true, force: true });
     clearPortalEnv();
     (global as unknown as { fetch: unknown }).fetch = realFetch;
   });


### PR DESCRIPTION
## Problem

`har control sync` (and the awaited auto-sync) **silently failed** for any repo with a sizeable run history — it reported a bare `fetch failed`. `listRuns` returns the **entire** history and it was serialized into a **single** HTTP body (~20 MB for a busy repo); the receiver drops the oversized request mid-stream (undici `UND_ERR_SOCKET: other side closed`), which was caught and flattened to `fetch failed`. So the repos we most want to dogfood never synced their runs.

## Changes

- **Bound the payload.** Runs are sent in size-capped batches (`HAR_SYNC_MAX_BATCH_BYTES`, default 4 MB) on both the local Mission Control and portal paths. All runs still land (idempotent upserts, order preserved); small repos still make exactly one request.
- **Surface the real error.** A failed request now reports the underlying undici cause (code/message) and the request body size, instead of a bare `fetch failed`.
- **Retry idempotent POSTs** on transient network throws — e.g. a keep-alive socket the server drops right after a large batch, which undici surfaces on the *next* pooled request.
- **Incremental sync.** A per-target runs watermark sends each run once instead of re-sending the whole history every sync; batches advance the watermark oldest-first, so a sync cut short (e.g. the awaited auto-sync's timeout) **resumes** instead of restarting. A small overlap window (`HAR_SYNC_OVERLAP_MS`, default 60 s) guards same-millisecond siblings and modest clock skew. `--full` resends everything.
- **Self-heal on a server wipe.** The watermark records the server repo id; a wiped/recreated repo (new id) invalidates it and triggers a full resend — locally (id known before the sync) and on the portal (id from the `/api/sync` response).
- **Timeout split.** Explicit `har control sync` gets a longer budget for a one-time backfill; the awaited auto-sync stays snappy and converges incrementally.

Composes with the token-refresh-on-401 (#128) and OTEL/harvest (#126) changes: portal POSTs get token refresh **and** network-retry + real-cause surfacing.

## Test plan

- `tsc --noEmit`, `eslint src`, and `npm run build` are clean.
- New `tests/control-sync-batching.test.ts` covers the size chunker, batched send on both targets, error surfacing, incremental/`--full`, resumable cut-short sync, the overlap window, and repo-id self-heal (local + portal). All sync/watermark suites pass. (Pre-existing nested-worktree env suites — `control-repo-path`, `slot-registry`, `hooks` — fail locally regardless of this change.)
- Manual: against live Mission Control with har-portal's real ~22 MB / 620-run history, `har control sync` now `✓ Synced` (was `fetch failed`); steady-state re-syncs send zero new runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)