### PR TITLE
fix: preserve AGENTS.md project content on maintain --finalize

### DIFF
--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -523,6 +523,8 @@ export async function handleMaintain(argv: {
       mode: 'maintain',
       autoYes: argv.yes,
       cursorRule: onboarding.cursorRule,
+      writeAgentsMd: !argv.finalize,
+      finalize: argv.finalize,
       ...onboarding.agentSkills,
     });
   } catch (err: unknown) {
@@ -632,6 +634,9 @@ export async function applyAgentIntegrations(options: {
   cursorRule?: boolean;
   agents?: string;
   enabled?: boolean;
+  /** Skip AGENTS.md writes (e.g. already handled during maintain --finalize). */
+  writeAgentsMd?: boolean;
+  finalize?: boolean;
 }): Promise<void> {
   const instruction = await handleInstructionFiles({
     repoPath: options.repoPath,
@@ -640,6 +645,8 @@ export async function applyAgentIntegrations(options: {
     cursorRule: options.cursorRule,
     autoYes: options.autoYes,
     mode: options.mode,
+    writeAgentsMd: options.writeAgentsMd,
+    finalize: options.finalize,
   });
 
   const cursorRuleFlag =

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { scaffoldHarnessBoilerplate, finalizeHarness, ScaffoldOptions } from '../harness/generator';
+import { finalizeAgentsMdInstructionFiles } from '../harness/agent-md';
 import { validateHarness, smokeTestHarness, ValidationResult } from '../harness/validator';
 import { compareHarnessToTemplate, HarnessDriftResult } from '../harness/drift';
 import {
@@ -134,6 +135,7 @@ export async function maintainHarness(options: MaintainHarnessOptions): Promise<
       throw new Error('Cannot finalize: harness validation has errors. Fix them first.');
     }
     syncAgentSlotsToHarnessEnv(repoPath);
+    finalizeAgentsMdInstructionFiles(repoPath);
     const existing = readManifest(repoPath);
     finalizeHarness(
       repoPath,

--- a/src/harness/agent-md.ts
+++ b/src/harness/agent-md.ts
@@ -4,7 +4,13 @@ import * as readline from 'readline';
 import { writeFileSafe } from '../utils/file-ops';
 import { info, warn } from '../utils/logging';
 import { getHarnessDir } from './manifest';
-import { AGENTS_MD } from './instruction-files';
+import {
+  AGENTS_MD,
+  AgentsMdShrinkError,
+  extractOutsideHarSection,
+  mergeAgentsMdContent,
+  upsertAgentsMdHarSection,
+} from './instruction-files';
 
 export const AGENTS_MD_PROPOSAL = 'AGENTS.md.proposed';
 export const AGENTS_MD_PROPOSAL_META = 'AGENTS.md.proposed.meta.json';
@@ -82,6 +88,56 @@ export function clearAgentMdProposal(repoPath: string): void {
   }
 }
 
+function wouldProposalShrinkExisting(existing: string, proposal: string): boolean {
+  const outsideExisting = extractOutsideHarSection(existing);
+  const outsideMerged = extractOutsideHarSection(mergeAgentsMdContent(existing, proposal));
+  const existingLines = outsideExisting.split('\n').filter((l) => l.trim()).length;
+  const mergedLines = outsideMerged.split('\n').filter((l) => l.trim()).length;
+  return existingLines >= 5 && mergedLines < existingLines * 0.9;
+}
+
+/**
+ * Merge a pending AGENTS.md.proposed into the live file (managed section only).
+ * Returns true when a proposal was applied.
+ */
+export function applyAgentMdProposalMerge(
+  repoPath: string,
+  options: { rejectSignificantShrink?: boolean } = {},
+): boolean {
+  const proposal = readAgentMdProposal(repoPath);
+  if (!proposal) return false;
+
+  const agentsMdPath = path.join(repoPath, AGENTS_MD);
+  if (fs.existsSync(agentsMdPath)) {
+    const existing = fs.readFileSync(agentsMdPath, 'utf8');
+    if (wouldProposalShrinkExisting(existing, proposal.content)) {
+      const message =
+        `${AGENTS_MD} proposal would drop project-specific content outside har:agent-environment markers — ` +
+        `merge custom sections from .har/${AGENTS_MD_PROPOSAL} manually, then delete the proposal.`;
+      if (options.rejectSignificantShrink) {
+        throw new AgentsMdShrinkError(message);
+      }
+      warn(message);
+      return false;
+    }
+    writeFileSafe(agentsMdPath, mergeAgentsMdContent(existing, proposal.content));
+  } else {
+    writeFileSafe(agentsMdPath, proposal.content);
+  }
+
+  clearAgentMdProposal(repoPath);
+  info(`Merged ${AGENTS_MD} proposal into repo root (preserved content outside managed markers)`);
+  return true;
+}
+
+/**
+ * On finalize: merge any pending proposal, then refresh the managed HAR section.
+ */
+export function finalizeAgentsMdInstructionFiles(repoPath: string): void {
+  applyAgentMdProposalMerge(repoPath, { rejectSignificantShrink: true });
+  upsertAgentsMdHarSection(repoPath, { rejectSignificantShrink: true });
+}
+
 export async function promptApplyAgentMdProposal(repoPath: string): Promise<boolean> {
   const proposal = readAgentMdProposal(repoPath);
   if (!proposal) return false;
@@ -109,7 +165,15 @@ export async function promptApplyAgentMdProposal(repoPath: string): Promise<bool
 
   if (exists) {
     warn(`${AGENTS_MD} already exists at repo root.`);
-    const answer = await askYesNo(`Replace ${AGENTS_MD} with this proposal? (y/n)`);
+    if (wouldProposalShrinkExisting(fs.readFileSync(agentsMdPath, 'utf8'), proposal.content)) {
+      warn(
+        'Proposal would drop project-specific content outside har:agent-environment markers — merge manually from the proposal file.',
+      );
+      return false;
+    }
+    const answer = await askYesNo(
+      `Merge managed HAR section from this proposal into ${AGENTS_MD}? (y/n)`,
+    );
     if (!answer) {
       info(`Skipped — proposal kept at .har/${AGENTS_MD_PROPOSAL}`);
       return false;
@@ -122,9 +186,7 @@ export async function promptApplyAgentMdProposal(repoPath: string): Promise<bool
     }
   }
 
-  writeFileSafe(agentsMdPath, proposal.content);
-  clearAgentMdProposal(repoPath);
-  info(`Wrote ${AGENTS_MD}`);
+  applyAgentMdProposalMerge(repoPath);
   return true;
 }
 

--- a/src/harness/instruction-files.ts
+++ b/src/harness/instruction-files.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as readline from 'readline';
 import { writeFileSafe } from '../utils/file-ops';
-import { divider, info, success } from '../utils/logging';
+import { divider, info, success, warn } from '../utils/logging';
 import { resolveTemplateFile } from '../utils/paths';
 import { AGENT_SKILL_TARGETS, detectAgentTargets, parseAgentTargets } from './agent-skills';
 import type { AgentSkillTarget } from './schema';
@@ -52,6 +52,25 @@ export interface InstructionFilesOptions {
    * AGENTS.md is the shared project contract even when skills are skipped.
    */
   writeAgentsMd?: boolean;
+  /**
+   * When true (har env maintain --finalize), refuse updates that would drop
+   * project-specific content outside har:agent-environment markers.
+   */
+  finalize?: boolean;
+}
+
+export interface UpsertAgentsMdOptions {
+  /** Throw when outside-marker content would shrink significantly. */
+  rejectSignificantShrink?: boolean;
+  /** Minimum fraction of non-empty outside-marker lines to preserve (default 0.9). */
+  minOutsidePreservationRatio?: number;
+}
+
+export class AgentsMdShrinkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentsMdShrinkError';
+  }
 }
 
 export interface InstructionFilesResult {
@@ -65,6 +84,86 @@ export interface InstructionFilesResult {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function countNonEmptyLines(text: string): number {
+  return text.split('\n').filter((line) => line.trim().length > 0).length;
+}
+
+/** Remove CLAUDE-only pointer markers if they were copied into AGENTS.md by mistake. */
+export function stripClaudePointerFromAgentsMd(content: string): string {
+  if (!content.includes(CLAUDE_HAR_SECTION_START)) return content;
+  const pattern = new RegExp(
+    `${escapeRegExp(CLAUDE_HAR_SECTION_START)}[\\s\\S]*?${escapeRegExp(CLAUDE_HAR_SECTION_END)}\\n?`,
+    'g',
+  );
+  return content.replace(pattern, '').replace(/\n{3,}/g, '\n\n');
+}
+
+/** Content outside the managed har:agent-environment block (project-specific guidance). */
+export function extractOutsideHarSection(content: string): string {
+  const sanitized = stripClaudePointerFromAgentsMd(content);
+  return removeCompleteMarkedBlocks(sanitized, HAR_SECTION_START, HAR_SECTION_END).trim();
+}
+
+function findLastCompleteMarkedBlock(
+  content: string,
+  startMarker: string,
+  endMarker: string,
+): { start: number; end: number } | null {
+  let last: { start: number; end: number } | null = null;
+  let searchFrom = 0;
+
+  while (searchFrom < content.length) {
+    const start = content.indexOf(startMarker, searchFrom);
+    if (start === -1) break;
+    const end = content.indexOf(endMarker, start + startMarker.length);
+    if (end === -1) break;
+    const nestedStart = content.indexOf(startMarker, start + startMarker.length);
+    if (nestedStart !== -1 && nestedStart < end) {
+      searchFrom = start + startMarker.length;
+      continue;
+    }
+    last = { start, end: end + endMarker.length };
+    searchFrom = end + endMarker.length;
+  }
+
+  return last;
+}
+
+function removeCompleteMarkedBlocks(content: string, startMarker: string, endMarker: string): string {
+  let result = content;
+  let block = findLastCompleteMarkedBlock(result, startMarker, endMarker);
+  while (block) {
+    result = result.slice(0, block.start) + result.slice(block.end);
+    block = findLastCompleteMarkedBlock(result, startMarker, endMarker);
+  }
+  return result;
+}
+
+function checkOutsideContentPreserved(
+  before: string,
+  after: string,
+  options: UpsertAgentsMdOptions,
+): 'ok' | 'shrink' {
+  const outsideBefore = extractOutsideHarSection(before);
+  const outsideAfter = extractOutsideHarSection(after);
+  const beforeLines = countNonEmptyLines(outsideBefore);
+  const afterLines = countNonEmptyLines(outsideAfter);
+  const minRatio = options.minOutsidePreservationRatio ?? 0.9;
+
+  if (beforeLines >= 5 && afterLines < beforeLines * minRatio) {
+    return 'shrink';
+  }
+  return 'ok';
+}
+
+function outsideContentShrinkMessage(beforeLines: number, afterLines: number): string {
+  return (
+    `Refusing to update ${AGENTS_MD}: refresh would drop project-specific content outside ` +
+    `har:agent-environment markers (${beforeLines} → ${afterLines} non-empty lines). ` +
+    `Keep custom sections outside those markers, or merge manually before --finalize.`
+  );
 }
 
 export function detectInstructionFiles(repoPath: string): InstructionFileDetection {
@@ -166,20 +265,49 @@ function upsertMarkedBlock(
   startMarker: string,
   endMarker: string,
 ): { content: string; action: 'updated' | 'appended' } {
-  if (content.includes(startMarker)) {
-    const pattern = new RegExp(
-      `${escapeRegExp(startMarker)}[\\s\\S]*?${escapeRegExp(endMarker)}`,
-    );
-    return { content: content.replace(pattern, block), action: 'updated' };
+  const existingBlock = findLastCompleteMarkedBlock(content, startMarker, endMarker);
+  if (existingBlock) {
+    const newContent =
+      content.slice(0, existingBlock.start) + block + content.slice(existingBlock.end);
+    return { content: newContent, action: 'updated' };
   }
   const suffix = content.endsWith('\n') ? '' : '\n';
   return { content: `${content}${suffix}\n${block}\n`, action: 'appended' };
 }
 
 /**
+ * Merge incoming AGENTS.md content into an existing file — refresh only the managed
+ * HAR section; preserve all other project-specific guidance.
+ */
+export function mergeAgentsMdContent(existing: string, incoming: string): string {
+  const sanitizedExisting = stripClaudePointerFromAgentsMd(existing);
+  const sanitizedIncoming = stripClaudePointerFromAgentsMd(incoming);
+
+  let harSection = loadHarAgentsSectionFromTemplate();
+  if (sanitizedIncoming.includes(HAR_SECTION_START)) {
+    const start = sanitizedIncoming.indexOf(HAR_SECTION_START);
+    const end = sanitizedIncoming.indexOf(HAR_SECTION_END, start + HAR_SECTION_START.length);
+    if (end !== -1) {
+      harSection = sanitizedIncoming.slice(start, end + HAR_SECTION_END.length);
+    }
+  }
+
+  const { content } = upsertMarkedBlock(
+    sanitizedExisting,
+    harSection,
+    HAR_SECTION_START,
+    HAR_SECTION_END,
+  );
+  return content;
+}
+
+/**
  * Create AGENTS.md from template, or upsert the managed HAR section into an existing file.
  */
-export function upsertAgentsMdHarSection(repoPath: string): 'created' | 'updated' | 'appended' {
+export function upsertAgentsMdHarSection(
+  repoPath: string,
+  options: UpsertAgentsMdOptions = {},
+): 'created' | 'updated' | 'appended' | 'skipped' {
   const dest = path.join(repoPath, AGENTS_MD);
   const section = loadHarAgentsSectionFromTemplate();
 
@@ -189,12 +317,29 @@ export function upsertAgentsMdHarSection(repoPath: string): 'created' | 'updated
   }
 
   const existing = fs.readFileSync(dest, 'utf8');
+  const sanitized = stripClaudePointerFromAgentsMd(existing);
   const { content, action } = upsertMarkedBlock(
-    existing,
+    sanitized,
     section,
     HAR_SECTION_START,
     HAR_SECTION_END,
   );
+
+  if (checkOutsideContentPreserved(existing, content, options) === 'shrink') {
+    const beforeLines = countNonEmptyLines(extractOutsideHarSection(existing));
+    const afterLines = countNonEmptyLines(extractOutsideHarSection(content));
+    const message = outsideContentShrinkMessage(beforeLines, afterLines);
+    if (options.rejectSignificantShrink) {
+      throw new AgentsMdShrinkError(message);
+    }
+    warn(message);
+    return 'skipped';
+  }
+
+  if (content === existing) {
+    return 'skipped';
+  }
+
   writeFileSafe(dest, content);
   return action;
 }
@@ -214,6 +359,12 @@ export function migrateLegacyAgentMd(repoPath: string): boolean {
     writeFileSafe(agentsPath, legacy);
     upsertAgentsMdHarSection(repoPath);
   } else {
+    const agents = fs.readFileSync(agentsPath, 'utf8');
+    const legacyTrimmed = legacy.trim();
+    if (legacyTrimmed.length > 0 && !agents.includes(legacyTrimmed)) {
+      const suffix = agents.endsWith('\n') ? '' : '\n';
+      writeFileSafe(agentsPath, `${agents}${suffix}\n${legacyTrimmed}\n`);
+    }
     upsertAgentsMdHarSection(repoPath);
   }
 
@@ -389,13 +540,19 @@ export async function handleInstructionFiles(
     if (detection.agentMd) {
       migratedLegacy = migrateLegacyAgentMd(repoPath);
     }
-    agentsMdAction = upsertAgentsMdHarSection(repoPath);
+    agentsMdAction = upsertAgentsMdHarSection(repoPath, {
+      rejectSignificantShrink: options.finalize === true,
+    });
 
     if (agentsMdAction === 'created') {
       success(`Wrote ${AGENTS_MD}`);
     } else if (agentsMdAction === 'updated' || agentsMdAction === 'appended') {
       info(
         `${agentsMdAction === 'updated' ? 'Refreshed' : 'Appended'} HAR section in ${AGENTS_MD}`,
+      );
+    } else if (agentsMdAction === 'skipped' && options.finalize) {
+      warn(
+        `${AGENTS_MD} left unchanged — project-specific content outside har:agent-environment markers was preserved.`,
       );
     }
   } else {

--- a/src/harness/maintain-bundle.ts
+++ b/src/harness/maintain-bundle.ts
@@ -328,6 +328,10 @@ function buildReadme(report: MaintainBundleReport): string {
     lines.push(
       'Repo-root agent docs are **outside** `.har/` checksum drift. Apply while adapting:',
       '',
+      '**Merge contract:** `har env maintain --finalize` refreshes only the content between',
+      '`<!-- har:agent-environment:start/end -->` in `AGENTS.md`. Custom `## Project` sections and',
+      'other guidance **outside** those markers must survive finalize — relocate them if needed.',
+      '',
     );
     for (const note of report.instructionFiles) {
       lines.push(`- **\`${note.path}\`** (${note.kind}): ${note.message}`);

--- a/tests/instruction-files.test.ts
+++ b/tests/instruction-files.test.ts
@@ -4,16 +4,25 @@ import * as path from 'path';
 import {
   AGENTS_MD,
   CLAUDE_MD,
+  CLAUDE_HAR_SECTION_END,
+  CLAUDE_HAR_SECTION_START,
+  HAR_SECTION_END,
   HAR_SECTION_START,
   LEGACY_AGENT_MD,
   buildInstallPlan,
   detectInstructionFiles,
   ensureClaudeMdPointer,
+  extractOutsideHarSection,
   formatDetectionReport,
   formatInstallPlan,
+  mergeAgentsMdContent,
   migrateLegacyAgentMd,
+  stripClaudePointerFromAgentsMd,
   upsertAgentsMdHarSection,
 } from '../src/harness/instruction-files';
+import { writeAgentMdProposal } from '../src/harness/agent-md';
+import { maintainHarness } from '../src/core/harness';
+import { scaffoldHarnessBoilerplate } from '../src/harness/generator';
 
 function makeTempRepo(prefix: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
@@ -112,5 +121,87 @@ describe('instruction-files', () => {
     expect(plan.claudeMd).toBe(true);
     expect(plan.cursorRule).toBe(true);
     expect(formatInstallPlan(plan, detection)).toContain('[x] Create AGENTS.md');
+  });
+
+  it('strips misplaced claude-pointer markers from AGENTS.md', () => {
+    const repoPath = makeTempRepo('har-strip-claude');
+    const content = `# Project\n\n${CLAUDE_HAR_SECTION_START}\nclaude only\n${CLAUDE_HAR_SECTION_END}\n\nKeep me.\n`;
+    fs.writeFileSync(path.join(repoPath, AGENTS_MD), content);
+    upsertAgentsMdHarSection(repoPath);
+    const updated = fs.readFileSync(path.join(repoPath, AGENTS_MD), 'utf8');
+    expect(updated).toContain('Keep me.');
+    expect(updated).not.toContain('har:claude-pointer');
+    expect(updated).toContain(HAR_SECTION_START);
+  });
+
+  it('appends HAR section when start marker exists without end marker', () => {
+    const repoPath = makeTempRepo('har-orphan-start');
+    fs.writeFileSync(
+      path.join(repoPath, AGENTS_MD),
+      `# Project\n\n${HAR_SECTION_START}\norphaned\n\n## Build\nnpm test\n`,
+    );
+    const action = upsertAgentsMdHarSection(repoPath);
+    expect(action).toBe('appended');
+    const content = fs.readFileSync(path.join(repoPath, AGENTS_MD), 'utf8');
+    expect(content).toContain('npm test');
+    expect(content.match(/har:agent-environment:start/g)?.length).toBe(2);
+  });
+
+  it('rejects finalize refresh that would shrink outside-marker content', () => {
+    const repoPath = makeTempRepo('har-shrink');
+    const outside = Array.from({ length: 20 }, (_, i) => `- item ${i}`).join('\n');
+    fs.writeFileSync(
+      path.join(repoPath, AGENTS_MD),
+      `${outside}\n\n${HAR_SECTION_START}\n${outside}\n${HAR_SECTION_END}\n`,
+    );
+    expect(() =>
+      upsertAgentsMdHarSection(repoPath, { rejectSignificantShrink: true }),
+    ).not.toThrow();
+    const content = fs.readFileSync(path.join(repoPath, AGENTS_MD), 'utf8');
+    expect(content).toContain('- item 0');
+    expect(content).toContain('Launch first');
+  });
+
+  it('mergeAgentsMdContent preserves project guidance outside managed markers', () => {
+    const existing = '# Project\n\n## Build\nnpm run build\n\n';
+    const proposal = `# Scaffold\n\n${HAR_SECTION_START}\nnew har\n${HAR_SECTION_END}\n\n## Project\nlost\n`;
+    const merged = mergeAgentsMdContent(existing, proposal);
+    expect(merged).toContain('npm run build');
+    expect(merged).toContain('new har');
+    expect(merged).not.toContain('lost');
+    expect(extractOutsideHarSection(merged)).toContain('npm run build');
+  });
+
+  it('migrateLegacyAgentMd merges legacy notes when AGENTS.md already exists', () => {
+    const repoPath = makeTempRepo('har-migrate-both');
+    fs.writeFileSync(path.join(repoPath, AGENTS_MD), '# Existing\n\n## Project\nKeep.\n');
+    fs.writeFileSync(path.join(repoPath, LEGACY_AGENT_MD), '# Legacy\n\nUnique legacy note.\n');
+    expect(migrateLegacyAgentMd(repoPath)).toBe(true);
+    const content = fs.readFileSync(path.join(repoPath, AGENTS_MD), 'utf8');
+    expect(content).toContain('Keep.');
+    expect(content).toContain('Unique legacy note.');
+    expect(fs.existsSync(path.join(repoPath, LEGACY_AGENT_MD))).toBe(false);
+  });
+
+  it('finalize merges AGENTS.md.proposed without dropping outside-marker content', async () => {
+    const repoPath = makeTempRepo('har-finalize-merge');
+    fs.writeFileSync(path.join(repoPath, 'package.json'), JSON.stringify({ name: 'app' }) + '\n');
+    scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'cli' });
+    const projectSection = Array.from({ length: 15 }, (_, i) => `## Section ${i}\nDetail ${i}.`).join(
+      '\n\n',
+    );
+    fs.writeFileSync(path.join(repoPath, AGENTS_MD), `# App\n\n${projectSection}\n`);
+    writeAgentMdProposal(
+      repoPath,
+      `# Proposed\n\n${HAR_SECTION_START}\nshould not replace project\n${HAR_SECTION_END}\n`,
+      'test proposal',
+    );
+
+    await maintainHarness({ repoPath, finalize: true, summary: 'test finalize merge' });
+
+    const content = fs.readFileSync(path.join(repoPath, AGENTS_MD), 'utf8');
+    expect(content).toContain('## Section 0');
+    expect(content).toContain('Launch first');
+    expect(stripClaudePointerFromAgentsMd(content)).toBe(content);
   });
 });


### PR DESCRIPTION
## Summary
- Merge only the managed `har:agent-environment` section during `har env maintain --finalize`, preserving project-specific guidance outside those markers
- Fix orphaned marker pairing that could treat custom sections as managed content and replace them on refresh
- Strip misplaced `har:claude-pointer` blocks from `AGENTS.md`, merge `.har/AGENTS.md.proposed` instead of replacing wholesale, and document the merge contract in the maintain bundle

Fixes #155

## Test plan
- [x] `har env verify 4 --full`
- [x] New unit/integration tests in `tests/instruction-files.test.ts` cover marker merge, claude-pointer stripping, legacy migration, and finalize proposal merge

Made with [Cursor](https://cursor.com)