### PR TITLE
ci: path-filter Verify jobs and add Playwright/docs caches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,8 +27,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: pages-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -42,24 +42,36 @@ jobs:
           node-version: '22'
           cache: npm
           cache-dependency-path: docs/package-lock.json
-      - name: Check documentation
+      - name: Install and check documentation
         run: |
           npm ci --prefix docs
           npm run drift --prefix docs
           npm run check --prefix docs
           npm run build --prefix docs
+      - name: Cache lychee
+        id: lychee-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/lychee-bin
+          key: lychee-v0.24.2-x86_64-unknown-linux-gnu
       - name: Install lychee
+        if: steps.lychee-cache.outputs.cache-hit != 'true'
         run: |
+          mkdir -p /tmp/lychee-bin
           curl -fsSL -o /tmp/lychee.tgz https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz
           tar xzf /tmp/lychee.tgz -C /tmp
-          echo "/tmp/lychee-x86_64-unknown-linux-gnu" >> "$GITHUB_PATH"
+          cp /tmp/lychee-x86_64-unknown-linux-gnu/lychee /tmp/lychee-bin/lychee
+      - name: Add lychee to PATH
+        run: echo "/tmp/lychee-bin" >> "$GITHUB_PATH"
       - name: Check documentation links
         run: npm run links --prefix docs
-      - name: Build and upload Pages artifact
-        uses: withastro/action@v3
+      # Single build above — upload the artifact directly (avoids withastro/action
+      # re-installing deps and rebuilding the site a second time).
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: docs
-          node-version: 22
+          path: docs/dist
 
   deploy:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           node-version: '22'
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            packages/schemas/package-lock.json
+            control/package-lock.json
 
       - name: Install and verify CLI
         run: |
@@ -38,9 +42,27 @@ jobs:
           npm ci --prefix packages/schemas
           npm ci --prefix control
 
+      - name: Get Playwright version
+        id: playwright-version
+        working-directory: control
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: control
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: control
+        run: npx playwright install-deps chromium
 
       - name: Launch Mission Control harness
         working-directory: control

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,47 @@
 name: Test
+
 on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      cli: ${{ steps.filter.outputs.cli }}
+      control: ${{ steps.filter.outputs.control }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            cli:
+              - 'src/**'
+              - 'tests/**'
+              - 'packages/schemas/**'
+              - 'scripts/**'
+              - '.har/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'jest.config.*'
+              - '.eslintrc*'
+              - 'eslint.config.*'
+              - '.github/workflows/test.yml'
+            control:
+              - 'control/**'
+              - 'packages/schemas/**'
+              - '.github/workflows/test.yml'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +55,8 @@ jobs:
       - run: node dist/index.js env verify 1 --full
 
   control:
+    needs: changes
+    if: needs.changes.outputs.control == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -27,7 +66,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-          cache-dependency-path: control/package-lock.json
+          cache-dependency-path: |
+            control/package-lock.json
+            packages/schemas/package-lock.json
 
       # @har/schemas path alias typechecks source files — zod must exist under packages/schemas/
       - name: Install dependencies
@@ -35,9 +76,27 @@ jobs:
           npm ci --prefix packages/schemas
           npm ci --prefix control
 
+      - name: Get Playwright version
+        id: playwright-version
+        working-directory: control
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: control
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: control
+        run: npx playwright install-deps chromium
 
       # Dogfood control/.har (same path agents use locally). --no-worktree: the
       # Actions checkout is already the code under test.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Verify
 
 on:
   pull_request:
@@ -6,11 +6,12 @@ on:
       - main
 
 concurrency:
-  group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: verify-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   changes:
+    name: Detect changed paths
     runs-on: ubuntu-latest
     outputs:
       cli: ${{ steps.filter.outputs.cli }}
@@ -40,6 +41,7 @@ jobs:
               - '.github/workflows/test.yml'
 
   test:
+    name: CLI harness
     needs: changes
     if: needs.changes.outputs.cli == 'true'
     runs-on: ubuntu-latest
@@ -55,6 +57,7 @@ jobs:
       - run: node dist/index.js env verify 1 --full
 
   control:
+    name: Mission Control
     needs: changes
     if: needs.changes.outputs.control == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Path-filter PR Test jobs so Mission Control verify runs only when `control/**` (or schemas/workflow) changes, and CLI verify only when CLI-related paths change
- Cache Playwright browsers (Test + Release) and lychee; expand npm cache to cover schemas + control lockfiles
- Stop rebuilding docs twice by uploading `docs/dist` directly instead of re-running `withastro/action`

## Test plan
- [ ] Open a docs-only PR and confirm both CLI and control Test jobs are skipped
- [ ] Open a `control/**`-only PR and confirm only the control job runs
- [ ] Open a `src/**` PR and confirm only the CLI test job runs (plus docs if path filters match)
- [ ] Confirm Documentation workflow still builds once and deploys on merge to main
- [ ] Confirm Release verify still installs Playwright (cache miss then hit on re-run)


Made with [Cursor](https://cursor.com)