### PR TITLE
fix(telemetry): quote generated env values so spaced repo paths stay source-safe

### DIFF
--- a/src/core/local-executor.ts
+++ b/src/core/local-executor.ts
@@ -9,7 +9,13 @@ import {
 } from '../harness/stages';
 import { HarnessStage, StageResult } from '../harness/schema';
 import { validateAgentId } from '../utils/validation';
-import { runScript, runScriptCapture, runShellCommand, ShellResult } from '../utils/shell';
+import {
+  quoteShellArg,
+  runScript,
+  runScriptCapture,
+  runShellCommand,
+  ShellResult,
+} from '../utils/shell';
 import { buildStageResult, parseVerificationResult } from './results';
 import {
   ArtifactEntry,
@@ -19,12 +25,6 @@ import {
   StageRunOptions,
 } from './types';
 import { readSlotRegistry } from './slot-registry';
-
-/** Quote a single argv token for `bash -lc` when it needs shell metacharacters. */
-export function quoteShellArg(arg: string): string {
-  if (/^[A-Za-z0-9_./:=+-]+$/.test(arg)) return arg;
-  return `'${arg.replace(/'/g, `'\\''`)}'`;
-}
 
 /** Argv fragments forwarded to launch.sh for a launch stage. */
 export function buildLaunchFlagArgs(flags: LaunchFlags): string[] {

--- a/src/core/telemetry-env.ts
+++ b/src/core/telemetry-env.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { getControlApiUrl } from './control-config';
+import { quoteShellArg } from '../utils/shell';
 
 export interface TelemetrySessionAttrs {
   sessionKey: string;
@@ -50,14 +51,17 @@ export function buildSessionKey(input: {
  */
 export function buildTelemetryEnvBlock(attrs: TelemetrySessionAttrs): string {
   const apiUrl = getControlApiUrl().replace(/\/$/, '');
+  // Quote every value so the file stays safe to `source` even when a value
+  // contains a space or shell metacharacter (e.g. a repo path with a space).
+  // quoteShellArg leaves plain tokens unquoted, so ordinary values are unchanged.
   const lines: string[] = [
     '',
     '# HAR session attribution (generated)',
-    `HAR_SESSION_KEY=${attrs.sessionKey}`,
-    ...(attrs.workUnitId ? [`HAR_WORK_UNIT_ID=${attrs.workUnitId}`] : []),
-    ...(attrs.attemptId ? [`HAR_ATTEMPT_ID=${attrs.attemptId}`] : []),
-    `HAR_CONTROL_API_URL=${apiUrl}`,
-    `OTEL_RESOURCE_ATTRIBUTES=${buildOtelResourceAttributes(attrs)}`,
+    `HAR_SESSION_KEY=${quoteShellArg(attrs.sessionKey)}`,
+    ...(attrs.workUnitId ? [`HAR_WORK_UNIT_ID=${quoteShellArg(attrs.workUnitId)}`] : []),
+    ...(attrs.attemptId ? [`HAR_ATTEMPT_ID=${quoteShellArg(attrs.attemptId)}`] : []),
+    `HAR_CONTROL_API_URL=${quoteShellArg(apiUrl)}`,
+    `OTEL_RESOURCE_ATTRIBUTES=${quoteShellArg(buildOtelResourceAttributes(attrs))}`,
     '# Agent telemetry: @osfactory/otel-hook → Mission Control (har telemetry on|off)',
   ];
   return lines.join('\n') + '\n';

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -6,6 +6,12 @@ export interface ShellResult {
   code: number;
 }
 
+/** Quote a single token so it stays intact when a shell reads it (e.g. `source`d env files or `bash -lc`). */
+export function quoteShellArg(arg: string): string {
+  if (/^[A-Za-z0-9_./:=+-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
 export interface RunScriptOptions extends SpawnOptions {
   stream?: boolean;
 }

--- a/tests/launch-flags.test.ts
+++ b/tests/launch-flags.test.ts
@@ -1,4 +1,5 @@
-import { buildLaunchFlagArgs, quoteShellArg } from '../src/core/local-executor';
+import { buildLaunchFlagArgs } from '../src/core/local-executor';
+import { quoteShellArg } from '../src/utils/shell';
 import { LaunchEnvironmentInputSchema } from '../src/mcp/schemas';
 
 describe('launch flag plumbing', () => {

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -167,6 +168,44 @@ describe('telemetry env', () => {
     const text = fs.readFileSync(envFile, 'utf8');
     expect(text).toContain('HAR_SESSION_KEY=s2');
     expect(text.match(/HAR_SESSION_KEY=/g)?.length).toBe(1);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('quotes OTEL_RESOURCE_ATTRIBUTES when the repo path contains a space', () => {
+    const block = buildTelemetryEnvBlock({
+      sessionKey: 's1',
+      agentId: 1,
+      repoPath: '/Users/dev/My Projects/service',
+      workDir: '/Users/dev/My Projects/service',
+    });
+    const line = block
+      .split('\n')
+      .find((l) => l.startsWith('OTEL_RESOURCE_ATTRIBUTES='));
+    expect(line).toBeDefined();
+    // Value is single-quoted so the space survives, and the real path is preserved.
+    expect(line).toMatch(/^OTEL_RESOURCE_ATTRIBUTES='.*'$/);
+    expect(line).toContain('har.repo_path=/Users/dev/My Projects/service');
+  });
+
+  it('stays safe to source when a value contains a space (issue #172)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-env-source-'));
+    const envFile = path.join(dir, '.env.agent.1');
+    const repoPath = '/Users/dev/My Projects/service';
+    appendTelemetryEnvToFile(envFile, {
+      sessionKey: 's1',
+      agentId: 1,
+      repoPath,
+      workDir: repoPath,
+    });
+    // Reproduces the downstream launcher: `set -a; source <file>` then read back.
+    // On the unquoted (buggy) output this bash invocation exits non-zero with
+    // "No such file or directory"; execSync throws. On the fixed output it
+    // sources cleanly and prints the value with the space intact.
+    const out = execSync(
+      `set -a; . ${JSON.stringify(envFile)}; set +a; printf '%s' "$OTEL_RESOURCE_ATTRIBUTES"`,
+      { shell: '/bin/bash', encoding: 'utf8' },
+    );
+    expect(out).toContain(`har.repo_path=${repoPath}`);
     fs.rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #172.

`har telemetry write-env` (and `print-env`) wrote the `OTEL_RESOURCE_ATTRIBUTES` line — and the other `HAR_*` values — into the generated `.env.agent.<id>` **unquoted**. When the repo path contains a space, any script that `source`s that file breaks: the shell splits the value at the space and runs the remainder as a command, so the launcher aborts before starting its process.

```
.env.agent.1: line 4: My: command not found   # exit 127
```

## Fix

`buildTelemetryEnvBlock` now routes every generated value through the existing `quoteShellArg` helper, so the file stays safe to `source`. `quoteShellArg` leaves plain tokens unquoted, so ordinary (space-free) values are byte-identical to before — only values with a space or shell metacharacter get single-quoted.

- `src/core/telemetry-env.ts` — quote `HAR_SESSION_KEY`, `HAR_WORK_UNIT_ID`, `HAR_ATTEMPT_ID`, `HAR_CONTROL_API_URL`, and `OTEL_RESOURCE_ATTRIBUTES`.
- `src/utils/shell.ts` — `quoteShellArg` moves here (dependency-light module) to avoid pulling the executor module graph into `telemetry-env.ts`.
- `src/core/local-executor.ts` — imports `quoteShellArg` from `../utils/shell` (its only caller, unchanged).
- Tests — added two regression tests (one actually `source`s the generated file in bash); updated the `launch-flags` import to the helper's new location.

### Why quote, not percent-encode

The generated file is consumed by shell `source` across the boilerplate stage scripts (`launch.sh`, `agent-slot.sh`, `agent-cli.sh`, `verify.sh`, plugin stages) and by `dotenv` in `ecosystem.agent.template.cjs`; both strip surrounding quotes. HAR's own attribute parser (`parseResourceAttributesString`) never percent-decodes and never reads the file line, and `@osfactory/otel-hook` consumes a decoded JSON config rather than the env line. Percent-encoding would leave literal `%20` in attribute values; quoting preserves the real value.

## Verification

- `npm test` — added regression tests pass; full telemetry + launch-flags suites green. (Pre-existing macOS `/private/var` symlink / worktree failures in `hooks`/`plugins`/`slot-registry`/`control-repo-path` are unrelated and fail identically on `main`.)
- `npm run typecheck` and `npm run lint` clean.
- End-to-end with a spaced path `/tmp/har172 My Projects/service`:
  - Before: `source` → `line 4: My: command not found`, exit 127.
  - After: `OTEL_RESOURCE_ATTRIBUTES='...har.repo_path=/tmp/har172 My Projects/service...'`, `source` exit 0, value intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)