### PR TITLE
feat: attribute runs and validations to the syncing member

### DIFF
--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -384,6 +384,9 @@ async function buildPortalPayload(
   const workUnits = listWorkUnits(harnessRoot);
   const attempts = listWorkAttempts(harnessRoot);
   const validationBindings = listValidationBindings(harnessRoot);
+  // Attribute runs/validations to the syncing member so the portal can resolve
+  // a real user FK instead of the lossy (repo, agentId) derivation.
+  const userEmail = resolvePortalUserEmail();
   const { usage, events, maxSyncedAt } = await collectPortalTelemetry(
     repoPath,
     status.slots,
@@ -406,14 +409,24 @@ async function buildPortalPayload(
     ...(stagesRegistry ? { stagesRegistry } : {}),
     slots: status.slots,
     generatedAt: status.generatedAt,
-    ...(validations.length > 0 ? { validations } : {}),
+    ...(validations.length > 0
+      ? {
+          validations: userEmail
+            ? validations.map((v) => ({ ...v, userEmail }))
+            : validations,
+        }
+      : {}),
     ...(workUnits.length > 0 ? { workUnits } : {}),
     ...(attempts.length > 0 ? { attempts } : {}),
     ...(validationBindings.length > 0 ? { validationBindings } : {}),
     ...(usage.length > 0 ? { usage } : {}),
   };
 
-  return { syncBody, runs, events, maxSyncedAt };
+  const runsPayload = userEmail
+    ? runs.map((run) => ({ ...run, userEmail }))
+    : runs;
+
+  return { syncBody, runs: runsPayload, events, maxSyncedAt };
 }
 
 export async function isControlApiReachable(apiUrl = getControlApiUrl()): Promise<boolean> {

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -12,14 +12,14 @@ jest.mock('../src/core/portal-credentials', () => ({
 jest.mock('../src/core/control-repo-path', () => ({
   canonicalizeControlRepoPath: (p: string) => p,
 }));
-jest.mock('../src/core/runs', () => ({ listRuns: () => [] }));
+jest.mock('../src/core/runs', () => ({ listRuns: jest.fn(() => []) }));
 jest.mock('../src/core/slot-status', () => ({
   collectEnvironmentStatus: jest.fn(() => ({
     slots: [],
     generatedAt: '2026-01-01T00:00:00.000Z',
   })),
 }));
-jest.mock('../src/core/validations', () => ({ listValidations: () => [] }));
+jest.mock('../src/core/validations', () => ({ listValidations: jest.fn(() => []) }));
 jest.mock('../src/core/work-units', () => ({
   listWorkUnits: jest.fn(() => []),
   listWorkAttempts: jest.fn(() => []),
@@ -51,6 +51,8 @@ jest.mock('../src/harness/manifest', () => ({
 jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
 
 import { collectEnvironmentStatus } from '../src/core/slot-status';
+import { listRuns } from '../src/core/runs';
+import { listValidations } from '../src/core/validations';
 import {
   readPortalCredentials,
   writePortalCredentials,
@@ -65,6 +67,8 @@ import { fetchPersistedPortalTelemetry } from '../src/core/control-persisted-usa
 import { readPortalWatermark, writePortalWatermark } from '../src/core/portal-watermark';
 
 const collectEnvironmentStatusMock = collectEnvironmentStatus as jest.Mock;
+const listRunsMock = listRuns as jest.Mock;
+const listValidationsMock = listValidations as jest.Mock;
 const readPortalCredentialsMock = readPortalCredentials as jest.Mock;
 const writePortalCredentialsMock = writePortalCredentials as jest.Mock;
 const listWorkUnitsMock = listWorkUnits as jest.Mock;
@@ -82,6 +86,8 @@ function resetPayloadMocks(): void {
     generatedAt: '2026-01-01T00:00:00.000Z',
   });
   readPortalCredentialsMock.mockReturnValue(null);
+  listRunsMock.mockReturnValue([]);
+  listValidationsMock.mockReturnValue([]);
   listWorkUnitsMock.mockReturnValue([]);
   listWorkAttemptsMock.mockReturnValue([]);
   listValidationBindingsMock.mockReturnValue([]);
@@ -509,6 +515,85 @@ describe('syncRepoWithControl — portal full payload', () => {
     const [, init] = portalSyncCall(fetchMock);
     const body = JSON.parse(init.body as string);
     expect('userEmail' in body.usage[0]).toBe(false);
+  });
+
+  it('attributes runs and validations to the authenticated login email', async () => {
+    readPortalCredentialsMock.mockReturnValue({
+      portalUrl: 'https://portal.example.com',
+      token: 'har_ingest_secret',
+      email: 'login@haulieros.io',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    listRunsMock.mockReturnValue([
+      {
+        runId: '11111111-1111-1111-1111-111111111111',
+        repoPath: '/repo/x',
+        stageId: 'verify',
+        status: 'pass',
+        trigger: 'cli',
+        startedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    listValidationsMock.mockReturnValue([
+      {
+        validationId: '22222222-2222-2222-2222-222222222222',
+        treeHash: 'a'.repeat(40),
+        workDir: '/repo/x',
+        harnessRoot: '/repo/x',
+        status: 'pass',
+        full: false,
+        changedFiles: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    const fetchMock = mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const [, init] = portalSyncCall(fetchMock);
+    const body = JSON.parse(init.body as string);
+    expect(body.runs[0].userEmail).toBe('login@haulieros.io');
+    expect(body.validations[0].userEmail).toBe('login@haulieros.io');
+  });
+
+  it('leaves runs and validations unattributed when credentials carry no email', async () => {
+    readPortalCredentialsMock.mockReturnValue({
+      portalUrl: 'https://portal.example.com',
+      token: 'har_ingest_secret',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    listRunsMock.mockReturnValue([
+      {
+        runId: '11111111-1111-1111-1111-111111111111',
+        repoPath: '/repo/x',
+        stageId: 'verify',
+        status: 'pass',
+        trigger: 'cli',
+        startedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    listValidationsMock.mockReturnValue([
+      {
+        validationId: '22222222-2222-2222-2222-222222222222',
+        treeHash: 'a'.repeat(40),
+        workDir: '/repo/x',
+        harnessRoot: '/repo/x',
+        status: 'pass',
+        full: false,
+        changedFiles: [],
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    const fetchMock = mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const [, init] = portalSyncCall(fetchMock);
+    const body = JSON.parse(init.body as string);
+    expect('userEmail' in body.runs[0]).toBe(false);
+    expect('userEmail' in body.validations[0]).toBe(false);
   });
 
   it('forwards Mission Control persisted usage when the slot is torn down', async () => {


### PR DESCRIPTION
## What

Stamp the authenticated portal user's email onto each run and validation in the portal sync payload, so a downstream portal can resolve a real user FK instead of the lossy `(repo, agentId)` derivation.

## How

`buildPortalPayload` reads `resolvePortalUserEmail()` (the credentials email already used for usage attribution) and adds `userEmail` to each run and validation record when present. Mirrors the existing usage-attribution pattern exactly. The local-control (`/api/repos/{id}/runs`) and cloud sync paths are untouched — attribution is a portal concern.

## Tests

`control-portal-sync` gains two cases: runs + validations carry the login email when credentials have one, and stay unattributed when they don't. Full suite green for the touched areas (`control-sync*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)