### PR TITLE
feat: streamline work unit binding guidance (#140, #148)

### DIFF
--- a/.cursor/rules/har-workflow.mdc
+++ b/.cursor/rules/har-workflow.mdc
@@ -18,7 +18,8 @@ startup. If a harness command fails, fix the harness or surface the failure.
 2. **Launch first** — MCP `har_launch_environment` / `har env launch 1`. Use the
    returned **work dir** for ALL edits (never the main checkout). Path looks like
    `~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>` (see `.har/slots/agent-<id>.json`).
-   Bind tracker work with `workUnitId`/`title` or `--work-id`/`--work-title` when needed.
+   **Bind tracker work** when the task names an issue or ticket — short `--work-id`
+   (e.g. `widget-123`) plus `--work-source` / `--work-url` / `--work-title`. Skip for ad-hoc work.
 3. Read `AGENTS.md`, `.har/README.md`, `.har/stages.json`, then
    `.har/CLAUDE.agent.md` (slot URLs / definition of done).
 4. Hot-reload usually applies; if not, `./.har/agent-cli.sh <id> restart` (no-op on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ Run harness commands from the directory that owns the harness (e.g. `cd control 
 Follow [`.cursor/rules/har-workflow.mdc`](.cursor/rules/har-workflow.mdc) and
 [`.har/README.md`](.har/README.md): launch first, edit only under the session work
 dir, full-verify before done, then present a session handoff and wait for approval.
+When the task names a tracker issue or ticket, bind at launch with a short
+`--work-id`, plus `--work-source`, `--work-url`, and `--work-title` when known.
 Default recommendation is complete + open a PR when tooling is available (still
 requires approval); never run `complete`, push, or PR autonomously.
 

--- a/control/src/lib/schemas.test.ts
+++ b/control/src/lib/schemas.test.ts
@@ -17,17 +17,18 @@ describe('RegisterRepoInputSchema', () => {
 });
 
 describe('SyncWorkUnitsInputSchema', () => {
-  it('parses provider-neutral work and attempt identity', () => {
+  it('parses short work unit ids with source metadata', () => {
     const result = SyncWorkUnitsInputSchema.parse({
       workUnits: [{
-        workUnitId: 'github:acme/widget#123',
+        workUnitId: 'widget-123',
         source: 'github',
+        sourceUrl: 'https://github.com/acme/widget/issues/123',
         createdAt: '2026-07-23T20:00:00.000Z',
         updatedAt: '2026-07-23T20:00:00.000Z',
       }],
       attempts: [{
         attemptId: '11111111-1111-4111-8111-111111111111',
-        workUnitId: 'github:acme/widget#123',
+        workUnitId: 'widget-123',
         agentId: 1,
         createdAt: '2026-07-23T20:00:00.000Z',
       }],

--- a/docs/architecture/decisions/0001-work-identity.md
+++ b/docs/architecture/decisions/0001-work-identity.md
@@ -27,8 +27,12 @@ WorkUnit -> WorkAttempt -> slot session/worktree -> runs -> validation binding
 ### Work unit
 
 `workUnitId` is a stable, caller-provided identifier scoped to one registered
-repository. A durable work-unit record stores only immutable correlation metadata:
-optional source, source URL, title, and parent work-unit ID.
+repository. Prefer a short repo-scoped id (for example `widget-123` or `har-115`);
+put the tracker provider in `source` and the canonical URL in `sourceUrl`. Legacy
+composite ids such as `github:owner/repo#123` remain valid but are deprecated.
+
+A durable work-unit record stores only immutable correlation metadata: optional
+source, source URL, title, and parent work-unit ID.
 
 Mutable tracker fields such as assignee, labels, priority, and tracker workflow
 state are not copied into HAR.

--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -88,14 +88,20 @@ Factory is the default Mission Control experience. It answers four questions:
 
 ![Mission Control Factory overview showing completed and active work units](/assets/factory-overview.png)
 
-Launch with a provider-neutral work identifier to create that evidence chain:
+Launch with a short work identifier plus source metadata to create that evidence chain:
 
 ```bash
 har env launch 1 \
-  --work-id "github:acme/widget#123" \
+  --work-id "widget-123" \
   --work-source github \
+  --work-url "https://github.com/acme/widget/issues/123" \
   --work-title "Add saved filters"
 ```
+
+Bind on launch when the task names a tracker issue or ticket. Use a repo-scoped
+`--work-id` (not a provider-prefixed composite such as `github:owner/repo#123`);
+pass the provider in `--work-source` and the canonical link in `--work-url`. Skip
+binding for ad-hoc work with no tracker identity.
 
 Every fresh launch creates an immutable attempt ID. Runs and telemetry inherit the
 work and attempt correlation. Full verification produces exact-tree proof, and

--- a/docs/src/content/docs/docs/guides/skill-pack-compatibility.md
+++ b/docs/src/content/docs/docs/guides/skill-pack-compatibility.md
@@ -24,7 +24,7 @@ Give every implementation ticket a stable identifier:
 
 ```bash
 har env launch 1 \
-  --work-id "github:acme/widget#123" \
+  --work-id "widget-123" \
   --work-source github \
   --work-url "https://github.com/acme/widget/issues/123" \
   --work-title "Add saved filters"
@@ -46,7 +46,8 @@ A compatible flow is:
 
 1. Use the pack's grilling and requirements flow.
 2. Produce or select one implementation issue.
-3. Use that issue's provider-neutral key as `--work-id`.
+3. Use that issue's short repo-scoped key as `--work-id` (with `--work-source` and
+   `--work-url` when available).
 4. Launch HAR before editing and work only in the returned directory.
 5. Continue using the pack's implementation and review skills.
 6. Run `har env verify <slot> --full`, then `har env complete <slot>`.

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -116,7 +116,9 @@ If the worktree has uncommitted changes, commit or discard them in the
 worktree first. Use `--resume` / `recover` only for a failed or starting
 launch — it is not a way to replace an active session.
 
-Work metadata is optional and backward compatible. A fresh bound launch creates an
+Work metadata is optional and backward compatible. Bind when the task names a
+tracker issue or ticket: pass a short repo-scoped `--work-id`, plus `--work-source`,
+`--work-url`, and `--work-title` when known. A fresh bound launch creates an
 immutable attempt UUID; `--resume` preserves the failed session's attempt.
 
 ### Verify and finish

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -19,6 +19,10 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 | --- | --- | --- |
 | `har_preflight_environment` | `agentId` | Readiness, blockers, and whether launch is safe |
 | `har_launch_environment` | `agentId`, optional `worktree`, `claude`, `resume`, `workUnitId`, `source`, `sourceUrl`, `title`, `parentWorkUnitId` | Work directory, branch, work/attempt IDs, URLs, and normalized stage result |
+
+Pass `workUnitId`, `source`, and `sourceUrl` when the task names a tracker issue or
+ticket (short repo-scoped id such as `widget-123`, not a provider-prefixed composite).
+Omit them for ad-hoc work with no tracker identity.
 | `har_recover_environment` | `agentId` | Resumed failed or partial launch |
 | `har_get_status` | optional `agentId` | Slot, process, worktree, branch, and dirty state |
 | `har_get_logs` | `agentId`, optional `service` | Recent service output |

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -265,14 +265,21 @@ export const envCommand = {
             })
             .option('work-id', {
               type: 'string',
-              describe: 'Bind this session to a durable external work identifier',
+              describe:
+                'Short repo-scoped work id (e.g. widget-123). Bind when the task names a tracker issue or ticket',
             })
             .option('work-source', {
               type: 'string',
-              describe: 'Optional provider/source name (for example github or linear)',
+              describe: 'Tracker provider when binding work (for example github or linear)',
             })
-            .option('work-url', { type: 'string', describe: 'Optional source URL for the work' })
-            .option('work-title', { type: 'string', describe: 'Optional human-readable title' })
+            .option('work-url', {
+              type: 'string',
+              describe: 'Canonical URL for the work item (for example a GitHub issue URL)',
+            })
+            .option('work-title', {
+              type: 'string',
+              describe: 'Human-readable work title when known',
+            })
             .option('parent-work-id', {
               type: 'string',
               describe: 'Optional parent work unit identifier',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -89,11 +89,18 @@ export const HAR_MCP_TOOLS: Tool[] = [
         },
         workUnitId: {
           type: 'string',
-          description: 'Durable external work identifier to bind to this session.',
+          description:
+            'Short repo-scoped work id (e.g. widget-123). Pass when the task names a tracker issue or ticket so Factory records work → attempt → evidence. Omit for ad-hoc work.',
         },
-        source: { type: 'string', description: 'Optional provider/source name.' },
-        sourceUrl: { type: 'string', description: 'Optional source URL.' },
-        title: { type: 'string', description: 'Optional human-readable work title.' },
+        source: {
+          type: 'string',
+          description: 'Tracker provider when binding work (e.g. github, linear).',
+        },
+        sourceUrl: {
+          type: 'string',
+          description: 'Canonical URL for the work item (e.g. GitHub issue URL).',
+        },
+        title: { type: 'string', description: 'Human-readable work title when known.' },
         parentWorkUnitId: {
           type: 'string',
           description: 'Optional parent work unit identifier.',

--- a/src/templates/AGENTS.md.template
+++ b/src/templates/AGENTS.md.template
@@ -20,6 +20,11 @@ fall back to ad-hoc commands.
    creates a worktree from that HEAD.
 2. **Launch first** — MCP `har_launch_environment` / `har env launch 1`. Use the
    returned **work dir** for ALL edits (never the main checkout).
+   **Bind tracker work** when the task names a durable issue or ticket (GitHub,
+   Linear, etc.): pass a short repo-scoped `--work-id` / `workUnitId` (e.g.
+   `widget-123`), `--work-source` / `source`, `--work-url` / `sourceUrl`, and
+   `--work-title` / `title` when known. Skip binding for ad-hoc work with no
+   tracker identity.
 3. Read [`.har/README.md`](.har/README.md), [`.har/stages.json`](.har/stages.json), then
    [`.har/CLAUDE.agent.md`](.har/CLAUDE.agent.md) (slot URLs / definition of done).
 4. Hot-reload usually applies; if not, `./.har/agent-cli.sh <id> restart` (no-op on

--- a/src/templates/agent-skills/har-wt.md
+++ b/src/templates/agent-skills/har-wt.md
@@ -21,11 +21,16 @@ har env launch <id>   # or ./.har/launch.sh <id>
 
 Launch creates a fresh session worktree from HEAD and prints its **work dir** (also recorded in `.har/slots/agent-<id>.json`, path like `~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>`). If a previous launch failed partway, retry with `--resume` instead of starting fresh.
 
-If the task already has a stable issue or ticket ID, bind it without changing the
-methodology that produced it:
+If the task already has a stable issue or ticket, bind it without changing the
+methodology that produced it. Use a short repo-scoped id; put the provider and
+canonical URL in separate fields:
 
 ```bash
-har env launch <id> --work-id "<provider-neutral-id>" --work-title "<title>"
+har env launch <id> \
+  --work-id "widget-123" \
+  --work-source github \
+  --work-url "https://github.com/acme/widget/issues/123" \
+  --work-title "<title>"
 ```
 
 External planning/TDD/review skills remain in control of implementation strategy.

--- a/src/templates/cursor-rule.mdc.template
+++ b/src/templates/cursor-rule.mdc.template
@@ -18,7 +18,8 @@ startup. If a harness command fails, fix the harness or surface the failure.
 2. **Launch first** — MCP `har_launch_environment` / `har env launch 1`. Use the
    returned **work dir** for ALL edits (never the main checkout). Path looks like
    `~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>` (see `.har/slots/agent-<id>.json`).
-   Bind tracker work with `workUnitId`/`title` or `--work-id`/`--work-title` when needed.
+   **Bind tracker work** when the task names an issue or ticket — short `--work-id`
+   (e.g. `widget-123`) plus `--work-source` / `--work-url` / `--work-title`. Skip for ad-hoc work.
 3. Read `AGENTS.md`, `.har/README.md`, `.har/stages.json`, then
    `.har/CLAUDE.agent.md` (slot URLs / definition of done).
 4. Hot-reload usually applies; if not, `./.har/agent-cli.sh <id> restart` (no-op on

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -318,7 +318,7 @@ describe('syncRepoWithControl — portal full payload', () => {
           branch: 'feat/x',
           suffix: 'a',
           sessionCreatedAt: '2026-01-01T00:00:00.000Z',
-          workUnitId: 'github:acme/widget#123',
+          workUnitId: 'widget-123',
           attemptId: '00000000-0000-4000-8000-000000000002',
         }),
       ],
@@ -326,7 +326,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     });
     listWorkUnitsMock.mockReturnValue([
       {
-        workUnitId: 'github:acme/widget#123',
+        workUnitId: 'widget-123',
         source: 'github',
         title: 't',
         createdAt: '2026-01-01T00:00:00.000Z',
@@ -336,7 +336,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     listWorkAttemptsMock.mockReturnValue([
       {
         attemptId: '00000000-0000-4000-8000-000000000002',
-        workUnitId: 'github:acme/widget#123',
+        workUnitId: 'widget-123',
         agentId: 1,
         createdAt: '2026-01-01T00:00:00.000Z',
       },
@@ -344,7 +344,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     listValidationBindingsMock.mockReturnValue([
       {
         bindingId: '00000000-0000-4000-8000-000000000004',
-        workUnitId: 'github:acme/widget#123',
+        workUnitId: 'widget-123',
         attemptId: '00000000-0000-4000-8000-000000000002',
         validationId: '00000000-0000-4000-8000-000000000003',
         treeHash: 'a'.repeat(40),
@@ -379,7 +379,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(body.validationBindings).toHaveLength(1);
     expect(body.usage).toHaveLength(1);
     expect('userEmail' in body.usage[0]).toBe(false);
-    expect(body.usage[0].workUnitId).toBe('github:acme/widget#123');
+    expect(body.usage[0].workUnitId).toBe('widget-123');
     expect(body.usage[0].attemptId).toBe('00000000-0000-4000-8000-000000000002');
     expect(body.usage[0].sessionKey).toBe('feat/x');
     expect(body.usage[0].models).toEqual([
@@ -401,7 +401,7 @@ describe('syncRepoWithControl — portal full payload', () => {
           workDir: '/repo/x/wt-1',
           worktreePath: '/repo/x/wt-1',
           branch: 'feat/x',
-          workUnitId: 'github:acme/widget#123',
+          workUnitId: 'widget-123',
           attemptId: '00000000-0000-4000-8000-000000000002',
         }),
       ],
@@ -436,7 +436,7 @@ describe('syncRepoWithControl — portal full payload', () => {
     const otelBody = JSON.parse(otelInit.body as string);
     expect(otelBody.path).toBe('/repo/x');
     expect(otelBody.events).toHaveLength(1);
-    expect(otelBody.events[0].workUnitId).toBe('github:acme/widget#123');
+    expect(otelBody.events[0].workUnitId).toBe('widget-123');
     expect(otelBody.events[0].promptText).toBe('hi');
     expect('responseText' in otelBody.events[0]).toBe(false);
     expect('rawTruncated' in otelBody.events[0]).toBe(false);

--- a/tests/work-units.test.ts
+++ b/tests/work-units.test.ts
@@ -24,21 +24,21 @@ describe('durable work identity', () => {
 
   it('persists metadata and immutable attempt identity', () => {
     upsertWorkUnit(repo, {
-      workUnitId: 'github:os-factory/har#123',
+      workUnitId: 'har-123',
       source: 'github',
       sourceUrl: 'https://github.com/os-factory/har/issues/123',
       title: 'Factory control plane',
     });
     createWorkAttempt(repo, {
       attemptId: '11111111-1111-4111-8111-111111111111',
-      workUnitId: 'github:os-factory/har#123',
+      workUnitId: 'har-123',
       agentId: 2,
       branch: 'factory-attempt',
     });
 
     expect(listWorkUnits(repo)).toEqual([
       expect.objectContaining({
-        workUnitId: 'github:os-factory/har#123',
+        workUnitId: 'har-123',
         source: 'github',
       }),
     ]);


### PR DESCRIPTION
## Summary

- Clarifies **when** to bind work at launch (#140): bind when the task names a tracker issue or ticket; skip for ad-hoc work
- Adopts **short repo-scoped** `workUnitId` values with separate `source` and `sourceUrl` (#148), e.g. `widget-123` + `github` + issue URL instead of `github:owner/repo#123`
- Updates agent injection surfaces aligned with 0.44.0's AGENTS.md pattern: `AGENTS.md.template`, cursor rule template, `har-wt` skill, MCP tool descriptions, CLI flag help, docs, and ADR 0001
- Refreshes test fixtures to the new convention

## Test plan

- [x] `./.har/verify.sh 1 --full` passes (typecheck, build, docs-check, docs-build, unit tests, lint, docs-drift)

Closes #140
Closes #148

Made with [Cursor](https://cursor.com)