### PR TITLE
fix(harness): quote agent env values in the dogfooded harnesses

### DIFF
--- a/.har/provision-toolchain.sh
+++ b/.har/provision-toolchain.sh
@@ -30,7 +30,9 @@ pt_log() {
 append_env() {
   local key="$1"
   local value="$2"
-  printf '%s=%s\n' "$key" "$value" >> "$HAR_ENV_FILE"
+  # %q, not a raw value: an unquoted value with spaces (a PATH entry under
+  # Application Support, a repo path) breaks `source .env.agent.<id>`.
+  printf '%s=%q\n' "$key" "$value" >> "$HAR_ENV_FILE"
 }
 
 append_path_prefix() {

--- a/control/.har/provision-toolchain.sh
+++ b/control/.har/provision-toolchain.sh
@@ -30,7 +30,9 @@ pt_log() {
 append_env() {
   local key="$1"
   local value="$2"
-  printf '%s=%s\n' "$key" "$value" >> "$HAR_ENV_FILE"
+  # %q, not a raw value: an unquoted value with spaces (a PATH entry under
+  # Application Support, a repo path) breaks `source .env.agent.<id>`.
+  printf '%s=%q\n' "$key" "$value" >> "$HAR_ENV_FILE"
 }
 
 append_path_prefix() {

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -104,6 +104,19 @@ describe('provision-toolchain.sh template contract', () => {
     expect(envContent).toContain('HARNESS_TOOLCHAIN_PROVISIONED=true');
   });
 
+  // This repo dogfoods HAR: its own harnesses are scaffolded copies that only move
+  // when someone runs `har env maintain`, so a template fix does not reach them.
+  // Env-file quoting is not cosmetic drift — an unquoted value breaks `source` for
+  // every contributor whose PATH or repo path contains a space.
+  for (const harness of ['.har', 'control/.har'] as const) {
+    it(`${harness}/provision-toolchain.sh quotes values it appends to the agent env`, () => {
+      const scriptPath = path.join(process.cwd(), harness, 'provision-toolchain.sh');
+      const content = fs.readFileSync(scriptPath, 'utf8');
+      expect(content).toContain("printf '%s=%q\\n'");
+      expect(content).not.toContain("printf '%s=%s\\n'");
+    });
+  }
+
   it('verify.sh dispatches stock smoke by ecosystem', () => {
     for (const profile of ['har-boilerplate', 'har-boilerplate-cli'] as const) {
       const verifyPath = path.join(resolveTemplatesDir(), profile, 'verify.sh');


### PR DESCRIPTION
Same class of bug as #172 / #177, but in the shell writer rather than the TypeScript one, and in this repository's own harnesses rather than in shipped code. Independent of that fix — neither one addresses the other.

## Problem

#168 changed `append_env` to `printf '%s=%q\n'` in the three boilerplate templates, so scaffolded harnesses write agent env values that can be sourced. This repository's own harnesses never got that fix: `.har/` and `control/.har/` are scaffolded copies that only move when someone runs `har env maintain`, and both still use `printf '%s=%s\n'`.

`append_env` writes `PATH`. Any contributor whose `PATH` contains a directory with a space gets an `.env.agent.<id>` that cannot be sourced, and every `har env verify` dies before its first stage:

```
.env.agent.1: line 11: Support/Claude/.../bin:/Users/me/Library/Application: No such file or directory
```

This is not an exotic setup — a tool installed under `~/Library/Application Support`, or a checkout under a directory with a space, both produce it. The harness is unusable for that contributor, and the documented fallback in CONTRIBUTING.md (`npm run typecheck && npm run lint && npm test && npm run build`) is the only way to verify a change.

## Fix

Apply the same `%q` the templates already use, in both in-repo harnesses.

Only the `append_env` line changes. The rest of the drift between these copies and the current templates is deliberate local adaptation (the docs dependency install in `.har/`, for instance) and is left alone — this is a targeted fix, not a re-scaffold.

Note for whoever merges second: #174 also edits `.har/provision-toolchain.sh` and `tests/provision-toolchain.test.ts`, so one of the two will need a trivial rebase. It does not touch `control/.har/` or this line.

## Testing

New cases in `tests/provision-toolchain.test.ts` asserting that both in-repo harnesses quote what they append. The existing suite already covers the templates (`writes values with spaces so the agent env file can be sourced`, added by #168); the gap was that template coverage cannot catch this class of drift, which is exactly what let the bug survive. Both new cases fail on `main`.

End-to-end check, running each version of the script against the same input and sourcing the result:

| `append_env` | `set -a; source .env.agent.9` |
| --- | --- |
| `printf '%s=%s\n'` (before) | fails on the `PATH` line |
| `printf '%s=%q\n'` (after) | sources cleanly |

Ran in a session worktree:

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 487 tests. Three suites fail (`control-repo-path`, `hooks`, `slot-registry`), identically to unmodified `main` on this machine: macOS `/var` vs `/private/var` symlink assertions, unrelated to this change.
- `npm run build` — clean
- `npm run drift --prefix docs` — documentation contract current
