### PR TITLE
fix(control): enrich factory work unit detail beyond evidence timeline

### DIFF
--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/control",
-  "version": "0.36.2",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "0.36.2",
+      "version": "0.42.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -66,7 +66,7 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "0.36.2",
+      "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/control/src/app/factory/[id]/page.tsx
+++ b/control/src/app/factory/[id]/page.tsx
@@ -1,7 +1,14 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { WorkUnitEvidenceTable } from '@/components/work-unit-evidence-table';
+import { WorkUnitWorktreesTable } from '@/components/work-unit-worktrees-table';
+import { gitRemoteBrowseUrl } from '@/lib/git-remote-url';
+import {
+  buildWorkUnitEvidenceRows,
+  buildWorkUnitWorktreeRows,
+} from '@/lib/work-unit-evidence';
 import { getFactoryWorkUnitById } from '@/server/work-units';
 
 export const dynamic = 'force-dynamic';
@@ -15,69 +22,174 @@ export default async function WorkUnitPage({
   const unit = await getFactoryWorkUnitById(id);
   if (!unit) notFound();
   const outcome = unit.outcome as { decision?: string; decidedAt?: string } | null;
+  const status = outcome?.decision ?? (unit.slot ? 'active' : 'open');
+  const browseUrl = gitRemoteBrowseUrl(unit.repository.gitRemote);
+  const repoName =
+    unit.repository.path.split('/').pop() ?? unit.repository.path;
 
-  const timeline = [
-    ...unit.attempts.map((attempt) => ({
-      at: attempt.sourceCreatedAt,
-      title: `Attempt ${attempt.attemptId.slice(0, 8)}`,
-      detail: `slot ${attempt.agentId}${attempt.branch ? ` · ${attempt.branch}` : ''}`,
-      state: 'attempt',
-    })),
-    ...unit.runs.map((run) => ({
-      at: run.startedAt,
-      title: run.stageId,
-      detail: `${run.status}${run.durationMs ? ` · ${run.durationMs}ms` : ''}`,
-      state: run.status,
-    })),
-    ...unit.validationBindings.map((binding) => ({
-      at: binding.sourceCreatedAt,
-      title: 'Exact-tree validation',
-      detail: binding.treeHash,
-      state: (() => {
-        const validation = unit.validations.find(
-          (candidate) => candidate.validationId === binding.validationId,
-        );
-        return validation?.status === 'pass' && validation.full
-          ? 'verified'
-          : validation?.status ?? 'validation';
-      })(),
-    })),
-  ].sort((a, b) => b.at.getTime() - a.at.getTime());
+  const agents = [
+    ...new Map(
+      [
+        ...unit.slots.map((slot) => ({
+          agentId: slot.slotId,
+          active: slot.active,
+          purpose: slot.purpose,
+        })),
+        ...unit.attempts.map((attempt) => ({
+          agentId: attempt.agentId,
+          active: unit.slots.some(
+            (slot) => slot.slotId === attempt.agentId && slot.active,
+          ),
+          purpose: null as string | null,
+        })),
+      ].map((agent) => [agent.agentId, agent]),
+    ).values(),
+  ].sort((a, b) => {
+    if (a.active !== b.active) return a.active ? -1 : 1;
+    return a.agentId - b.agentId;
+  });
+
+  const worktrees = buildWorkUnitWorktreeRows({
+    repoId: unit.repository.id,
+    attempts: unit.attempts,
+    slots: unit.slots,
+  });
+
+  const evidence = buildWorkUnitEvidenceRows({
+    attempts: unit.attempts,
+    runs: unit.runs,
+    validationBindings: unit.validationBindings,
+    validations: unit.validations,
+  });
 
   return (
-    <div className="space-y-6 px-4 py-4 md:px-6 md:py-6">
+    <div className="min-w-0 space-y-6 overflow-x-hidden px-4 py-4 md:px-6 md:py-6">
       <div>
-        <Link href="/" className="text-sm text-muted-foreground hover:underline">← Factory</Link>
+        <Link href="/" className="text-sm text-muted-foreground hover:underline">
+          ← Factory
+        </Link>
         <div className="mt-2 flex flex-wrap items-center gap-3">
           <h2 className="text-2xl font-semibold">{unit.title ?? unit.workUnitId}</h2>
-          <Badge variant="secondary">{outcome?.decision ?? (unit.slot ? 'active' : 'open')}</Badge>
+          <Badge variant="secondary">{status}</Badge>
         </div>
         <p className="font-mono text-xs text-muted-foreground">{unit.workUnitId}</p>
+        {unit.sourceUrl ? (
+          <p className="mt-1 text-sm">
+            <a
+              href={unit.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary underline-offset-2 hover:underline"
+            >
+              Source
+            </a>
+          </p>
+        ) : null}
       </div>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <Card><CardHeader><CardTitle className="text-base">Repository</CardTitle></CardHeader><CardContent className="break-all text-sm">{unit.repository.path}</CardContent></Card>
-        <Card><CardHeader><CardTitle className="text-base">Attempts</CardTitle></CardHeader><CardContent className="text-2xl font-bold">{unit.attempts.length}</CardContent></Card>
-        <Card><CardHeader><CardTitle className="text-base">Agent cost</CardTitle></CardHeader><CardContent className="text-2xl font-bold">${Number(unit.usage.costUsd ?? 0).toFixed(4)}</CardContent></Card>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Repository</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <Link
+              href={`/repos/${unit.repository.id}`}
+              className="font-medium text-primary underline-offset-2 hover:underline"
+            >
+              {repoName}
+            </Link>
+            <p className="break-all font-mono text-xs text-muted-foreground">
+              {unit.repository.path}
+            </p>
+            {browseUrl ? (
+              <a
+                href={browseUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-block text-xs text-primary underline-offset-2 hover:underline"
+              >
+                Open remote
+              </a>
+            ) : unit.repository.gitRemote ? (
+              <p className="break-all font-mono text-xs text-muted-foreground">
+                {unit.repository.gitRemote}
+              </p>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Agent</CardTitle>
+            <CardDescription>Slots that worked this unit</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {agents.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No agent linked yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {agents.map((agent) => (
+                  <li key={agent.agentId} className="flex flex-wrap items-center gap-2 text-sm">
+                    <Link
+                      href={`/repos/${unit.repository.id}/slots/${agent.agentId}`}
+                      className="font-medium text-primary underline-offset-2 hover:underline"
+                    >
+                      Slot {agent.agentId}
+                    </Link>
+                    <Badge variant={agent.active ? 'success' : 'outline'}>
+                      {agent.active ? 'active' : 'idle'}
+                    </Badge>
+                    {agent.purpose ? (
+                      <span className="max-w-48 truncate text-xs text-muted-foreground" title={agent.purpose}>
+                        {agent.purpose}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Attempts</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">{unit.attempts.length}</CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Agent cost</CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            ${Number(unit.usage.costUsd ?? 0).toFixed(4)}
+          </CardContent>
+        </Card>
       </div>
 
-      <Card>
-        <CardHeader><CardTitle>Evidence timeline</CardTitle></CardHeader>
+      <Card className="min-w-0">
+        <CardHeader>
+          <CardTitle>Worktrees</CardTitle>
+          <CardDescription>
+            Session worktrees and attempts bound to this work unit.
+          </CardDescription>
+        </CardHeader>
         <CardContent>
-          {timeline.length === 0 ? <p className="text-sm text-muted-foreground">No execution evidence synchronized yet.</p> : (
-            <ol className="space-y-4">
-              {timeline.map((item, index) => (
-                <li key={`${item.title}-${item.at.toISOString()}-${index}`} className="border-l pl-4">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <p className="font-medium">{item.title}</p>
-                    <Badge variant={item.state === 'fail' || item.state === 'error' ? 'destructive' : 'outline'}>{item.state}</Badge>
-                  </div>
-                  <p className="break-all font-mono text-xs text-muted-foreground">{item.detail}</p>
-                  <time className="text-xs text-muted-foreground">{item.at.toLocaleString()}</time>
-                </li>
-              ))}
-            </ol>
-          )}
+          <WorkUnitWorktreesTable rows={worktrees} />
+        </CardContent>
+      </Card>
+
+      <Card className="min-w-0">
+        <CardHeader>
+          <CardTitle>Evidence</CardTitle>
+          <CardDescription>
+            Attempts, runs, and exact-tree validations in a searchable table.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <WorkUnitEvidenceTable repoId={unit.repository.id} rows={evidence} />
         </CardContent>
       </Card>
     </div>

--- a/control/src/components/columns/work-unit-evidence-columns.tsx
+++ b/control/src/components/columns/work-unit-evidence-columns.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import Link from 'next/link';
+import { type ColumnDef } from '@tanstack/react-table';
+
+import { Badge } from '@/components/ui/badge';
+import type { WorkUnitEvidenceRow } from '@/lib/work-unit-evidence';
+
+export type { WorkUnitEvidenceRow };
+
+export function createWorkUnitEvidenceColumns(
+  repoId: string,
+): ColumnDef<WorkUnitEvidenceRow>[] {
+  return [
+    {
+      accessorKey: 'at',
+      header: 'Time',
+      cell: ({ row }) => (
+        <span className="whitespace-nowrap text-muted-foreground" suppressHydrationWarning>
+          {row.original.at.toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'kind',
+      header: 'Kind',
+      cell: ({ row }) => <Badge variant="outline">{row.original.kind}</Badge>,
+    },
+    {
+      accessorKey: 'title',
+      header: 'Event',
+      cell: ({ row }) => <span className="font-medium">{row.original.title}</span>,
+    },
+    {
+      accessorKey: 'state',
+      header: 'State',
+      cell: ({ row }) => (
+        <Badge
+          variant={
+            row.original.state === 'fail' || row.original.state === 'error'
+              ? 'destructive'
+              : row.original.state === 'pass' || row.original.state === 'verified'
+                ? 'success'
+                : 'secondary'
+          }
+        >
+          {row.original.state}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: 'agentId',
+      header: 'Agent',
+      cell: ({ row }) =>
+        row.original.agentId != null ? (
+          <Link
+            href={`/repos/${repoId}/slots/${row.original.agentId}`}
+            className="tabular-nums text-primary underline-offset-2 hover:underline"
+          >
+            {row.original.agentId}
+          </Link>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    },
+    {
+      accessorKey: 'detail',
+      header: 'Detail',
+      cell: ({ row }) => (
+        <span
+          className="max-w-md truncate font-mono text-xs text-muted-foreground"
+          title={row.original.detail}
+        >
+          {row.original.detail}
+        </span>
+      ),
+    },
+  ];
+}

--- a/control/src/components/columns/work-unit-worktree-columns.tsx
+++ b/control/src/components/columns/work-unit-worktree-columns.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Link from 'next/link';
+import { type ColumnDef } from '@tanstack/react-table';
+
+import { Badge } from '@/components/ui/badge';
+import type { WorkUnitWorktreeRow } from '@/lib/work-unit-evidence';
+
+export type { WorkUnitWorktreeRow };
+
+export const workUnitWorktreeColumns: ColumnDef<WorkUnitWorktreeRow>[] = [
+  {
+    accessorKey: 'agentId',
+    header: 'Agent',
+    cell: ({ row }) => (
+      <Link
+        href={`/repos/${row.original.repoId}/slots/${row.original.agentId}`}
+        className="font-medium text-primary underline-offset-2 hover:underline"
+      >
+        {row.original.agentId}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: 'active',
+    header: 'Status',
+    cell: ({ row }) =>
+      row.original.active ? (
+        <Badge variant="success">active</Badge>
+      ) : (
+        <Badge variant="outline">idle</Badge>
+      ),
+  },
+  {
+    id: 'path',
+    accessorFn: (row) => row.worktreePath ?? row.workDir ?? '',
+    header: 'Worktree',
+    cell: ({ row }) => {
+      const path = row.original.worktreePath ?? row.original.workDir;
+      if (!path) return <span className="text-muted-foreground">—</span>;
+      return (
+        <span className="max-w-md truncate font-mono text-xs text-muted-foreground" title={path}>
+          {path}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: 'branch',
+    header: 'Branch',
+    cell: ({ row }) =>
+      row.original.branch ? (
+        <span className="max-w-48 truncate font-mono text-xs" title={row.original.branch}>
+          {row.original.branch}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+  {
+    accessorKey: 'attemptId',
+    header: 'Attempt',
+    cell: ({ row }) =>
+      row.original.attemptId ? (
+        <span className="font-mono text-xs text-muted-foreground">
+          {row.original.attemptId.slice(0, 8)}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+  {
+    accessorKey: 'baseCommit',
+    header: 'Base',
+    cell: ({ row }) =>
+      row.original.baseCommit ? (
+        <span className="font-mono text-xs text-muted-foreground">
+          {row.original.baseCommit.slice(0, 7)}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+];

--- a/control/src/components/work-unit-evidence-table.tsx
+++ b/control/src/components/work-unit-evidence-table.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { DataTable } from '@/components/data-table/data-table';
+import {
+  createWorkUnitEvidenceColumns,
+  type WorkUnitEvidenceRow,
+} from '@/components/columns/work-unit-evidence-columns';
+
+export function WorkUnitEvidenceTable({
+  repoId,
+  rows,
+}: {
+  repoId: string;
+  rows: WorkUnitEvidenceRow[];
+}) {
+  const columns = useMemo(() => createWorkUnitEvidenceColumns(repoId), [repoId]);
+
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">No execution evidence synchronized yet.</p>
+    );
+  }
+
+  return (
+    <DataTable
+      columns={columns}
+      data={rows}
+      getRowId={(row) => row.id}
+      showPagination={rows.length > 15}
+      pageSize={15}
+      searchPlaceholder="Search evidence…"
+      searchAriaLabel="Search evidence"
+      emptyMessage="No evidence matches the search."
+    />
+  );
+}

--- a/control/src/components/work-unit-worktrees-table.tsx
+++ b/control/src/components/work-unit-worktrees-table.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { DataTable } from '@/components/data-table/data-table';
+import {
+  workUnitWorktreeColumns,
+  type WorkUnitWorktreeRow,
+} from '@/components/columns/work-unit-worktree-columns';
+
+export function WorkUnitWorktreesTable({ rows }: { rows: WorkUnitWorktreeRow[] }) {
+  const router = useRouter();
+
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No worktrees linked to this work unit yet.
+      </p>
+    );
+  }
+
+  return (
+    <DataTable
+      columns={workUnitWorktreeColumns}
+      data={rows}
+      getRowId={(row) => row.id}
+      showPagination={rows.length > 10}
+      pageSize={10}
+      searchPlaceholder="Search worktrees…"
+      searchAriaLabel="Search worktrees for this unit"
+      emptyMessage="No worktrees match the search."
+      onRowClick={(row) => {
+        router.push(`/repos/${row.repoId}/slots/${row.agentId}`);
+      }}
+    />
+  );
+}

--- a/control/src/lib/git-remote-url.test.ts
+++ b/control/src/lib/git-remote-url.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { gitRemoteBrowseUrl } from './git-remote-url';
+
+describe('gitRemoteBrowseUrl', () => {
+  it('keeps https remotes and strips .git', () => {
+    expect(gitRemoteBrowseUrl('https://github.com/os-factory/har.git')).toBe(
+      'https://github.com/os-factory/har',
+    );
+  });
+
+  it('converts ssh remotes', () => {
+    expect(gitRemoteBrowseUrl('git@github.com:os-factory/har.git')).toBe(
+      'https://github.com/os-factory/har',
+    );
+  });
+
+  it('returns null for empty or unknown forms', () => {
+    expect(gitRemoteBrowseUrl(null)).toBeNull();
+    expect(gitRemoteBrowseUrl('')).toBeNull();
+    expect(gitRemoteBrowseUrl('file:///tmp/repo')).toBeNull();
+  });
+});

--- a/control/src/lib/git-remote-url.ts
+++ b/control/src/lib/git-remote-url.ts
@@ -1,0 +1,26 @@
+/** Convert a git remote (HTTPS or SSH) into a browser URL when possible. */
+export function gitRemoteBrowseUrl(remote: string | null | undefined): string | null {
+  if (!remote) return null;
+  const trimmed = remote.trim();
+  if (!trimmed) return null;
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed.replace(/\.git$/i, '');
+  }
+
+  const ssh = trimmed.match(/^git@([^:]+):(.+)$/i);
+  if (ssh) {
+    const host = ssh[1];
+    const path = ssh[2].replace(/\.git$/i, '');
+    return `https://${host}/${path}`;
+  }
+
+  const sshProtocol = trimmed.match(/^ssh:\/\/git@([^/]+)\/(.+)$/i);
+  if (sshProtocol) {
+    const host = sshProtocol[1];
+    const path = sshProtocol[2].replace(/\.git$/i, '');
+    return `https://${host}/${path}`;
+  }
+
+  return null;
+}

--- a/control/src/lib/work-unit-evidence.test.ts
+++ b/control/src/lib/work-unit-evidence.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorkUnitEvidenceRows, buildWorkUnitWorktreeRows } from './work-unit-evidence';
+
+describe('buildWorkUnitEvidenceRows', () => {
+  it('merges attempts, runs, and validations newest-first as table rows', () => {
+    const rows = buildWorkUnitEvidenceRows({
+      attempts: [
+        {
+          attemptId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          agentId: 2,
+          branch: 'feat/x',
+          sourceCreatedAt: new Date('2026-08-01T10:00:00.000Z'),
+        },
+      ],
+      runs: [
+        {
+          id: 'run-1',
+          stageId: 'verify',
+          status: 'pass',
+          durationMs: 1200,
+          agentId: 2,
+          startedAt: new Date('2026-08-01T11:00:00.000Z'),
+        },
+      ],
+      validationBindings: [
+        {
+          bindingId: 'bind-1',
+          validationId: 'val-1',
+          treeHash: 'abc123',
+          sourceCreatedAt: new Date('2026-08-01T12:00:00.000Z'),
+        },
+      ],
+      validations: [{ validationId: 'val-1', status: 'pass', full: true }],
+    });
+
+    expect(rows.map((row) => row.kind)).toEqual(['validation', 'run', 'attempt']);
+    expect(rows[0]).toMatchObject({
+      title: 'Exact-tree validation',
+      detail: 'abc123',
+      state: 'verified',
+    });
+    expect(rows[1]).toMatchObject({
+      title: 'verify',
+      detail: 'pass · 1200ms',
+      state: 'pass',
+      agentId: 2,
+    });
+    expect(rows[2].title).toContain('Attempt aaaaaaaa');
+  });
+});
+
+describe('buildWorkUnitWorktreeRows', () => {
+  it('merges attempt and slot worktrees by path and prefers active slots', () => {
+    const rows = buildWorkUnitWorktreeRows({
+      repoId: 'repo-1',
+      attempts: [
+        {
+          attemptId: 'att-1',
+          agentId: 1,
+          workDir: '/tmp/wt-a/control',
+          worktreePath: '/tmp/wt-a',
+          branch: 'branch-a',
+          baseCommit: 'deadbeef',
+          sourceCreatedAt: new Date('2026-08-01T10:00:00.000Z'),
+        },
+      ],
+      slots: [
+        {
+          slotId: 1,
+          active: true,
+          workDir: '/tmp/wt-a/control',
+          worktreePath: '/tmp/wt-a',
+          branch: 'branch-a',
+          baseCommit: 'deadbeef',
+          attemptId: 'att-1',
+          updatedAt: new Date('2026-08-01T12:00:00.000Z'),
+        },
+        {
+          slotId: 3,
+          active: false,
+          workDir: null,
+          worktreePath: '/tmp/wt-b',
+          branch: 'branch-b',
+          baseCommit: null,
+          attemptId: null,
+          updatedAt: new Date('2026-08-01T09:00:00.000Z'),
+        },
+      ],
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      worktreePath: '/tmp/wt-a',
+      active: true,
+      agentId: 1,
+      attemptId: 'att-1',
+    });
+    expect(rows[1].worktreePath).toBe('/tmp/wt-b');
+  });
+});

--- a/control/src/lib/work-unit-evidence.ts
+++ b/control/src/lib/work-unit-evidence.ts
@@ -1,0 +1,180 @@
+export type WorkUnitEvidenceKind = 'attempt' | 'run' | 'validation';
+
+export interface WorkUnitEvidenceRow {
+  id: string;
+  kind: WorkUnitEvidenceKind;
+  at: Date;
+  title: string;
+  detail: string;
+  state: string;
+  agentId: number | null;
+}
+
+export interface WorkUnitEvidenceInput {
+  attempts: Array<{
+    attemptId: string;
+    agentId: number;
+    branch: string | null;
+    sourceCreatedAt: Date;
+  }>;
+  runs: Array<{
+    id: string;
+    stageId: string;
+    status: string;
+    durationMs: number | null;
+    agentId: number | null;
+    startedAt: Date;
+  }>;
+  validationBindings: Array<{
+    bindingId: string;
+    validationId: string;
+    treeHash: string;
+    sourceCreatedAt: Date;
+  }>;
+  validations: Array<{
+    validationId: string;
+    status: string;
+    full: boolean;
+  }>;
+}
+
+export function buildWorkUnitEvidenceRows(input: WorkUnitEvidenceInput): WorkUnitEvidenceRow[] {
+  const rows: WorkUnitEvidenceRow[] = [
+    ...input.attempts.map((attempt) => ({
+      id: `attempt:${attempt.attemptId}`,
+      kind: 'attempt' as const,
+      at: attempt.sourceCreatedAt,
+      title: `Attempt ${attempt.attemptId.slice(0, 8)}`,
+      detail: `slot ${attempt.agentId}${attempt.branch ? ` · ${attempt.branch}` : ''}`,
+      state: 'attempt',
+      agentId: attempt.agentId,
+    })),
+    ...input.runs.map((run) => ({
+      id: `run:${run.id}`,
+      kind: 'run' as const,
+      at: run.startedAt,
+      title: run.stageId,
+      detail: `${run.status}${run.durationMs != null ? ` · ${run.durationMs}ms` : ''}`,
+      state: run.status,
+      agentId: run.agentId,
+    })),
+    ...input.validationBindings.map((binding) => {
+      const validation = input.validations.find(
+        (candidate) => candidate.validationId === binding.validationId,
+      );
+      const state =
+        validation?.status === 'pass' && validation.full
+          ? 'verified'
+          : (validation?.status ?? 'validation');
+      return {
+        id: `validation:${binding.bindingId}`,
+        kind: 'validation' as const,
+        at: binding.sourceCreatedAt,
+        title: 'Exact-tree validation',
+        detail: binding.treeHash,
+        state,
+        agentId: null,
+      };
+    }),
+  ];
+
+  return rows.sort((a, b) => b.at.getTime() - a.at.getTime());
+}
+
+export interface WorkUnitWorktreeRow {
+  id: string;
+  repoId: string;
+  agentId: number;
+  attemptId: string | null;
+  worktreePath: string | null;
+  workDir: string | null;
+  branch: string | null;
+  baseCommit: string | null;
+  active: boolean;
+  source: 'attempt' | 'slot';
+  at: Date | null;
+}
+
+export function buildWorkUnitWorktreeRows(input: {
+  repoId: string;
+  attempts: Array<{
+    attemptId: string;
+    agentId: number;
+    workDir: string | null;
+    worktreePath: string | null;
+    branch: string | null;
+    baseCommit: string | null;
+    sourceCreatedAt: Date;
+  }>;
+  slots: Array<{
+    slotId: number;
+    active: boolean;
+    workDir: string | null;
+    worktreePath: string | null;
+    branch: string | null;
+    baseCommit: string | null;
+    attemptId: string | null;
+    updatedAt: Date;
+  }>;
+}): WorkUnitWorktreeRow[] {
+  const byKey = new Map<string, WorkUnitWorktreeRow>();
+
+  for (const attempt of input.attempts) {
+    const path = attempt.worktreePath ?? attempt.workDir;
+    const key = path
+      ? `path:${path}`
+      : `attempt:${attempt.attemptId}`;
+    byKey.set(key, {
+      id: key,
+      repoId: input.repoId,
+      agentId: attempt.agentId,
+      attemptId: attempt.attemptId,
+      worktreePath: attempt.worktreePath,
+      workDir: attempt.workDir,
+      branch: attempt.branch,
+      baseCommit: attempt.baseCommit,
+      active: false,
+      source: 'attempt',
+      at: attempt.sourceCreatedAt,
+    });
+  }
+
+  for (const slot of input.slots) {
+    const path = slot.worktreePath ?? slot.workDir;
+    const key = path ? `path:${path}` : `slot:${slot.slotId}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      byKey.set(key, {
+        ...existing,
+        agentId: slot.slotId,
+        attemptId: slot.attemptId ?? existing.attemptId,
+        worktreePath: slot.worktreePath ?? existing.worktreePath,
+        workDir: slot.workDir ?? existing.workDir,
+        branch: slot.branch ?? existing.branch,
+        baseCommit: slot.baseCommit ?? existing.baseCommit,
+        active: slot.active,
+        source: slot.active ? 'slot' : existing.source,
+        at: slot.updatedAt,
+      });
+      continue;
+    }
+    byKey.set(key, {
+      id: key,
+      repoId: input.repoId,
+      agentId: slot.slotId,
+      attemptId: slot.attemptId,
+      worktreePath: slot.worktreePath,
+      workDir: slot.workDir,
+      branch: slot.branch,
+      baseCommit: slot.baseCommit,
+      active: slot.active,
+      source: 'slot',
+      at: slot.updatedAt,
+    });
+  }
+
+  return [...byKey.values()].sort((a, b) => {
+    if (a.active !== b.active) return a.active ? -1 : 1;
+    return (b.at?.getTime() ?? 0) - (a.at?.getTime() ?? 0);
+  });
+}

--- a/control/src/server/work-units.ts
+++ b/control/src/server/work-units.ts
@@ -140,14 +140,15 @@ export async function listFactoryWorkUnits(repositoryId?: string) {
 
   return Promise.all(
     units.map(async (unit) => {
-      const [slot, runs, usage, validations] = await Promise.all([
-        prisma.agentSlot.findFirst({
-          where: { repositoryId: unit.repositoryId, workUnitId: unit.workUnitId, active: true },
+      const [slots, runs, usage, validations] = await Promise.all([
+        prisma.agentSlot.findMany({
+          where: { repositoryId: unit.repositoryId, workUnitId: unit.workUnitId },
+          orderBy: [{ active: 'desc' }, { updatedAt: 'desc' }],
         }),
         prisma.run.findMany({
           where: { repositoryId: unit.repositoryId, workUnitId: unit.workUnitId },
           orderBy: { startedAt: 'desc' },
-          take: 20,
+          take: 100,
         }),
         prisma.agentSessionUsage.aggregate({
           where: { repositoryId: unit.repositoryId, workUnitId: unit.workUnitId },
@@ -162,7 +163,8 @@ export async function listFactoryWorkUnits(repositoryId?: string) {
           },
         }),
       ]);
-      return { ...unit, slot, runs, usage: usage._sum, validations };
+      const slot = slots.find((candidate) => candidate.active) ?? null;
+      return { ...unit, slot, slots, runs, usage: usage._sum, validations };
     }),
   );
 }

--- a/control/tests/frontend/factory-work-unit.spec.js
+++ b/control/tests/frontend/factory-work-unit.spec.js
@@ -1,0 +1,32 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Factory work unit detail', () => {
+  test('work unit page shows overview sections instead of timeline-only', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Factory' })).toBeVisible();
+
+    const unitLink = page.locator('a[href^="/factory/"]').first();
+    if ((await unitLink.count()) === 0) {
+      test.skip(true, 'No synchronized work units in this environment');
+    }
+
+    await unitLink.click();
+    await page.waitForURL(/\/factory\//, { timeout: 10_000 });
+
+    await expect(page.getByRole('link', { name: '← Factory' })).toBeVisible();
+    await expect(page.getByText('Worktrees', { exact: true })).toBeVisible();
+    await expect(page.getByText('Evidence', { exact: true })).toBeVisible();
+    await expect(page.getByText('Slots that worked this unit')).toBeVisible();
+
+    // Evidence is tabular (searchable data table), not a long timeline list.
+    await expect(
+      page
+        .getByRole('searchbox', { name: /search evidence/i })
+        .or(page.getByText(/no execution evidence synchronized yet/i)),
+    ).toBeVisible();
+    await expect(page.getByText('Evidence timeline')).toHaveCount(0);
+
+    // Repository card links into Mission Control repo pages.
+    await expect(page.locator('a[href^="/repos/"]').first()).toBeVisible();
+  });
+});

--- a/control/tests/frontend/repo-validation.spec.js
+++ b/control/tests/frontend/repo-validation.spec.js
@@ -25,7 +25,8 @@ test.describe('Repository validation stages', () => {
     const table = panel.getByRole('table');
     if (!(await table.isVisible().catch(() => false))) {
       // Repo without declared verificationStages shows the empty state instead.
-      await expect(panel.getByText(/no validation stages declared/i)).toBeVisible();
+      // The empty copy can appear more than once (stages list + pipeline).
+      await expect(panel.getByText(/no validation stages declared/i).first()).toBeVisible();
       return;
     }
 

--- a/control/tests/frontend/validation-pipeline-visual.spec.js
+++ b/control/tests/frontend/validation-pipeline-visual.spec.js
@@ -20,9 +20,13 @@ test.describe('Validation pipeline visual', () => {
     const validationTab = page.getByRole('tab', { name: 'Validation' });
     await validationTab.click();
 
+    // Repos without declared verificationStages have no flow canvas.
+    if (await page.getByText(/no validation stages declared/i).first().isVisible().catch(() => false)) {
+      test.skip(true, 'No validation pipeline for this repository');
+    }
+
     await expect(page.getByText('Verification pipeline')).toBeVisible();
 
-    // Repos without declared verificationStages have no flow canvas.
     const firstNode = page.locator('.react-flow__node').first();
     if (!(await firstNode.isVisible().catch(() => false))) {
       test.skip(true, 'No validation pipeline nodes for this repository');

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/schemas",
-  "version": "0.36.2",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "0.36.2",
+      "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",


### PR DESCRIPTION
## Summary
- Factory work unit pages now show repository links (Mission Control + remote), agent/slot links, and related worktrees — not just an evidence dump
- Evidence is rendered as a searchable, paginated data table instead of a long timeline list
- Closes #136

## Test plan
- [ ] Open Factory → click a work unit
- [ ] Confirm Repository card links to `/repos/[id]` and remote when available
- [ ] Confirm Agent section lists slots with links
- [ ] Confirm Worktrees table shows attempt/slot paths
- [ ] Confirm Evidence is a data table (search/pagination), not “Evidence timeline”
- [ ] `har env verify 1 --full` in `control/` (already passed in session)


Made with [Cursor](https://cursor.com)