### PR TITLE
feat(harness): support bun, pnpm, and yarn for node provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 node_modules/
+# package-lock.json is this repo's committed lockfile; harness provisioning may
+# install with bun on machines without npm, so keep its artifacts out of git.
+bun.lock
+bun.lockb
+.bun-cache/
 dist/
 .astro/
 *.tsbuildinfo

--- a/.har/harness.env
+++ b/.har/harness.env
@@ -97,22 +97,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -130,8 +153,6 @@ har_pkg_exec() {
   if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
   echo "npx --yes"
 }
-
-export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Postgres client — uses host tools when installed, otherwise docker exec into
 # the shared db container. Usage: har_pg psql -d postgres -c "SELECT 1"

--- a/.har/harness.env
+++ b/.har/harness.env
@@ -20,6 +20,10 @@ export HARNESS_AGENT_SLOT_MAX=5
 # Toolchain provisioning — launch writes resolved paths into .env.agent.<id>
 # Ecosystem: auto (detect from manifests) | node | python | go | rust | java | ruby | none
 export HARNESS_ECOSYSTEM="auto"
+# Node package manager: auto-detected from package.json "packageManager" and the
+# lockfile (bun.lock → bun, pnpm-lock.yaml → pnpm, yarn.lock → yarn, else npm),
+# falling back to whichever is installed. Set to pin one: npm | bun | pnpm | yarn
+# export HARNESS_NODE_PACKAGE_MANAGER="bun"
 # Optional install override (eval in work dir after env file is created)
 # export HARNESS_INSTALL_CMD="make deps"
 
@@ -36,6 +40,98 @@ har_infra_enabled() {
     *) return 1 ;;
   esac
 }
+
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
+export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Postgres client — uses host tools when installed, otherwise docker exec into
 # the shared db container. Usage: har_pg psql -d postgres -c "SELECT 1"

--- a/.har/provision-toolchain.sh
+++ b/.har/provision-toolchain.sh
@@ -83,22 +83,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -120,8 +143,9 @@ har_pkg_exec() {
 append_env() {
   local key="$1"
   local value="$2"
-  # %q, not a raw value: an unquoted value with spaces (a PATH entry under
-  # Application Support, a repo path) breaks `source .env.agent.<id>`.
+  # %q, not a raw value: an unquoted value with spaces or parentheses (a repo
+  # path, a PATH carrying Windows entries under WSL) breaks
+  # `source .env.agent.<id>`.
   printf '%s=%q\n' "$key" "$value" >> "$HAR_ENV_FILE"
 }
 
@@ -182,15 +206,13 @@ provision_node() {
 
   if ! run_install_cmd "$dir"; then
     pt_log "Installing Node dependencies with ${pkg_manager}..."
-    # Unquoted on purpose: install args are a word list, not one argument.
-    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
+    har_node_install "$dir" "$pkg_manager" "$declared_manager"
   fi
 
   if [ -f "$dir/docs/package.json" ]; then
     pt_log "Installing documentation dependencies with ${pkg_manager}..."
-    # Unquoted on purpose: install args are a word list, not one argument.
-    (cd "$dir/docs" && "$pkg_manager" \
-      $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$dir/docs")"))
+    har_node_install "$dir/docs" "$pkg_manager" \
+      "$(har_node_declared_package_manager "$dir/docs")"
   fi
 
   if command -v node >/dev/null 2>&1; then
@@ -359,9 +381,8 @@ provision_monorepo_root() {
   pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
   local pkg_manager
   pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
-  # Unquoted on purpose: install args are a word list, not one argument.
-  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
-    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
+  har_node_install "$HAR_WORKTREE_DIR" "$pkg_manager" \
+    "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"
 }
 
 provision_ecosystem() {

--- a/.har/provision-toolchain.sh
+++ b/.har/provision-toolchain.sh
@@ -27,6 +27,96 @@ pt_log() {
   fi
 }
 
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
 append_env() {
   local key="$1"
   local value="$2"
@@ -81,37 +171,45 @@ run_install_cmd() {
 
 provision_node() {
   local dir="$1"
-  local npm_bin="npm"
   local node_bin="node"
+  local pkg_manager declared_manager
+  declared_manager="$(har_node_declared_package_manager "$dir")"
+  pkg_manager="$(har_node_package_manager "$dir")"
 
-  if ! run_install_cmd "$dir"; then
-    pt_log "Installing Node dependencies..."
-    if [ -f "$dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-      (cd "$dir" && pnpm install --silent)
-      npm_bin="pnpm"
-    elif [ -f "$dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
-      (cd "$dir" && yarn install --silent)
-      npm_bin="yarn"
-    else
-      (cd "$dir" && npm install --silent)
-    fi
+  if [ -n "$declared_manager" ] && [ "$declared_manager" != "$pkg_manager" ]; then
+    pt_log "Repo declares ${declared_manager}, which is not on PATH — installing with ${pkg_manager} and leaving the lockfile untouched."
   fi
 
-  if [ -f "$dir/docs/package-lock.json" ]; then
-    pt_log "Installing documentation dependencies..."
-    (cd "$dir" && npm ci --prefix docs --silent)
+  if ! run_install_cmd "$dir"; then
+    pt_log "Installing Node dependencies with ${pkg_manager}..."
+    # Unquoted on purpose: install args are a word list, not one argument.
+    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
+  fi
+
+  if [ -f "$dir/docs/package.json" ]; then
+    pt_log "Installing documentation dependencies with ${pkg_manager}..."
+    # Unquoted on purpose: install args are a word list, not one argument.
+    (cd "$dir/docs" && "$pkg_manager" \
+      $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$dir/docs")"))
   fi
 
   if command -v node >/dev/null 2>&1; then
     node_bin="$(command -v node)"
+  elif [ "$pkg_manager" = "bun" ]; then
+    # bun-only machine: bun runs the `node -e` snippets verify.sh relies on.
+    node_bin="$(command -v bun)"
   fi
-  if [ "$npm_bin" = "npm" ] && command -v npm >/dev/null 2>&1; then
-    npm_bin="$(command -v npm)"
+
+  local npm_bin="$pkg_manager"
+  if command -v "$pkg_manager" >/dev/null 2>&1; then
+    npm_bin="$(command -v "$pkg_manager")"
   fi
 
   append_env "HARNESS_ECOSYSTEM" "node"
   append_env "NODE_BIN" "$node_bin"
   append_env "NPM_BIN" "$npm_bin"
+  append_env "HARNESS_NODE_PACKAGE_MANAGER" "$pkg_manager"
+  append_env "HARNESS_PKG_EXEC" "$(har_pkg_exec "$pkg_manager")"
   append_path_prefix "$dir/node_modules/.bin"
 }
 
@@ -259,7 +357,11 @@ provision_monorepo_root() {
   [ -f "$HAR_WORKTREE_DIR/package.json" ] || return 0
   [ -d "$HAR_WORKTREE_DIR/node_modules" ] && return 0
   pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
-  (cd "$HAR_WORKTREE_DIR" && npm install --silent)
+  local pkg_manager
+  pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
+  # Unquoted on purpose: install args are a word list, not one argument.
+  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
+    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
 }
 
 provision_ecosystem() {

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -97,11 +97,11 @@ process.stdout.write(JSON.stringify(arr));
 run_step "typecheck" '${NPM_BIN:-npm} run typecheck' || { [ -z "$FULL" ] && true; }
 # Some unit tests exec dist/index.js (e.g. plugins CLI add-plugin).
 run_step "build" '${NPM_BIN:-npm} run build' || { [ -z "$FULL" ] && true; }
-run_step "docs-check" '${NPM_BIN:-npm} run check --prefix docs' || { [ -z "$FULL" ] && true; }
-run_step "docs-build" '${NPM_BIN:-npm} run build --prefix docs' || { [ -z "$FULL" ] && true; }
+run_step "docs-check" '(cd docs && ${NPM_BIN:-npm} run check)' || { [ -z "$FULL" ] && true; }
+run_step "docs-build" '(cd docs && ${NPM_BIN:-npm} run build)' || { [ -z "$FULL" ] && true; }
 
 if [ -n "$FULL" ]; then
-  run_step "unit-tests" '${NPM_BIN:-npm} test' || true
+  run_step "unit-tests" '${NPM_BIN:-npm} run test' || true
   run_step "lint" '${NPM_BIN:-npm} run lint' || true
   run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
   # Registered verification stages from .har/stages.json (see .har/STAGES.md).

--- a/docs/src/content/docs/docs/reference/environment.md
+++ b/docs/src/content/docs/docs/reference/environment.md
@@ -21,6 +21,7 @@ Edit shared configuration in `.har/harness.env`. Launch expands resolved values 
 | --- | --- |
 | `HARNESS_ECOSYSTEM` | `auto`, `node`, `python`, `go`, `rust`, `java`, `ruby`, `ios`, or `none` |
 | `HARNESS_INSTALL_CMD` | Project-specific install override |
+| `HARNESS_NODE_PACKAGE_MANAGER` | Pins the Node package manager: `npm`, `bun`, `pnpm`, or `yarn` (auto-detected when unset) |
 | `HARNESS_PYTHON_VENV_DIR` | Python virtual environment path relative to the work directory |
 | `DEVELOPER_DIR` | Optional Xcode developer directory |
 | `HARNESS_XCODE_SCHEME` | iOS scheme |
@@ -31,6 +32,22 @@ Edit shared configuration in `.har/harness.env`. Launch expands resolved values 
 Provisioning records resolved values such as `NODE_BIN`, `NPM_BIN`, `PYTHON_BIN`,
 `GO_BIN`, `CARGO_BIN`, `RUSTC_BIN`, `JAVA_HOME`, `RUBY_BIN`, and
 `XCODEBUILD_BIN` in the slot environment.
+
+### Node package managers
+
+`node` projects install with bun, pnpm, yarn, or npm. The manager is taken from
+`HARNESS_NODE_PACKAGE_MANAGER`, then the `packageManager` field in
+`package.json`, then the lockfile (`bun.lock` → bun, `pnpm-lock.yaml` → pnpm,
+`yarn.lock` → yarn, `package-lock.json` → npm).
+
+When the declared manager is not installed, provisioning falls back to one that
+is — so a bun repository still launches on an npm-only machine, and an npm
+repository still launches on a bun-only machine. A substitute never migrates the
+repository: any lockfile it writes is removed after the install.
+
+`NPM_BIN` holds the resolved manager (use `${NPM_BIN:-npm} run <script>` in
+verification steps) and `HARNESS_PKG_EXEC` holds the matching package runner
+(`npx --yes`, `bunx`, `pnpm dlx`, or `yarn dlx`).
 
 ## iOS simulator allocation
 

--- a/src/core/otel-hooks.ts
+++ b/src/core/otel-hooks.ts
@@ -204,25 +204,45 @@ function resolveOtelHookCommand(hooksHome: string): string | null {
   return null;
 }
 
+/**
+ * Installer for the private hooks prefix, in preference order. Each writes into
+ * `hooksHome/node_modules/.bin`, so a machine with any one of them can run the
+ * hook — npm is not a hard requirement.
+ */
+function resolveHooksInstaller(
+  hooksHome: string,
+): { command: string; args: string[] } | null {
+  const candidates: Array<{ command: string; args: string[] }> = [
+    {
+      command: 'npm',
+      args: ['install', '--prefix', hooksHome, '--no-fund', '--no-audit', OTEL_HOOKS_PACKAGE],
+    },
+    { command: 'bun', args: ['add', '--cwd', hooksHome, OTEL_HOOKS_PACKAGE] },
+    { command: 'pnpm', args: ['add', '--dir', hooksHome, OTEL_HOOKS_PACKAGE] },
+  ];
+  return candidates.find((candidate) => commandExists(candidate.command)) ?? null;
+}
+
 function tryInstallPackage(hooksHome: string): { ok: boolean; detail: string } {
   fs.mkdirSync(hooksHome, { recursive: true });
-  if (!commandExists('npm')) {
+  const installer = resolveHooksInstaller(hooksHome);
+  if (!installer) {
     return {
       ok: false,
-      detail: 'npm not found; install Node.js to use @osfactory/otel-hook',
+      detail: 'no package manager found; install Node.js or bun to use @osfactory/otel-hook',
     };
   }
-  const result = spawnSync(
-    'npm',
-    ['install', '--prefix', hooksHome, '--no-fund', '--no-audit', OTEL_HOOKS_PACKAGE],
-    { encoding: 'utf8', timeout: 180_000 },
-  );
+  const described = `${installer.command} ${installer.args.join(' ')}`;
+  const result = spawnSync(installer.command, installer.args, {
+    encoding: 'utf8',
+    timeout: 180_000,
+  });
   if (result.status === 0 && fs.existsSync(localOtelHookBin(hooksHome))) {
-    return { ok: true, detail: `npm install --prefix ${hooksHome} ${OTEL_HOOKS_PACKAGE}` };
+    return { ok: true, detail: described };
   }
   return {
     ok: false,
-    detail: `npm install ${OTEL_HOOKS_PACKAGE} failed: ${(result.stderr || result.stdout || '').trim().slice(0, 400)}`,
+    detail: `${described} failed: ${(result.stderr || result.stdout || '').trim().slice(0, 400)}`,
   };
 }
 

--- a/src/core/slot-preflight.ts
+++ b/src/core/slot-preflight.ts
@@ -23,6 +23,7 @@ import {
 } from './slot-ports';
 import { readSlotRegistry, isSlotResumable } from './slot-registry';
 import { execSync } from 'child_process';
+import { packageRunner } from '../utils/package-runner';
 
 export interface PreflightOptions extends LaunchGuardOptions {
   allocatePorts?: boolean;
@@ -44,7 +45,7 @@ interface Pm2Process {
 
 function listPm2Processes(): Pm2Process[] | undefined {
   try {
-    const raw = execSync('npx --yes pm2 jlist', {
+    const raw = execSync(`${packageRunner()} pm2 jlist`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
       timeout: 3000,
@@ -172,7 +173,7 @@ export function inspectSlotReadiness(
         'Stop the other harness session (./.har/teardown.sh in that repo) or use a different agent slot.',
       details: { processes: foreign.processes },
     });
-    remediations.push('Inspect with: npx pm2 jlist | grep agent-' + agentId);
+    remediations.push(`Inspect with: ${packageRunner()} pm2 jlist | grep agent-${agentId}`);
   }
 
   if (usesPm2 && pm2Procs) {

--- a/src/core/slot-status.ts
+++ b/src/core/slot-status.ts
@@ -16,6 +16,7 @@ import { computePreviewUrls } from './local-executor';
 import { listRuns, resolveAgentWorkDir } from './runs';
 import { readSlotRegistry } from './slot-registry';
 import { inspectSlotReadiness } from './slot-preflight';
+import { packageRunner } from '../utils/package-runner';
 
 const BYPASS_WARNING_MS = 15 * 60 * 1000;
 
@@ -158,7 +159,7 @@ function lastBuildPass(run: RunRecord | undefined): boolean | undefined {
 
 function listPm2Processes(): Array<{ name?: string }> | undefined {
   try {
-    const raw = execSync('npx --yes pm2 jlist', {
+    const raw = execSync(`${packageRunner()} pm2 jlist`, {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
       timeout: 3000,

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -69,6 +69,11 @@ how this project is built and tested. Use toolchain variables from `.env.agent.<
 The stock verify section is keyed by `HARNESS_ECOSYSTEM`; it is a starting point,
 not the repo's final contract. Replace conventions that do not match this project.
 
+`${NPM_BIN}` may resolve to bun, pnpm, or yarn as well as npm, so keep Node steps
+package-manager agnostic: always `${NPM_BIN:-npm} run <script>` (never bare
+`${NPM_BIN} test`, which runs bun's own test runner), and never npm-only flags
+such as `--prefix` — use a subshell like `(cd docs && ${NPM_BIN:-npm} run build)`.
+
 **Tier contract:**
 
 | Mode | Command | Intent |

--- a/src/templates/adaptation-prompt-maintain.md
+++ b/src/templates/adaptation-prompt-maintain.md
@@ -25,7 +25,7 @@ Prefer targeted edits over full rewrites. Key files to review:
 Keep this accurate — it is the harness index. Update whenever scripts, stages, or workflow change.
 
 ### `.har/harness.env`, `verify.sh`, `provision-toolchain.sh`, `ecosystem.agent.template.cjs`, `CLAUDE.agent.md`
-Align commands and instructions with the current stack. Verify steps must use toolchain paths from `.env.agent.<id>` (`PYTHON_BIN`, `NPM_BIN`, `XCODEBUILD_BIN`, …) — never hardcoded venv or interpreter paths. Replace stock ecosystem conventions that do not match the repository; do not leave npm/pytest/go/cargo/maven/gradle examples in place by accident.
+Align commands and instructions with the current stack. Verify steps must use toolchain paths from `.env.agent.<id>` (`PYTHON_BIN`, `NPM_BIN`, `XCODEBUILD_BIN`, …) — never hardcoded venv or interpreter paths. `NPM_BIN` may be bun, pnpm, or yarn, so Node steps must use `${NPM_BIN:-npm} run <script>` and avoid npm-only flags such as `--prefix`. Replace stock ecosystem conventions that do not match the repository; do not leave npm/pytest/go/cargo/maven/gradle examples in place by accident.
 
 ### `.har/env.template`, `setup-infra.sh`, `docker-compose.agent.yml`
 Update only if infra changed.

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -164,7 +164,7 @@ har_check_foreign_pm2() {
   local agent_id="$1"
   local pm2_raw
   har_harness_uses_pm2 || return 0
-  pm2_raw="$(npx --yes pm2 jlist 2>/dev/null || true)"
+  pm2_raw="$($(har_pkg_exec) pm2 jlist 2>/dev/null || true)"
   [ -n "$pm2_raw" ] || return 0
   set +e
   echo "$pm2_raw" | node -e "

--- a/src/templates/har-boilerplate-cli/harness.env
+++ b/src/templates/har-boilerplate-cli/harness.env
@@ -23,6 +23,10 @@ export HARNESS_AGENT_SLOT_MAX=3
 export HARNESS_ECOSYSTEM="auto"
 # Optional install override (eval in work dir after env file is created)
 # export HARNESS_INSTALL_CMD="make deps"
+# Node package manager: auto-detected from package.json "packageManager" and the
+# lockfile (bun.lock → bun, pnpm-lock.yaml → pnpm, yarn.lock → yarn, else npm),
+# falling back to whichever is installed. Set to pin one: npm | bun | pnpm | yarn
+# export HARNESS_NODE_PACKAGE_MANAGER="bun"
 
 # Shared infrastructure — space-separated docker compose service names from
 # docker-compose.agent.yml, started ONCE by setup-infra.sh and shared by all
@@ -37,6 +41,98 @@ har_infra_enabled() {
     *) return 1 ;;
   esac
 }
+
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
+export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Postgres client — uses host tools when installed, otherwise docker exec into
 # the shared db container. Usage: har_pg psql -d postgres -c "SELECT 1"

--- a/src/templates/har-boilerplate-cli/harness.env
+++ b/src/templates/har-boilerplate-cli/harness.env
@@ -98,22 +98,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -131,8 +154,6 @@ har_pkg_exec() {
   if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
   echo "npx --yes"
 }
-
-export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Postgres client — uses host tools when installed, otherwise docker exec into
 # the shared db container. Usage: har_pg psql -d postgres -c "SELECT 1"

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -187,8 +187,9 @@ elif [ -f "$SCRIPT_DIR/provision-toolchain.sh" ]; then
   HAR_AGENT_ID="$AGENT_ID" \
     "$SCRIPT_DIR/provision-toolchain.sh"
 elif [ -f "$WORK_DIR/package.json" ] && [ ! -d "$WORK_DIR/node_modules" ]; then
-  log "Installing dependencies in $WORK_DIR..."
-  (cd "$WORK_DIR" && npm install --silent)
+  PKG_MANAGER="$(har_node_package_manager "$WORK_DIR")"
+  log "Installing dependencies in $WORK_DIR with ${PKG_MANAGER}..."
+  (cd "$WORK_DIR" && "$PKG_MANAGER" install --silent)
 fi
 
 SLOT_AGENT_ID="$AGENT_ID" \

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -189,7 +189,7 @@ elif [ -f "$SCRIPT_DIR/provision-toolchain.sh" ]; then
 elif [ -f "$WORK_DIR/package.json" ] && [ ! -d "$WORK_DIR/node_modules" ]; then
   PKG_MANAGER="$(har_node_package_manager "$WORK_DIR")"
   log "Installing dependencies in $WORK_DIR with ${PKG_MANAGER}..."
-  (cd "$WORK_DIR" && "$PKG_MANAGER" install --silent)
+  har_node_install "$WORK_DIR" "$PKG_MANAGER" "$(har_node_declared_package_manager "$WORK_DIR")"
 fi
 
 SLOT_AGENT_ID="$AGENT_ID" \

--- a/src/templates/har-boilerplate-cli/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-cli/provision-toolchain.sh
@@ -83,22 +83,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -182,8 +205,7 @@ provision_node() {
 
   if ! run_install_cmd "$dir"; then
     pt_log "Installing Node dependencies with ${pkg_manager}..."
-    # Unquoted on purpose: install args are a word list, not one argument.
-    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
+    har_node_install "$dir" "$pkg_manager" "$declared_manager"
   fi
 
   if command -v node >/dev/null 2>&1; then
@@ -351,9 +373,8 @@ provision_monorepo_root() {
   local pkg_manager
   pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
   pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR with ${pkg_manager}..."
-  # Unquoted on purpose: install args are a word list, not one argument.
-  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
-    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
+  har_node_install "$HAR_WORKTREE_DIR" "$pkg_manager" \
+    "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"
 }
 
 provision_ecosystem() {

--- a/src/templates/har-boilerplate-cli/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-cli/provision-toolchain.sh
@@ -27,6 +27,96 @@ pt_log() {
   fi
 }
 
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
 append_env() {
   local key="$1"
   local value="$2"
@@ -81,32 +171,38 @@ run_install_cmd() {
 
 provision_node() {
   local dir="$1"
-  local npm_bin="npm"
   local node_bin="node"
+  local pkg_manager declared_manager
+  declared_manager="$(har_node_declared_package_manager "$dir")"
+  pkg_manager="$(har_node_package_manager "$dir")"
+
+  if [ -n "$declared_manager" ] && [ "$declared_manager" != "$pkg_manager" ]; then
+    pt_log "Repo declares ${declared_manager}, which is not on PATH — installing with ${pkg_manager} and leaving the lockfile untouched."
+  fi
 
   if ! run_install_cmd "$dir"; then
-    pt_log "Installing Node dependencies..."
-    if [ -f "$dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-      (cd "$dir" && pnpm install --silent)
-      npm_bin="pnpm"
-    elif [ -f "$dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
-      (cd "$dir" && yarn install --silent)
-      npm_bin="yarn"
-    else
-      (cd "$dir" && npm install --silent)
-    fi
+    pt_log "Installing Node dependencies with ${pkg_manager}..."
+    # Unquoted on purpose: install args are a word list, not one argument.
+    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
   fi
 
   if command -v node >/dev/null 2>&1; then
     node_bin="$(command -v node)"
+  elif [ "$pkg_manager" = "bun" ]; then
+    # bun-only machine: bun runs the `node -e` snippets verify.sh relies on.
+    node_bin="$(command -v bun)"
   fi
-  if [ "$npm_bin" = "npm" ] && command -v npm >/dev/null 2>&1; then
-    npm_bin="$(command -v npm)"
+
+  local npm_bin="$pkg_manager"
+  if command -v "$pkg_manager" >/dev/null 2>&1; then
+    npm_bin="$(command -v "$pkg_manager")"
   fi
 
   append_env "HARNESS_ECOSYSTEM" "node"
   append_env "NODE_BIN" "$node_bin"
   append_env "NPM_BIN" "$npm_bin"
+  append_env "HARNESS_NODE_PACKAGE_MANAGER" "$pkg_manager"
+  append_env "HARNESS_PKG_EXEC" "$(har_pkg_exec "$pkg_manager")"
   append_path_prefix "$dir/node_modules/.bin"
 }
 
@@ -252,8 +348,12 @@ provision_monorepo_root() {
   [ -n "$HAR_WORKTREE_DIR" ] || return 0
   [ -f "$HAR_WORKTREE_DIR/package.json" ] || return 0
   [ -d "$HAR_WORKTREE_DIR/node_modules" ] && return 0
-  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
-  (cd "$HAR_WORKTREE_DIR" && npm install --silent)
+  local pkg_manager
+  pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
+  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR with ${pkg_manager}..."
+  # Unquoted on purpose: install args are a word list, not one argument.
+  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
+    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
 }
 
 provision_ecosystem() {

--- a/src/templates/har-boilerplate-cli/setup-infra.sh
+++ b/src/templates/har-boilerplate-cli/setup-infra.sh
@@ -165,7 +165,7 @@ fi
 SHARED_ECOSYSTEM="$SCRIPT_DIR/ecosystem.shared.config.cjs"
 if [ -f "$SHARED_ECOSYSTEM" ]; then
   log "Starting shared app services from ecosystem.shared.config.cjs..."
-  (cd "$REPO_ROOT" && npx --yes pm2 startOrReload "$SHARED_ECOSYSTEM" >/dev/null)
+  (cd "$REPO_ROOT" && $(har_pkg_exec) pm2 startOrReload "$SHARED_ECOSYSTEM" >/dev/null)
   log "Shared app services running (pm2 ls | grep har-${HARNESS_PROJECT_NAME}-shared-)."
 fi
 

--- a/src/templates/har-boilerplate-ios/harness.env
+++ b/src/templates/har-boilerplate-ios/harness.env
@@ -130,22 +130,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -163,8 +186,6 @@ har_pkg_exec() {
   if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
   echo "npx --yes"
 }
-
-export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Optional "agent usable" smoke beyond build/test, such as a simulator flow or
 # backend-auth check. Enable only when this project needs it.

--- a/src/templates/har-boilerplate-ios/harness.env
+++ b/src/templates/har-boilerplate-ios/harness.env
@@ -10,6 +10,10 @@ export HARNESS_AGENT_SLOT_MAX=3
 # Toolchain provisioning — launch writes Xcode/simulator paths into .env.agent.<id>
 export HARNESS_ECOSYSTEM="ios"
 # export HARNESS_INSTALL_CMD="xcodebuild -resolvePackageDependencies ..."
+# Node package manager: auto-detected from package.json "packageManager" and the
+# lockfile (bun.lock → bun, pnpm-lock.yaml → pnpm, yarn.lock → yarn, else npm),
+# falling back to whichever is installed. Set to pin one: npm | bun | pnpm | yarn
+# export HARNESS_NODE_PACKAGE_MANAGER="bun"
 
 # ── Xcode project ─────────────────────────────────────────────────────────────
 # Set one of HARNESS_XCODE_WORKSPACE or HARNESS_XCODE_PROJECT (workspace wins).
@@ -69,6 +73,98 @@ har_infra_enabled() {
     *) return 1 ;;
   esac
 }
+
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
+export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Optional "agent usable" smoke beyond build/test, such as a simulator flow or
 # backend-auth check. Enable only when this project needs it.

--- a/src/templates/har-boilerplate-ios/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-ios/provision-toolchain.sh
@@ -83,22 +83,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -182,8 +205,7 @@ provision_node() {
 
   if ! run_install_cmd "$dir"; then
     pt_log "Installing Node dependencies with ${pkg_manager}..."
-    # Unquoted on purpose: install args are a word list, not one argument.
-    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
+    har_node_install "$dir" "$pkg_manager" "$declared_manager"
   fi
 
   if command -v node >/dev/null 2>&1; then
@@ -351,9 +373,8 @@ provision_monorepo_root() {
   local pkg_manager
   pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
   pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR with ${pkg_manager}..."
-  # Unquoted on purpose: install args are a word list, not one argument.
-  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
-    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
+  har_node_install "$HAR_WORKTREE_DIR" "$pkg_manager" \
+    "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"
 }
 
 provision_ecosystem() {

--- a/src/templates/har-boilerplate-ios/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-ios/provision-toolchain.sh
@@ -27,6 +27,96 @@ pt_log() {
   fi
 }
 
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
 append_env() {
   local key="$1"
   local value="$2"
@@ -81,32 +171,38 @@ run_install_cmd() {
 
 provision_node() {
   local dir="$1"
-  local npm_bin="npm"
   local node_bin="node"
+  local pkg_manager declared_manager
+  declared_manager="$(har_node_declared_package_manager "$dir")"
+  pkg_manager="$(har_node_package_manager "$dir")"
+
+  if [ -n "$declared_manager" ] && [ "$declared_manager" != "$pkg_manager" ]; then
+    pt_log "Repo declares ${declared_manager}, which is not on PATH — installing with ${pkg_manager} and leaving the lockfile untouched."
+  fi
 
   if ! run_install_cmd "$dir"; then
-    pt_log "Installing Node dependencies..."
-    if [ -f "$dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-      (cd "$dir" && pnpm install --silent)
-      npm_bin="pnpm"
-    elif [ -f "$dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
-      (cd "$dir" && yarn install --silent)
-      npm_bin="yarn"
-    else
-      (cd "$dir" && npm install --silent)
-    fi
+    pt_log "Installing Node dependencies with ${pkg_manager}..."
+    # Unquoted on purpose: install args are a word list, not one argument.
+    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
   fi
 
   if command -v node >/dev/null 2>&1; then
     node_bin="$(command -v node)"
+  elif [ "$pkg_manager" = "bun" ]; then
+    # bun-only machine: bun runs the `node -e` snippets verify.sh relies on.
+    node_bin="$(command -v bun)"
   fi
-  if [ "$npm_bin" = "npm" ] && command -v npm >/dev/null 2>&1; then
-    npm_bin="$(command -v npm)"
+
+  local npm_bin="$pkg_manager"
+  if command -v "$pkg_manager" >/dev/null 2>&1; then
+    npm_bin="$(command -v "$pkg_manager")"
   fi
 
   append_env "HARNESS_ECOSYSTEM" "node"
   append_env "NODE_BIN" "$node_bin"
   append_env "NPM_BIN" "$npm_bin"
+  append_env "HARNESS_NODE_PACKAGE_MANAGER" "$pkg_manager"
+  append_env "HARNESS_PKG_EXEC" "$(har_pkg_exec "$pkg_manager")"
   append_path_prefix "$dir/node_modules/.bin"
 }
 
@@ -252,8 +348,12 @@ provision_monorepo_root() {
   [ -n "$HAR_WORKTREE_DIR" ] || return 0
   [ -f "$HAR_WORKTREE_DIR/package.json" ] || return 0
   [ -d "$HAR_WORKTREE_DIR/node_modules" ] && return 0
-  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
-  (cd "$HAR_WORKTREE_DIR" && npm install --silent)
+  local pkg_manager
+  pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
+  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR with ${pkg_manager}..."
+  # Unquoted on purpose: install args are a word list, not one argument.
+  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
+    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
 }
 
 provision_ecosystem() {

--- a/src/templates/har-boilerplate/agent-cli.sh
+++ b/src/templates/har-boilerplate/agent-cli.sh
@@ -28,7 +28,7 @@ case "$COMMAND" in
     ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT" || true)"
     WORKTREE_DIR="$(existing_slot_worktree "$AGENT_ID")"
     REG_FILE="$(slot_registry_file "$AGENT_ID")"
-    PM2_RAW=$(npx --yes pm2 jlist 2>/dev/null || true)
+    PM2_RAW=$($(har_pkg_exec) pm2 jlist 2>/dev/null || true)
     PM2_FOUND=false
     PM2_FOREIGN=false
     PM2_LEGACY=false
@@ -123,22 +123,23 @@ process.stdin.on('end', () => {
   logs)
     SERVICE="${3:-}"
     if [ -n "$SERVICE" ]; then
-      npx pm2 logs "${PM2_SLOT_PREFIX}-${SERVICE}" --lines 100
+      $(har_pkg_exec) pm2 logs "${PM2_SLOT_PREFIX}-${SERVICE}" --lines 100
     else
-      npx pm2 logs --name "${PM2_SLOT_PREFIX}" --lines 100
+      $(har_pkg_exec) pm2 logs --name "${PM2_SLOT_PREFIX}" --lines 100
     fi
     ;;
 
   restart)
     SERVICE="${3:-}"
+    PKG_EXEC="$(har_pkg_exec)"
     if [ -n "$SERVICE" ]; then
-      npx pm2 restart "${PM2_SLOT_PREFIX}-${SERVICE}"
+      $(har_pkg_exec) pm2 restart "${PM2_SLOT_PREFIX}-${SERVICE}"
     else
-      npx pm2 jlist 2>/dev/null | node -e "
+      $(har_pkg_exec) pm2 jlist 2>/dev/null | node -e "
 const prefix = '${PM2_SLOT_PREFIX}-';
 const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
 const names = d.filter(x => x.name && x.name.startsWith(prefix)).map(x => x.name);
-names.forEach(n => require('child_process').execSync('npx pm2 restart ' + n, {stdio:'inherit'}));
+names.forEach(n => require('child_process').execSync('${PKG_EXEC} pm2 restart ' + n, {stdio:'inherit'}));
 if (names.length === 0) console.log('No processes found for ${PM2_SLOT_PREFIX}');
 " 2>/dev/null || true
     fi

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -184,7 +184,7 @@ har_check_foreign_pm2() {
   local agent_id="$1"
   local pm2_raw
   har_harness_uses_pm2 || return 0
-  pm2_raw="$(npx --yes pm2 jlist 2>/dev/null || true)"
+  pm2_raw="$($(har_pkg_exec) pm2 jlist 2>/dev/null || true)"
   [ -n "$pm2_raw" ] || return 0
   set +e
   echo "$pm2_raw" | node -e "

--- a/src/templates/har-boilerplate/harness.env
+++ b/src/templates/har-boilerplate/harness.env
@@ -51,6 +51,10 @@ export HARNESS_AGENT_SLOT_MAX=5
 # Ecosystem: auto (detect from manifests) | node | python | go | rust | java | ruby | none
 export HARNESS_ECOSYSTEM="auto"
 # export HARNESS_INSTALL_CMD="make deps"
+# Node package manager: auto-detected from package.json "packageManager" and the
+# lockfile (bun.lock → bun, pnpm-lock.yaml → pnpm, yarn.lock → yarn, else npm),
+# falling back to whichever is installed. Set to pin one: npm | bun | pnpm | yarn
+# export HARNESS_NODE_PACKAGE_MANAGER="bun"
 
 # Shared infrastructure — space-separated docker compose service names from
 # docker-compose.agent.yml. Started ONCE by setup-infra.sh and shared by all
@@ -65,6 +69,98 @@ har_infra_enabled() {
     *) return 1 ;;
   esac
 }
+
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
+export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Postgres client — uses host tools when installed, otherwise docker exec into
 # the shared db container. Usage: har_pg psql -d postgres -c "SELECT 1"

--- a/src/templates/har-boilerplate/harness.env
+++ b/src/templates/har-boilerplate/harness.env
@@ -126,22 +126,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -159,8 +182,6 @@ har_pkg_exec() {
   if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
   echo "npx --yes"
 }
-
-export -f har_node_declared_package_manager har_node_package_manager har_node_install_args har_pkg_exec
 
 # Postgres client — uses host tools when installed, otherwise docker exec into
 # the shared db container. Usage: har_pg psql -d postgres -c "SELECT 1"

--- a/src/templates/har-boilerplate/launch.sh
+++ b/src/templates/har-boilerplate/launch.sh
@@ -249,13 +249,13 @@ DEBUG_PORT="$DEBUG_PORT" \
 
 PM2_REGEX="$(har_pm2_delete_regex "$AGENT_ID")"
 # Stop existing processes for this agent (project-scoped — never touch other harnesses).
-npx --yes pm2 delete "$PM2_REGEX" 2>/dev/null || true
+$(har_pkg_exec) pm2 delete "$PM2_REGEX" 2>/dev/null || true
 
 # Start PM2 processes
 log "Starting PM2 processes..."
 cd "$WORK_DIR"
-npx pm2 start "$ECOSYSTEM_FILE"
-npx pm2 save --force >/dev/null 2>&1 || true
+$(har_pkg_exec) pm2 start "$ECOSYSTEM_FILE"
+$(har_pkg_exec) pm2 save --force >/dev/null 2>&1 || true
 
 # Health check
 if [ -n "${HARNESS_HEALTH_CHECK_PATH:-}" ]; then

--- a/src/templates/har-boilerplate/provision-toolchain.sh
+++ b/src/templates/har-boilerplate/provision-toolchain.sh
@@ -83,22 +83,45 @@ har_node_package_manager() {
   echo "${declared:-npm}"
 }
 
-# Install arguments for a manager. A substitute manager installs without writing
-# a lockfile — provisioning must not migrate the repo to a different one.
-har_node_install_args() {
-  local manager="$1"
-  local declared="${2:-}"
-
-  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
-    echo "install --silent"
-    return
-  fi
-  case "$manager" in
-    bun) echo "install --silent --no-save" ;;
-    npm) echo "install --silent --no-package-lock" ;;
-    pnpm|yarn) echo "install --silent --no-lockfile" ;;
-    *) echo "install --silent" ;;
+# Lockfile a manager writes, so a substitute install can clean up after itself.
+har_node_lockfile() {
+  case "$1" in
+    bun) echo "bun.lock" ;;
+    npm) echo "package-lock.json" ;;
+    pnpm) echo "pnpm-lock.yaml" ;;
+    yarn) echo "yarn.lock" ;;
+    *) echo "" ;;
   esac
+}
+
+# Install dependencies in a directory. When a substitute manager stands in for
+# the one the repo declares, any lockfile it creates is removed afterwards:
+# provisioning must not migrate the repo to a different package manager.
+# (bun writes bun.lock even under --no-save, so the flags alone are not enough.)
+har_node_install() {
+  local dir="$1"
+  local manager="$2"
+  local declared="${3:-}"
+  local substituting=false
+  local lockfile=""
+  local had_lockfile=false
+
+  if [ -n "$declared" ] && [ "$declared" != "$manager" ]; then
+    substituting=true
+    lockfile="$(har_node_lockfile "$manager")"
+    if [ -n "$lockfile" ] && [ -e "$dir/$lockfile" ]; then
+      had_lockfile=true
+    fi
+  fi
+
+  local code=0
+  (cd "$dir" && "$manager" install --silent) || code=$?
+
+  if [ "$substituting" = true ] && [ "$had_lockfile" = false ] && [ -n "$lockfile" ]; then
+    rm -f "$dir/$lockfile"
+    [ "$manager" = "bun" ] && rm -f "$dir/bun.lockb"
+  fi
+  return $code
 }
 
 # Package runner (npx equivalent) for one-off CLIs such as pm2, including the
@@ -182,8 +205,7 @@ provision_node() {
 
   if ! run_install_cmd "$dir"; then
     pt_log "Installing Node dependencies with ${pkg_manager}..."
-    # Unquoted on purpose: install args are a word list, not one argument.
-    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
+    har_node_install "$dir" "$pkg_manager" "$declared_manager"
   fi
 
   if command -v node >/dev/null 2>&1; then
@@ -351,9 +373,8 @@ provision_monorepo_root() {
   local pkg_manager
   pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
   pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR with ${pkg_manager}..."
-  # Unquoted on purpose: install args are a word list, not one argument.
-  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
-    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
+  har_node_install "$HAR_WORKTREE_DIR" "$pkg_manager" \
+    "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"
 }
 
 provision_ecosystem() {

--- a/src/templates/har-boilerplate/provision-toolchain.sh
+++ b/src/templates/har-boilerplate/provision-toolchain.sh
@@ -27,6 +27,96 @@ pt_log() {
   fi
 }
 
+# ── Node package manager helpers ──────────────────────────────────────────────
+# Mirrored verbatim in harness.env and provision-toolchain.sh so a sourcing
+# script and the provisioning subprocess resolve the same tool.
+
+# Package managers HAR can drive, in fallback preference order.
+HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"
+
+# Package manager the repo declares: an explicit HARNESS_NODE_PACKAGE_MANAGER
+# wins, then package.json "packageManager", then the lockfile. Empty when the
+# repo says nothing.
+har_node_declared_package_manager() {
+  local dir="${1:-.}"
+
+  if [ -n "${HARNESS_NODE_PACKAGE_MANAGER:-}" ]; then
+    echo "$HARNESS_NODE_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$dir/package.json" ]; then
+    local field
+    field="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"\([a-z]*\)@.*/\1/p' "$dir/package.json" | head -1)"
+    if [ -n "$field" ]; then
+      echo "$field"
+      return
+    fi
+  fi
+  if [ -f "$dir/bun.lock" ] || [ -f "$dir/bun.lockb" ]; then echo bun; return; fi
+  if [ -f "$dir/pnpm-lock.yaml" ]; then echo pnpm; return; fi
+  if [ -f "$dir/yarn.lock" ]; then echo yarn; return; fi
+  if [ -f "$dir/package-lock.json" ]; then echo npm; return; fi
+  echo ""
+}
+
+# Package manager to actually run. A manager the repo declares but this machine
+# lacks falls back to one that is installed, so a repo pinned to npm still
+# provisions on a bun-only machine (and the reverse).
+har_node_package_manager() {
+  local dir="${1:-.}"
+  local declared
+  declared="$(har_node_declared_package_manager "$dir")"
+
+  if [ -n "$declared" ] && command -v "$declared" >/dev/null 2>&1; then
+    echo "$declared"
+    return
+  fi
+
+  local candidate
+  for candidate in $HAR_NODE_PACKAGE_MANAGERS; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "${declared:-npm}"
+}
+
+# Install arguments for a manager. A substitute manager installs without writing
+# a lockfile — provisioning must not migrate the repo to a different one.
+har_node_install_args() {
+  local manager="$1"
+  local declared="${2:-}"
+
+  if [ -z "$declared" ] || [ "$declared" = "$manager" ]; then
+    echo "install --silent"
+    return
+  fi
+  case "$manager" in
+    bun) echo "install --silent --no-save" ;;
+    npm) echo "install --silent --no-package-lock" ;;
+    pnpm|yarn) echo "install --silent --no-lockfile" ;;
+    *) echo "install --silent" ;;
+  esac
+}
+
+# Package runner (npx equivalent) for one-off CLIs such as pm2, including the
+# flag that keeps it non-interactive. Takes a manager name, or none to resolve
+# from the environment and PATH.
+har_pkg_exec() {
+  case "${1:-${HARNESS_NODE_PACKAGE_MANAGER:-}}" in
+    bun) echo "bunx"; return ;;
+    pnpm) echo "pnpm dlx"; return ;;
+    yarn) echo "yarn dlx"; return ;;
+    npm) echo "npx --yes"; return ;;
+  esac
+  if command -v npx >/dev/null 2>&1; then echo "npx --yes"; return; fi
+  if command -v bunx >/dev/null 2>&1; then echo "bunx"; return; fi
+  if command -v pnpm >/dev/null 2>&1; then echo "pnpm dlx"; return; fi
+  echo "npx --yes"
+}
+
 append_env() {
   local key="$1"
   local value="$2"
@@ -81,32 +171,38 @@ run_install_cmd() {
 
 provision_node() {
   local dir="$1"
-  local npm_bin="npm"
   local node_bin="node"
+  local pkg_manager declared_manager
+  declared_manager="$(har_node_declared_package_manager "$dir")"
+  pkg_manager="$(har_node_package_manager "$dir")"
+
+  if [ -n "$declared_manager" ] && [ "$declared_manager" != "$pkg_manager" ]; then
+    pt_log "Repo declares ${declared_manager}, which is not on PATH — installing with ${pkg_manager} and leaving the lockfile untouched."
+  fi
 
   if ! run_install_cmd "$dir"; then
-    pt_log "Installing Node dependencies..."
-    if [ -f "$dir/pnpm-lock.yaml" ] && command -v pnpm >/dev/null 2>&1; then
-      (cd "$dir" && pnpm install --silent)
-      npm_bin="pnpm"
-    elif [ -f "$dir/yarn.lock" ] && command -v yarn >/dev/null 2>&1; then
-      (cd "$dir" && yarn install --silent)
-      npm_bin="yarn"
-    else
-      (cd "$dir" && npm install --silent)
-    fi
+    pt_log "Installing Node dependencies with ${pkg_manager}..."
+    # Unquoted on purpose: install args are a word list, not one argument.
+    (cd "$dir" && "$pkg_manager" $(har_node_install_args "$pkg_manager" "$declared_manager"))
   fi
 
   if command -v node >/dev/null 2>&1; then
     node_bin="$(command -v node)"
+  elif [ "$pkg_manager" = "bun" ]; then
+    # bun-only machine: bun runs the `node -e` snippets verify.sh relies on.
+    node_bin="$(command -v bun)"
   fi
-  if [ "$npm_bin" = "npm" ] && command -v npm >/dev/null 2>&1; then
-    npm_bin="$(command -v npm)"
+
+  local npm_bin="$pkg_manager"
+  if command -v "$pkg_manager" >/dev/null 2>&1; then
+    npm_bin="$(command -v "$pkg_manager")"
   fi
 
   append_env "HARNESS_ECOSYSTEM" "node"
   append_env "NODE_BIN" "$node_bin"
   append_env "NPM_BIN" "$npm_bin"
+  append_env "HARNESS_NODE_PACKAGE_MANAGER" "$pkg_manager"
+  append_env "HARNESS_PKG_EXEC" "$(har_pkg_exec "$pkg_manager")"
   append_path_prefix "$dir/node_modules/.bin"
 }
 
@@ -252,8 +348,12 @@ provision_monorepo_root() {
   [ -n "$HAR_WORKTREE_DIR" ] || return 0
   [ -f "$HAR_WORKTREE_DIR/package.json" ] || return 0
   [ -d "$HAR_WORKTREE_DIR/node_modules" ] && return 0
-  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR..."
-  (cd "$HAR_WORKTREE_DIR" && npm install --silent)
+  local pkg_manager
+  pkg_manager="$(har_node_package_manager "$HAR_WORKTREE_DIR")"
+  pt_log "Installing monorepo root dependencies in $HAR_WORKTREE_DIR with ${pkg_manager}..."
+  # Unquoted on purpose: install args are a word list, not one argument.
+  (cd "$HAR_WORKTREE_DIR" && "$pkg_manager" \
+    $(har_node_install_args "$pkg_manager" "$(har_node_declared_package_manager "$HAR_WORKTREE_DIR")"))
 }
 
 provision_ecosystem() {

--- a/src/templates/har-boilerplate/setup-infra.sh
+++ b/src/templates/har-boilerplate/setup-infra.sh
@@ -165,7 +165,7 @@ fi
 SHARED_ECOSYSTEM="$SCRIPT_DIR/ecosystem.shared.config.cjs"
 if [ -f "$SHARED_ECOSYSTEM" ]; then
   log "Starting shared app services from ecosystem.shared.config.cjs..."
-  (cd "$REPO_ROOT" && npx --yes pm2 startOrReload "$SHARED_ECOSYSTEM" >/dev/null)
+  (cd "$REPO_ROOT" && $(har_pkg_exec) pm2 startOrReload "$SHARED_ECOSYSTEM" >/dev/null)
   log "Shared app services running (pm2 ls | grep har-${HARNESS_PROJECT_NAME}-shared-)."
 fi
 

--- a/src/templates/har-boilerplate/teardown.sh
+++ b/src/templates/har-boilerplate/teardown.sh
@@ -41,7 +41,7 @@ fi
 [ -n "$WORKTREE_PATH" ] || WORKTREE_PATH="$HOME/worktrees/${HARNESS_PROJECT_NAME}-agent-${AGENT_ID}"
 
 PM2_REGEX="$(har_pm2_delete_regex "$AGENT_ID")"
-npx --yes pm2 delete "$PM2_REGEX" 2>/dev/null || true
+$(har_pkg_exec) pm2 delete "$PM2_REGEX" 2>/dev/null || true
 echo "✓ Stopped PM2 processes"
 
 if har_infra_enabled db; then

--- a/src/utils/package-runner.ts
+++ b/src/utils/package-runner.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from 'child_process';
+
+/**
+ * Package runners HAR can use to execute a one-off CLI (pm2 and friends),
+ * in preference order, each with the flag that keeps it non-interactive.
+ *
+ * Mirrors `har_pkg_exec` in the harness templates: the CLI must not assume npm
+ * is installed, since bun-only machines are common.
+ */
+const RUNNERS = ['npx --yes', 'bunx', 'pnpm dlx', 'yarn dlx'] as const;
+
+let cached: string | undefined;
+
+function commandExists(command: string): boolean {
+  const result = spawnSync('sh', ['-c', `command -v ${JSON.stringify(command)}`], {
+    encoding: 'utf8',
+  });
+  return result.status === 0 && Boolean(result.stdout?.trim());
+}
+
+/**
+ * Returns the package-runner prefix to put in front of a package name, e.g.
+ * `npx --yes` or `bunx`. Falls back to `npx --yes` when nothing is installed so
+ * callers still produce a recognizable command in error messages.
+ */
+export function packageRunner(): string {
+  if (cached !== undefined) return cached;
+  const available = RUNNERS.find((runner) => commandExists(runner.split(' ')[0]));
+  cached = available ?? RUNNERS[0];
+  return cached;
+}
+
+/** Test seam — clears the memoized lookup. */
+export function resetPackageRunnerCache(): void {
+  cached = undefined;
+}

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -117,6 +117,110 @@ describe('provision-toolchain.sh template contract', () => {
     });
   }
 
+  it('resolves the package manager from lockfile, packageManager field, and override', () => {
+    const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-pm-'));
+
+    const declared = (files: Record<string, string>, env = ''): string => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.mkdirSync(tmpDir, { recursive: true });
+      for (const [name, body] of Object.entries(files)) {
+        fs.writeFileSync(path.join(tmpDir, name), body);
+      }
+      // A sourced slot env exports HARNESS_NODE_PACKAGE_MANAGER; drop it so the
+      // detection order is what is under test, not the ambient pin.
+      const result = run(
+        `env -u HARNESS_NODE_PACKAGE_MANAGER ${env} ` +
+          `bash -c '. "${harnessEnv}" && har_node_declared_package_manager "${tmpDir}"'`,
+      );
+      expect(result.code).toBe(0);
+      return result.stdout.trim();
+    };
+
+    const pkg = JSON.stringify({ name: 'fixture' });
+    expect(declared({ 'package.json': pkg, 'bun.lock': '' })).toBe('bun');
+    expect(declared({ 'package.json': pkg, 'bun.lockb': '' })).toBe('bun');
+    expect(declared({ 'package.json': pkg, 'pnpm-lock.yaml': '' })).toBe('pnpm');
+    expect(declared({ 'package.json': pkg, 'yarn.lock': '' })).toBe('yarn');
+    expect(declared({ 'package.json': pkg, 'package-lock.json': '{}' })).toBe('npm');
+    expect(declared({ 'package.json': pkg })).toBe('');
+
+    // The packageManager field outranks the lockfile.
+    expect(
+      declared({
+        'package.json': JSON.stringify({ name: 'fixture', packageManager: 'bun@1.3.14' }),
+        'package-lock.json': '{}',
+      }),
+    ).toBe('bun');
+
+    // An explicit override outranks everything.
+    expect(
+      declared({ 'package.json': pkg, 'bun.lock': '' }, 'HARNESS_NODE_PACKAGE_MANAGER=pnpm'),
+    ).toBe('pnpm');
+  });
+
+  it('maps each package manager to its runner and lockfile', () => {
+    const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+    const result = run(
+      `bash -c '. "${harnessEnv}" && for m in npm bun pnpm yarn; do ` +
+        `echo "$m|$(har_pkg_exec "$m")|$(har_node_lockfile "$m")"; done'`,
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim().split('\n')).toEqual([
+      'npm|npx --yes|package-lock.json',
+      'bun|bunx|bun.lock',
+      'pnpm|pnpm dlx|pnpm-lock.yaml',
+      'yarn|yarn dlx|yarn.lock',
+    ]);
+  });
+
+  it('falls back to an installed manager and leaves the declared lockfile alone', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-fallback-'));
+    const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+
+    // A repo that declares pnpm, installed by npm because pnpm is missing: the
+    // substitute writes package-lock.json, which must not survive the install.
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'fixture' }));
+    fs.writeFileSync(path.join(tmpDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+
+    const substitute = run(
+      `bash -c '. "${harnessEnv}" && npm() { : > package-lock.json; } && ` +
+        `har_node_install "${tmpDir}" npm pnpm'`,
+    );
+
+    expect(substitute.code).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-lock.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'package-lock.json'))).toBe(false);
+
+    // The declared manager keeps its own lockfile.
+    const declaredRun = run(
+      `bash -c '. "${harnessEnv}" && npm() { : > package-lock.json; } && ` +
+        `har_node_install "${tmpDir}" npm npm'`,
+    );
+
+    expect(declaredRun.code).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, 'package-lock.json'))).toBe(true);
+  });
+
+  it('ships the package manager helpers identically in harness.env and provision-toolchain.sh', () => {
+    const extract = (file: string): string => {
+      const content = fs.readFileSync(file, 'utf8');
+      const start = content.indexOf('# ── Node package manager helpers');
+      const end = content.indexOf('  echo "npx --yes"\n}', start);
+      expect(start).toBeGreaterThan(-1);
+      expect(end).toBeGreaterThan(start);
+      return content.slice(start, end);
+    };
+
+    for (const profile of PROFILES) {
+      const dir = path.join(resolveTemplatesDir(), profile);
+      expect(extract(path.join(dir, 'harness.env'))).toBe(
+        extract(path.join(dir, 'provision-toolchain.sh')),
+      );
+    }
+  });
+
   it('verify.sh dispatches stock smoke by ecosystem', () => {
     for (const profile of ['har-boilerplate', 'har-boilerplate-cli'] as const) {
       const verifyPath = path.join(resolveTemplatesDir(), profile, 'verify.sh');


### PR DESCRIPTION
## Problem

`provision-toolchain.sh` hard-coded `npm install` as its only install fallback. It knew about pnpm and yarn, but never bun, and it had no answer at all when the declared package manager was missing from the machine.

On a machine with node and bun but no npm, every `har env launch` died at the first provisioning step:

```
==> [agent-1] toolchain: Installing Node dependencies...
.har/provision-toolchain.sh: line 94: npm: command not found
```

Since `launch` is step one of every workflow, the harness was unusable end to end on such a machine. `npx` is equally absent there, so the PM2 paths in the default profile failed for the same reason.

## Approach

A package-manager helper block, mirrored verbatim in `harness.env` and `provision-toolchain.sh` for all three profiles (a test asserts the two copies stay byte-identical).

**Resolution order:** `HARNESS_NODE_PACKAGE_MANAGER` → `package.json` `packageManager` field → lockfile (`bun.lock`/`bun.lockb` → bun, `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `package-lock.json` → npm) → whichever manager is actually installed.

**Fallback instead of failure.** A repo that declares a manager this machine lacks now provisions with an installed one, so a bun repo launches on an npm-only machine and an npm repo launches on a bun-only machine.

**A substitute never migrates the repo.** Any lockfile the stand-in writes is removed after the install. This needs an explicit guard rather than a flag: `bun install` writes `bun.lock` even under `--no-save`, so it would silently convert an npm repo's lockfile on every launch.

## Changes

- Provisioning records `NPM_BIN` (resolved manager), `HARNESS_NODE_PACKAGE_MANAGER`, and `HARNESS_PKG_EXEC` (`npx --yes` / `bunx` / `pnpm dlx` / `yarn dlx`) in the slot env.
- Hardcoded `npx` replaced with the resolved runner across `launch.sh`, `teardown.sh`, `agent-cli.sh`, `agent-slot.sh`, and `setup-infra.sh`.
- The CLI's own pm2 lookups (`slot-status.ts`, `slot-preflight.ts`) go through a new `src/utils/package-runner.ts`.
- The otel hook installs via bun or pnpm when npm is absent, instead of reporting `npm not found`.
- Adaptation prompts now warn that `NPM_BIN` may be bun: use `${NPM_BIN:-npm} run <script>`, never bare `${NPM_BIN} test` (bun's own test runner), and avoid npm-only flags such as `--prefix`.

This repo's own `.har/` verify steps hit both of those traps and are fixed here.

## Testing

Five new cases in `tests/provision-toolchain.test.ts`: detection order, `packageManager` field outranking the lockfile, explicit override outranking everything, runner/lockfile mapping per manager, the substitute lockfile guard, and the mirrored-block equality check.

`har env verify 1 --full` passes all 8 stages (typecheck, build, docs-check, docs-build, 489 unit tests, lint, readiness, docs-drift) on a machine with **no npm installed at all**, dogfooding the change.

Also validated against an external bun workspace monorepo: `har env init` succeeds, detection resolves bun/bunx, and provisioning reproduces the same dependency layout as a manual `bun install`.

## Note

Provisioning writes the agent env with `printf '%s=%q'` in the shipped templates, but this repo's adapted `.har/` copy still used `%s`. That breaks `source .env.agent.<id>` when `PATH` contains spaces or parentheses (a WSL checkout carrying Windows entries). Fixed here since it blocked verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
