### PR TITLE
fix(schemas): add temporary Cursor model pricing overlay

### DIFF
--- a/packages/schemas/src/cursor-pricing-overlay.ts
+++ b/packages/schemas/src/cursor-pricing-overlay.ts
@@ -1,0 +1,106 @@
+import { calcPrice, type Provider, type Usage } from '@pydantic/genai-prices';
+
+/**
+ * Temporary Cursor provider catalog until pydantic/genai-prices#537 merges.
+ * Source: https://github.com/pydantic/genai-prices/pull/537
+ * Pricing: https://cursor.com/docs/models-and-pricing
+ */
+export const CURSOR_PRICING_PROVIDER: Provider = {
+  id: 'cursor',
+  name: 'Cursor',
+  pricing_urls: ['https://cursor.com/docs/models-and-pricing'],
+  api_pattern: String.raw`https://(.*\.)?cursor\.(com|sh)`,
+  model_match: {
+    or: [{ starts_with: 'composer' }, { contains: 'grok-4.5' }],
+  },
+  provider_match: { contains: 'cursor' },
+  models: [
+    {
+      id: 'composer-2.5-fast',
+      name: 'Composer 2.5 (Fast)',
+      description: 'Fast-mode variant of Composer 2.5.',
+      match: {
+        or: [
+          { equals: 'composer-2.5-fast' },
+          { equals: 'cursor-composer-2.5-fast' },
+        ],
+      },
+      prices: {
+        input_mtok: 3,
+        cache_read_mtok: 0.5,
+        output_mtok: 15,
+      },
+    },
+    {
+      id: 'composer-2.5',
+      name: 'Composer 2.5',
+      description: "Cursor's own agentic coding model.",
+      match: {
+        or: [
+          { equals: 'composer-2.5' },
+          { equals: 'cursor-composer-2.5' },
+        ],
+      },
+      prices: {
+        input_mtok: 0.5,
+        cache_read_mtok: 0.2,
+        output_mtok: 2.5,
+      },
+    },
+    {
+      id: 'grok-4.5-fast',
+      name: 'Grok 4.5 (Fast)',
+      description: 'Fast-mode variant of Grok 4.5.',
+      match: {
+        or: [
+          { equals: 'grok-4.5-fast' },
+          { equals: 'grok-4.5-high-fast' },
+          { equals: 'cursor-grok-4.5-high-fast' },
+          { equals: 'cursor-grok-4.5-fast' },
+        ],
+      },
+      prices: {
+        input_mtok: 4,
+        cache_read_mtok: 1,
+        output_mtok: 18,
+      },
+    },
+    {
+      id: 'grok-4.5',
+      name: 'Grok 4.5',
+      description:
+        'Jointly trained by Cursor and SpaceXAI for long-running coding and knowledge work.',
+      match: {
+        or: [
+          { equals: 'grok-4.5' },
+          { equals: 'grok-4.5-high' },
+          { equals: 'cursor-grok-4.5-high' },
+          { equals: 'cursor-grok-4.5' },
+        ],
+      },
+      prices: {
+        input_mtok: 2,
+        cache_read_mtok: 0.5,
+        output_mtok: 6,
+      },
+    },
+  ],
+};
+
+/** True when the model id looks like a Cursor-native slug (Composer / Grok 4.5). */
+export function isCursorNativeModel(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  const normalized = id.startsWith('cursor-') ? id.slice('cursor-'.length) : id;
+  return normalized.startsWith('composer') || normalized.includes('grok-4.5');
+}
+
+/** Price a Cursor-native model using the temporary overlay catalog. */
+export function estimateCursorNativeCostUsd(usage: Usage, modelId: string): number | null {
+  if (!isCursorNativeModel(modelId)) return null;
+  try {
+    const result = calcPrice(usage, modelId, { provider: CURSOR_PRICING_PROVIDER });
+    return result?.total_price ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/schemas/src/usage-pricing.ts
+++ b/packages/schemas/src/usage-pricing.ts
@@ -1,4 +1,5 @@
 import { calcPrice } from '@pydantic/genai-prices';
+import { estimateCursorNativeCostUsd } from './cursor-pricing-overlay';
 import type { AgentSessionUsage, AgentTool } from './schema';
 
 /** Per-model token and cost fields stored on AgentSessionUsage.modelBreakdown. */
@@ -78,6 +79,11 @@ export function estimateModelCostUsd(
     } catch {
       continue;
     }
+  }
+
+  for (const candidate of pricingModelCandidates(modelId)) {
+    const overlay = estimateCursorNativeCostUsd(usage, candidate);
+    if (overlay != null) return overlay;
   }
   return null;
 }

--- a/tests/usage-pricing.test.ts
+++ b/tests/usage-pricing.test.ts
@@ -4,6 +4,10 @@ import {
   pricingModelCandidates,
   toGenaiPricesUsage,
 } from '../packages/schemas/src/usage-pricing';
+import {
+  estimateCursorNativeCostUsd,
+  isCursorNativeModel,
+} from '../packages/schemas/src/cursor-pricing-overlay';
 import type { AgentSessionUsage } from '../packages/schemas/src/schema';
 
 function usage(overrides: Partial<AgentSessionUsage> = {}): AgentSessionUsage {
@@ -63,6 +67,27 @@ describe('toGenaiPricesUsage', () => {
   });
 });
 
+describe('isCursorNativeModel', () => {
+  it('detects composer and grok-4.5 slugs', () => {
+    expect(isCursorNativeModel('composer-2.5-fast')).toBe(true);
+    expect(isCursorNativeModel('cursor-grok-4.5-high-fast')).toBe(true);
+    expect(isCursorNativeModel('claude-opus-4-8')).toBe(false);
+  });
+});
+
+describe('estimateCursorNativeCostUsd', () => {
+  it('prices grok-4.5 fast slugs from the temporary overlay', () => {
+    const usage = {
+      input_tokens: 1000,
+      output_tokens: 100,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    };
+    expect(estimateCursorNativeCostUsd(usage, 'cursor-grok-4.5-high-fast')).toBeGreaterThan(0);
+    expect(estimateCursorNativeCostUsd(usage, 'composer-2.5-fast')).toBeGreaterThan(0);
+  });
+});
+
 describe('estimateModelCostUsd', () => {
   it('prices anthropic models from per-model token totals', () => {
     const cost = estimateModelCostUsd(
@@ -100,6 +125,26 @@ describe('estimateModelCostUsd', () => {
         'cursor',
       ),
     ).toBeNull();
+  });
+
+  it('prices cursor-native models via the temporary overlay', () => {
+    const cost = estimateModelCostUsd(
+      'cursor-grok-4.5-high-fast',
+      { tokensInput: 1000, tokensOutput: 100 },
+      'cursor',
+    );
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeGreaterThan(0);
+  });
+
+  it('prices composer models via the temporary overlay', () => {
+    const cost = estimateModelCostUsd(
+      'composer-2.5',
+      { tokensInput: 10_000, tokensOutput: 1000 },
+      'cursor',
+    );
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds a local Cursor provider catalog (`cursor-pricing-overlay.ts`) mirroring [pydantic/genai-prices#537](https://github.com/pydantic/genai-prices/pull/537) until it merges upstream
- Falls back to the overlay in `estimateModelCostUsd` when bundled genai-prices does not recognize Composer / Grok 4.5 slugs (including `cursor-grok-4.5-high-fast`, etc.)
- Keeps using genai-prices' own `calcPrice()` for token math consistency

## Test plan

- [x] `har env verify 4 --full` passes
- [x] Unit tests cover Composer/Grok overlay pricing and existing Anthropic catalog paths
- [ ] After merge, confirm Mission Control shows non-zero `costUsd` for Cursor-native model rows

## Cleanup

Remove `cursor-pricing-overlay.ts` and the fallback loop once `@pydantic/genai-prices` ships Cursor models and we bump the dependency.

Made with [Cursor](https://cursor.com)