### PR TITLE
refactor: keep adaptation profile hints plugin-agnostic

### DIFF
--- a/src/harness/adaptation-prompt.ts
+++ b/src/harness/adaptation-prompt.ts
@@ -14,13 +14,16 @@ import {
 
 export const ADAPTATION_PROMPT_FILE = 'ADAPT-PROMPT.md';
 
+// Profile hints describe harness mechanics only — keep them independent of optional
+// verification plugins (Playwright, Semgrep, RocketSim, etc.). Plugin choice belongs
+// in plugin docs and repo-specific AGENTS.md, not in these init prompt hints.
 const PROFILE_HINTS: Record<HarnessProfile, string> = {
   default:
-    'Web app profile (SaaS/full-stack) — Docker Compose for shared infra (HARNESS_INFRA_SERVICES), PM2 for the primary application only, git worktree per agent slot by default. Launch provisions toolchain via harness.env (HARNESS_ECOSYSTEM, HARNESS_INSTALL_CMD) and writes paths to .env.agent.<id>. Identify the primary app agents modify; run supporting services shared. Install the Semgrep plugin (har env add-plugin semgrep) when the repo needs a SAST verification stage.',
+    'Web app profile (SaaS/full-stack) — Docker Compose for shared infra (HARNESS_INFRA_SERVICES), PM2 for the primary application only, git worktree per agent slot by default. Launch provisions toolchain via harness.env (HARNESS_ECOSYSTEM, HARNESS_INSTALL_CMD) and writes paths to .env.agent.<id>. Identify the primary app agents modify; run supporting services shared.',
   cli:
-    'CLI/library profile (typical SWE-bench) — no PM2. Optional Docker Compose via HARNESS_INFRA_SERVICES. Git worktree by default. Launch provisions toolchain declaratively (HARNESS_ECOSYSTEM auto-detects common ecosystems); verify must use resolved tool paths from .env.agent.<id>, never hardcoded interpreter or package-manager paths. Install the Semgrep plugin (har env add-plugin semgrep) when the repo needs a SAST verification stage.',
+    'CLI/library profile (typical SWE-bench) — no PM2. Optional Docker Compose via HARNESS_INFRA_SERVICES. Git worktree by default. Launch provisions toolchain declaratively (HARNESS_ECOSYSTEM auto-detects common ecosystems); verify must use resolved tool paths from .env.agent.<id>, never hardcoded interpreter or package-manager paths.',
   ios:
-    'iOS mobile app profile — xcodebuild + iOS Simulator in an isolated git worktree. Set HARNESS_XCODE_SCHEME, workspace/project, HARNESS_SIMULATOR_NAME, HARNESS_BUNDLE_ID. Launch writes XCODEBUILD_BIN to .env.agent.<id>; verify uses it. Install RocketSim plugin (har env add-plugin rocketsim) for user-flow validation.',
+    'iOS mobile app profile — xcodebuild + iOS Simulator in an isolated git worktree. Set HARNESS_XCODE_SCHEME, workspace/project, HARNESS_SIMULATOR_NAME, HARNESS_BUNDLE_ID. Launch writes XCODEBUILD_BIN to .env.agent.<id>; verify uses it.',
 };
 
 function loadTemplate(name: string): string {


### PR DESCRIPTION
## Summary
- Remove Semgrep and RocketSim plugin recommendations from `PROFILE_HINTS` in `adaptation-prompt.ts`
- Add a comment documenting that init profile hints must stay independent of optional verification plugins

## Test plan
- [x] `npm test -- tests/adaptation-prompt.test.ts`


Made with [Cursor](https://cursor.com)