### PR TITLE
feat: default session handoff to complete + open a PR

### DIFF
--- a/.cursor/rules/har-workflow.mdc
+++ b/.cursor/rules/har-workflow.mdc
@@ -64,13 +64,15 @@ UI changes with Playwright: update specs under `tests/` (full verify includes br
 ## Session handoff (required)
 
 After full verify and commit, stop. Include summary, session branch
-(`.har/slots/agent-<id>.json`), and preview URLs. Propose: (1) complete the slot
-(`har env complete` / `har_complete_environment` — branch kept), (2) open a PR if
-`gh`/GitHub MCP is available, or (3) something else. Wait for the user — never
-autonomously complete, teardown, push, or open a PR.
+(`.har/slots/agent-<id>.json`), and preview URLs. Wait — never autonomously
+complete, teardown, push, or open a PR. **Default (1 is the default):** when
+`gh`/GitHub MCP is available, recommend **Complete + open a PR** — push → open
+PR → `har env complete` / `har_complete_environment` (branch kept). Still needs
+approval. Alternatives: **Complete only**, or **Something else**. Without PR
+tooling, recommend **Complete only** and give the session branch for a manual push.
 
 ## Commit gate
 
 Full verify records a tree hash under `.har/validations/`. With `har hooks install`,
-commits must match a passing full verify. Re-verify after any edit; `git add -A` the
-verified tree. Do not bypass (`--no-verify`, `HAR_SKIP_GATE=1`).
+commits must match a passing full verify. Re-verify after any edit; `git add -A`.
+Do not bypass (`--no-verify`, `HAR_SKIP_GATE=1`).

--- a/.har/CLAUDE.agent.md
+++ b/.har/CLAUDE.agent.md
@@ -30,15 +30,17 @@ For Mission Control (Next.js + Postgres), use `control/.har/` instead.
 - [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
 
 ### Session handoff
 
 After full verify and commit, stop and propose next steps. Never autonomously run
-`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
-`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
-available (and only after explicit approval); otherwise report the session branch
-for a manual push. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
+`complete`, `teardown`, `git push`, or open a PR. **Default recommendation:** when
+`gh` or GitHub MCP is available, complete the slot **and** open a PR (push → PR →
+`har env complete` / `har_complete_environment`). Offer complete-only or something
+else as alternatives. If PR tooling is unavailable, recommend complete and report
+the session branch for a manual push. Prefer `complete` over bare `teardown` when
+the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
 Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -23,8 +23,9 @@ Run harness commands from the directory that owns the harness (e.g. `cd control 
 
 Follow [`.cursor/rules/har-workflow.mdc`](.cursor/rules/har-workflow.mdc) and
 [`.har/README.md`](.har/README.md): launch first, edit only under the session work
-dir, full-verify before done, then present a session handoff and wait for approval
-before `complete`, push, or PR.
+dir, full-verify before done, then present a session handoff and wait for approval.
+Default recommendation is complete + open a PR when tooling is available (still
+requires approval); never run `complete`, push, or PR autonomously.
 
 Configure Cursor MCP from [`.cursor/mcp.json.example`](.cursor/mcp.json.example)
 (see [CONTRIBUTING.md](./CONTRIBUTING.md)). Prefer MCP or `har env …` over
@@ -195,12 +196,13 @@ For docs-only updates: branch `docs/<topic>`, title `docs: …`. For CI-only upd
 har env launch 1                # if not already launched this session
 har env verify 1                # typecheck + unit tests
 har env verify 1 --full         # + lint + build — required before declaring done
-# then: session handoff → wait for user → on approval:
+# then: session handoff → wait for user → on approval of default (complete + PR):
+# push + open PR, then:
 har env complete 1              # full verify + validation + teardown; branch kept
 ```
 
 Or use MCP `har_run_verification` / `har_complete_environment` (preferred in Cursor). Shell fallback: `./.har/verify.sh 1 --full` then `./.har/teardown.sh 1` (no validation record — prefer CLI/MCP `complete` when available).
 
-Do not end the session without a handoff prompt. Never autonomously run `complete`, push, or open a PR.
+Do not end the session without a handoff prompt. Never autonomously run `complete`, push, or open a PR. The default handoff recommendation is complete + PR when tooling is available.
 
 If you changed `src/templates/`: `npm run build`, then `har env init --force --profile cli` on a fixture (or `--profile default` for web apps).

--- a/control/.har/CLAUDE.agent.md
+++ b/control/.har/CLAUDE.agent.md
@@ -32,15 +32,17 @@ A task is complete only when:
 - [ ] Changes are committed **in the session worktree** with a clear message
 - [ ] The user got the app URL (http://localhost:${FE_PORT}) to test themselves
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
 
 ### Session handoff
 
 After full verify and commit, stop and propose next steps. Never autonomously run
-`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
-`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
-available (and only after explicit approval); otherwise report the session branch
-for a manual push. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
+`complete`, `teardown`, `git push`, or open a PR. **Default recommendation:** when
+`gh` or GitHub MCP is available, complete the slot **and** open a PR (push → PR →
+`har env complete` / `har_complete_environment`). Offer complete-only or something
+else as alternatives. If PR tooling is unavailable, recommend complete and report
+the session branch for a manual push. Prefer `complete` over bare `teardown` when
+the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
 Quick check during development: `./.har/verify.sh ${AGENT_ID}` (stops before lint/e2e).
 

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -68,13 +68,15 @@ har env status --json
 3. Stage exactly the state that passed.
 4. Commit inside the session worktree.
 5. Present a **session handoff** and wait for the user's next instruction.
-6. On user approval: complete the environment (and optionally open a PR).
+6. On user approval of the default: push + open a PR (when tooling is available),
+   then complete the environment.
 
 ```bash
 har env verify 2 --full
 git add -A
 git commit -m "feat: describe the change"
-# hand off → wait for user → on approval:
+# hand off → wait for user → on approval of default:
+# push + open PR, then:
 har env complete 2
 ```
 
@@ -84,17 +86,19 @@ verify.
 ### What agents must propose
 
 After verify and commit, the agent should stop and offer numbered options — not
-silently finish the session:
+silently finish the session. **Complete + open a PR** is the default recommendation
+when `gh` or GitHub MCP is available; it still requires explicit user approval
+(default behaviour, not automatic).
 
-1. **Complete the slot** (recommended) — `har env complete <id>` / MCP
-   `har_complete_environment` runs full verification, records the validated tree
-   hash, tears down the worktree/runtime, and **keeps the session branch**. Prefer
-   this over bare `teardown` when the work succeeded.
-2. **Open a pull request** — only when `gh` or GitHub MCP is available, and only
-   after explicit user approval.
-3. **Keep the branch only** — if PR tooling is unavailable, report the session
-   branch name so the user can push manually. Omit option 2 and describe a manual
-   push instead when PR tooling is unavailable.
+1. **Complete + open a PR** (recommended when PR tooling is available) — push the
+   session branch, open the PR, then `har env complete <id>` / MCP
+   `har_complete_environment` (full verify + validation + teardown; **branch kept**).
+2. **Complete only** — same finish without a PR. Prefer `complete` over bare
+   `teardown` when the work succeeded.
+3. **Something else** — keep the slot running, more changes, or push only.
+
+If neither `gh` nor GitHub MCP is available, omit option 1 and recommend
+**Complete only**, with the session branch name for a manual push.
 
 Never run `complete`, `teardown`, `git push`, or create a PR without user
 approval. Canonical handoff shape:
@@ -106,9 +110,9 @@ approval. Canonical handoff shape:
 **Branch:** `<session-branch>` (session worktree)
 **Preview:** … (if applicable)
 
-Next steps — tell me which you want:
-1. **Complete the slot** — I'll run `har env complete <id>` (full verify + validation record + teardown; branch kept)
-2. **Open a PR** — I can create one with `gh`/GitHub MCP (requires your approval)
+Next steps — reply with a number (1 is the default):
+1. **Complete + open a PR** (recommended) — push, open PR, then `har env complete <id>`
+2. **Complete only** — same finish, no PR
 3. **Something else** — e.g. keep the slot running, more changes, or push only
 
 I'll wait for your instruction before running complete, teardown, push, or PR.

--- a/src/templates/AGENT.md.template
+++ b/src/templates/AGENT.md.template
@@ -29,9 +29,10 @@ Prefer **HAR MCP tools** (Cursor) or **`har env launch/verify/complete`** — th
 Use `./.har/*.sh` only when the CLI is not installed.
 
 When the work is done: full verify, commit in the session worktree, then present a
-**session handoff** and wait for the user before `har env complete <id>` /
-`har_complete_environment` (recommended finish: validation + teardown, branch kept),
-push, or opening a PR. See `.cursor/rules/har-workflow.mdc` for the handoff template.
+**session handoff** and wait for the user. The **default recommendation** is
+complete + open a PR when `gh`/GitHub MCP is available (still requires approval);
+alternatives are complete-only or something else. See
+`.cursor/rules/har-workflow.mdc` for the handoff template.
 
 ## Commit gate
 

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -64,13 +64,15 @@ UI changes with Playwright: update specs under `tests/` (full verify includes br
 ## Session handoff (required)
 
 After full verify and commit, stop. Include summary, session branch
-(`.har/slots/agent-<id>.json`), and preview URLs. Propose: (1) complete the slot
-(`har env complete` / `har_complete_environment` — branch kept), (2) open a PR if
-`gh`/GitHub MCP is available, or (3) something else. Wait for the user — never
-autonomously complete, teardown, push, or open a PR.
+(`.har/slots/agent-<id>.json`), and preview URLs. Wait — never autonomously
+complete, teardown, push, or open a PR. **Default (1 is the default):** when
+`gh`/GitHub MCP is available, recommend **Complete + open a PR** — push → open
+PR → `har env complete` / `har_complete_environment` (branch kept). Still needs
+approval. Alternatives: **Complete only**, or **Something else**. Without PR
+tooling, recommend **Complete only** and give the session branch for a manual push.
 
 ## Commit gate
 
 Full verify records a tree hash under `.har/validations/`. With `har hooks install`,
-commits must match a passing full verify. Re-verify after any edit; `git add -A` the
-verified tree. Do not bypass (`--no-verify`, `HAR_SKIP_GATE=1`).
+commits must match a passing full verify. Re-verify after any edit; `git add -A`.
+Do not bypass (`--no-verify`, `HAR_SKIP_GATE=1`).

--- a/src/templates/har-boilerplate-cli/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-cli/CLAUDE.agent.md
@@ -30,15 +30,17 @@ workflow, document the required credentials/default data and wire a smoke into
 - [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
 
 ### Session handoff
 
 After full verify and commit, stop and propose next steps. Never autonomously run
-`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
-`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
-available (and only after explicit approval); otherwise report the session branch
-for a manual push. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
+`complete`, `teardown`, `git push`, or open a PR. **Default recommendation:** when
+`gh` or GitHub MCP is available, complete the slot **and** open a PR (push → PR →
+`har env complete` / `har_complete_environment`). Offer complete-only or something
+else as alternatives. If PR tooling is unavailable, recommend complete and report
+the session branch for a manual push. Prefer `complete` over bare `teardown` when
+the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
 Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
 

--- a/src/templates/har-boilerplate-ios/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-ios/CLAUDE.agent.md
@@ -32,15 +32,17 @@ seeded data, or a simulator flow, document it here and wire the smoke into
 - [ ] New behavior has automated test coverage (unit tests via XCTest)
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
 
 ### Session handoff
 
 After full verify and commit, stop and propose next steps. Never autonomously run
-`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
-`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
-available (and only after explicit approval); otherwise report the session branch
-for a manual push. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
+`complete`, `teardown`, `git push`, or open a PR. **Default recommendation:** when
+`gh` or GitHub MCP is available, complete the slot **and** open a PR (push → PR →
+`har env complete` / `har_complete_environment`). Offer complete-only or something
+else as alternatives. If PR tooling is unavailable, recommend complete and report
+the session branch for a manual push. Prefer `complete` over bare `teardown` when
+the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
 Quick loop: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}`
 

--- a/src/templates/har-boilerplate/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate/CLAUDE.agent.md
@@ -44,15 +44,17 @@ is alive; it does not automatically mean an agent can use the app.
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] The user got the preview URLs to test the app themselves
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval: `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete ${AGENT_ID}` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
 
 ### Session handoff
 
 After full verify and commit, stop and propose next steps. Never autonomously run
-`complete`, `teardown`, `git push`, or open a PR. Prefer `complete` over bare
-`teardown` when the work succeeded. Offer a PR only if `gh` or GitHub MCP is
-available (and only after explicit approval); otherwise report the session branch
-for a manual push. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
+`complete`, `teardown`, `git push`, or open a PR. **Default recommendation:** when
+`gh` or GitHub MCP is available, complete the slot **and** open a PR (push → PR →
+`har env complete` / `har_complete_environment`). Offer complete-only or something
+else as alternatives. If PR tooling is unavailable, recommend complete and report
+the session branch for a manual push. Prefer `complete` over bare `teardown` when
+the work succeeded. See `.cursor/rules/har-workflow.mdc` for the handoff shape.
 
 Quick loop during development: MCP `har_run_verification`, `har env verify ${AGENT_ID}`, or `./.har/verify.sh ${AGENT_ID}` (smoke + health only; `--full` adds the registered verification stages).
 

--- a/tests/cursor-rule.test.ts
+++ b/tests/cursor-rule.test.ts
@@ -43,6 +43,9 @@ describe('cursor-rule', () => {
     expect(content).toContain('har_complete_environment');
     expect(content).toContain('Occupied slots always block');
     expect(content).toContain('Session handoff (required)');
+    expect(content).toContain('Complete + open a PR');
+    expect(content).toContain('1 is the default');
+    expect(content).toContain('Complete only');
     expect(content).not.toContain('harproject.dev');
     expect(content).not.toContain('har env restart');
     expect(content).not.toContain('confirmReplace');


### PR DESCRIPTION
## Summary
- Make **complete + open a PR** the recommended session handoff default (still requires explicit approval)
- Update Cursor rule template, CLAUDE/AGENT boilerplates, agent-workflow docs, and dogfood copies
- Assert the new default phrasing in cursor-rule tests (rule stays within the 80-line cap)

## Test plan
- [x] `har env verify 3 --full` passed
- [ ] Confirm agents propose complete+PR as option 1 when `gh`/GitHub MCP is available
- [ ] Confirm complete-only fallback when PR tooling is unavailable
- [ ] After merge, run `har env maintain --cursor-rule` in consumer repos to refresh the rule


Made with [Cursor](https://cursor.com)