### PR TITLE
fix: send git remote in control sync payload

### DIFF
--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -401,6 +401,7 @@ async function buildPortalPayload(
 
   const syncBody: Record<string, unknown> = {
     path: repoPath,
+    ...(status.gitRemote ? { gitRemote: status.gitRemote } : {}),
     ...(manifest ? { manifest } : {}),
     ...(stagesRegistry ? { stagesRegistry } : {}),
     slots: status.slots,

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -624,6 +624,35 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(otelBody.events[0].promptText).toBe('persisted');
     expect('responseText' in otelBody.events[0]).toBe(false);
   });
+
+  it('forwards the git remote to /api/sync so the portal can group repos', async () => {
+    collectEnvironmentStatusMock.mockReturnValue({
+      slots: [],
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      gitRemote: 'https://github.com/os-factory/har.git',
+    });
+    const fetchMock = mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const [, init] = portalSyncCall(fetchMock);
+    const body = JSON.parse(init.body as string);
+    expect(body.gitRemote).toBe('https://github.com/os-factory/har.git');
+  });
+
+  it('omits gitRemote when the repo has no origin remote', async () => {
+    collectEnvironmentStatusMock.mockReturnValue({
+      slots: [],
+      generatedAt: '2026-01-01T00:00:00.000Z',
+    });
+    const fetchMock = mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const [, init] = portalSyncCall(fetchMock);
+    const body = JSON.parse(init.body as string);
+    expect('gitRemote' in body).toBe(false);
+  });
 });
 
 describe('syncRepoWithControl — portal watermark', () => {


### PR DESCRIPTION
## Problem

Mission Control / the portal keys repositories on their absolute filesystem path, so the same upstream repo checked out at different paths on different machines becomes separate rows — there is nothing to group or dedup them by.

The omnibus `POST /api/sync` body dropped the git remote even though `collectEnvironmentStatus` → `readGitRemote` already carries it as `status.gitRemote`, so the receiver only ever saw a null remote.

## Fix

Forward `status.gitRemote` in the sync body built by `buildPortalPayload`, using the same conditional-spread idiom as every other optional field (omitted when the repo has no `origin` remote). Normalization is left to the receiver; the raw remote is sent.

## Tests

Two cases added to the portal-sync suite: remote present → body carries `gitRemote`; remote absent → key omitted.

- `typecheck` ✅ · `eslint` ✅ · `control-portal-sync` 27/27 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)