### PR TITLE
fix(docs): hardcode PostHog public token for Pages builds

### DIFF
--- a/docs/.env.template
+++ b/docs/.env.template
@@ -1,2 +1,2 @@
-PUBLIC_POSTHOG_PROJECT_TOKEN=your_posthog_project_token_here
+PUBLIC_POSTHOG_PROJECT_TOKEN=phc_Btprma6YFgCEh22DcBWUJTf7YLWMrEymWmCWxeRGUsJG
 PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/docs/src/components/posthog.astro
+++ b/docs/src/components/posthog.astro
@@ -1,34 +1,27 @@
 ---
-const projectToken = import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN;
-const apiHost = import.meta.env.PUBLIC_POSTHOG_HOST;
-const missingToken = !projectToken;
-const missingHost = !apiHost;
-const isDev = import.meta.env.DEV;
+// Public PostHog project token — safe to ship in client JS (same as control Dockerfile).
+// Hardcoded so GitHub Pages static builds work without CI env wiring.
+const projectToken =
+  import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN ||
+  'phc_Btprma6YFgCEh22DcBWUJTf7YLWMrEymWmCWxeRGUsJG';
+const apiHost =
+  import.meta.env.PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com';
 ---
-<script is:inline define:vars={{ projectToken, apiHost, missingToken, missingHost, isDev }}>
-  if (missingToken || missingHost) {
-    if (isDev) {
-      if (missingToken) {
-        throw new Error('PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once PUBLIC_POSTHOG_PROJECT_TOKEN is configured');
-      }
-      throw new Error('PUBLIC_POSTHOG_HOST variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once PUBLIC_POSTHOG_HOST is configured');
-    }
-  } else {
-    const script = document.createElement('script');
-    script.src = `${apiHost}/static/array.js`;
-    script.async = true;
-    script.crossOrigin = 'anonymous';
-    script.onload = () => {
-      window.posthog.init(projectToken, {
-        api_host: apiHost,
-        tracing_headers: [window.location.hostname],
-      });
-      window.posthog.startExceptionAutocapture({
-        capture_unhandled_errors: true,
-        capture_unhandled_rejections: true,
-        capture_console_errors: false,
-      });
-    };
-    document.head.appendChild(script);
-  }
+<script is:inline define:vars={{ projectToken, apiHost }}>
+  const script = document.createElement('script');
+  script.src = `${apiHost}/static/array.js`;
+  script.async = true;
+  script.crossOrigin = 'anonymous';
+  script.onload = () => {
+    window.posthog.init(projectToken, {
+      api_host: apiHost,
+      tracing_headers: [window.location.hostname],
+    });
+    window.posthog.startExceptionAutocapture({
+      capture_unhandled_errors: true,
+      capture_unhandled_rejections: true,
+      capture_console_errors: false,
+    });
+  };
+  document.head.appendChild(script);
 </script>


### PR DESCRIPTION
## Summary
- Hardcode the public PostHog project token + EU host in `docs/src/components/posthog.astro` (with env override still allowed)
- Update `docs/.env.template` to match the same public values used by Mission Control
- Fixes production analytics: GitHub Pages builds never received `PUBLIC_POSTHOG_*`, so the snippet shipped with `projectToken = undefined` and silently skipped init

## Test plan
- [ ] After merge + docs deploy: `curl -fsSL https://harproject.dev/ | rg 'phc_|eu\.i\.posthog'` shows the real token (not `undefined`)
- [ ] Browser Network on `/`: requests to `eu.i.posthog.com`
- [ ] PostHog Live events for `$pageview` / `install_command_copied` after interacting with the homepage
- [ ] Note: Starlight `/docs/*` still has no PostHog (BaseLayout-only)


Made with [Cursor](https://cursor.com)