### PR TITLE
fix(control): attribute agent work done in the main checkout

### DIFF
--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -36,6 +36,7 @@ import {
 } from './work-units';
 import { createRemoteExecutor } from './cloud-executor';
 import { isTelemetryEnabled } from './telemetry-config';
+import { warn } from '../utils/logging';
 import { harvestEventsForSlot, harvestUsageForSlot, omitHarvestEventsWhenOtelPresent, omitHarvestWhenOtelPresent } from './usage-harvest';
 import { buildSessionKey } from './telemetry-env';
 import { fetchPersistedPortalTelemetry } from './control-persisted-usage';
@@ -292,6 +293,8 @@ async function collectPortalTelemetry(
   if (!isTelemetryEnabled()) return { usage: [], events: [], maxSyncedAt: null };
   try {
     const userEmail = resolvePortalUserEmail();
+    const fallbackAgentId =
+      slots.length > 0 ? Math.min(...slots.map((slot) => slot.agentId)) : null;
     const liveUsage: AgentSessionUsage[] = slots.flatMap((slot) =>
       harvestUsageForSlot({
         agentId: slot.agentId,
@@ -301,6 +304,7 @@ async function collectPortalTelemetry(
         suffix: slot.suffix,
         sessionCreatedAt: slot.sessionCreatedAt,
         repoPath,
+        includeRepoPathFallback: slot.agentId === fallbackAgentId,
       }).map((row) => ({
         ...row,
         workUnitId: slot.workUnitId ?? row.workUnitId,
@@ -325,6 +329,7 @@ async function collectPortalTelemetry(
         suffix: slot.suffix,
         sessionCreatedAt: slot.sessionCreatedAt,
         repoPath,
+        includeRepoPathFallback: slot.agentId === fallbackAgentId,
       }).map((event) => ({
         ...event,
         workUnitId: slot.workUnitId ?? event.workUnitId,
@@ -363,6 +368,7 @@ async function buildPortalPayload(
   repoPath: string,
   controlApiUrl: string,
   since: string | null,
+  full = false,
 ): Promise<{
   syncBody: Record<string, unknown>;
   runs: RunRecord[];
@@ -384,6 +390,14 @@ async function buildPortalPayload(
     controlApiUrl,
     since,
   );
+
+  if (full && isTelemetryEnabled() && usage.length === 0 && runs.some((r) => r.agentId != null)) {
+    warn(
+      `${path.basename(repoPath)}: agent runs found but no usage harvested — attribution will be missing. ` +
+        'This happens when agent sessions ran outside the har worktree slot (e.g. in the main checkout). ' +
+        'Run agents inside `har env launch`.',
+    );
+  }
 
   const syncBody: Record<string, unknown> = {
     path: repoPath,
@@ -606,6 +620,7 @@ async function syncRepoWithPortal(
     repoPath,
     controlApiUrl,
     since,
+    full,
   );
   const { selected: newRuns } = selectSince(runs, runsSince, runTimestamp);
 

--- a/src/core/usage-harvest/claude.ts
+++ b/src/core/usage-harvest/claude.ts
@@ -14,6 +14,7 @@ export interface HarvestSlotContext {
   suffix?: string;
   sessionCreatedAt?: string;
   repoPath: string;
+  includeRepoPathFallback?: boolean;
 }
 
 function claudeProjectsRoot(): string {
@@ -116,39 +117,54 @@ function extractClaudeUsageFromRecords(records: unknown[]): {
 }
 
 function findMatchingClaudeTranscripts(slot: HarvestSlotContext): Array<{ filePath: string; records: unknown[]; mtimeMs: number }> {
-  const targets = [slot.workDir, slot.worktreePath].filter(Boolean) as string[];
-  if (targets.length === 0) return [];
+  const primaryTargets = [slot.workDir, slot.worktreePath].filter(Boolean) as string[];
+  const fallbackTargets =
+    slot.includeRepoPathFallback && slot.repoPath && !primaryTargets.includes(slot.repoPath)
+      ? [slot.repoPath]
+      : [];
+  if (primaryTargets.length === 0 && fallbackTargets.length === 0) return [];
 
   const root = claudeProjectsRoot();
   if (!fs.existsSync(root)) return [];
 
-  const matches: Array<{ filePath: string; records: unknown[]; mtimeMs: number }> = [];
+  const primary: Array<{ filePath: string; records: unknown[]; mtimeMs: number }> = [];
+  const fallback: Array<{ filePath: string; records: unknown[]; mtimeMs: number }> = [];
 
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const projectDir = path.join(root, entry.name);
-    const encodedHit = targets.some((t) => entry.name === encodeClaudeProjectDir(t));
+    const primaryEncoded = primaryTargets.some((t) => entry.name === encodeClaudeProjectDir(t));
+    const fallbackEncoded = fallbackTargets.some((t) => entry.name === encodeClaudeProjectDir(t));
 
     for (const file of fs.readdirSync(projectDir)) {
       if (!file.endsWith('.jsonl')) continue;
       const filePath = path.join(projectDir, file);
       const stat = fs.statSync(filePath);
       const records = readJsonlRecords(filePath);
-      let cwdHit = encodedHit;
-      for (const record of records) {
-        if (!record || typeof record !== 'object') continue;
-        const cwd = String((record as { cwd?: string }).cwd ?? '');
-        if (cwd && workspaceMatchesTarget(cwd, targets)) {
-          cwdHit = true;
-          break;
+      let primaryHit = primaryEncoded;
+      let fallbackHit = fallbackEncoded;
+      if (!primaryHit) {
+        for (const record of records) {
+          if (!record || typeof record !== 'object') continue;
+          const cwd = String((record as { cwd?: string }).cwd ?? '');
+          if (!cwd) continue;
+          if (workspaceMatchesTarget(cwd, primaryTargets)) {
+            primaryHit = true;
+            break;
+          }
+          if (!fallbackHit && workspaceMatchesTarget(cwd, fallbackTargets)) {
+            fallbackHit = true;
+          }
         }
       }
-      if (!cwdHit) continue;
-      matches.push({ filePath, records, mtimeMs: stat.mtimeMs });
+      if (primaryHit) primary.push({ filePath, records, mtimeMs: stat.mtimeMs });
+      else if (fallbackHit) fallback.push({ filePath, records, mtimeMs: stat.mtimeMs });
     }
   }
 
-  return matches.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  primary.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  fallback.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return [...primary, ...fallback];
 }
 
 function extractPromptEvents(

--- a/src/core/usage-harvest/codex.ts
+++ b/src/core/usage-harvest/codex.ts
@@ -89,8 +89,12 @@ function extractCodexTokens(records: unknown[]): {
 }
 
 export function harvestCodexUsage(slot: HarvestSlotContext): AgentSessionUsage | null {
-  const targets = [slot.workDir, slot.worktreePath].filter(Boolean) as string[];
-  if (targets.length === 0) return null;
+  const primaryTargets = [slot.workDir, slot.worktreePath].filter(Boolean) as string[];
+  const fallbackTargets =
+    slot.includeRepoPathFallback && slot.repoPath && !primaryTargets.includes(slot.repoPath)
+      ? [slot.repoPath]
+      : [];
+  if (primaryTargets.length === 0 && fallbackTargets.length === 0) return null;
 
   const root = codexSessionsRoot();
   const files = walkJsonlFiles(root);
@@ -103,21 +107,32 @@ export function harvestCodexUsage(slot: HarvestSlotContext): AgentSessionUsage |
     createdAt: slot.sessionCreatedAt,
   });
 
-  let best: { tokensInput: number; tokensOutput: number; tokensCacheRead: number } | null = null;
-  let bestMtime = 0;
+  type CodexTokens = { tokensInput: number; tokensOutput: number; tokensCacheRead: number };
+  let bestPrimary: CodexTokens | null = null;
+  let bestPrimaryMtime = 0;
+  let bestFallback: CodexTokens | null = null;
+  let bestFallbackMtime = 0;
 
   for (const file of files) {
     const records = readJsonl(file);
     const extracted = extractCodexTokens(records);
-    if (!extracted.cwd || !workspaceMatchesTarget(extracted.cwd, targets)) continue;
+    if (!extracted.cwd) continue;
     if (extracted.tokensInput + extracted.tokensOutput + extracted.tokensCacheRead === 0) continue;
     const mtime = fs.statSync(file).mtimeMs;
-    if (mtime >= bestMtime) {
-      bestMtime = mtime;
-      best = extracted;
+    if (workspaceMatchesTarget(extracted.cwd, primaryTargets)) {
+      if (mtime >= bestPrimaryMtime) {
+        bestPrimaryMtime = mtime;
+        bestPrimary = extracted;
+      }
+    } else if (workspaceMatchesTarget(extracted.cwd, fallbackTargets)) {
+      if (mtime >= bestFallbackMtime) {
+        bestFallbackMtime = mtime;
+        bestFallback = extracted;
+      }
     }
   }
 
+  const best = bestPrimary ?? bestFallback;
   if (!best) return null;
   const now = new Date().toISOString();
   const tokensTotal = best.tokensInput + best.tokensOutput + best.tokensCacheRead;

--- a/tests/usage-harvest.test.ts
+++ b/tests/usage-harvest.test.ts
@@ -185,6 +185,80 @@ describe('usage harvest claude', () => {
     expect(harvested[1]?.costUsd).toBe(0.2);
     expect(harvested[2]).toBeNull();
   });
+
+  it('attributes a main-checkout transcript when the worktree has none and fallback is enabled', () => {
+    const repoPath = '/home/user/Documents/Kerno/fecore';
+    const worktree = '/home/user/worktrees/main-2b19-har-agent-1-5wrz';
+    const checkoutProject = path.join(tmp, encodeClaudeProjectDir(repoPath));
+    fs.mkdirSync(checkoutProject, { recursive: true });
+    fs.writeFileSync(
+      path.join(checkoutProject, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: repoPath }),
+        JSON.stringify({
+          type: 'result',
+          usage: { input_tokens: 30, output_tokens: 15 },
+          total_cost_usd: 0.3,
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const slot = {
+      agentId: 1,
+      workDir: worktree,
+      worktreePath: worktree,
+      branch: 'main-2b19-har-agent-1-5wrz',
+      suffix: '5wrz',
+      repoPath,
+    };
+
+    expect(harvestClaudeUsage(slot)).toBeNull();
+
+    const withFallback = harvestClaudeUsage({ ...slot, includeRepoPathFallback: true });
+    expect(withFallback).not.toBeNull();
+    expect(withFallback!.tokensOutput).toBe(15);
+    expect(withFallback!.costUsd).toBe(0.3);
+  });
+
+  it('prefers the worktree transcript over the main checkout when both exist', () => {
+    const repoPath = '/home/user/Documents/Kerno/fecore';
+    const worktree = '/home/user/worktrees/main-2b19-har-agent-1-5wrz';
+
+    const checkoutProject = path.join(tmp, encodeClaudeProjectDir(repoPath));
+    fs.mkdirSync(checkoutProject, { recursive: true });
+    fs.writeFileSync(
+      path.join(checkoutProject, 'checkout.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: repoPath }),
+        JSON.stringify({ type: 'result', usage: { input_tokens: 99, output_tokens: 99 } }),
+      ].join('\n') + '\n',
+    );
+
+    const worktreeProject = path.join(tmp, encodeClaudeProjectDir(worktree));
+    fs.mkdirSync(worktreeProject, { recursive: true });
+    fs.writeFileSync(
+      path.join(worktreeProject, 'worktree.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: worktree }),
+        JSON.stringify({ type: 'result', usage: { input_tokens: 5, output_tokens: 7 } }),
+      ].join('\n') + '\n',
+    );
+
+    fs.utimesSync(path.join(worktreeProject, 'worktree.jsonl'), 1000, 1000);
+    fs.utimesSync(path.join(checkoutProject, 'checkout.jsonl'), 2000, 2000);
+
+    const usage = harvestClaudeUsage({
+      agentId: 1,
+      workDir: worktree,
+      worktreePath: worktree,
+      branch: 'main-2b19-har-agent-1-5wrz',
+      suffix: '5wrz',
+      repoPath,
+      includeRepoPathFallback: true,
+    });
+
+    expect(usage!.tokensOutput).toBe(7);
+  });
 });
 
 describe('workspace path match', () => {


### PR DESCRIPTION
## Problem

Agent activity is attributed to a person only by joining a run to an `AgentSessionUsage` row on `repositoryId:agentId` — runs carry no user FK. Those usage rows come from `har control sync`'s telemetry harvest, which matches each transcript **strictly against a slot's worktree path**.

When an agent's LLM session runs in the repo's **main checkout** instead of inside a `har env launch` worktree slot, the harness still logs stage runs (with an `agentId`), but harvest finds no matching transcript → `usage[]` is empty → those runs are **permanently unattributed**, with no surfaced reason.

## Fix

- **Checkout fallback (Claude + Codex harvest):** transcripts are classified as *primary* (the slot's worktree) or *fallback* (the repo's main checkout, via the already-passed `repoPath`). Primary always wins; the fallback only applies when the worktree has no transcript. Worktrees and the checkout live in disjoint paths, so the two never cross-match.
- **No double-counting:** the checkout fallback is enabled for only the **lowest active `agentId`** on a repo, so a shared main-checkout transcript is attributed once rather than to every idle slot.
- **Diagnostic:** a `--full` sync now warns when a repo has runs carrying an `agentId` but zero harvested usage, so the unattributed state has a discoverable cause.

Attribution is set at ingest, so pre-existing unattributed runs do not backfill — this is forward-only.

## Tests

Added harvest cases: checkout transcript attributes when the worktree has none / stays unattributed when the fallback is off / the worktree wins over a *newer* checkout transcript. `typecheck`, `lint`, and the telemetry/sync suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)