### PR TITLE
feat(control): paginate and search Usage sessions with DataTable

### DIFF
--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/control",
-  "version": "0.36.2",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "0.36.2",
+      "version": "0.42.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -66,7 +66,7 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "0.36.2",
+      "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/control/src/app/usage/page.tsx
+++ b/control/src/app/usage/page.tsx
@@ -1,23 +1,29 @@
-import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { UsageTable, type UsageRow } from '@/components/usage-table';
+import { formatCostUsd, formatTokens } from '@/lib/usage-models';
 import { listAllSessionUsage, summarizeUsageRows } from '@/server/usage';
 
 export const dynamic = 'force-dynamic';
 
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
-}
-
 export default async function UsagePage() {
-  const rows = await listAllSessionUsage();
-  const summary = summarizeUsageRows(rows);
+  const records = await listAllSessionUsage();
+  const summary = summarizeUsageRows(records);
+
+  const rows: UsageRow[] = records.map((row) => ({
+    id: row.id,
+    repositoryId: row.repositoryId,
+    repositoryPath: row.repository.path,
+    agentId: row.agentId,
+    sessionKey: row.sessionKey,
+    agentTool: row.agentTool,
+    tokensTotal: Number(row.tokensTotal),
+    costUsd: row.costUsd == null ? null : Number(row.costUsd),
+    sources: row.sources,
+    lastSeenAt: row.lastSeenAt,
+  }));
 
   return (
-    <div className="space-y-6 px-4 py-4 md:px-6 md:py-6">
+    <div className="min-w-0 space-y-6 overflow-x-hidden px-4 py-4 md:px-6 md:py-6">
       <div>
         <h2 className="text-2xl font-semibold">Usage</h2>
         <p className="text-sm text-muted-foreground">
@@ -58,9 +64,7 @@ export default async function UsagePage() {
             <CardTitle className="text-base">Estimated cost</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-2xl font-bold tabular-nums">
-              {summary.costUsd == null ? '—' : `$${summary.costUsd.toFixed(4)}`}
-            </p>
+            <p className="text-2xl font-bold tabular-nums">{formatCostUsd(summary.costUsd)}</p>
           </CardContent>
         </Card>
         <Card>
@@ -75,85 +79,15 @@ export default async function UsagePage() {
         </Card>
       </div>
 
-      <Card>
+      <Card className="min-w-0">
         <CardHeader>
           <CardTitle>Sessions</CardTitle>
-          <CardDescription>Click through to the slot leaf for verify + timeline</CardDescription>
+          <CardDescription>
+            Paginated usage sessions — search or filter, then open a slot for verify + timeline
+          </CardDescription>
         </CardHeader>
-        <CardContent>
-          {rows.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No usage recorded yet. Enable telemetry and sync, or run an agent with OTEL pointed at
-              Mission Control.
-            </p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-left text-sm">
-                <thead>
-                  <tr className="border-b text-muted-foreground">
-                    <th className="py-2 pr-4 font-medium">Repository</th>
-                    <th className="py-2 pr-4 font-medium">Slot</th>
-                    <th className="py-2 pr-4 font-medium">Session</th>
-                    <th className="py-2 pr-4 font-medium">Agent</th>
-                    <th className="py-2 pr-4 font-medium">Tokens</th>
-                    <th className="py-2 pr-4 font-medium">Cost</th>
-                    <th className="py-2 pr-4 font-medium">Sources</th>
-                    <th className="py-2 font-medium">Last seen</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((row) => (
-                    <tr key={row.id} className="border-b border-border/60">
-                      <td className="py-2 pr-4">
-                        <Link
-                          href={`/repos/${row.repositoryId}`}
-                          className="text-primary underline-offset-2 hover:underline"
-                          title={row.repository.path}
-                        >
-                          {row.repository.path.split('/').pop() ?? row.repository.path}
-                        </Link>
-                      </td>
-                      <td className="py-2 pr-4">
-                        <Link
-                          href={`/repos/${row.repositoryId}/slots/${row.agentId}`}
-                          className="font-medium text-primary underline-offset-2 hover:underline"
-                        >
-                          {row.agentId}
-                        </Link>
-                      </td>
-                      <td
-                        className="max-w-xs truncate py-2 pr-4 font-mono text-xs"
-                        title={row.sessionKey}
-                      >
-                        {row.sessionKey}
-                      </td>
-                      <td className="py-2 pr-4">
-                        <Badge variant="outline">{formatAgentToolLabel(row.agentTool)}</Badge>
-                      </td>
-                      <td className="py-2 pr-4 tabular-nums">
-                        {formatTokens(Number(row.tokensTotal))}
-                      </td>
-                      <td className="py-2 pr-4 tabular-nums">
-                        {row.costUsd == null ? '—' : `$${Number(row.costUsd).toFixed(4)}`}
-                      </td>
-                      <td className="py-2 pr-4">
-                        <div className="flex flex-wrap gap-1">
-                          {row.sources.map((s) => (
-                            <Badge key={s} variant="secondary">
-                              {s}
-                            </Badge>
-                          ))}
-                        </div>
-                      </td>
-                      <td className="py-2 text-muted-foreground" suppressHydrationWarning>
-                        {row.lastSeenAt.toLocaleString()}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+        <CardContent className="min-w-0">
+          <UsageTable rows={rows} />
         </CardContent>
       </Card>
     </div>

--- a/control/src/components/columns/usage-columns.tsx
+++ b/control/src/components/columns/usage-columns.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Link from 'next/link';
+import { type ColumnDef } from '@tanstack/react-table';
+
+import { Badge } from '@/components/ui/badge';
+import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { formatCostUsd, formatTokens } from '@/lib/usage-models';
+
+export interface UsageRow {
+  id: string;
+  repositoryId: string;
+  repositoryPath: string;
+  agentId: number;
+  sessionKey: string;
+  agentTool: string;
+  tokensTotal: number;
+  costUsd: number | null;
+  sources: string[];
+  lastSeenAt: Date | string;
+}
+
+function repoLabel(path: string): string {
+  return path.split('/').pop() ?? path;
+}
+
+function asDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+export const usageColumns: ColumnDef<UsageRow>[] = [
+  {
+    id: 'repository',
+    accessorFn: (row) => repoLabel(row.repositoryPath),
+    header: 'Repository',
+    cell: ({ row }) => (
+      <Link
+        href={`/repos/${row.original.repositoryId}`}
+        title={row.original.repositoryPath}
+        className="text-primary underline-offset-2 hover:underline"
+      >
+        {repoLabel(row.original.repositoryPath)}
+      </Link>
+    ),
+  },
+  {
+    id: 'slot',
+    accessorKey: 'agentId',
+    header: 'Slot',
+    cell: ({ row }) => (
+      <Link
+        href={`/repos/${row.original.repositoryId}/slots/${row.original.agentId}`}
+        className="font-medium text-primary underline-offset-2 hover:underline"
+      >
+        {row.original.agentId}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: 'sessionKey',
+    header: 'Session',
+    cell: ({ row }) => (
+      <span className="max-w-xs truncate font-mono text-xs" title={row.original.sessionKey}>
+        {row.original.sessionKey}
+      </span>
+    ),
+  },
+  {
+    accessorKey: 'agentTool',
+    header: 'Agent',
+    cell: ({ row }) => (
+      <Badge variant="outline">{formatAgentToolLabel(row.original.agentTool)}</Badge>
+    ),
+    filterFn: (row, _columnId, filterValue) => {
+      if (!filterValue) return true;
+      return row.original.agentTool === filterValue;
+    },
+  },
+  {
+    accessorKey: 'tokensTotal',
+    header: 'Tokens',
+    cell: ({ row }) => (
+      <span className="tabular-nums">{formatTokens(row.original.tokensTotal)}</span>
+    ),
+  },
+  {
+    id: 'cost',
+    accessorFn: (row) => row.costUsd ?? -1,
+    header: 'Cost',
+    cell: ({ row }) => (
+      <span className="tabular-nums">{formatCostUsd(row.original.costUsd)}</span>
+    ),
+  },
+  {
+    id: 'sources',
+    accessorFn: (row) => row.sources.join(' '),
+    header: 'Sources',
+    enableSorting: false,
+    cell: ({ row }) => (
+      <div className="flex flex-wrap gap-1">
+        {row.original.sources.map((source) => (
+          <Badge key={source} variant="secondary">
+            {source}
+          </Badge>
+        ))}
+      </div>
+    ),
+  },
+  {
+    id: 'lastSeen',
+    accessorFn: (row) => asDate(row.lastSeenAt).getTime(),
+    header: 'Last seen',
+    cell: ({ row }) => (
+      <span className="text-muted-foreground" suppressHydrationWarning>
+        {asDate(row.original.lastSeenAt).toLocaleString()}
+      </span>
+    ),
+  },
+];

--- a/control/src/components/usage-table.tsx
+++ b/control/src/components/usage-table.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { type ColumnFiltersState } from '@tanstack/react-table';
+import { useRouter } from 'next/navigation';
+
+import { usageColumns, type UsageRow } from '@/components/columns/usage-columns';
+import { DataTable } from '@/components/data-table/data-table';
+import { Button } from '@/components/ui/button';
+import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { matchesUsageSearch } from '@/lib/usage-models';
+
+export type { UsageRow };
+
+export function UsageTable({ rows }: { rows: UsageRow[] }) {
+  const router = useRouter();
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const agents = useMemo(
+    () => Array.from(new Set(rows.map((row) => row.agentTool).filter(Boolean))).sort(),
+    [rows],
+  );
+
+  const activeAgent =
+    (columnFilters.find((filter) => filter.id === 'agentTool')?.value as string | undefined) ??
+    null;
+
+  const filteredCount = useMemo(() => {
+    return rows.filter((row) => {
+      if (activeAgent && row.agentTool !== activeAgent) return false;
+      return matchesUsageSearch(row, globalFilter, formatAgentToolLabel);
+    }).length;
+  }, [rows, globalFilter, activeAgent]);
+
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No usage recorded yet. Enable telemetry and sync, or run an agent with OTEL pointed at
+        Mission Control.
+      </p>
+    );
+  }
+
+  return (
+    <div className="min-w-0 space-y-3">
+      {agents.length > 1 ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant={activeAgent === null ? 'secondary' : 'outline'}
+            size="sm"
+            onClick={() => setColumnFilters([])}
+          >
+            All
+          </Button>
+          {agents.map((agent) => (
+            <Button
+              key={agent}
+              variant={activeAgent === agent ? 'secondary' : 'outline'}
+              size="sm"
+              onClick={() => setColumnFilters([{ id: 'agentTool', value: agent }])}
+            >
+              {formatAgentToolLabel(agent)}
+            </Button>
+          ))}
+        </div>
+      ) : null}
+
+      <DataTable
+        columns={usageColumns}
+        data={rows}
+        getRowId={(row) => row.id}
+        pageSize={10}
+        searchPlaceholder="Search repository, session, slot, agent…"
+        searchAriaLabel="Search usage sessions"
+        emptyMessage={
+          filteredCount === 0 ? 'No sessions match your filters.' : 'No results.'
+        }
+        globalFilter={globalFilter}
+        onGlobalFilterChange={setGlobalFilter}
+        globalFilterFn={(row, _columnId, filterValue) =>
+          matchesUsageSearch(row.original, String(filterValue ?? ''), formatAgentToolLabel)
+        }
+        columnFilters={columnFilters}
+        onColumnFiltersChange={setColumnFilters}
+        onRowClick={(row) => {
+          router.push(`/repos/${row.repositoryId}/slots/${row.agentId}`);
+        }}
+      />
+    </div>
+  );
+}

--- a/control/src/lib/usage-models.test.ts
+++ b/control/src/lib/usage-models.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { formatCostUsd, formatModelId, modelsFromBreakdown, modelTotalsFromBreakdown } from './usage-models';
+import {
+  formatCostUsd,
+  formatModelId,
+  formatTokens,
+  matchesUsageSearch,
+  modelsFromBreakdown,
+  modelTotalsFromBreakdown,
+} from './usage-models';
 
 describe('usage-models', () => {
   it('lists model ids from breakdown', () => {
@@ -30,4 +37,30 @@ describe('usage-models', () => {
     expect(formatCostUsd(null)).toBe('—');
     expect(formatCostUsd(0.1234)).toBe('$0.1234');
   });
+
+  it('formats token counts', () => {
+    expect(formatTokens(42)).toBe('42');
+    expect(formatTokens(1500)).toBe('1.5k');
+    expect(formatTokens(2_500_000)).toBe('2.50M');
+  });
+
+  it('matches usage search across repo, slot, session, agent, and sources', () => {
+    const row = {
+      repositoryPath: '/home/user/projects/har-project',
+      agentId: 2,
+      sessionKey: 'main-abcd-har-agent-2-wxyz',
+      agentTool: 'claude_code',
+      sources: ['otel', 'harvest'],
+    };
+    expect(matchesUsageSearch(row, '', (t) => t)).toBe(true);
+    expect(matchesUsageSearch(row, 'har-project', (t) => t)).toBe(true);
+    expect(matchesUsageSearch(row, '2', (t) => t)).toBe(true);
+    expect(matchesUsageSearch(row, 'wxyz', (t) => t)).toBe(true);
+    expect(matchesUsageSearch(row, 'Claude', (t) => (t === 'claude_code' ? 'Claude' : t))).toBe(
+      true,
+    );
+    expect(matchesUsageSearch(row, 'harvest', (t) => t)).toBe(true);
+    expect(matchesUsageSearch(row, 'zzz-missing', (t) => t)).toBe(false);
+  });
 });
+

--- a/control/src/lib/usage-models.ts
+++ b/control/src/lib/usage-models.ts
@@ -40,3 +40,37 @@ export function formatCostUsd(value: number | null | undefined): string {
   if (value == null || !Number.isFinite(value)) return '—';
   return `$${value.toFixed(4)}`;
 }
+
+/** Compact token count for tables and summary cards. */
+export function formatTokens(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
+/** Global search matcher for Usage session rows (repository, slot, session, agent, sources). */
+export function matchesUsageSearch(
+  row: {
+    repositoryPath: string;
+    agentId: number;
+    sessionKey: string;
+    agentTool: string;
+    sources: string[];
+  },
+  filterValue: string,
+  agentLabel: (tool: string) => string = (tool) => tool,
+): boolean {
+  const q = filterValue.trim().toLowerCase();
+  if (!q) return true;
+  const repoName = row.repositoryPath.split('/').pop() ?? row.repositoryPath;
+  return (
+    repoName.toLowerCase().includes(q) ||
+    row.repositoryPath.toLowerCase().includes(q) ||
+    String(row.agentId).includes(q) ||
+    row.sessionKey.toLowerCase().includes(q) ||
+    row.agentTool.toLowerCase().includes(q) ||
+    agentLabel(row.agentTool).toLowerCase().includes(q) ||
+    row.sources.some((source) => source.toLowerCase().includes(q))
+  );
+}

--- a/control/tests/frontend/usage.spec.js
+++ b/control/tests/frontend/usage.spec.js
@@ -4,9 +4,10 @@ test.describe('Usage page', () => {
   test('shows summary cards and empty or table state', async ({ page }) => {
     await page.goto('/usage');
     await expect(page.getByRole('heading', { name: 'Usage' })).toBeVisible();
+    // Summary card titles can also appear as column headers when rows exist.
     await expect(page.getByText('Sessions', { exact: true }).first()).toBeVisible();
-    await expect(page.getByText('Tokens', { exact: true })).toBeVisible();
-    await expect(page.getByText('Estimated cost', { exact: true })).toBeVisible();
+    await expect(page.getByText('Tokens', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Estimated cost', { exact: true }).first()).toBeVisible();
 
     const empty = page.getByText(/no usage recorded yet/i);
     const table = page.getByRole('table');

--- a/control/tests/frontend/usage.spec.js
+++ b/control/tests/frontend/usage.spec.js
@@ -1,0 +1,50 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Usage page', () => {
+  test('shows summary cards and empty or table state', async ({ page }) => {
+    await page.goto('/usage');
+    await expect(page.getByRole('heading', { name: 'Usage' })).toBeVisible();
+    await expect(page.getByText('Sessions', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Tokens', { exact: true })).toBeVisible();
+    await expect(page.getByText('Estimated cost', { exact: true })).toBeVisible();
+
+    const empty = page.getByText(/no usage recorded yet/i);
+    const table = page.getByRole('table');
+    await expect(empty.or(table)).toBeVisible();
+  });
+
+  test('exposes search when sessions exist', async ({ page }) => {
+    await page.goto('/usage');
+
+    const table = page.getByRole('table');
+    if (!(await table.isVisible().catch(() => false))) {
+      test.skip(true, 'No usage sessions recorded — nothing to search');
+    }
+
+    const search = page.getByRole('searchbox', { name: /search usage sessions/i });
+    await expect(search).toBeVisible();
+    await expect(page.getByRole('button', { name: /columns/i })).toBeVisible();
+
+    const totalRows = await page.getByRole('row').count();
+
+    await search.fill('zzz-no-such-usage-session-zzz');
+    await expect(page.getByRole('cell', { name: /no sessions match your filters/i })).toBeVisible();
+
+    await search.fill('');
+    await expect(page.getByRole('row')).toHaveCount(totalRows);
+  });
+
+  test('keeps horizontal scroll inside the table, not the page', async ({ page }) => {
+    await page.goto('/usage');
+    await expect(page.getByRole('heading', { name: 'Usage' })).toBeVisible();
+
+    const metrics = await page.evaluate(() => {
+      const doc = document.documentElement;
+      return {
+        pageOverflowsX: doc.scrollWidth > doc.clientWidth + 1,
+      };
+    });
+
+    expect(metrics.pageOverflowsX).toBe(false);
+  });
+});

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/schemas",
-  "version": "0.36.2",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "0.36.2",
+      "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",


### PR DESCRIPTION
## Summary
- Replace the unbounded Usage sessions HTML table with the shared Mission Control `DataTable` (search, pagination, sorting, column toggles).
- Add agent-tool filter chips and keep summary cards as global rollups.
- Cover search helpers with unit tests and add Playwright coverage for the Usage page ([#137](https://github.com/os-factory/har/issues/137)).

## Test plan
- [ ] Open `/usage` with many sessions — page stays paginated (default 10 rows)
- [ ] Search by repository / session / slot / agent; clearing search restores rows
- [ ] Agent filter chips narrow the list when multiple tools are present
- [ ] Repo and slot links still navigate correctly; row click opens the slot page
- [ ] Summary cards still reflect totals across all sessions, not the current page
- [ ] `har env verify 2 --full` passes in the control harness

Closes #137


Made with [Cursor](https://cursor.com)