### PR TITLE
docs: center README video in table with caption

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@
 
 HAR is an open-source, agent-agnostic framework for building multi-agent coding workflows. Run a fleet of coding agents in parallel on any repository, with deterministic validation gates, verifiable proof, and full observability across every agent, all extensible and customizable to your own workflow and tooling.
 
-<p align="center">
-  <a href="https://youtu.be/XKl4ZzWy7mQ">
-    <img src="https://img.youtube.com/vi/XKl4ZzWy7mQ/maxresdefault.jpg" alt="HAR introduction demo" width="540">
-  </a>
-  <br>
-</p>
+<table align="center">
+  <caption>▶ <strong>Introduction demo</strong> — click the thumbnail to watch on YouTube</caption>
+  <tr>
+    <td align="center">
+      <a href="https://youtu.be/XKl4ZzWy7mQ">
+        <img src="https://img.youtube.com/vi/XKl4ZzWy7mQ/maxresdefault.jpg" alt="HAR introduction demo" width="540">
+      </a>
+    </td>
+  </tr>
+</table>
 
 Works with **Claude Code** · **Cursor** · **Codex** · any MCP agent.
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@
 HAR is an open-source, agent-agnostic framework for building multi-agent coding workflows. Run a fleet of coding agents in parallel on any repository, with deterministic validation gates, verifiable proof, and full observability across every agent, all extensible and customizable to your own workflow and tooling.
 
 <table align="center">
-  <caption>▶ <strong>Introduction demo</strong> — click the thumbnail to watch on YouTube</caption>
   <tr>
     <td align="center">
       <a href="https://youtu.be/XKl4ZzWy7mQ">
         <img src="https://img.youtube.com/vi/XKl4ZzWy7mQ/maxresdefault.jpg" alt="HAR introduction demo" width="540">
       </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+    ▶ <strong>Introduction demo</strong> — click the thumbnail to watch on YouTube
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
- Wrap the README introduction demo thumbnail in a centered HTML table
- Add a caption that labels it as a clickable YouTube video

## Test plan
- [x] Preview README rendering on GitHub
- [ ] Confirm the table is centered and the caption reads clearly above the thumbnail


Made with [Cursor](https://cursor.com)