### PR TITLE
feat(ios): read the Xcode project at init to fill in the harness config

### DIFF
--- a/docs/src/content/docs/docs/guides/profiles.md
+++ b/docs/src/content/docs/docs/guides/profiles.md
@@ -34,6 +34,36 @@ The scaffold intentionally contains project-specific placeholders. Adapt:
 HAR writes `.har/ADAPT-PROMPT.md` for your coding agent to adapt the scaffold.
 Your agent tailors scripts, ports, verification, and `AGENTS.md` to the repository.
 
+## The iOS profile reads your Xcode project
+
+`har env init --profile ios` does the mechanical part of the adaptation for you. It
+locates the `.xcworkspace` or `.xcodeproj`, asks `xcodebuild` for the shared schemes
+and the bundle id, and writes `HARNESS_XCODE_WORKSPACE` / `HARNESS_XCODE_PROJECT`,
+`HARNESS_XCODE_SCHEME`, and `HARNESS_BUNDLE_ID` into `harness.env`.
+
+Two rules govern it:
+
+- **it never guesses.** When several schemes match and none carries the project name,
+  `HARNESS_XCODE_SCHEME` is left unset and the candidates are printed. A wrong scheme
+  costs more to discover than a missing one;
+- **it never fails init.** No Xcode, a project that does not exist yet, a stalled
+  `xcodebuild` — each case degrades to a partial result with a warning explaining what
+  is left to do.
+
+Values written this way are recorded in `.har/manifest.json` as `initEnvOverrides`, so
+`har env maintain` compares against what HAR generated rather than reporting its own
+output as drift. Your own later edits to `harness.env` still show up as drift.
+
+Use `--no-introspect` to scaffold placeholders only.
+
+### Projects that are generated rather than tracked
+
+With Tuist, XcodeGen, or CocoaPods, the `.xcodeproj` and `.xcworkspace` are build
+products: a fresh worktree has none. `launch` runs the right generator
+(`tuist generate`, `xcodegen generate`, `pod install`) before building, and fails with
+a message naming the missing tool rather than letting the build report a scheme it
+cannot find. Set `HARNESS_INSTALL_CMD` in `harness.env` to take that over yourself.
+
 ## Toolchains
 
 Generated harnesses can detect or explicitly configure Node.js, Python, Go, Rust,

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -57,6 +57,7 @@ With `--yes` and no `--agent-slots`, the profile template default is kept.
 ```bash
 har env init [--profile default|cli|ios] [--yes]
              [--smoke] [--force] [--verbose]
+             [--introspect|--no-introspect]
              [--agents claude,cursor,codex] [--no-agents]
              [--cursor-rule|--no-cursor-rule]
              [--commit-gate prompt|always|never]
@@ -64,6 +65,10 @@ har env init [--profile default|cli|ios] [--yes]
 ```
 
 `--force` replaces an existing harness and is destructive.
+
+`--no-introspect` skips reading the Xcode project on the `ios` profile and leaves the
+scaffold placeholders in place. Introspection is on by default and never fails init —
+whatever it cannot resolve is printed as a warning to act on.
 
 ### Maintenance
 

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -11,7 +11,12 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 | Tool | Inputs | Result |
 | --- | --- | --- |
 | `har_describe_project` | `repo` | Manifest, stack hints, scripts, stages, and slot limits |
-| `har_init_harness` | `repo`, `force`, `smoke`, `profile` (`default` \| `cli` \| `ios`) | Scaffold and validation result |
+| `har_init_harness` | `repo`, `force`, `smoke`, `profile` (`default` \| `cli` \| `ios`), `introspect` | Scaffold and validation result, plus `warnings` and — on the `ios` profile — `introspection` |
+
+On the `ios` profile, `har_init_harness` reads the Xcode project and fills in scheme,
+project/workspace, and bundle id. Read `warnings` before launching a slot: an
+ambiguous scheme is left unset on purpose, and the candidates are listed there.
+Pass `introspect: false` to scaffold placeholders only.
 
 ## Session lifecycle
 

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -47,6 +47,13 @@ export const HarnessManifestSchema = z.object({
     .optional(),
   adaptationSummary: z.string().optional(),
   profile: z.enum(['default', 'cli', 'ios']).optional(),
+  /**
+   * harness.env exports written by `init` itself, from project introspection.
+   * Drift replays them onto the template before comparing, so values HAR generated
+   * are not reported back to the user as their own local edits — and, worse, are not
+   * handed to a coding agent as a diff to revert.
+   */
+  initEnvOverrides: z.record(z.string()).optional(),
   fileChecksums: z.record(z.string()).optional(),
   scaffoldedAgentFiles: z.array(ScaffoldedAgentFileSchema).optional(),
 });

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -66,6 +66,12 @@ export const envCommand = {
               default: 'default' as const,
               describe: 'Boilerplate profile: default (web app), cli (library/CLI, no PM2), ios (iOS mobile app)',
             })
+            .option('introspect', {
+              type: 'boolean',
+              default: true,
+              describe:
+                'Read the Xcode project to fill in harness.env (ios profile); --no-introspect to scaffold placeholders only',
+            })
             .option('yes', {
               type: 'boolean',
               default: false,
@@ -380,6 +386,19 @@ export const envCommand = {
   handler: () => {},
 };
 
+/**
+ * Everything init could not resolve on its own. Printed before validation so an
+ * unresolved scheme is read as "finish the config", not as a broken harness.
+ */
+function printInitWarnings(warnings: string[]): void {
+  if (warnings.length === 0) return;
+  divider();
+  warn('Harness config needs a hand:');
+  for (const message of warnings) {
+    warn(`  • ${message}`);
+  }
+}
+
 export async function handleInit(argv: {
   repo: string;
   verbose: boolean;
@@ -387,6 +406,8 @@ export async function handleInit(argv: {
   smoke: boolean;
   yes: boolean;
   profile: 'default' | 'cli' | 'ios';
+  /** --no-introspect skips reading the Xcode project on the iOS profile. */
+  introspect?: boolean;
   /** Tri-state from yargs: unset | --cursor-rule | --no-cursor-rule */
   cursorRule?: boolean;
   /** String from --agents=…, or `false` when --no-agents (yargs negation). */
@@ -408,7 +429,10 @@ export async function handleInit(argv: {
       verbose: argv.verbose,
       smoke: argv.smoke,
       profile: argv.profile,
+      introspect: argv.introspect,
     });
+
+    printInitWarnings(result.warnings);
 
     divider();
     info('Validating harness...');

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -4,6 +4,7 @@ import type { Argv } from 'yargs';
 import { harnessExists } from '../../harness/parser';
 import type { HarnessProfile } from '../../harness/generator';
 import { PluginId } from '../../harness/plugins';
+import { suggestsIosProfile } from '../../harness/xcode-introspect';
 import {
   HAR_AGENT_SLOT_MIN,
   HAR_AGENT_SLOT_ONBOARD_MAX,
@@ -142,6 +143,9 @@ async function promptChoices(args: OnboardArgs): Promise<{
   const repoPath = path.resolve(args.repo);
   const alreadyPresent = harnessExists(repoPath);
   const needProfile = !alreadyPresent && !args.skipInit && args.profile === undefined;
+  // Only pre-selects the entry in the interactive list. `har env init --profile`
+  // keeps its explicit default so scripted invocations do not change behavior.
+  const iosDetected = needProfile && suggestsIosProfile(repoPath);
   const needAgentSlots = shouldConfigureSlots && flaggedSlots === undefined;
 
   if (needAgentSlots) {
@@ -165,9 +169,14 @@ async function promptChoices(args: OnboardArgs): Promise<{
       choices: [
         { name: 'default — web / full-stack apps', value: 'default' },
         { name: 'cli — libraries and CLI tools (no PM2)', value: 'cli' },
-        { name: 'ios — Xcode / iOS Simulator', value: 'ios' },
+        {
+          name: iosDetected
+            ? 'ios — Xcode / iOS Simulator (detected)'
+            : 'ios — Xcode / iOS Simulator',
+          value: 'ios',
+        },
       ],
-      default: 'default',
+      default: iosDetected ? 'ios' : 'default',
     },
     {
       type: 'list',

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -19,6 +19,7 @@ import {
 } from '../harness/plugins';
 import { harnessExists } from '../harness/parser';
 import { HarnessManifest, HarnessStage } from '../harness/schema';
+import type { XcodeProjectInfo } from '../harness/xcode-introspect';
 
 export interface InitHarnessOptions extends ScaffoldOptions {
   repoPath: string;
@@ -30,6 +31,10 @@ export interface InitHarnessResult {
   harnessDir: string;
   validation: ValidationResult;
   smoke?: ValidationResult;
+  /** What init could not resolve on its own — surfaced by every adapter (CLI, MCP). */
+  warnings: string[];
+  /** iOS profile only: what reading the Xcode project produced. */
+  introspection?: XcodeProjectInfo;
 }
 
 export interface MaintainHarnessOptions {
@@ -103,6 +108,7 @@ export async function initHarness(options: InitHarnessOptions): Promise<InitHarn
   const scaffold = scaffoldHarnessBoilerplate(repoPath, {
     force: options.force,
     profile: options.profile,
+    introspect: options.introspect,
   });
   syncAgentSlotsToHarnessEnv(repoPath);
 
@@ -116,6 +122,8 @@ export async function initHarness(options: InitHarnessOptions): Promise<InitHarn
     harnessDir: scaffold.harnessDir,
     validation,
     smoke,
+    warnings: scaffold.warnings,
+    introspection: scaffold.introspection,
   };
 }
 

--- a/src/harness/adaptation-prompt.ts
+++ b/src/harness/adaptation-prompt.ts
@@ -20,7 +20,7 @@ const PROFILE_HINTS: Record<HarnessProfile, string> = {
   cli:
     'CLI/library profile (typical SWE-bench) — no PM2. Optional Docker Compose via HARNESS_INFRA_SERVICES. Git worktree by default. Launch provisions toolchain declaratively (HARNESS_ECOSYSTEM auto-detects common ecosystems); verify must use resolved tool paths from .env.agent.<id>, never hardcoded interpreter or package-manager paths.',
   ios:
-    'iOS mobile app profile — xcodebuild + iOS Simulator in an isolated git worktree. Set HARNESS_XCODE_SCHEME, workspace/project, HARNESS_SIMULATOR_NAME, HARNESS_BUNDLE_ID. Launch writes XCODEBUILD_BIN to .env.agent.<id>; verify uses it. Install RocketSim plugin (har env add-plugin rocketsim) for user-flow validation.',
+    'iOS mobile app profile — xcodebuild + iOS Simulator in an isolated git worktree. Init already read the Xcode project and filled in workspace/project, HARNESS_XCODE_SCHEME and HARNESS_BUNDLE_ID: check those before editing, and read the init warnings for what it deliberately left unset (an ambiguous scheme is never guessed). HARNESS_SIMULATOR_NAME stays yours to pick. Launch runs tuist/xcodegen/pod install for generated projects and writes XCODEBUILD_BIN to .env.agent.<id>; verify uses it. Install RocketSim plugin (har env add-plugin rocketsim) for user-flow validation.',
 };
 
 function loadTemplate(name: string): string {

--- a/src/harness/drift.ts
+++ b/src/harness/drift.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import type { HarnessProfile } from './generator';
-import { readHarnessEnv } from './env';
+import { applyHarnessEnvValues, readHarnessEnv } from './env';
 import {
   harnessFileForTemplate,
   isExpectedHarnessOnlyFile,
@@ -147,6 +147,11 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
     let templateContent = fs.readFileSync(templatePath, 'utf8');
     if (file === 'harness.env') {
       templateContent = substituteProjectName(templateContent, projectName);
+      // Replay what init generated, so a harness HAR just wrote compares equal.
+      // Without this, `maintain` hands a coding agent a diff whose direction
+      // restores the MyApp / com.example.myapp placeholders — the feature would
+      // silently undo itself on the first maintain.
+      templateContent = applyHarnessEnvValues(templateContent, manifest?.initEnvOverrides ?? {});
     }
 
     if (!fs.existsSync(harnessPath)) {

--- a/src/harness/env.ts
+++ b/src/harness/env.ts
@@ -2,17 +2,63 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getHarnessDir } from './manifest';
 
+/**
+ * Parse `export KEY=value` lines out of harness.env content.
+ *
+ * A double-quoted value is unescaped the way the shell would, so callers read the
+ * value the harness scripts actually see. Without it, a value written by
+ * `applyHarnessEnvValues` and containing `$`, `"`, a backtick or a backslash would
+ * be read back with its escaping still attached, and any comparison against it fails.
+ */
+export function parseHarnessEnvContent(content: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const match = line.match(/^export\s+([A-Z0-9_]+)=(.*)$/);
+    if (!match) continue;
+    const raw = match[2];
+    values[match[1]] =
+      raw.length >= 2 && raw.startsWith('"') && raw.endsWith('"')
+        ? raw.slice(1, -1).replace(/\\([\\"$`])/g, '$1')
+        : raw.replace(/^"|"$/g, '');
+  }
+  return values;
+}
+
 export function readHarnessEnv(repoPath: string): Record<string, string> {
   const envPath = path.join(getHarnessDir(repoPath), 'harness.env');
   if (!fs.existsSync(envPath)) return {};
+  return parseHarnessEnvContent(fs.readFileSync(envPath, 'utf8'));
+}
 
-  const values: Record<string, string> = {};
-  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
-    const match = line.match(/^export\s+([A-Z0-9_]+)=(.*)$/);
-    if (!match) continue;
-    values[match[1]] = match[2].replace(/^"|"$/g, '');
+/** Escape a value for a double-quoted shell assignment. */
+function escapeHarnessEnvValue(value: string): string {
+  return value.replace(/([\\"$`])/g, '\\$1');
+}
+
+/**
+ * Rewrite `export KEY="value"` lines in harness.env content.
+ *
+ * Pure on purpose: `init` applies the values before the manifest seals its
+ * checksums, and drift replays the very same values onto the template before
+ * comparing. Both paths must produce byte-identical output or a freshly generated
+ * harness reports itself as drifted.
+ *
+ * Keys the template does not declare are skipped rather than appended — a stale
+ * manifest must not resurrect an export a newer template deliberately removed.
+ */
+export function applyHarnessEnvValues(
+  content: string,
+  values: Record<string, string>,
+): string {
+  let out = content;
+  for (const [key, value] of Object.entries(values)) {
+    if (!/^[A-Z0-9_]+$/.test(key)) continue;
+    const pattern = new RegExp(`^export ${key}=.*$`, 'm');
+    if (!pattern.test(out)) continue;
+    const line = `export ${key}="${escapeHarnessEnvValue(value)}"`;
+    out = out.replace(pattern, () => line);
   }
-  return values;
+  return out;
 }
 
 export function parseHarnessEnvInt(

--- a/src/harness/generator.ts
+++ b/src/harness/generator.ts
@@ -7,6 +7,12 @@ import { ensureRootGitignorePatterns } from '../core/gitignore';
 import { writeHarnessGitignore } from './gitignore-template';
 import { createManifest, writeManifest, DEFAULT_HAR_DIR, readManifest } from './manifest';
 import { syncAgentSlotsToHarnessEnv } from './stages';
+import { applyHarnessEnvValues } from './env';
+import {
+  introspectXcodeProject,
+  xcodeHarnessEnvValues,
+  type XcodeProjectInfo,
+} from './xcode-introspect';
 
 export type HarnessProfile = 'default' | 'cli' | 'ios';
 
@@ -37,11 +43,17 @@ export { DEFAULT_HAR_DIR };
 export interface ScaffoldOptions {
   force?: boolean;
   profile?: HarnessProfile;
+  /** Skip project introspection on the iOS profile (CI, or a deliberately blank harness). */
+  introspect?: boolean;
 }
 
 export interface ScaffoldResult {
   harnessDir: string;
   projectName: string;
+  /** Everything init could not resolve on its own, phrased for the user to act on. */
+  warnings: string[];
+  /** Present on the iOS profile whenever introspection ran. */
+  introspection?: XcodeProjectInfo;
 }
 
 /**
@@ -94,12 +106,25 @@ export function scaffoldHarnessBoilerplate(
 
   syncAgentSlotsToHarnessEnv(repoPath);
 
+  // Introspection runs before the manifest is written: createManifest seals the
+  // checksums, so every edit to harness.env has to land first.
+  let introspection: XcodeProjectInfo | undefined;
+  let initEnvOverrides: Record<string, string> = {};
+  const warnings: string[] = [];
+
+  if (profile === 'ios' && options.introspect !== false) {
+    introspection = introspectXcodeProject(repoPath);
+    initEnvOverrides = xcodeHarnessEnvValues(introspection);
+    warnings.push(...introspection.warnings);
+  }
+
   const harnessEnvPath = path.join(harnessDir, 'harness.env');
   if (fs.existsSync(harnessEnvPath)) {
     let content = fs.readFileSync(harnessEnvPath, 'utf8');
     content = content
       .replace(/__PROJECT_NAME__/g, projectName)
       .replace(/template___PROJECT_NAME__/g, `template_${projectName}`);
+    content = applyHarnessEnvValues(content, initEnvOverrides);
     fs.writeFileSync(harnessEnvPath, content);
   }
 
@@ -112,6 +137,7 @@ export function scaffoldHarnessBoilerplate(
         : 'Boilerplate copied — adapt with your coding agent (see .har/ADAPT-PROMPT.md).',
     undefined,
     profile,
+    initEnvOverrides,
   );
   writeManifest(repoPath, manifest);
 
@@ -121,8 +147,11 @@ export function scaffoldHarnessBoilerplate(
 
   success(`Copied harness boilerplate to .har/ (profile: ${profile})`);
   info(`Project name: ${projectName}`);
+  if (introspection?.scheme) {
+    info(`Xcode scheme: ${introspection.scheme}`);
+  }
 
-  return { harnessDir, projectName };
+  return { harnessDir, projectName, warnings, introspection };
 }
 
 export function finalizeHarness(
@@ -131,7 +160,16 @@ export function finalizeHarness(
   stack?: { language?: string; packageManager?: string; database?: string },
 ): void {
   const existing = readManifest(repoPath);
-  const manifest = createManifest(repoPath, adaptationSummary, stack, existing?.profile);
+  // initEnvOverrides is carried over: it records what init generated, which
+  // finalizing an adaptation does not change. Dropping it here would make every
+  // later `maintain` report the generated harness.env as drifted.
+  const manifest = createManifest(
+    repoPath,
+    adaptationSummary,
+    stack,
+    existing?.profile,
+    existing?.initEnvOverrides,
+  );
   writeManifest(repoPath, manifest);
   success('Harness adaptation complete.');
 }

--- a/src/harness/manifest.ts
+++ b/src/harness/manifest.ts
@@ -59,6 +59,7 @@ export function createManifest(
   adaptationSummary?: string,
   stack?: HarnessManifest['stack'],
   profile?: HarnessManifest['profile'],
+  initEnvOverrides?: HarnessManifest['initEnvOverrides'],
 ): HarnessManifest {
   const now = new Date().toISOString();
   const harnessDir = getHarnessDir(repoPath);
@@ -71,6 +72,9 @@ export function createManifest(
     stack,
     adaptationSummary,
     profile,
+    ...(initEnvOverrides && Object.keys(initEnvOverrides).length > 0
+      ? { initEnvOverrides }
+      : {}),
     fileChecksums: computeHarnessChecksums(harnessDir),
   };
 }

--- a/src/harness/validator.ts
+++ b/src/harness/validator.ts
@@ -1,8 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { run } from '../utils/shell';
+import { parseHarnessEnvContent } from './env';
 import { getHarnessDir, readManifest } from './manifest';
 import { readStageRegistry } from './stages';
+import { resolveTemplatesDir } from '../utils/paths';
 
 export interface ValidationIssue {
   file: string;
@@ -68,6 +70,67 @@ const SHELL_SCRIPTS = [
   'attach.sh',
 ];
 
+/** Keys whose scaffold placeholder means the harness was never adapted. */
+const IOS_PLACEHOLDER_KEYS = ['HARNESS_XCODE_SCHEME', 'HARNESS_BUNDLE_ID'] as const;
+
+/**
+ * The placeholder values the iOS scaffold actually ships, read from the template
+ * rather than restated here — otherwise changing the template silently disables
+ * this check.
+ */
+function iosPlaceholders(): Record<string, string> {
+  const templateEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-ios', 'harness.env');
+  if (!fs.existsSync(templateEnv)) return {};
+  const template = parseHarnessEnvContent(fs.readFileSync(templateEnv, 'utf8'));
+
+  const placeholders: Record<string, string> = {};
+  for (const key of IOS_PLACEHOLDER_KEYS) {
+    if (template[key]) placeholders[key] = template[key];
+  }
+  return placeholders;
+}
+
+/**
+ * Filesystem-only checks on the iOS harness config.
+ *
+ * Deliberately does not shell out to `xcodebuild` to confirm the scheme still
+ * exists in the project: validation runs on every init and maintain, and must stay
+ * fast and work on machines without Xcode. What is checked here — placeholders left
+ * in place, and a project path that no longer resolves — covers the cases that
+ * actually break a build, at no cost.
+ *
+ * Takes the already-read harness.env content: the caller has it in hand, and
+ * validation runs on every init and maintain.
+ */
+function validateIosHarnessEnv(repoPath: string, harnessEnvContent: string): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const env = parseHarnessEnvContent(harnessEnvContent);
+
+  for (const [key, placeholder] of Object.entries(iosPlaceholders())) {
+    if (env[key] === placeholder) {
+      issues.push({
+        file: 'harness.env',
+        message: `${key} is still the scaffold placeholder "${placeholder}" — the build will not find it`,
+        severity: 'warning',
+      });
+    }
+  }
+
+  for (const key of ['HARNESS_XCODE_WORKSPACE', 'HARNESS_XCODE_PROJECT']) {
+    const configured = env[key];
+    if (!configured) continue;
+    if (!fs.existsSync(path.join(repoPath, configured))) {
+      issues.push({
+        file: 'harness.env',
+        message: `${key} points at "${configured}", which does not exist — it was renamed, moved, or is generated at launch`,
+        severity: 'warning',
+      });
+    }
+  }
+
+  return issues;
+}
+
 export function validateHarness(repoPath: string): ValidationResult {
   const harnessDir = getHarnessDir(repoPath);
   const issues: ValidationIssue[] = [];
@@ -128,6 +191,9 @@ export function validateHarness(repoPath: string): ValidationResult {
     }
     if (content.includes('TODO: set seed command')) {
       issues.push({ file: 'harness.env', message: 'Seed command still has TODO', severity: 'warning' });
+    }
+    if (profile === 'ios') {
+      issues.push(...validateIosHarnessEnv(repoPath, content));
     }
   }
 

--- a/src/harness/xcode-introspect.ts
+++ b/src/harness/xcode-introspect.ts
@@ -1,0 +1,361 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { run } from '../utils/shell';
+
+/**
+ * Reads an Xcode project well enough to fill in the iOS harness profile.
+ *
+ * The scaffold ships placeholders (`MyApp`, `com.example.myapp`), so a freshly
+ * initialized iOS harness cannot build anything until someone adapts it by hand.
+ * This module resolves the mechanical part — which project file, which scheme,
+ * which bundle id — and leaves everything genuinely project-specific alone.
+ *
+ * Two rules shape the whole module:
+ *  - it never guesses. An ambiguous scheme stays unset, with the candidates
+ *    reported as a warning, because a wrong scheme costs more than a missing one;
+ *  - it never fails init. No Xcode, no macOS, a stalled `xcodebuild` — every path
+ *    degrades to a partial result carrying an explanation.
+ */
+
+/** How long `xcodebuild` may take before we stop waiting on it. */
+const LIST_TIMEOUT_MS = 45_000;
+const SETTINGS_TIMEOUT_MS = 60_000;
+
+/** Directories that never hold the project we are looking for. */
+const SKIP_DIRS = new Set(['node_modules', 'Pods', 'DerivedData', 'build', 'vendor']);
+
+/** Tool that produces the .xcodeproj, when it is a build product rather than a tracked file. */
+export type XcodeProjectGenerator = 'tuist' | 'xcodegen' | 'cocoapods';
+
+/**
+ * Generator manifests, in the precedence the harness applies. `provision_ios_generate_project`
+ * in provision-toolchain.sh must check the same files in the same order — a test binds
+ * the two, since a divergence would have init name one generator and launch run another.
+ */
+export const GENERATOR_MANIFESTS: ReadonlyArray<{
+  id: XcodeProjectGenerator;
+  manifest: string;
+}> = [
+  { id: 'tuist', manifest: 'Project.swift' },
+  { id: 'xcodegen', manifest: 'project.yml' },
+  { id: 'cocoapods', manifest: 'Podfile' },
+];
+
+export interface XcodeProjectLocation {
+  /** Repo-relative path to the .xcworkspace, when one exists outside any .xcodeproj. */
+  workspace?: string;
+  /** Repo-relative path to the .xcodeproj. */
+  project?: string;
+  generator: XcodeProjectGenerator | null;
+  /**
+   * Every project and workspace found, sorted. More than one entry means the pick
+   * above was arbitrary and the caller should say so rather than choose silently.
+   */
+  candidates: string[];
+}
+
+export interface XcodeProjectInfo extends XcodeProjectLocation {
+  /** Resolved only when unambiguous — see `schemes` for what was on offer. */
+  scheme?: string;
+  schemes: string[];
+  bundleId?: string;
+  /**
+   * `high`   — scheme and bundle id resolved, the harness can build as generated.
+   * `partial`— something is known, but manual adaptation is still required.
+   * `none`   — this does not look like an Xcode project at all.
+   */
+  confidence: 'high' | 'partial' | 'none';
+  warnings: string[];
+}
+
+export interface IntrospectOptions {
+  listTimeoutMs?: number;
+  settingsTimeoutMs?: number;
+}
+
+/** Single-quote a path for safe interpolation into a shell command. */
+function quote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Parse JSON that may carry leading tool chatter. */
+function parseJsonLoose<T>(raw: string): T | null {
+  const start = raw.search(/[[{]/);
+  if (start < 0) return null;
+  try {
+    return JSON.parse(raw.slice(start)) as T;
+  } catch {
+    return null;
+  }
+}
+
+function detectGenerator(repoPath: string): XcodeProjectGenerator | null {
+  // Precedence matters: a Tuist repo may also carry a Podfile, and Tuist is what
+  // produces the project file the rest of the pipeline needs.
+  const found = GENERATOR_MANIFESTS.find((entry) =>
+    fs.existsSync(path.join(repoPath, entry.manifest)),
+  );
+  return found?.id ?? null;
+}
+
+/**
+ * Locate the Xcode project on disk. Filesystem only — safe to call on every
+ * `har env init`, including on machines without Xcode.
+ */
+export function detectXcodeProject(repoPath: string): XcodeProjectLocation | null {
+  const resolved = path.resolve(repoPath);
+  const generator = detectGenerator(resolved);
+
+  const workspaces: string[] = [];
+  const projects: string[] = [];
+
+  const walk = (dir: string, depth: number): void => {
+    if (depth > 2) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const name = entry.name;
+      if (name.startsWith('.') || SKIP_DIRS.has(name)) continue;
+      const full = path.join(dir, name);
+
+      if (name.endsWith('.xcodeproj')) {
+        // Never descend: every .xcodeproj holds an inner project.xcworkspace that
+        // would otherwise shadow the real workspace.
+        projects.push(path.relative(resolved, full));
+        continue;
+      }
+      if (name.endsWith('.xcworkspace')) {
+        workspaces.push(path.relative(resolved, full));
+        continue;
+      }
+      walk(full, depth + 1);
+    }
+  };
+
+  walk(resolved, 1);
+
+  // Sorted, not readdir order: that order is filesystem-dependent, and an arbitrary
+  // pick must at least be the same arbitrary pick on every machine.
+  workspaces.sort();
+  projects.sort();
+
+  const workspace = workspaces[0];
+  const project = projects[0];
+
+  if (!workspace && !project && !generator) return null;
+  return { workspace, project, generator, candidates: [...workspaces, ...projects] };
+}
+
+/** Root manifests that mean the repository is primarily something other than an iOS app. */
+const FOREIGN_ROOT_MANIFESTS = ['package.json', 'pyproject.toml', 'go.mod', 'Cargo.toml'];
+
+/**
+ * Whether `har env onboard` should offer the iOS profile by default.
+ *
+ * Deliberately stricter than `detectXcodeProject`: the project must sit at the
+ * repository root, and no other ecosystem may own the root. A React Native repo
+ * (package.json at root, project under ios/) must keep its own profile, and a
+ * monorepo with one iOS app among many packages must not be reclassified.
+ *
+ * A suggestion only — the choice stays the user's, and `--profile` is unaffected.
+ */
+export function suggestsIosProfile(repoPath: string): boolean {
+  const resolved = path.resolve(repoPath);
+
+  for (const manifest of FOREIGN_ROOT_MANIFESTS) {
+    if (fs.existsSync(path.join(resolved, manifest))) return false;
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(resolved, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+
+  return entries.some((entry) => {
+    if (entry.isDirectory()) {
+      return entry.name.endsWith('.xcodeproj') || entry.name.endsWith('.xcworkspace');
+    }
+    return entry.name === 'Project.swift' || entry.name === 'project.yml';
+  });
+}
+
+/** xcodebuild flags selecting the target — workspace wins, as CocoaPods requires. */
+function targetFlags(repoPath: string, location: XcodeProjectLocation): string | null {
+  if (location.workspace) return `-workspace ${quote(path.join(repoPath, location.workspace))}`;
+  if (location.project) return `-project ${quote(path.join(repoPath, location.project))}`;
+  return null;
+}
+
+interface XcodeListOutput {
+  project?: { name?: string; schemes?: string[] };
+  workspace?: { name?: string; schemes?: string[] };
+}
+
+interface XcodeBuildSettings {
+  buildSettings?: Record<string, string>;
+}
+
+/**
+ * Pick a scheme only when the choice is unambiguous: an exact match on the project
+ * name, or a single candidate. Anything else is left for a human.
+ */
+function chooseScheme(schemes: string[], location: XcodeProjectLocation): string | undefined {
+  if (schemes.length === 0) return undefined;
+  if (schemes.length === 1) return schemes[0];
+
+  const target = location.workspace ?? location.project;
+  if (target) {
+    const base = path.basename(target).replace(/\.(xcworkspace|xcodeproj)$/, '');
+    const exact = schemes.find((scheme) => scheme === base);
+    if (exact) return exact;
+  }
+  return undefined;
+}
+
+export function introspectXcodeProject(
+  repoPath: string,
+  options: IntrospectOptions = {},
+): XcodeProjectInfo {
+  const resolved = path.resolve(repoPath);
+  const warnings: string[] = [];
+  const location = detectXcodeProject(resolved);
+
+  if (!location) {
+    warnings.push(
+      'No Xcode project, workspace, or generator manifest found here — left the iOS ' +
+        'scaffold placeholders in place. Set HARNESS_XCODE_PROJECT (or _WORKSPACE), ' +
+        'HARNESS_XCODE_SCHEME and HARNESS_BUNDLE_ID in .har/harness.env, or re-run ' +
+        'init with a different --profile.',
+    );
+    return { generator: null, schemes: [], candidates: [], confidence: 'none', warnings };
+  }
+
+  const base: XcodeProjectInfo = {
+    ...location,
+    schemes: [],
+    confidence: 'partial',
+    warnings,
+  };
+
+  if (location.candidates.length > 1) {
+    // Refusing to guess a scheme while silently guessing a project would be
+    // inconsistent; the pick is reported so it can be overridden.
+    warnings.push(
+      `Several Xcode projects/workspaces found — picked ${location.workspace ?? location.project}. ` +
+        `Set HARNESS_XCODE_WORKSPACE or HARNESS_XCODE_PROJECT to choose another: ${location.candidates.join(', ')}.`,
+    );
+  }
+
+  const flags = targetFlags(resolved, location);
+  if (!flags) {
+    warnings.push(
+      `No .xcodeproj found — this project is generated by ${location.generator ?? 'a build tool'}. ` +
+        'The harness generates it at launch; set HARNESS_XCODE_SCHEME and HARNESS_BUNDLE_ID by hand until then.',
+    );
+    return base;
+  }
+
+  if (run('command -v xcodebuild').code !== 0) {
+    warnings.push(
+      'xcodebuild is not available — skipped project introspection. ' +
+        'Set HARNESS_XCODE_SCHEME and HARNESS_BUNDLE_ID in .har/harness.env by hand.',
+    );
+    return base;
+  }
+
+  const listResult = run(`xcodebuild -list -json ${flags}`, {
+    cwd: resolved,
+    timeout: options.listTimeoutMs ?? LIST_TIMEOUT_MS,
+  });
+
+  if (listResult.code !== 0) {
+    warnings.push(
+      listResult.timedOut
+        ? 'xcodebuild -list timed out — left the scheme unset in .har/harness.env.'
+        : 'xcodebuild -list failed — left the scheme unset in .har/harness.env.',
+    );
+    return base;
+  }
+
+  const listed = parseJsonLoose<XcodeListOutput>(listResult.stdout);
+  const schemes = listed?.workspace?.schemes ?? listed?.project?.schemes ?? [];
+  base.schemes = schemes;
+
+  if (schemes.length === 0) {
+    warnings.push(
+      'No shared scheme found. Mark a scheme as shared in Xcode (Product → Scheme → Manage Schemes), ' +
+        'then set HARNESS_XCODE_SCHEME.',
+    );
+    return base;
+  }
+
+  const scheme = chooseScheme(schemes, location);
+  if (!scheme) {
+    warnings.push(
+      `Several schemes match and none carries the project name — left HARNESS_XCODE_SCHEME unset. ` +
+        `Pick one of: ${schemes.join(', ')}.`,
+    );
+    return base;
+  }
+  base.scheme = scheme;
+
+  // The destination is pinned: on a project whose default destination is a device,
+  // build settings differ from the simulator ones the harness actually builds for.
+  const settingsResult = run(
+    `xcodebuild -showBuildSettings -json ${flags} -scheme ${quote(scheme)} ` +
+      `-destination 'generic/platform=iOS Simulator'`,
+    { cwd: resolved, timeout: options.settingsTimeoutMs ?? SETTINGS_TIMEOUT_MS },
+  );
+
+  if (settingsResult.code !== 0) {
+    warnings.push(
+      settingsResult.timedOut
+        ? `xcodebuild -showBuildSettings timed out — left HARNESS_BUNDLE_ID unset.`
+        : `xcodebuild -showBuildSettings failed — left HARNESS_BUNDLE_ID unset.`,
+    );
+    return base;
+  }
+
+  const settingsList = parseJsonLoose<XcodeBuildSettings[]>(settingsResult.stdout);
+  if (!Array.isArray(settingsList)) {
+    // Distinct from "the setting is missing": blaming project config for output we
+    // failed to parse sends the user hunting through Xcode for a correct setting.
+    warnings.push(
+      'Could not parse xcodebuild -showBuildSettings output — left HARNESS_BUNDLE_ID unset.',
+    );
+    return base;
+  }
+
+  const settings = settingsList[0]?.buildSettings;
+  const bundleId = settings?.PRODUCT_BUNDLE_IDENTIFIER;
+
+  if (!bundleId) {
+    warnings.push('PRODUCT_BUNDLE_IDENTIFIER is not set for this scheme — left HARNESS_BUNDLE_ID unset.');
+    return base;
+  }
+  base.bundleId = bundleId;
+
+  base.confidence = 'high';
+  return base;
+}
+
+/**
+ * The harness.env exports this introspection can fill in. Keys absent from the
+ * result are left at their template value rather than blanked.
+ */
+export function xcodeHarnessEnvValues(info: XcodeProjectInfo): Record<string, string> {
+  const values: Record<string, string> = {};
+  // Only one of the two is ever set: verify.sh prefers the workspace when both are.
+  if (info.workspace) values.HARNESS_XCODE_WORKSPACE = info.workspace;
+  else if (info.project) values.HARNESS_XCODE_PROJECT = info.project;
+  if (info.scheme) values.HARNESS_XCODE_SCHEME = info.scheme;
+  if (info.bundleId) values.HARNESS_BUNDLE_ID = info.bundleId;
+  return values;
+}

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -60,6 +60,20 @@ export const InitHarnessInputSchema = z.object({
   force: z.boolean().default(false),
   smoke: z.boolean().default(false),
   profile: z.enum(['default', 'cli', 'ios']).default('default'),
+  introspect: z.boolean().default(true),
+});
+
+/** iOS profile: what reading the Xcode project resolved, and what it did not. */
+export const XcodeIntrospectionOutputSchema = z.object({
+  workspace: z.string().optional(),
+  project: z.string().optional(),
+  generator: z.enum(['tuist', 'xcodegen', 'cocoapods']).nullable(),
+  scheme: z.string().optional(),
+  schemes: z.array(z.string()),
+  bundleId: z.string().optional(),
+  candidates: z.array(z.string()),
+  confidence: z.enum(['high', 'partial', 'none']),
+  warnings: z.array(z.string()),
 });
 
 export const LaunchEnvironmentInputSchema = z.object({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -53,6 +53,7 @@ import {
   RunVerificationInputSchema,
   RunVerificationOutputSchema,
   StageResultSchema,
+  XcodeIntrospectionOutputSchema,
 } from './schemas';
 
 export const HAR_MCP_TOOLS: Tool[] = [
@@ -63,12 +64,14 @@ export const HAR_MCP_TOOLS: Tool[] = [
   },
   {
     name: 'har_init_harness',
-    description: 'Scaffold .har/ boilerplate for a coding agent to adapt.',
+    description:
+      'Scaffold .har/ boilerplate for a coding agent to adapt. On the ios profile it also reads the Xcode project to fill in scheme, project/workspace and bundle id; read the returned warnings for anything left unresolved.',
     inputSchema: objectJsonSchema({
       repo: repoJsonProperty,
       force: { type: 'boolean' },
       smoke: { type: 'boolean' },
       profile: { type: 'string', enum: ['default', 'cli', 'ios'] },
+      introspect: { type: 'boolean' },
     }),
   },
   {
@@ -270,11 +273,18 @@ export async function handleMcpToolCall(
         force: input.force,
         smoke: input.smoke,
         profile: input.profile,
+        introspect: input.introspect,
       });
       return jsonContent({
         harnessDir: result.harnessDir,
         validation: result.validation,
         smoke: result.smoke,
+        // An agent initializing over MCP gets the same signal as a CLI user:
+        // without this, an unresolved scheme stays invisible until the first build.
+        warnings: result.warnings,
+        ...(result.introspection
+          ? { introspection: XcodeIntrospectionOutputSchema.parse(result.introspection) }
+          : {}),
       });
     }
 

--- a/src/templates/har-boilerplate-cli/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-cli/provision-toolchain.sh
@@ -229,9 +229,71 @@ provision_ruby() {
   append_path_prefix "$dir/vendor/bundle/bin"
 }
 
+# Echo the first path in <dir> matching <pattern>, or return 1. Bash 3.2 on stock
+# macOS has no nullglob, so an unmatched glob comes back as the pattern itself —
+# hence the -e test. Directory and pattern stay separate arguments so the directory
+# can be quoted: a single pre-joined string would word-split on a path with a space
+# before the glob ever ran.
+first_glob_match() {
+  local dir="$1"
+  local pattern="$2"
+  local match
+  for match in "$dir"/$pattern; do
+    [ -e "$match" ] && { printf '%s' "$match"; return 0; }
+  done
+  return 1
+}
+
+# Generated-project workflows (Tuist, XcodeGen) and CocoaPods leave nothing to build
+# in a fresh worktree: the .xcodeproj / .xcworkspace is a build product, not a tracked
+# file. Without this, xcodebuild fails with an opaque "scheme not found" and the cause
+# is invisible. Called only when no HARNESS_INSTALL_CMD is configured — see provision_ios.
+provision_ios_generate_project() {
+  local dir="$1"
+
+  if [ -f "$dir/Project.swift" ] && ! first_glob_match "$dir" '*.xcodeproj' >/dev/null; then
+    if ! command -v tuist >/dev/null 2>&1; then
+      echo "Error: $dir/Project.swift needs Tuist, but 'tuist' is not on PATH." >&2
+      echo "  Install Tuist, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Generating Xcode project with Tuist..."
+    (cd "$dir" && tuist generate --no-open)
+  elif [ -f "$dir/project.yml" ] && ! first_glob_match "$dir" '*.xcodeproj' >/dev/null; then
+    if ! command -v xcodegen >/dev/null 2>&1; then
+      echo "Error: $dir/project.yml needs XcodeGen, but 'xcodegen' is not on PATH." >&2
+      echo "  Install XcodeGen, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Generating Xcode project with XcodeGen..."
+    (cd "$dir" && xcodegen generate)
+  fi
+
+  # Pods come after generation: CocoaPods needs the .xcodeproj to build its workspace.
+  if [ -f "$dir/Podfile" ] && [ ! -d "$dir/Pods" ]; then
+    if ! command -v pod >/dev/null 2>&1; then
+      echo "Error: $dir/Podfile needs CocoaPods, but 'pod' is not on PATH." >&2
+      echo "  Install CocoaPods, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Installing CocoaPods dependencies..."
+    (cd "$dir" && pod install)
+  fi
+
+  return 0
+}
+
 provision_ios() {
   local dir="$1"
-  run_install_cmd "$dir" || true
+  # An explicit HARNESS_INSTALL_CMD owns provisioning outright. Dispatching on the
+  # variable rather than on run_install_cmd's exit status matters: that status is 1
+  # both when no command is configured and when a configured one failed, so a `||`
+  # would run the generators the user overrode — and hide the failure behind them.
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    run_install_cmd "$dir"
+  else
+    provision_ios_generate_project "$dir"
+  fi
   append_env "HARNESS_ECOSYSTEM" "ios"
   append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
   if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then

--- a/src/templates/har-boilerplate-ios/ADAPT-PROMPT.md
+++ b/src/templates/har-boilerplate-ios/ADAPT-PROMPT.md
@@ -11,15 +11,22 @@ structure, then make the changes listed below. Commit when done.
 - `.har/stages.json` (stage registry)
 - Root of the repo: look for `*.xcworkspace`, `*.xcodeproj`, `Podfile`, `Package.swift`
 
-## 2 — Set Xcode project config in `.har/harness.env`
+## 2 — Check the Xcode project config in `.har/harness.env`
+
+`har env init` already reads the project and fills most of this in. **Check what it
+wrote before changing anything** — and read the warnings init printed, which name
+exactly what it could not resolve.
 
 | Variable | What to set |
 |----------|-------------|
 | `HARNESS_XCODE_WORKSPACE` | Relative path to `.xcworkspace` (e.g. `MyApp.xcworkspace`). Use when CocoaPods or a workspace is present. Leave empty otherwise. |
 | `HARNESS_XCODE_PROJECT` | Relative path to `.xcodeproj` (e.g. `MyApp.xcodeproj`). Only set when no workspace. |
-| `HARNESS_XCODE_SCHEME` | Name of the shared Xcode scheme (must be marked Shared in Xcode → Product → Scheme → Manage Schemes). |
-| `HARNESS_SIMULATOR_NAME` | Display name exactly as shown in `xcrun simctl list devices` (e.g. `iPhone 16`). |
+| `HARNESS_XCODE_SCHEME` | Name of the shared Xcode scheme (must be marked Shared in Xcode → Product → Scheme → Manage Schemes). Left unset by init when several schemes matched — pick from the list it printed. |
+| `HARNESS_SIMULATOR_NAME` | Device model as listed by `xcrun simctl list devicetypes` (e.g. `iPhone 16`). Init does not set this: the right model depends on the runtimes installed on each machine. |
 | `HARNESS_BUNDLE_ID` | App bundle identifier from the Xcode target (e.g. `com.example.myapp`). |
+
+Still showing `MyApp` or `com.example.myapp`? Init could not resolve it — `har env maintain`
+reports those placeholders as warnings until they are set.
 
 Run `./.har/setup-infra.sh` after editing to confirm the simulator boots.
 

--- a/src/templates/har-boilerplate-ios/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-ios/provision-toolchain.sh
@@ -229,9 +229,71 @@ provision_ruby() {
   append_path_prefix "$dir/vendor/bundle/bin"
 }
 
+# Echo the first path in <dir> matching <pattern>, or return 1. Bash 3.2 on stock
+# macOS has no nullglob, so an unmatched glob comes back as the pattern itself —
+# hence the -e test. Directory and pattern stay separate arguments so the directory
+# can be quoted: a single pre-joined string would word-split on a path with a space
+# before the glob ever ran.
+first_glob_match() {
+  local dir="$1"
+  local pattern="$2"
+  local match
+  for match in "$dir"/$pattern; do
+    [ -e "$match" ] && { printf '%s' "$match"; return 0; }
+  done
+  return 1
+}
+
+# Generated-project workflows (Tuist, XcodeGen) and CocoaPods leave nothing to build
+# in a fresh worktree: the .xcodeproj / .xcworkspace is a build product, not a tracked
+# file. Without this, xcodebuild fails with an opaque "scheme not found" and the cause
+# is invisible. Called only when no HARNESS_INSTALL_CMD is configured — see provision_ios.
+provision_ios_generate_project() {
+  local dir="$1"
+
+  if [ -f "$dir/Project.swift" ] && ! first_glob_match "$dir" '*.xcodeproj' >/dev/null; then
+    if ! command -v tuist >/dev/null 2>&1; then
+      echo "Error: $dir/Project.swift needs Tuist, but 'tuist' is not on PATH." >&2
+      echo "  Install Tuist, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Generating Xcode project with Tuist..."
+    (cd "$dir" && tuist generate --no-open)
+  elif [ -f "$dir/project.yml" ] && ! first_glob_match "$dir" '*.xcodeproj' >/dev/null; then
+    if ! command -v xcodegen >/dev/null 2>&1; then
+      echo "Error: $dir/project.yml needs XcodeGen, but 'xcodegen' is not on PATH." >&2
+      echo "  Install XcodeGen, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Generating Xcode project with XcodeGen..."
+    (cd "$dir" && xcodegen generate)
+  fi
+
+  # Pods come after generation: CocoaPods needs the .xcodeproj to build its workspace.
+  if [ -f "$dir/Podfile" ] && [ ! -d "$dir/Pods" ]; then
+    if ! command -v pod >/dev/null 2>&1; then
+      echo "Error: $dir/Podfile needs CocoaPods, but 'pod' is not on PATH." >&2
+      echo "  Install CocoaPods, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Installing CocoaPods dependencies..."
+    (cd "$dir" && pod install)
+  fi
+
+  return 0
+}
+
 provision_ios() {
   local dir="$1"
-  run_install_cmd "$dir" || true
+  # An explicit HARNESS_INSTALL_CMD owns provisioning outright. Dispatching on the
+  # variable rather than on run_install_cmd's exit status matters: that status is 1
+  # both when no command is configured and when a configured one failed, so a `||`
+  # would run the generators the user overrode — and hide the failure behind them.
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    run_install_cmd "$dir"
+  else
+    provision_ios_generate_project "$dir"
+  fi
   append_env "HARNESS_ECOSYSTEM" "ios"
   append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
   if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -57,10 +57,15 @@ xc_target_flags() {
   elif [ -n "${HARNESS_XCODE_PROJECT:-}" ] && [ -e "$WORK_DIR/${HARNESS_XCODE_PROJECT}" ]; then
     echo "-project $WORK_DIR/${HARNESS_XCODE_PROJECT}"
   else
-    # Auto-detect: prefer workspace (CocoaPods), then project
+    # Auto-detect: prefer workspace (CocoaPods), then project.
+    # Every *.xcodeproj holds an inner project.xcworkspace at depth 2 — matching it
+    # would shadow the real project, so *.xcodeproj/* is excluded. Pods/ likewise
+    # ships Pods.xcodeproj, which is never the target.
     local ws prj
-    ws="$(find "$WORK_DIR" -maxdepth 2 -name "*.xcworkspace" ! -path "*/\.*" 2>/dev/null | head -1 || true)"
-    prj="$(find "$WORK_DIR" -maxdepth 2 -name "*.xcodeproj" ! -path "*/\.*" 2>/dev/null | head -1 || true)"
+    ws="$(find "$WORK_DIR" -maxdepth 2 -name "*.xcworkspace" \
+      ! -path "*/\.*" ! -path "*.xcodeproj/*" ! -path "*/Pods/*" 2>/dev/null | head -1 || true)"
+    prj="$(find "$WORK_DIR" -maxdepth 2 -name "*.xcodeproj" \
+      ! -path "*/\.*" ! -path "*/Pods/*" 2>/dev/null | head -1 || true)"
     if [ -n "$ws" ]; then echo "-workspace $ws"
     elif [ -n "$prj" ]; then echo "-project $prj"
     fi

--- a/src/templates/har-boilerplate/provision-toolchain.sh
+++ b/src/templates/har-boilerplate/provision-toolchain.sh
@@ -229,9 +229,71 @@ provision_ruby() {
   append_path_prefix "$dir/vendor/bundle/bin"
 }
 
+# Echo the first path in <dir> matching <pattern>, or return 1. Bash 3.2 on stock
+# macOS has no nullglob, so an unmatched glob comes back as the pattern itself —
+# hence the -e test. Directory and pattern stay separate arguments so the directory
+# can be quoted: a single pre-joined string would word-split on a path with a space
+# before the glob ever ran.
+first_glob_match() {
+  local dir="$1"
+  local pattern="$2"
+  local match
+  for match in "$dir"/$pattern; do
+    [ -e "$match" ] && { printf '%s' "$match"; return 0; }
+  done
+  return 1
+}
+
+# Generated-project workflows (Tuist, XcodeGen) and CocoaPods leave nothing to build
+# in a fresh worktree: the .xcodeproj / .xcworkspace is a build product, not a tracked
+# file. Without this, xcodebuild fails with an opaque "scheme not found" and the cause
+# is invisible. Called only when no HARNESS_INSTALL_CMD is configured — see provision_ios.
+provision_ios_generate_project() {
+  local dir="$1"
+
+  if [ -f "$dir/Project.swift" ] && ! first_glob_match "$dir" '*.xcodeproj' >/dev/null; then
+    if ! command -v tuist >/dev/null 2>&1; then
+      echo "Error: $dir/Project.swift needs Tuist, but 'tuist' is not on PATH." >&2
+      echo "  Install Tuist, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Generating Xcode project with Tuist..."
+    (cd "$dir" && tuist generate --no-open)
+  elif [ -f "$dir/project.yml" ] && ! first_glob_match "$dir" '*.xcodeproj' >/dev/null; then
+    if ! command -v xcodegen >/dev/null 2>&1; then
+      echo "Error: $dir/project.yml needs XcodeGen, but 'xcodegen' is not on PATH." >&2
+      echo "  Install XcodeGen, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Generating Xcode project with XcodeGen..."
+    (cd "$dir" && xcodegen generate)
+  fi
+
+  # Pods come after generation: CocoaPods needs the .xcodeproj to build its workspace.
+  if [ -f "$dir/Podfile" ] && [ ! -d "$dir/Pods" ]; then
+    if ! command -v pod >/dev/null 2>&1; then
+      echo "Error: $dir/Podfile needs CocoaPods, but 'pod' is not on PATH." >&2
+      echo "  Install CocoaPods, or set HARNESS_INSTALL_CMD in .har/harness.env." >&2
+      return 1
+    fi
+    pt_log "Installing CocoaPods dependencies..."
+    (cd "$dir" && pod install)
+  fi
+
+  return 0
+}
+
 provision_ios() {
   local dir="$1"
-  run_install_cmd "$dir" || true
+  # An explicit HARNESS_INSTALL_CMD owns provisioning outright. Dispatching on the
+  # variable rather than on run_install_cmd's exit status matters: that status is 1
+  # both when no command is configured and when a configured one failed, so a `||`
+  # would run the generators the user overrode — and hide the failure behind them.
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    run_install_cmd "$dir"
+  else
+    provision_ios_generate_project "$dir"
+  fi
   append_env "HARNESS_ECOSYSTEM" "ios"
   append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
   if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -4,27 +4,51 @@ export interface ShellResult {
   stdout: string;
   stderr: string;
   code: number;
+  /** True when `timeout` elapsed and the command was killed rather than exiting. */
+  timedOut?: boolean;
 }
 
 export interface RunScriptOptions extends SpawnOptions {
   stream?: boolean;
 }
 
-export function run(command: string, options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): ShellResult {
+export interface RunOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Milliseconds before the command is killed. Callers that shell out to tools which
+   * can stall indefinitely (xcodebuild resolving packages, say) need this — a timed-out
+   * run reports `timedOut: true` so it can be told apart from a genuine failure.
+   * Only the direct child is killed; grandchildren it spawned may outlive it.
+   */
+  timeout?: number;
+}
+
+export function run(command: string, options: RunOptions = {}): ShellResult {
   try {
     const stdout = execSync(command, {
       cwd: options.cwd,
       env: { ...process.env, ...options.env },
       encoding: 'utf8',
       stdio: ['inherit', 'pipe', 'pipe'],
+      timeout: options.timeout,
     });
     return { stdout: stdout || '', stderr: '', code: 0 };
   } catch (err: unknown) {
-    const e = err as { stdout?: string; stderr?: string; status?: number };
+    const e = err as {
+      stdout?: string;
+      stderr?: string;
+      status?: number | null;
+      signal?: string | null;
+    };
+    // execSync surfaces a timeout as a signal kill with a null status, which would
+    // otherwise be indistinguishable from any other non-zero exit.
+    const timedOut = options.timeout !== undefined && e.status == null && e.signal != null;
     return {
       stdout: e.stdout || '',
       stderr: e.stderr || '',
       code: e.status ?? 1,
+      ...(timedOut ? { timedOut: true } : {}),
     };
   }
 }

--- a/tests/harness-init-ios.test.ts
+++ b/tests/harness-init-ios.test.ts
@@ -1,0 +1,126 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { initHarness } from '../src/core/harness';
+import { compareHarnessToTemplate } from '../src/harness/drift';
+import { readHarnessEnv } from '../src/harness/env';
+import { computeFileChecksum, readManifest } from '../src/harness/manifest';
+import { stubXcodebuild } from './helpers/stub-bin';
+
+function makeIosRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-init-ios-'));
+  fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj', 'project.xcworkspace'), { recursive: true });
+  return dir;
+}
+
+async function initIos(
+  dir: string,
+  options: { introspect?: boolean } = {},
+): Promise<Awaited<ReturnType<typeof initHarness>>> {
+  const original = process.env.PATH;
+  process.env.PATH = `${stubXcodebuild(dir)}:${original ?? '/usr/bin:/bin'}`;
+  try {
+    return await initHarness({ repoPath: dir, profile: 'ios', ...options });
+  } finally {
+    process.env.PATH = original;
+  }
+}
+
+describe('har env init --profile ios', () => {
+  it('writes the introspected project into harness.env', async () => {
+    const dir = makeIosRepo();
+
+    await initIos(dir);
+
+    const env = readHarnessEnv(dir);
+    expect(env.HARNESS_XCODE_SCHEME).toBe('MyApp');
+    expect(env.HARNESS_BUNDLE_ID).toBe('com.acme.myapp');
+    expect(env.HARNESS_XCODE_PROJECT).toBe('MyApp.xcodeproj');
+  });
+
+  it('records what it generated in the manifest', async () => {
+    const dir = makeIosRepo();
+
+    await initIos(dir);
+
+    expect(readManifest(dir)?.initEnvOverrides).toEqual({
+      HARNESS_XCODE_PROJECT: 'MyApp.xcodeproj',
+      HARNESS_XCODE_SCHEME: 'MyApp',
+      HARNESS_BUNDLE_ID: 'com.acme.myapp',
+    });
+  });
+
+  // The regression this whole feature hinges on. Without the drift replay, `maintain`
+  // hands a coding agent a diff that restores the MyApp / com.example.myapp
+  // placeholders — the generated config would silently undo itself.
+  it('does not report its own generated harness.env as drift', async () => {
+    const dir = makeIosRepo();
+
+    await initIos(dir);
+    const drift = compareHarnessToTemplate(dir);
+
+    expect(drift.checksumMismatch).not.toContain('harness.env');
+    expect(drift.unchanged).toContain('harness.env');
+  });
+
+  it('still reports a genuine local edit as drift', async () => {
+    const dir = makeIosRepo();
+    await initIos(dir);
+
+    const envPath = path.join(dir, '.har', 'harness.env');
+    fs.writeFileSync(
+      envPath,
+      fs.readFileSync(envPath, 'utf8').replace('HARNESS_SIMULATOR_FAMILY="auto"', 'HARNESS_SIMULATOR_FAMILY="iPad"'),
+    );
+
+    expect(compareHarnessToTemplate(dir).checksumMismatch).toContain('harness.env');
+  });
+
+  it('surfaces unresolved config as warnings rather than failing', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-init-ios-gen-'));
+    fs.writeFileSync(path.join(dir, 'Project.swift'), 'let project = Project()\n');
+
+    const result = await initIos(dir);
+
+    expect(result.validation.pass).toBe(true);
+    expect(result.warnings.join(' ')).toContain('tuist');
+    expect(result.introspection?.confidence).toBe('partial');
+  });
+
+  it('flags the placeholders left behind when introspection is skipped', async () => {
+    const dir = makeIosRepo();
+
+    const result = await initIos(dir, { introspect: false });
+
+    expect(readManifest(dir)?.initEnvOverrides).toBeUndefined();
+    expect(compareHarnessToTemplate(dir).checksumMismatch).not.toContain('harness.env');
+    const messages = result.validation.issues.map((issue) => issue.message).join(' ');
+    expect(messages).toContain('HARNESS_XCODE_SCHEME');
+  });
+
+  it('seals manifest checksums against the harness.env actually on disk', async () => {
+    // syncAgentSlotsToHarnessEnv runs again after createManifest has sealed the
+    // checksums. It is a no-op today only because template and stages.json agree —
+    // this locks that in, so a future template divergence fails here rather than
+    // surfacing as phantom drift.
+    const dir = makeIosRepo();
+
+    await initIos(dir);
+
+    const manifest = readManifest(dir);
+    const onDisk = fs.readFileSync(path.join(dir, '.har', 'harness.env'), 'utf8');
+    expect(manifest?.fileChecksums?.['harness.env']).toBe(computeFileChecksum(onDisk));
+  });
+
+  it('leaves the other profiles untouched', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-init-cli-'));
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"fixture"}');
+
+    const result = await initHarness({ repoPath: dir, profile: 'cli' });
+
+    expect(readManifest(dir)?.initEnvOverrides).toBeUndefined();
+    expect(result.warnings).toEqual([]);
+    expect(result.introspection).toBeUndefined();
+    expect(compareHarnessToTemplate(dir).checksumMismatch).not.toContain('harness.env');
+  });
+});

--- a/tests/helpers/stub-bin.ts
+++ b/tests/helpers/stub-bin.ts
@@ -1,0 +1,88 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Executable stubs on PATH — how these tests exercise macOS-only tooling on a
+ * Linux CI runner. One place on purpose: the stubbed xcodebuild contract is shared
+ * by several suites, and a copy that drifts passes silently.
+ */
+
+/** Write an executable script into `<dir>/stub-bin` and return that directory. */
+export function writeStubBin(dir: string, name: string, script: string): string {
+  const binDir = path.join(dir, 'stub-bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const binPath = path.join(binDir, name);
+  fs.writeFileSync(binPath, script.startsWith('#!') ? script : `#!/usr/bin/env bash\n${script}`);
+  fs.chmodSync(binPath, 0o755);
+  return binDir;
+}
+
+/** A stub that records the arguments it was called with into `markerPath`. */
+export function writeRecordingStub(dir: string, name: string, markerPath: string): string {
+  return writeStubBin(dir, name, `echo "$@" > ${JSON.stringify(markerPath)}\n`);
+}
+
+export interface XcodebuildStubOptions {
+  /** Payload for `xcodebuild -list -json`. */
+  list?: unknown;
+  /** Payload for `xcodebuild -showBuildSettings -json`. */
+  settings?: unknown;
+  /** Non-zero to make `-list` fail. */
+  listExit?: number;
+  /** Stall before answering, to exercise timeout handling. */
+  sleepSeconds?: number;
+}
+
+const DEFAULT_LIST = { project: { name: 'MyApp', schemes: ['MyApp'] } };
+const DEFAULT_SETTINGS = [
+  {
+    buildSettings: {
+      PRODUCT_BUNDLE_IDENTIFIER: 'com.acme.myapp',
+      IPHONEOS_DEPLOYMENT_TARGET: '18.0',
+    },
+  },
+];
+
+/** Install a fake `xcodebuild` and return the directory to prepend to PATH. */
+export function stubXcodebuild(dir: string, options: XcodebuildStubOptions = {}): string {
+  const listJson = JSON.stringify(options.list ?? DEFAULT_LIST);
+  const settingsJson = JSON.stringify(options.settings ?? DEFAULT_SETTINGS);
+  const listExit = options.listExit ?? 0;
+  const sleep = options.sleepSeconds ? `sleep ${options.sleepSeconds}` : ':';
+
+  return writeStubBin(
+    dir,
+    'xcodebuild',
+    [
+      sleep,
+      'for arg in "$@"; do',
+      '  if [ "$arg" = "-list" ]; then',
+      `    [ ${listExit} -ne 0 ] && { echo "xcodebuild: error" >&2; exit ${listExit}; }`,
+      `    cat <<'JSON'`,
+      listJson,
+      'JSON',
+      '    exit 0',
+      '  fi',
+      '  if [ "$arg" = "-showBuildSettings" ]; then',
+      `    cat <<'JSON'`,
+      settingsJson,
+      'JSON',
+      '    exit 0',
+      '  fi',
+      'done',
+      'exit 1',
+      '',
+    ].join('\n'),
+  );
+}
+
+/** Run `fn` with PATH temporarily replaced, restoring it even on failure. */
+export function withPath<T>(pathValue: string, fn: () => T): T {
+  const original = process.env.PATH;
+  process.env.PATH = pathValue;
+  try {
+    return fn();
+  } finally {
+    process.env.PATH = original;
+  }
+}

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -104,6 +104,234 @@ describe('provision-toolchain.sh template contract', () => {
     expect(envContent).toContain('HARNESS_TOOLCHAIN_PROVISIONED=true');
   });
 
+  it('ships the same provision-toolchain.sh in every profile', () => {
+    const contents = PROFILES.map((profile) =>
+      fs.readFileSync(path.join(resolveTemplatesDir(), profile, 'provision-toolchain.sh'), 'utf8'),
+    );
+    // The three copies are edited together on purpose — a divergence here means one
+    // profile silently lost a toolchain fix.
+    expect(contents[1]).toBe(contents[0]);
+    expect(contents[2]).toBe(contents[0]);
+  });
+
+  describe('iOS generated-project provisioning', () => {
+    const IOS_SCRIPT = path.join(
+      resolveTemplatesDir(),
+      'har-boilerplate-ios',
+      'provision-toolchain.sh',
+    );
+    // Stock PATH only: a real pod/tuist installed on the developer's machine must not
+    // decide the outcome of the "tool is missing" cases.
+    const BARE_PATH = '/usr/bin:/bin';
+
+    function makeWorkDir(prefix: string): { dir: string; envFile: string } {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+      const envFile = path.join(dir, '.env.agent.1');
+      fs.writeFileSync(envFile, `AGENT_ID=1\nREPO_ROOT=${dir}\n`);
+      return { dir, envFile };
+    }
+
+    function fakeBin(dir: string, name: string, marker: string): string {
+      const binDir = path.join(dir, 'fakebin');
+      fs.mkdirSync(binDir, { recursive: true });
+      const bin = path.join(binDir, name);
+      fs.writeFileSync(bin, `#!/usr/bin/env bash\necho "$@" > "${marker}"\n`);
+      fs.chmodSync(bin, 0o755);
+      return binDir;
+    }
+
+    function provision(dir: string, envFile: string, pathValue: string, extraEnv = '') {
+      return run(
+        `PATH="${pathValue}" HARNESS_ECOSYSTEM=ios ${extraEnv} ` +
+          `HAR_WORK_DIR="${dir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
+          `bash "${IOS_SCRIPT}"`,
+      );
+    }
+
+    it('fails with a named cause when a Podfile has no CocoaPods available', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-pods-missing-');
+      fs.writeFileSync(path.join(dir, 'Podfile'), "platform :ios, '17.0'\n");
+
+      const result = provision(dir, envFile, BARE_PATH);
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('CocoaPods');
+      expect(result.stderr).toContain('HARNESS_INSTALL_CMD');
+    });
+
+    it('runs pod install when a Podfile has no Pods directory', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-pods-run-');
+      fs.writeFileSync(path.join(dir, 'Podfile'), "platform :ios, '17.0'\n");
+      const marker = path.join(dir, 'pod-ran');
+      const binDir = fakeBin(dir, 'pod', marker);
+
+      const result = provision(dir, envFile, `${binDir}:${BARE_PATH}`);
+
+      expect(result.code).toBe(0);
+      expect(fs.existsSync(marker)).toBe(true);
+      expect(fs.readFileSync(marker, 'utf8').trim()).toBe('install');
+    });
+
+    it('skips pod install when Pods are already checked out', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-pods-present-');
+      fs.writeFileSync(path.join(dir, 'Podfile'), "platform :ios, '17.0'\n");
+      fs.mkdirSync(path.join(dir, 'Pods'));
+      const marker = path.join(dir, 'pod-ran');
+      const binDir = fakeBin(dir, 'pod', marker);
+
+      const result = provision(dir, envFile, `${binDir}:${BARE_PATH}`);
+
+      expect(result.code).toBe(0);
+      expect(fs.existsSync(marker)).toBe(false);
+    });
+
+    it('generates the project with Tuist when only Project.swift is tracked', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-tuist-');
+      fs.writeFileSync(path.join(dir, 'Project.swift'), 'let project = Project()\n');
+      const marker = path.join(dir, 'tuist-ran');
+      const binDir = fakeBin(dir, 'tuist', marker);
+
+      const result = provision(dir, envFile, `${binDir}:${BARE_PATH}`);
+
+      expect(result.code).toBe(0);
+      expect(fs.readFileSync(marker, 'utf8').trim()).toBe('generate --no-open');
+    });
+
+    it('fails with a named cause when project.yml has no XcodeGen available', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-xcodegen-missing-');
+      fs.writeFileSync(path.join(dir, 'project.yml'), 'name: MyApp\n');
+
+      const result = provision(dir, envFile, BARE_PATH);
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('XcodeGen');
+    });
+
+    it('leaves generation alone when HARNESS_INSTALL_CMD owns provisioning', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-installcmd-');
+      fs.writeFileSync(path.join(dir, 'Podfile'), "platform :ios, '17.0'\n");
+      const marker = path.join(dir, 'pod-ran');
+      const binDir = fakeBin(dir, 'pod', marker);
+
+      const result = provision(
+        dir,
+        envFile,
+        `${binDir}:${BARE_PATH}`,
+        `HARNESS_INSTALL_CMD="true"`,
+      );
+
+      expect(result.code).toBe(0);
+      expect(fs.existsSync(marker)).toBe(false);
+    });
+
+    it('fails loudly instead of falling back when HARNESS_INSTALL_CMD fails', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-installcmd-fail-');
+      fs.writeFileSync(path.join(dir, 'Podfile'), "platform :ios, '17.0'\n");
+      const marker = path.join(dir, 'pod-ran');
+      const binDir = fakeBin(dir, 'pod', marker);
+
+      const result = provision(
+        dir,
+        envFile,
+        `${binDir}:${BARE_PATH}`,
+        `HARNESS_INSTALL_CMD="false"`,
+      );
+
+      // run_install_cmd returns 1 both for "not configured" and "configured but
+      // failed"; dispatching on that status would silently run the generators the
+      // user overrode and hide the failure behind them.
+      expect(result.code).not.toBe(0);
+      expect(fs.existsSync(marker)).toBe(false);
+    });
+
+    it('finds an existing project under a path containing a space', () => {
+      const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-space-'));
+      const dir = path.join(parent, 'My Proj');
+      fs.mkdirSync(path.join(dir, 'App.xcodeproj'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'Project.swift'), 'let project = Project()\n');
+      const envFile = path.join(dir, '.env.agent.1');
+      fs.writeFileSync(envFile, `AGENT_ID=1\nREPO_ROOT=${dir}\n`);
+      const marker = path.join(dir, 'tuist-ran');
+      const binDir = fakeBin(dir, 'tuist', marker);
+
+      const result = provision(dir, envFile, `${binDir}:${BARE_PATH}`);
+
+      // The glob must survive the space: regenerating over an existing project
+      // would overwrite local project state on every launch.
+      expect(result.code).toBe(0);
+      expect(fs.existsSync(marker)).toBe(false);
+    });
+
+    it('skips generation when the project is already present', () => {
+      const { dir, envFile } = makeWorkDir('har-pt-generated-');
+      fs.writeFileSync(path.join(dir, 'Project.swift'), 'let project = Project()\n');
+      fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj'), { recursive: true });
+      const marker = path.join(dir, 'tuist-ran');
+      const binDir = fakeBin(dir, 'tuist', marker);
+
+      const result = provision(dir, envFile, `${binDir}:${BARE_PATH}`);
+
+      expect(result.code).toBe(0);
+      expect(fs.existsSync(marker)).toBe(false);
+    });
+  });
+
+  describe('iOS verify.sh target resolution', () => {
+    /** Lift one bash function out of a script so it can be exercised on its own. */
+    function extractShellFunction(scriptPath: string, name: string): string {
+      const content = fs.readFileSync(scriptPath, 'utf8');
+      const start = content.indexOf(`${name}() {`);
+      if (start < 0) throw new Error(`function ${name} not found in ${scriptPath}`);
+      let depth = 0;
+      let i = content.indexOf('{', start);
+      for (; i < content.length; i++) {
+        if (content[i] === '{') depth++;
+        else if (content[i] === '}') {
+          depth--;
+          if (depth === 0) {
+            i++;
+            break;
+          }
+        }
+      }
+      return content.slice(start, i);
+    }
+
+    function resolveTargets(workDir: string): string {
+      const verifyPath = path.join(resolveTemplatesDir(), 'har-boilerplate-ios', 'verify.sh');
+      const fn = extractShellFunction(verifyPath, 'xc_target_flags');
+      const script = path.join(workDir, 'probe.sh');
+      fs.writeFileSync(script, `set -uo pipefail\nWORK_DIR="${workDir}"\n${fn}\nxc_target_flags\n`);
+      const result = run(`bash "${script}"`);
+      expect(result.code).toBe(0);
+      return result.stdout.trim();
+    }
+
+    it('ignores the project.xcworkspace nested inside every .xcodeproj', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xc-inner-'));
+      // Xcode puts this inside every project bundle; picking it shadows the real target.
+      fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj', 'project.xcworkspace'), { recursive: true });
+
+      expect(resolveTargets(dir)).toBe(`-project ${dir}/MyApp.xcodeproj`);
+    });
+
+    it('still prefers a real workspace sitting next to the project', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xc-real-'));
+      fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj', 'project.xcworkspace'), { recursive: true });
+      fs.mkdirSync(path.join(dir, 'MyApp.xcworkspace'), { recursive: true });
+
+      expect(resolveTargets(dir)).toBe(`-workspace ${dir}/MyApp.xcworkspace`);
+    });
+
+    it('ignores Pods.xcodeproj generated by CocoaPods', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xc-pods-'));
+      fs.mkdirSync(path.join(dir, 'Pods', 'Pods.xcodeproj'), { recursive: true });
+      fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj'), { recursive: true });
+
+      expect(resolveTargets(dir)).toBe(`-project ${dir}/MyApp.xcodeproj`);
+    });
+  });
+
   it('verify.sh dispatches stock smoke by ecosystem', () => {
     for (const profile of ['har-boilerplate', 'har-boilerplate-cli'] as const) {
       const verifyPath = path.join(resolveTemplatesDir(), profile, 'verify.sh');

--- a/tests/xcode-introspect.test.ts
+++ b/tests/xcode-introspect.test.ts
@@ -1,0 +1,253 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  detectXcodeProject,
+  GENERATOR_MANIFESTS,
+  introspectXcodeProject,
+  suggestsIosProfile,
+  xcodeHarnessEnvValues,
+} from '../src/harness/xcode-introspect';
+import { resolveTemplatesDir } from '../src/utils/paths';
+import { stubXcodebuild, withPath } from './helpers/stub-bin';
+
+function makeProjectDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  // Xcode always nests a project.xcworkspace inside the project bundle.
+  fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj', 'project.xcworkspace'), { recursive: true });
+  return dir;
+}
+
+describe('detectXcodeProject', () => {
+  it('finds the project and ignores the workspace nested inside it', () => {
+    const dir = makeProjectDir('har-xci-detect-');
+
+    const location = detectXcodeProject(dir);
+
+    expect(location).not.toBeNull();
+    expect(location?.project).toBe('MyApp.xcodeproj');
+    expect(location?.workspace).toBeUndefined();
+  });
+
+  it('prefers a real workspace sitting beside the project', () => {
+    const dir = makeProjectDir('har-xci-ws-');
+    fs.mkdirSync(path.join(dir, 'MyApp.xcworkspace'));
+
+    expect(detectXcodeProject(dir)?.workspace).toBe('MyApp.xcworkspace');
+  });
+
+  it('skips Pods, which ships its own project', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-pods-'));
+    fs.mkdirSync(path.join(dir, 'Pods', 'Pods.xcodeproj'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj'), { recursive: true });
+
+    expect(detectXcodeProject(dir)?.project).toBe('MyApp.xcodeproj');
+  });
+
+  it('reports the generator when the project is a build product', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-tuist-'));
+    fs.writeFileSync(path.join(dir, 'Project.swift'), 'let project = Project()\n');
+
+    const location = detectXcodeProject(dir);
+
+    expect(location?.generator).toBe('tuist');
+    expect(location?.project).toBeUndefined();
+  });
+
+  it('returns null on a repository with nothing Xcode about it', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-none-'));
+    fs.writeFileSync(path.join(dir, 'main.go'), 'package main\n');
+
+    expect(detectXcodeProject(dir)).toBeNull();
+  });
+
+  it('reports every candidate, sorted, when more than one project exists', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-many-'));
+    fs.mkdirSync(path.join(dir, 'Zeta.xcodeproj'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'Alpha.xcodeproj'), { recursive: true });
+
+    const location = detectXcodeProject(dir);
+
+    // Sorted, not readdir order, so the arbitrary pick is at least reproducible.
+    expect(location?.candidates).toEqual(['Alpha.xcodeproj', 'Zeta.xcodeproj']);
+    expect(location?.project).toBe('Alpha.xcodeproj');
+  });
+});
+
+describe('generator manifest contract', () => {
+  it('matches the order provision-toolchain.sh checks', () => {
+    const script = fs.readFileSync(
+      path.join(resolveTemplatesDir(), 'har-boilerplate-ios', 'provision-toolchain.sh'),
+      'utf8',
+    );
+    // The bash side re-implements this precedence; binding them here means a
+    // divergence fails a test rather than silently disagreeing at launch.
+    const positions = GENERATOR_MANIFESTS.map((entry) => {
+      const at = script.indexOf(`$dir/${entry.manifest}`);
+      expect(at).toBeGreaterThan(-1);
+      return at;
+    });
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+});
+
+describe('introspectXcodeProject', () => {
+  it('resolves scheme and bundle id from a single-scheme project', () => {
+    const dir = makeProjectDir('har-xci-single-');
+    const binDir = stubXcodebuild(dir);
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    expect(info.confidence).toBe('high');
+    expect(info.scheme).toBe('MyApp');
+    expect(info.bundleId).toBe('com.acme.myapp');
+    expect(info.warnings).toEqual([]);
+    expect(xcodeHarnessEnvValues(info)).toEqual({
+      HARNESS_XCODE_PROJECT: 'MyApp.xcodeproj',
+      HARNESS_XCODE_SCHEME: 'MyApp',
+      HARNESS_BUNDLE_ID: 'com.acme.myapp',
+    });
+  });
+
+  it('leaves the scheme unset and lists candidates when the choice is ambiguous', () => {
+    const dir = makeProjectDir('har-xci-ambiguous-');
+    const binDir = stubXcodebuild(dir, {
+      list: { project: { name: 'MyApp', schemes: ['Alpha', 'Beta', 'Gamma'] } },
+    });
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    // Guessing wrong costs more than leaving it blank.
+    expect(info.scheme).toBeUndefined();
+    expect(info.confidence).toBe('partial');
+    expect(info.warnings.join(' ')).toContain('Alpha, Beta, Gamma');
+    expect(xcodeHarnessEnvValues(info)).not.toHaveProperty('HARNESS_XCODE_SCHEME');
+  });
+
+  it('resolves the ambiguity when one scheme carries the project name', () => {
+    const dir = makeProjectDir('har-xci-named-');
+    const binDir = stubXcodebuild(dir, {
+      list: { project: { name: 'MyApp', schemes: ['MyAppTests', 'MyApp', 'MyAppUITests'] } },
+    });
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    expect(info.scheme).toBe('MyApp');
+    expect(info.confidence).toBe('high');
+  });
+
+  it('degrades to a partial result when xcodebuild is unavailable', () => {
+    const dir = makeProjectDir('har-xci-noxcode-');
+
+    // An empty PATH stands in for a machine without Xcode — Linux CI, for instance.
+    const info = withPath('/nonexistent', () => introspectXcodeProject(dir));
+
+    expect(info.confidence).toBe('partial');
+    expect(info.project).toBe('MyApp.xcodeproj');
+    expect(info.warnings.join(' ')).toContain('xcodebuild is not available');
+  });
+
+  it('explains itself when the project has yet to be generated', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-gen-'));
+    fs.writeFileSync(path.join(dir, 'Project.swift'), 'let project = Project()\n');
+    const binDir = stubXcodebuild(dir);
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    expect(info.confidence).toBe('partial');
+    expect(info.warnings.join(' ')).toContain('tuist');
+  });
+
+  it('tells a timeout apart from a failure', () => {
+    const dir = makeProjectDir('har-xci-timeout-');
+    const binDir = stubXcodebuild(dir, { sleepSeconds: 5 });
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () =>
+      introspectXcodeProject(dir, { listTimeoutMs: 300 }),
+    );
+
+    expect(info.warnings.join(' ')).toContain('timed out');
+  });
+
+  it('keeps going when xcodebuild -list fails outright', () => {
+    const dir = makeProjectDir('har-xci-listfail-');
+    const binDir = stubXcodebuild(dir, { listExit: 65 });
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    expect(info.confidence).toBe('partial');
+    expect(info.warnings.join(' ')).toContain('xcodebuild -list failed');
+  });
+
+  it('warns when nothing Xcode-shaped is here at all', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-empty-'));
+    fs.writeFileSync(path.join(dir, 'main.go'), 'package main\n');
+
+    const info = withPath('/nonexistent', () => introspectXcodeProject(dir));
+
+    // The case that most needs a message must not be the silent one.
+    expect(info.confidence).toBe('none');
+    expect(info.warnings.length).toBeGreaterThan(0);
+    expect(info.warnings.join(' ')).toContain('--profile');
+  });
+
+  it('names the alternatives when several projects could have been picked', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-multi-'));
+    fs.mkdirSync(path.join(dir, 'Alpha.xcodeproj'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'Beta.xcodeproj'), { recursive: true });
+    const binDir = stubXcodebuild(dir);
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    expect(info.warnings.join(' ')).toContain('Beta.xcodeproj');
+  });
+
+  it('blames the parser, not the project, for unreadable build settings', () => {
+    const dir = makeProjectDir('har-xci-badjson-');
+    const binDir = stubXcodebuild(dir, { settings: 'not json at all' });
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    expect(info.warnings.join(' ')).toContain('Could not parse');
+    expect(info.warnings.join(' ')).not.toContain('PRODUCT_BUNDLE_IDENTIFIER is not set');
+  });
+
+  it('reports an unshared scheme as the actionable problem it is', () => {
+    const dir = makeProjectDir('har-xci-noscheme-');
+    const binDir = stubXcodebuild(dir, { list: { project: { name: 'MyApp', schemes: [] } } });
+
+    const info = withPath(`${binDir}:/usr/bin:/bin`, () => introspectXcodeProject(dir));
+
+    expect(info.warnings.join(' ')).toContain('shared');
+  });
+});
+
+describe('suggestsIosProfile', () => {
+  it('suggests iOS for a project at the repository root', () => {
+    const dir = makeProjectDir('har-xci-suggest-');
+
+    expect(suggestsIosProfile(dir)).toBe(true);
+  });
+
+  it('stays quiet when another ecosystem owns the root', () => {
+    const dir = makeProjectDir('har-xci-rn-');
+    // React Native and friends: JS at the root, Xcode below it.
+    fs.writeFileSync(path.join(dir, 'package.json'), '{"name":"app"}');
+
+    expect(suggestsIosProfile(dir)).toBe(false);
+  });
+
+  it('stays quiet when the project sits in a subdirectory', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-sub-'));
+    fs.mkdirSync(path.join(dir, 'ios', 'MyApp.xcodeproj'), { recursive: true });
+
+    expect(suggestsIosProfile(dir)).toBe(false);
+  });
+
+  it('suggests iOS for a Tuist repository with no generated project yet', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-xci-suggest-tuist-'));
+    fs.writeFileSync(path.join(dir, 'Project.swift'), 'let project = Project()\n');
+
+    expect(suggestsIosProfile(dir)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

`har env init --profile ios` shipped a scaffold whose scheme and bundle id were placeholders (`MyApp`, `com.example.myapp`), so the generated harness could not build anything until someone adapted it by hand. Init now reads the Xcode project and fills in the mechanical part.

- locates the `.xcworkspace` / `.xcodeproj`, asks `xcodebuild` for shared schemes and `PRODUCT_BUNDLE_IDENTIFIER`, writes them into `harness.env`
- **never guesses** — an ambiguous scheme, or several candidate projects, stay unset and are reported as warnings
- **never fails init** — no Xcode, a project not yet generated, or a stalled `xcodebuild` each degrade to a partial result with an explanation
- warnings surface through both the CLI and `har_init_harness` (MCP)
- `har env onboard` pre-selects `ios` when the repo root looks like an iOS app; `--profile` is unchanged, so scripted invocations behave exactly as before

Two related fixes came with it:

- **generated projects** — with Tuist, XcodeGen or CocoaPods the `.xcodeproj` is a build product, so a fresh worktree had nothing to build. Launch now runs the right generator, and fails naming the missing tool instead of letting `xcodebuild` report a scheme it cannot find.
- **target auto-detection** — every `.xcodeproj` nests a `project.xcworkspace`, which `verify.sh`'s `find` was matching in preference to the real project.

## Why the manifest changed

Values written by init are recorded as `initEnvOverrides` and replayed by the drift comparison. Without that, `har env maintain` hands a coding agent a diff whose direction restores the placeholders — the feature would silently undo itself on the first maintain. A test locks this in, and the replay is demonstrably load-bearing (removing the manifest entry makes `harness.env` drift again).

## Conflicts with #179

This branch changes `tests/provision-toolchain.test.ts` substantially, and so does #179. Whichever lands second will need a rebase. This PR deliberately leaves `.har/provision-toolchain.sh` alone so the `%q` quoting fix stays owned by #179; once that merges, the dogfood harness will need regenerating to pick up the new iOS provisioning helpers added to the templates here.

## Verification

`har env verify --full` on the CLI harness: typecheck, build, docs-check, docs-build, lint, readiness and docs-drift all pass.

`unit-tests` fails on **6 pre-existing failures** — `canonicalizeControlRepoPath` (4), `slot registry` (1) and `hooks` (1). The identical 6 fail on an untouched `main` at the same commit on this machine; they concern git worktree path resolution and `core.hooksPath`. Suite went from 485 to 528 tests, 479 to 522 passing, no regression.

## Review notes

Two behaviour changes worth a second opinion:

1. a failing `HARNESS_INSTALL_CMD` now **fails the launch** on the iOS profile instead of being tolerated. Dispatching on `run_install_cmd`'s exit status was ambiguous — it returns 1 both for "not configured" and "configured but failed" — which silently ran the generators the user had overridden.
2. `readHarnessEnv` now unescapes double-quoted values, so TypeScript readers see what the shell sees. It is a shared function; values without special characters read identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
