### PR TITLE
test: cover UnregisteredRepository tombstone and AGENTS.md shrink guard

### DIFF
--- a/control/src/app/api/repos/route.test.ts
+++ b/control/src/app/api/repos/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const registerRepository = vi.fn();
+
+vi.mock('@/server/repositories', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/server/repositories')>();
+  return {
+    ...actual,
+    registerRepository: (...args: unknown[]) => registerRepository(...args),
+  };
+});
+
+import { RepositoryUnregisteredError } from '@/server/repositories';
+import { POST } from './route';
+
+describe('POST /api/repos', () => {
+  beforeEach(() => {
+    registerRepository.mockReset();
+  });
+
+  it('returns 409 when repository was previously unregistered', async () => {
+    registerRepository.mockRejectedValue(new RepositoryUnregisteredError('/tmp/main'));
+
+    const response = await POST(
+      new Request('http://localhost/api/repos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: '/tmp/main' }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as { error: string; path: string };
+    expect(body.path).toBe('/tmp/main');
+    expect(body.error).toContain('/tmp/main');
+  });
+
+  it('returns 200 with repo id on successful register', async () => {
+    registerRepository.mockResolvedValue({ id: 'repo-1', path: '/tmp/main' });
+
+    const response = await POST(
+      new Request('http://localhost/api/repos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: '/tmp/main' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ id: 'repo-1', path: '/tmp/main' });
+  });
+
+  it('returns 400 for other register errors', async () => {
+    registerRepository.mockRejectedValue(new Error('invalid input'));
+
+    const response = await POST(
+      new Request('http://localhost/api/repos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: '/tmp/main' }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { error: string }).toMatchObject({
+      error: 'invalid input',
+    });
+  });
+});

--- a/control/src/server/repositories.test.ts
+++ b/control/src/server/repositories.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const findUniqueUnregistered = vi.fn();
+const upsertUnregistered = vi.fn();
+const deleteUnregistered = vi.fn();
+const findUniqueRepository = vi.fn();
+const upsertRepository = vi.fn();
+const deleteRepositoryRow = vi.fn();
+const deleteManyRepository = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    unregisteredRepository: {
+      findUnique: (...args: unknown[]) => findUniqueUnregistered(...args),
+      upsert: (...args: unknown[]) => upsertUnregistered(...args),
+      delete: (...args: unknown[]) => deleteUnregistered(...args),
+    },
+    repository: {
+      findUnique: (...args: unknown[]) => findUniqueRepository(...args),
+      upsert: (...args: unknown[]) => upsertRepository(...args),
+      delete: (...args: unknown[]) => deleteRepositoryRow(...args),
+      deleteMany: (...args: unknown[]) => deleteManyRepository(...args),
+    },
+  },
+}));
+
+vi.mock('@/server/git-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => (p === '/tmp/worktree' ? '/tmp/main' : p),
+}));
+
+vi.mock('@/server/worktree-cleanup', () => ({
+  cleanupSessionWorktrees: () => [],
+}));
+
+import {
+  deleteRepository,
+  registerRepository,
+  RepositoryUnregisteredError,
+} from './repositories';
+
+describe('registerRepository tombstone', () => {
+  beforeEach(() => {
+    findUniqueUnregistered.mockReset();
+    upsertUnregistered.mockReset();
+    deleteUnregistered.mockReset();
+    upsertRepository.mockReset();
+    deleteManyRepository.mockReset();
+    upsertRepository.mockResolvedValue({ id: 'repo-1', path: '/tmp/main' });
+    deleteManyRepository.mockResolvedValue({ count: 0 });
+  });
+
+  it('blocks re-register when path is tombstoned', async () => {
+    findUniqueUnregistered.mockResolvedValue({
+      path: '/tmp/main',
+      unregisteredAt: new Date(),
+      deleteWorktrees: false,
+    });
+
+    await expect(
+      registerRepository({ path: '/tmp/main', gitRemote: 'https://example.com/a.git' }),
+    ).rejects.toBeInstanceOf(RepositoryUnregisteredError);
+
+    expect(upsertRepository).not.toHaveBeenCalled();
+  });
+
+  it('checks tombstone against canonical path for linked worktrees', async () => {
+    findUniqueUnregistered.mockResolvedValue({
+      path: '/tmp/main',
+      unregisteredAt: new Date(),
+      deleteWorktrees: false,
+    });
+
+    await expect(
+      registerRepository({ path: '/tmp/worktree', gitRemote: 'https://example.com/a.git' }),
+    ).rejects.toMatchObject({ path: '/tmp/main' });
+
+    expect(findUniqueUnregistered).toHaveBeenCalledWith({ where: { path: '/tmp/main' } });
+  });
+
+  it('force register clears tombstone and upserts repository', async () => {
+    findUniqueUnregistered.mockResolvedValue({
+      path: '/tmp/main',
+      unregisteredAt: new Date(),
+      deleteWorktrees: false,
+    });
+    deleteUnregistered.mockResolvedValue({});
+    upsertRepository.mockResolvedValue({ id: 'repo-2', path: '/tmp/main' });
+
+    const repo = await registerRepository({
+      path: '/tmp/main',
+      gitRemote: 'https://example.com/a.git',
+      force: true,
+    });
+
+    expect(deleteUnregistered).toHaveBeenCalledWith({ where: { path: '/tmp/main' } });
+    expect(upsertRepository).toHaveBeenCalled();
+    expect(repo.path).toBe('/tmp/main');
+  });
+
+  it('allows register when no tombstone exists', async () => {
+    findUniqueUnregistered.mockResolvedValue(null);
+
+    await registerRepository({ path: '/tmp/main', gitRemote: 'https://example.com/a.git' });
+
+    expect(deleteUnregistered).not.toHaveBeenCalled();
+    expect(upsertRepository).toHaveBeenCalled();
+  });
+});
+
+describe('deleteRepository tombstone', () => {
+  beforeEach(() => {
+    findUniqueRepository.mockReset();
+    upsertUnregistered.mockReset();
+    deleteRepositoryRow.mockReset();
+    upsertUnregistered.mockResolvedValue({});
+    deleteRepositoryRow.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes tombstone before deleting repository row', async () => {
+    findUniqueRepository.mockResolvedValue({
+      id: 'repo-1',
+      path: '/tmp/main',
+      slots: [],
+    });
+
+    const result = await deleteRepository('repo-1');
+
+    expect(upsertUnregistered).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { path: '/tmp/main' },
+        create: expect.objectContaining({ path: '/tmp/main' }),
+      }),
+    );
+    expect(deleteRepositoryRow).toHaveBeenCalledWith({ where: { id: 'repo-1' } });
+    expect(result).toMatchObject({ ok: true, path: '/tmp/main' });
+  });
+
+  it('returns null when repository does not exist', async () => {
+    findUniqueRepository.mockResolvedValue(null);
+
+    await expect(deleteRepository('missing')).resolves.toBeNull();
+    expect(upsertUnregistered).not.toHaveBeenCalled();
+  });
+});
+
+describe('RepositoryUnregisteredError', () => {
+  it('exposes path for API 409 responses', () => {
+    const err = new RepositoryUnregisteredError('/tmp/main');
+    expect(err.path).toBe('/tmp/main');
+    expect(err.message).toContain('/tmp/main');
+    expect(err.message).toContain('--force');
+  });
+});

--- a/src/harness/agent-md.ts
+++ b/src/harness/agent-md.ts
@@ -88,7 +88,7 @@ export function clearAgentMdProposal(repoPath: string): void {
   }
 }
 
-function wouldProposalShrinkExisting(existing: string, proposal: string): boolean {
+export function wouldProposalShrinkExisting(existing: string, proposal: string): boolean {
   const outsideExisting = extractOutsideHarSection(existing);
   const outsideMerged = extractOutsideHarSection(mergeAgentsMdContent(existing, proposal));
   const existingLines = outsideExisting.split('\n').filter((l) => l.trim()).length;

--- a/src/harness/instruction-files.ts
+++ b/src/harness/instruction-files.ts
@@ -143,7 +143,7 @@ function removeCompleteMarkedBlocks(content: string, startMarker: string, endMar
   return result;
 }
 
-function checkOutsideContentPreserved(
+export function checkOutsideContentPreserved(
   before: string,
   after: string,
   options: UpsertAgentsMdOptions,

--- a/tests/agent-md-shrink.test.ts
+++ b/tests/agent-md-shrink.test.ts
@@ -1,0 +1,136 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as instructionFiles from '../src/harness/instruction-files';
+import {
+  AGENTS_MD,
+  AgentsMdShrinkError,
+  HAR_SECTION_END,
+  HAR_SECTION_START,
+  checkOutsideContentPreserved,
+  upsertAgentsMdHarSection,
+} from '../src/harness/instruction-files';
+import {
+  applyAgentMdProposalMerge,
+  wouldProposalShrinkExisting,
+  writeAgentMdProposal,
+} from '../src/harness/agent-md';
+
+function makeTempRepo(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+  fs.mkdirSync(path.join(dir, '.har'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: prefix }) + '\n');
+  return dir;
+}
+
+function outsideLines(count: number, prefix = 'line'): string {
+  return Array.from({ length: count }, (_, i) => `${prefix} ${i}`).join('\n');
+}
+
+describe('checkOutsideContentPreserved', () => {
+  it('detects shrink when outside-marker lines drop below 90%', () => {
+    const before = `# Project\n\n${outsideLines(10)}\n\n${HAR_SECTION_START}\nold\n${HAR_SECTION_END}\n`;
+    const after = `# Project\n\n${outsideLines(8)}\n\n${HAR_SECTION_START}\nnew\n${HAR_SECTION_END}\n`;
+
+    expect(checkOutsideContentPreserved(before, after, {})).toBe('shrink');
+  });
+
+  it('allows changes that preserve at least 90% of outside-marker lines', () => {
+    const before = `# Project\n\n${outsideLines(10)}\n\n${HAR_SECTION_START}\nold\n${HAR_SECTION_END}\n`;
+    const after = `# Project\n\n${outsideLines(9)}\n\n${HAR_SECTION_START}\nnew\n${HAR_SECTION_END}\n`;
+
+    expect(checkOutsideContentPreserved(before, after, {})).toBe('ok');
+  });
+
+  it('does not apply ratio guard when fewer than five outside-marker lines exist', () => {
+    const before = `# Small\n\n${outsideLines(3)}\n\n${HAR_SECTION_START}\nold\n${HAR_SECTION_END}\n`;
+    const after = `# Small\n\none\n\n${HAR_SECTION_START}\nnew\n${HAR_SECTION_END}\n`;
+
+    expect(checkOutsideContentPreserved(before, after, {})).toBe('ok');
+  });
+});
+
+describe('wouldProposalShrinkExisting', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns true when merged content would drop outside-marker lines', () => {
+    const existing = `# Project\n\n${outsideLines(10, 'keep')}\n\n${HAR_SECTION_START}\nold\n${HAR_SECTION_END}\n`;
+    const proposal = `# Proposed\n\n${HAR_SECTION_START}\nnew\n${HAR_SECTION_END}\n`;
+    const shrunk = `# Project\n\n${outsideLines(8, 'keep')}\n\n${HAR_SECTION_START}\nnew\n${HAR_SECTION_END}\n`;
+
+    jest.spyOn(instructionFiles, 'mergeAgentsMdContent').mockReturnValue(shrunk);
+
+    expect(wouldProposalShrinkExisting(existing, proposal)).toBe(true);
+  });
+
+  it('returns false when merge preserves outside-marker content', () => {
+    const existing = `# Project\n\n${outsideLines(10, 'keep')}\n\n${HAR_SECTION_START}\nold\n${HAR_SECTION_END}\n`;
+    const proposal = `# Proposed\n\n${HAR_SECTION_START}\nnew\n${HAR_SECTION_END}\n`;
+
+    expect(wouldProposalShrinkExisting(existing, proposal)).toBe(false);
+  });
+});
+
+describe('AGENTS.md shrink guard integration', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('allows refresh when outside-marker content is preserved', () => {
+    const repoPath = makeTempRepo('har-shrink-ok');
+    fs.writeFileSync(
+      path.join(repoPath, AGENTS_MD),
+      `# Project\n\n${outsideLines(10)}\n\n${HAR_SECTION_START}\nold har\n${HAR_SECTION_END}\n`,
+    );
+
+    expect(() =>
+      upsertAgentsMdHarSection(repoPath, { rejectSignificantShrink: true }),
+    ).not.toThrow();
+
+    const content = fs.readFileSync(path.join(repoPath, AGENTS_MD), 'utf8');
+    expect(content).toContain('line 0');
+    expect(content).toContain('Launch first');
+  });
+
+  it('rejects AGENTS.md.proposed merge that would drop outside-marker content', () => {
+    const repoPath = makeTempRepo('har-proposal-shrink');
+    const existing = `# Project\n\n${outsideLines(10, 'keep')}\n\n${HAR_SECTION_START}\nold har\n${HAR_SECTION_END}\n`;
+    fs.writeFileSync(path.join(repoPath, AGENTS_MD), existing);
+    writeAgentMdProposal(
+      repoPath,
+      `# Proposed\n\n${HAR_SECTION_START}\nnew har\n${HAR_SECTION_END}\n`,
+      'refresh managed section',
+    );
+
+    jest.spyOn(instructionFiles, 'mergeAgentsMdContent').mockReturnValue(
+      `# Project\n\n${outsideLines(8, 'keep')}\n\n${HAR_SECTION_START}\nnew har\n${HAR_SECTION_END}\n`,
+    );
+
+    expect(() =>
+      applyAgentMdProposalMerge(repoPath, { rejectSignificantShrink: true }),
+    ).toThrow(AgentsMdShrinkError);
+    expect(fs.existsSync(path.join(repoPath, '.har', 'AGENTS.md.proposed'))).toBe(true);
+  });
+
+  it('merges AGENTS.md.proposed when outside-marker content is preserved', () => {
+    const repoPath = makeTempRepo('har-proposal-ok');
+    fs.writeFileSync(
+      path.join(repoPath, AGENTS_MD),
+      `# Project\n\n${outsideLines(10, 'keep')}\n\n${HAR_SECTION_START}\nold har\n${HAR_SECTION_END}\n`,
+    );
+    writeAgentMdProposal(
+      repoPath,
+      `# Proposed\n\n${HAR_SECTION_START}\nnew har\n${HAR_SECTION_END}\n`,
+      'refresh managed section',
+    );
+
+    expect(applyAgentMdProposalMerge(repoPath, { rejectSignificantShrink: true })).toBe(true);
+
+    const content = fs.readFileSync(path.join(repoPath, AGENTS_MD), 'utf8');
+    expect(content).toContain('keep 0');
+    expect(content).toContain('new har');
+    expect(fs.existsSync(path.join(repoPath, '.har', 'AGENTS.md.proposed'))).toBe(false);
+  });
+});

--- a/tests/control-sync-unregistered.test.ts
+++ b/tests/control-sync-unregistered.test.ts
@@ -1,0 +1,97 @@
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+  resolveMainWorkingTree: (p: string) => p,
+}));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => ({ profile: 'cli' }),
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  listRegisteredRepos,
+  recordRepoForControlSync,
+  removeRegisteredRepo,
+} from '../src/core/control-registry';
+import { registerRepoWithControl } from '../src/core/control-sync';
+
+const realFetch = global.fetch;
+const FIXTURE = path.join(__dirname, 'fixtures/minimal-harness');
+
+describe('registerRepoWithControl unregistered tombstone', () => {
+  beforeEach(() => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-unreg-registry-'));
+    process.env.HAR_CONTROL_REGISTRY_PATH = path.join(tmpDir, 'repos.json');
+    recordRepoForControlSync(FIXTURE);
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_CONTROL_REGISTRY_PATH;
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  it('drops path from local registry on 409 and returns null', async () => {
+    expect(listRegisteredRepos().length).toBeGreaterThan(0);
+
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(async () => ({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      text: async () =>
+        JSON.stringify({
+          error: 'Repository was unregistered',
+          path: FIXTURE,
+        }),
+      json: async () => ({ error: 'Repository was unregistered', path: FIXTURE }),
+    }));
+
+    const result = await registerRepoWithControl({
+      repoPath: FIXTURE,
+      apiUrl: 'http://127.0.0.1:3847',
+    });
+
+    expect(result).toBeNull();
+    expect(listRegisteredRepos()).toEqual([]);
+  });
+
+  it('does not remove registry entry on successful register', async () => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '',
+      json: async () => ({ id: 'repo-1' }),
+    }));
+
+    const result = await registerRepoWithControl({
+      repoPath: FIXTURE,
+      apiUrl: 'http://127.0.0.1:3847',
+    });
+
+    expect(result).toEqual({ id: 'repo-1' });
+    expect(listRegisteredRepos().length).toBeGreaterThan(0);
+  });
+
+  it('throws on non-409 API errors without clearing registry', async () => {
+    recordRepoForControlSync(FIXTURE);
+    const before = listRegisteredRepos();
+
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'boom',
+      json: async () => ({}),
+    }));
+
+    await expect(
+      registerRepoWithControl({ repoPath: FIXTURE, apiUrl: 'http://127.0.0.1:3847' }),
+    ).rejects.toThrow(/Control API 500/);
+
+    expect(listRegisteredRepos()).toEqual(before);
+    expect(removeRegisteredRepo(FIXTURE)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Mission Control tests for the `UnregisteredRepository` tombstone flow: block re-register, force register clears tombstone, API 409 mapping, and CLI client backoff on 409 (drops path from local registry).
- Adds AGENTS.md shrink-guard tests for the 90% outside-marker preservation rule, proposal merge rejection, and successful merge when content is preserved.
- Exports `checkOutsideContentPreserved` and `wouldProposalShrinkExisting` so the guard logic can be unit-tested directly.

Closes #166.

## Test plan

- [x] `npm test -- tests/control-sync-unregistered.test.ts tests/agent-md-shrink.test.ts`
- [x] `cd control && npm test` (includes `repositories.test.ts` and `route.test.ts`)
- [x] CI: CLI harness verify job
- [x] CI: Mission Control job (control path filter)


Made with [Cursor](https://cursor.com)