### PR TITLE
fix(control): keep the portal repo id until a wipe resend lands

### DIFF
--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -639,7 +639,9 @@ async function syncRepoWithPortal(
   const { selected: newRuns } = selectSince(runs, runsSince, runTimestamp);
 
   let repoId: string | undefined;
-  await syncRunBatches(newRuns, repoPath, runsTarget, () => repoId, dryRun, async (batch, i) => {
+  // Stamping a changed id here would hide the wipe if the resend below fails.
+  const deltaRepoId = () => stored?.repoId ?? repoId;
+  await syncRunBatches(newRuns, repoPath, runsTarget, deltaRepoId, dryRun, async (batch, i) => {
     const body = i === 0 ? { ...syncBody, runs: batch } : { path: repoPath, runs: batch };
     const res = await postPortal(portal, '/api/sync', body, dryRun);
     if (i === 0 && typeof res?.repositoryId === 'string') repoId = res.repositoryId;

--- a/tests/control-sync-batching.test.ts
+++ b/tests/control-sync-batching.test.ts
@@ -50,6 +50,16 @@ function makeRuns(count: number, bytesEach: number): RunRecord[] {
   }));
 }
 
+const newerRun: RunRecord = {
+  runId: '00000000-0000-4000-8000-000000000099',
+  repoPath: '/repos/big',
+  stageId: 'verify',
+  status: 'pass',
+  startedAt: '2026-02-01T00:00:00.000Z',
+  finishedAt: '2026-02-01T00:00:05.000Z',
+  trigger: 'cli',
+};
+
 describe('chunkBySerializedSize', () => {
   it('returns [] for empty input', () => {
     expect(chunkBySerializedSize([], 1000)).toEqual([]);
@@ -273,20 +283,11 @@ describe('incremental runs sync', () => {
     mockedListRuns.mockReturnValue(runs);
     await syncReposWithControl({ repoPaths: ['/repos/big'] });
 
-    const newer: RunRecord = {
-      runId: '00000000-0000-4000-8000-000000000099',
-      repoPath: '/repos/big',
-      stageId: 'verify',
-      status: 'pass',
-      startedAt: '2026-02-01T00:00:00.000Z',
-      finishedAt: '2026-02-01T00:00:05.000Z',
-      trigger: 'cli',
-    };
-    mockedListRuns.mockReturnValue([...runs, newer]);
+    mockedListRuns.mockReturnValue([...runs, newerRun]);
 
     const mark = calls.length;
     await syncReposWithControl({ repoPaths: ['/repos/big'] });
-    expect(localRunIdsSince(mark)).toEqual([newer.runId]); // only the new run
+    expect(localRunIdsSince(mark)).toEqual([newerRun.runId]); // only the new run
   });
 
   it('--full resends the whole history despite the watermark', async () => {
@@ -327,6 +328,8 @@ describe('self-heals on a server wipe (repo id change)', () => {
   let stateDir: string;
   let localRepoId: string;
   let portalRepoId: string;
+  let failPortalResend: boolean;
+  let omitPortalRepoId: boolean;
 
   const runIdsSince = (from: number, urlSuffix: string): string[] =>
     calls
@@ -338,6 +341,8 @@ describe('self-heals on a server wipe (repo id change)', () => {
     calls.length = 0;
     localRepoId = 'repo-A';
     portalRepoId = 'p-A';
+    failPortalResend = false;
+    omitPortalRepoId = false;
     stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-sync-state-'));
     process.env.HAR_PORTAL_SYNC_STATE_PATH = path.join(stateDir, 'state.json');
     process.env.HAR_PORTAL_URL = 'https://portal.example.com';
@@ -349,7 +354,13 @@ describe('self-heals on a server wipe (repo id change)', () => {
         const body = init?.body ? JSON.parse(String(init.body)) : {};
         if (method === 'POST') calls.push({ url: String(url), body });
         if (String(url).includes('portal.example.com')) {
-          return jsonResponse({ repositoryId: portalRepoId });
+          const isResend = String(url).endsWith('/api/sync') && body.slots === undefined;
+          if (failPortalResend && isResend) {
+            throw Object.assign(new TypeError('fetch failed'), {
+              cause: { code: 'UND_ERR_SOCKET', message: 'other side closed' },
+            });
+          }
+          return jsonResponse(omitPortalRepoId ? {} : { repositoryId: portalRepoId });
         }
         if (String(url).endsWith('/api/repos') && method === 'POST') {
           return jsonResponse({ id: localRepoId });
@@ -398,6 +409,43 @@ describe('self-heals on a server wipe (repo id change)', () => {
     const mark = calls.length;
     await syncReposWithControl({ repoPaths: ['/repos/big'] });
     expect(new Set(runIdsSince(mark, '/api/sync'))).toEqual(new Set(runs.map((r) => r.runId)));
+  });
+
+  it('portal: a failed resend leaves the wipe detectable on the next sync', async () => {
+    const runs = makeRuns(4, 100);
+    mockedListRuns.mockReturnValue(runs);
+    await syncReposWithControl({ repoPaths: ['/repos/big'] }); // portal p-A → all
+
+    mockedListRuns.mockReturnValue([...runs, newerRun]); // delta pass advances the watermark
+    portalRepoId = 'p-B';
+    failPortalResend = true;
+    const wiped = await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(wiped.failed).toBe(1);
+
+    failPortalResend = false;
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(new Set(runIdsSince(mark, '/api/sync'))).toEqual(
+      new Set([...runs, newerRun].map((r) => r.runId)),
+    );
+  });
+
+  it('portal: a response without a repo id does not erase the stored one', async () => {
+    const runs = makeRuns(4, 100);
+    mockedListRuns.mockReturnValue(runs);
+    await syncReposWithControl({ repoPaths: ['/repos/big'] }); // portal p-A → all
+
+    mockedListRuns.mockReturnValue([...runs, newerRun]);
+    omitPortalRepoId = true;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+
+    omitPortalRepoId = false;
+    portalRepoId = 'p-B'; // the wipe must still be detected against p-A
+    const mark = calls.length;
+    await syncReposWithControl({ repoPaths: ['/repos/big'] });
+    expect(new Set(runIdsSince(mark, '/api/sync'))).toEqual(
+      new Set([...runs, newerRun].map((r) => r.runId)),
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

When the portal repo is wiped and re-created, the client detects it via the changed `repositoryId` in the `/api/sync` response and resends the whole history. That recovery was not atomic:

1. The optimistic delta pass runs first and, per batch, writes the runs watermark stamped with the **new** repo id.
2. The wipe is only detected afterwards (`stored.repoId !== responseRepoId`) — against the in-memory value, while disk already carries the new id.
3. If the resend then fails before its first batch lands, the next sync sees no mismatch and never re-triggers. The pre-wipe history stays orphaned on the portal until someone runs `har control sync --full`.

Low probability — it needs a wipe *and* a resend failure at just the wrong moment — but it's a real hole in the self-heal guarantee.

## Fix

Stamp the *stored* repo id through the delta pass; only the resend stamps the new one. A failed resend therefore leaves the mismatch intact and the next sync re-triggers.

The resend still advances the watermark per batch, oldest-first, so the existing resume property is preserved: a resend that fails partway self-completes on the next sync rather than restarting from scratch. Only the "nothing landed" case rewinds to a preserved mismatch.

Same change also stops a sync response **without** a `repositoryId` from erasing the stored id — which previously made any later wipe undetectable.

No behaviour change on `--full`, a first-ever sync, or the normal no-wipe path. The local Mission Control path is untouched; it already knows the repo id before sending.

## Tests

Two regression tests in the existing wipe suite, both set up with a non-empty delta pass (the window the bug lives in):

- a failed resend leaves the wipe detectable on the next sync
- a response without a repo id does not erase the stored one

Both are red without the `src` change and green with it. Also verified end-to-end by driving the real `har control sync` against a stub portal: with the fix the whole history re-lands on the sync after the failure; without it, nothing does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)