### PR TITLE
fix(ios): keep code signing on the verify test step

### DIFF
--- a/src/templates/har-boilerplate-ios/CLAUDE.agent.md
+++ b/src/templates/har-boilerplate-ios/CLAUDE.agent.md
@@ -60,8 +60,8 @@ source .env.agent.${AGENT_ID}
 # Build
 xcodebuild build -scheme MyApp -destination "$HARNESS_IOS_DESTINATION" CODE_SIGNING_ALLOWED=NO
 
-# Run unit tests
-xcodebuild test -scheme MyApp -destination "$HARNESS_IOS_DESTINATION" CODE_SIGNING_ALLOWED=NO
+# Run unit tests — signed, or an app with entitlements traps at launch
+xcodebuild test -scheme MyApp -destination "$HARNESS_IOS_DESTINATION"
 
 # Install and launch on this slot's device
 ./.har/agent-cli.sh ${AGENT_ID} install path/to/MyApp.app

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -118,6 +118,8 @@ process.stdout.write(JSON.stringify(arr));
 }
 
 # Quick (default): compile-only — use XCODEBUILD_BIN from .env.agent.<id> (written by launch)
+# Nothing is installed or run, so CODE_SIGNING_ALLOWED=NO keeps the smoke build
+# from needing a signing identity.
 run_step "build" '${XCODEBUILD_BIN:-xcodebuild} build \
   ${XC_FLAGS} \
   -scheme "${XC_SCHEME}" \
@@ -133,18 +135,20 @@ run_step "build" '${XCODEBUILD_BIN:-xcodebuild} build \
 
 if [ -n "$FULL" ]; then
   # Full: project-specific checks — add/remove/reorder steps for this repo.
+  # No CODE_SIGNING_ALLOWED=NO here, unlike the build step: tests install and run
+  # the host app on the simulator, and an unsigned app gets no entitlements. Apps
+  # using CloudKit, NSUbiquitousKeyValueStore, or push then trap at launch, before
+  # the test harness connects — the whole bundle is lost, not one test.
   run_step "unit-tests" '${XCODEBUILD_BIN:-xcodebuild} test \
     ${XC_FLAGS} \
     -scheme "${XC_SCHEME}" \
     -destination "${XC_DESTINATION}" \
     -derivedDataPath "${XC_DERIVED}" \
-    CODE_SIGNING_ALLOWED=NO \
     | xcbeautify 2>/dev/null || ${XCODEBUILD_BIN:-xcodebuild} test \
       ${XC_FLAGS} \
       -scheme "${XC_SCHEME}" \
       -destination "${XC_DESTINATION}" \
-      -derivedDataPath "${XC_DERIVED}" \
-      CODE_SIGNING_ALLOWED=NO' || true
+      -derivedDataPath "${XC_DERIVED}"' || true
 
   # SwiftLint — optional, skip gracefully when not installed
   run_step "lint" "command -v \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" >/dev/null 2>&1 && \

--- a/tests/ios-verify-code-signing.test.ts
+++ b/tests/ios-verify-code-signing.test.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveTemplatesDir } from '../src/utils/paths';
+
+const IOS_TEMPLATE = path.join(resolveTemplatesDir(), 'har-boilerplate-ios');
+
+/**
+ * Body of a `run_step "<name>" '<command>'` block. Step commands are
+ * single-quoted in verify.sh and contain no single quote of their own.
+ */
+function runStepCommand(script: string, name: string): string {
+  const marker = `run_step "${name}" '`;
+  const start = script.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const from = start + marker.length;
+  const end = script.indexOf("'", from);
+  expect(end).toBeGreaterThan(from);
+  return script.slice(from, end);
+}
+
+describe('iOS verify.sh code signing', () => {
+  const verify = fs.readFileSync(path.join(IOS_TEMPLATE, 'verify.sh'), 'utf8');
+
+  it('disables code signing for the compile-only build step', () => {
+    expect(runStepCommand(verify, 'build')).toContain('CODE_SIGNING_ALLOWED=NO');
+  });
+
+  // Tests install and run the host app on the simulator. Unsigned means no
+  // entitlements, so an app using iCloud, KVS, or push traps on launch before the
+  // test harness connects — every test in the bundle is lost.
+  it('leaves code signing alone for the unit-tests step', () => {
+    const unitTests = runStepCommand(verify, 'unit-tests');
+    expect(unitTests).toContain('xcodebuild} test');
+    expect(unitTests).not.toContain('CODE_SIGNING');
+  });
+
+  it('keeps the agent doc xcodebuild examples in step with verify.sh', () => {
+    const doc = fs.readFileSync(path.join(IOS_TEMPLATE, 'CLAUDE.agent.md'), 'utf8');
+    const examples = doc.split('\n').filter((line) => line.startsWith('xcodebuild '));
+    const build = examples.filter((line) => line.includes('xcodebuild build'));
+    const test = examples.filter((line) => line.includes('xcodebuild test'));
+
+    expect(build.length).toBeGreaterThan(0);
+    expect(test.length).toBeGreaterThan(0);
+    expect(build.every((line) => line.includes('CODE_SIGNING_ALLOWED=NO'))).toBe(true);
+    expect(test.some((line) => line.includes('CODE_SIGNING'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`src/templates/har-boilerplate-ios/verify.sh` passes `CODE_SIGNING_ALLOWED=NO` to `xcodebuild` for both the `build` step and the `unit-tests` step.

An unsigned build gets no entitlements. The test step installs and runs the host app on the simulator, so an app that touches iCloud at startup dies before the test harness establishes its connection. Running `./.har/verify.sh <id> --full` on an app using CloudKit and `NSUbiquitousKeyValueStore`:

```
Testing failed:
  MyApp (19282) encountered an error (Early unexpected exit, operation never
  finished bootstrapping — Test crashed with signal trap before establishing connection)
```

and in the simulator log:

```
BUG IN CLIENT OF KVS: Trying to initialize NSUbiquitousKeyValueStore without a store identifier
[CK] In order to use CloudKit, your process must have a com.apple.developer.icloud-services entitlement
```

The whole bundle is lost, not a single test.

## Evidence

Same worktree, same simulator, same command — only the flag changes:

| `CODE_SIGNING_ALLOWED=NO` | Result |
| --- | --- |
| present | crash at startup, 0 tests executed |
| absent | `Executed 429 tests, with 0 failures`, `** TEST SUCCEEDED **` in 14 s |

Reproduced both on a simulator created by HAR and on a pre-existing device, so it is neither the pristine device nor one specific project.

## Fix

Drop the flag from the `unit-tests` step and keep it on `build`.

The flag is legitimate for a compile-only smoke: nothing is installed or run, and it avoids requiring a signing identity. It is wrong on the test step — simulator destinations need no signing identity to run tests, so the flag strips entitlements without buying anything.

Plain removal rather than a `harness.env` knob: the only value worth having is the default, so a knob would add configuration surface whose non-default setting is the broken one, on a case that affects a large share of real apps.

Both branches of the step are updated (the primary command and the `xcbeautify`-less fallback), each side of the asymmetry is commented, and the `xcodebuild test` example in the profile's `CLAUDE.agent.md` follows the same rule. No documentation change is needed: neither the template README nor the docs site mentions code signing.

## Testing

New `tests/ios-verify-code-signing.test.ts`, source-level in the spirit of `tests/ios-simulator-allocation.test.ts` — running a real `xcodebuild` in CI is not viable. It parses the `run_step` bodies out of the template and asserts that the `build` step carries `CODE_SIGNING_ALLOWED=NO` while `unit-tests` does not, plus a third case keeping the agent-doc examples in step with the script. The two new assertions fail on `main`.

Also ran `bash -n` on the modified template.

Ran in a session worktree:

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 488 tests. Three suites fail (`control-repo-path`, `hooks`, `slot-registry`), identically to unmodified `main` on this machine: macOS `/var` vs `/private/var` symlink assertions, unrelated to this change.
- `npm run build` — clean
- `npm run drift --prefix docs` — documentation contract current
