### PR TITLE
docs: make introduction demo video fill the content column

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -496,15 +496,27 @@ site-search button[data-open-modal]:hover {
 	}
 }
 
-/* Introduction demo video */
+/* Introduction demo video — full content width, 16:9 fill */
 .sl-markdown-content .intro-video {
 	margin: 1.75rem 0 0.5rem;
-	max-width: 720px;
+	max-width: none;
+	width: 100%;
 }
 .sl-markdown-content .intro-video .video-embed {
+	position: relative;
+	aspect-ratio: 16 / 9;
+	width: 100%;
+	overflow: hidden;
 	border: 1px solid var(--sl-color-hairline);
 	border-radius: var(--har-radius);
 	background: var(--har-surface);
+}
+.sl-markdown-content .intro-video .video-embed iframe {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	border: 0;
 }
 
 /* Tables — shared hairline grid with a 5px rounded frame */


### PR DESCRIPTION
## Summary
- Fix the Introduction YouTube embed so it fills the docs content column at 16:9 instead of sitting at the default iframe size inside a capped dark box
- Docs pages only load `custom.css` (not landing `global.css`), so the fill rules needed to live there

## Test plan
- [x] `har env verify 1 --full` (docs harness) passed
- [x] Check http://localhost:4321/docs/getting-started/introduction/ (or preview) — video spans full content width, no empty side gutter
- [x] Compare before/after screenshots under `docs/.har/artifacts/browser-e2e/screenshots/`


Made with [Cursor](https://cursor.com)