### PR TITLE
feat(control): default the login portal instead of erroring

### DIFF
--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -186,11 +186,13 @@ har control unregister [--repo .] [--api-url <url>] [--yes] [--delete-worktrees]
 har control reset [--yes] [--no-scrub-local] [--keep-registry] [--api-url <url>] [--dry-run] [--json]
 har control sync [--select] [--api-url <url>] [--dry-run] [--json] [--cloud] [--full]
 har control watch [--repo .] [--interval 10] [--api-url <url>]
-har control login --portal <url> [--api-key <key>]
+har control login [--portal <url>] [--api-key <key>]
 ```
 
-`login` requires `--portal` (or `HAR_PORTAL_URL`). With `--api-key` it stores that
-ingest token; without it, HAR opens browser SSO and saves the resulting token.
+`login` resolves the portal from `--portal`, then `HAR_PORTAL_URL`, then the
+portal of your last login, and finally `https://har.kerno.io`; it prints which
+one it picked. With `--api-key` it stores that ingest token; without it, HAR
+opens browser SSO and saves the resulting token.
 `sync --select` interactively chooses repositories; `--full` ignores the portal
 watermark and resends the complete payload.
 

--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -2,8 +2,11 @@ import * as path from 'path';
 import inquirer from 'inquirer';
 import type { Argv } from 'yargs';
 import {
+  DEFAULT_PORTAL_URL,
   getControlApiUrl,
   isControlEnabled,
+  resolvePortalUrl,
+  type PortalUrlSource,
 } from '../../core/control-config';
 import { inspectControlUpReadiness } from '../../core/control-port';
 import {
@@ -123,7 +126,10 @@ export const controlCommand = {
         'Log in to a har-portal (browser SSO) and store an ingest token',
         (y: Argv) =>
           y
-            .option('portal', { type: 'string', describe: 'Portal base URL (or set HAR_PORTAL_URL)' })
+            .option('portal', {
+              type: 'string',
+              describe: `Portal base URL (or HAR_PORTAL_URL; defaults to the last login, else ${DEFAULT_PORTAL_URL})`,
+            })
             .option('api-key', {
               type: 'string',
               describe: 'Store this ingest token directly instead of browser login',
@@ -521,13 +527,17 @@ async function handleSync(argv: {
   }
 }
 
+const PORTAL_SOURCE_LABEL: Record<PortalUrlSource, string> = {
+  flag: '--portal',
+  env: 'HAR_PORTAL_URL',
+  saved: 'saved login',
+  default: 'default',
+};
+
 async function handleLogin(argv: { apiKey?: string; portal?: string }): Promise<void> {
   header('har control login');
-  const portalUrl = (argv.portal ?? process.env.HAR_PORTAL_URL ?? '').replace(/\/+$/, '');
-  if (!portalUrl) {
-    error('Provide --portal <url> (or set HAR_PORTAL_URL)');
-    return finishCommand(1);
-  }
+  const { url: portalUrl, source } = resolvePortalUrl(argv.portal);
+  info(`Portal: ${portalUrl} (${PORTAL_SOURCE_LABEL[source]})`);
 
   if (argv.apiKey) {
     writePortalCredentials({

--- a/src/core/control-config.ts
+++ b/src/core/control-config.ts
@@ -3,6 +3,8 @@ import { readPortalCredentials } from './portal-credentials';
 /** Default Mission Control API base URL (local Docker Compose). */
 export const DEFAULT_CONTROL_API_URL = 'http://localhost:3847';
 
+export const DEFAULT_PORTAL_URL = 'https://har.kerno.io';
+
 export function getControlApiUrl(): string {
   return process.env.HAR_CONTROL_API_URL ?? DEFAULT_CONTROL_API_URL;
 }
@@ -19,6 +21,26 @@ export interface PortalTarget {
 
 function normalizeUrl(url: string): string {
   return url.replace(/\/+$/, '');
+}
+
+export type PortalUrlSource = 'flag' | 'env' | 'saved' | 'default';
+
+export function resolvePortalUrl(explicit?: string): {
+  url: string;
+  source: PortalUrlSource;
+} {
+  const candidates: Array<[string | undefined, PortalUrlSource]> = [
+    [explicit, 'flag'],
+    [process.env.HAR_PORTAL_URL, 'env'],
+    [readPortalCredentials()?.portalUrl, 'saved'],
+  ];
+
+  for (const [value, source] of candidates) {
+    const url = normalizeUrl((value ?? '').trim());
+    if (url) return { url, source };
+  }
+
+  return { url: DEFAULT_PORTAL_URL, source: 'default' };
 }
 
 export function getPortalTarget(): PortalTarget | null {

--- a/tests/portal-credentials.test.ts
+++ b/tests/portal-credentials.test.ts
@@ -6,7 +6,11 @@ import {
   readPortalCredentials,
   writePortalCredentials,
 } from '../src/core/portal-credentials';
-import { getPortalTarget } from '../src/core/control-config';
+import {
+  DEFAULT_PORTAL_URL,
+  getPortalTarget,
+  resolvePortalUrl,
+} from '../src/core/control-config';
 
 const PORTAL_ENV = [
   'HAR_PORTAL_URL',
@@ -102,6 +106,62 @@ describe('getPortalTarget source precedence', () => {
     expect(getPortalTarget()).toEqual({
       url: 'https://env.example.com',
       token: 'har_ingest_env',
+    });
+  });
+});
+
+describe('resolvePortalUrl', () => {
+  function storePortal(portalUrl: string): void {
+    writePortalCredentials({
+      portalUrl,
+      token: 'har_ingest_stored',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+  }
+
+  it('falls back to the default portal when nothing is set', () => {
+    expect(resolvePortalUrl()).toEqual({
+      url: DEFAULT_PORTAL_URL,
+      source: 'default',
+    });
+  });
+
+  it('reuses the portal from a previous login', () => {
+    storePortal('https://stored.example.com');
+    expect(resolvePortalUrl()).toEqual({
+      url: 'https://stored.example.com',
+      source: 'saved',
+    });
+  });
+
+  it('prefers HAR_PORTAL_URL over a previous login', () => {
+    storePortal('https://stored.example.com');
+    process.env.HAR_PORTAL_URL = 'https://env.example.com';
+    expect(resolvePortalUrl()).toEqual({
+      url: 'https://env.example.com',
+      source: 'env',
+    });
+  });
+
+  it('prefers the explicit portal over env and a previous login', () => {
+    storePortal('https://stored.example.com');
+    process.env.HAR_PORTAL_URL = 'https://env.example.com';
+    expect(resolvePortalUrl('https://flag.example.com')).toEqual({
+      url: 'https://flag.example.com',
+      source: 'flag',
+    });
+  });
+
+  it('normalizes trailing slashes and blank values on every source', () => {
+    storePortal('https://stored.example.com//');
+    expect(resolvePortalUrl('  ')).toEqual({
+      url: 'https://stored.example.com',
+      source: 'saved',
+    });
+    process.env.HAR_PORTAL_URL = 'https://env.example.com/';
+    expect(resolvePortalUrl('')).toEqual({
+      url: 'https://env.example.com',
+      source: 'env',
     });
   });
 });


### PR DESCRIPTION
## Problem

`har control login` had no default portal: it resolved `--portal` → `HAR_PORTAL_URL` → empty string and exited 1 with `Provide --portal <url> (or set HAR_PORTAL_URL)`. Every login meant retyping the portal URL, including a re-login against the portal already sitting in `~/.har/credentials.json`.

## Change

`resolvePortalUrl()` in `src/core/control-config.ts` resolves, in order:

1. `--portal <url>`
2. `HAR_PORTAL_URL`
3. the `portalUrl` of the last login (`readPortalCredentials()`)
4. `https://har.kerno.io`

Trailing slashes are normalized on every source (previously only on the flag), and blank/whitespace values fall through instead of resolving to an empty URL. `handleLogin` prints `Portal: <url> (<source>)` before opening the browser or storing an `--api-key` token, so a fallback to the hosted default is never silent.

`har control sync` is untouched — it resolves its target separately through `getPortalTarget()`.

## Verification

`npm run typecheck`, `npm run lint`, and the portal suites (`portal-credentials`, `portal-login`, `control-portal-sync`) are green — 5 new cases cover each rung of the chain plus normalization. Pre-existing failures in `control-repo-path` / `hooks` / `plugins` / `slot-registry` are unrelated (macOS `/private` symlink + nested-worktree artifacts; identical on `main`).

Exercised end to end against the built CLI via `--api-key` (same resolution, no browser): default → saved → `--portal` override → saved-follows-override → env-over-saved all print the expected portal and source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)