### PR TITLE
fix(harness): tell Mission Control when a slot changes

### DIFF
--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -298,7 +298,6 @@ WORKTREE_DIR=${worktree_dir}
 NODE_ENV=test
 EOF
   fi
-  # Session attribution for Mission Control (hooks export via har telemetry on)
   if command -v har >/dev/null 2>&1; then
     har telemetry write-env \
       --agent-id "$agent_id" \
@@ -428,6 +427,35 @@ try {
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
 #             SLOT_STATUS, SLOT_LAST_ERROR, SLOT_WORK_UNIT_ID, SLOT_ATTEMPT_ID
+# Mission Control re-reads slot state only when something syncs, and a sync takes
+# about twenty seconds — too long to make a slot change wait for it. Detached, and
+# coalesced so a run of slot changes leaves one sync going, then one more if needed.
+har_notify_control() {
+  local root bin lock
+  root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  bin="$(command -v har 2>/dev/null || echo "${root}/node_modules/.bin/har")"
+  [ -x "$bin" ] || return 0
+
+  lock="${TMPDIR:-/tmp}/har-control-sync.$(id -u)"
+  : > "${lock}.pending"
+  mkdir "$lock" 2>/dev/null || return 0
+  (
+    trap "" HUP
+    trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+    cd "$root" || exit 0
+    while [ -f "${lock}.pending" ]; do
+      rm -f "${lock}.pending"
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 120 "$bin" control sync || true
+      else
+        "$bin" control sync || true
+      fi
+    done
+  # Redirected as a whole, not per command: a background job that keeps the inherited
+  # stdout open makes any caller reading that pipe wait for it.
+  ) >/dev/null 2>&1 &
+}
+
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -457,10 +485,12 @@ for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PR
 }
 fs.writeFileSync(process.argv[1], JSON.stringify(entry, null, 2) + "\n");
 ' "$file"
+  har_notify_control
 }
 
 remove_slot_registry() {
   rm -f "$(slot_registry_file "$1")"
+  har_notify_control
 }
 
 # Exit 0 when the worktree has uncommitted or untracked changes.

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -439,6 +439,35 @@ try {
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
 #             SLOT_STATUS, SLOT_LAST_ERROR, SLOT_WORK_UNIT_ID, SLOT_ATTEMPT_ID
+# Mission Control re-reads slot state only when something syncs, and a sync takes
+# about twenty seconds — too long to make a slot change wait for it. Detached, and
+# coalesced so a run of slot changes leaves one sync going, then one more if needed.
+har_notify_control() {
+  local root bin lock
+  root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  bin="$(command -v har 2>/dev/null || echo "${root}/node_modules/.bin/har")"
+  [ -x "$bin" ] || return 0
+
+  lock="${TMPDIR:-/tmp}/har-control-sync.$(id -u)"
+  : > "${lock}.pending"
+  mkdir "$lock" 2>/dev/null || return 0
+  (
+    trap "" HUP
+    trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+    cd "$root" || exit 0
+    while [ -f "${lock}.pending" ]; do
+      rm -f "${lock}.pending"
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 120 "$bin" control sync || true
+      else
+        "$bin" control sync || true
+      fi
+    done
+  # Redirected as a whole, not per command: a background job that keeps the inherited
+  # stdout open makes any caller reading that pipe wait for it.
+  ) >/dev/null 2>&1 &
+}
+
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -468,10 +497,12 @@ for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PR
 }
 fs.writeFileSync(process.argv[1], JSON.stringify(entry, null, 2) + "\n");
 ' "$file"
+  har_notify_control
 }
 
 remove_slot_registry() {
   rm -f "$(slot_registry_file "$1")"
+  har_notify_control
 }
 
 # Exit 0 when the worktree has uncommitted or untracked changes.

--- a/docs/.har/agent-slot.sh
+++ b/docs/.har/agent-slot.sh
@@ -445,6 +445,35 @@ try {
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
 #             SLOT_STATUS, SLOT_LAST_ERROR, SLOT_WORK_UNIT_ID, SLOT_ATTEMPT_ID
+# Mission Control re-reads slot state only when something syncs, and a sync takes
+# about twenty seconds — too long to make a slot change wait for it. Detached, and
+# coalesced so a run of slot changes leaves one sync going, then one more if needed.
+har_notify_control() {
+  local root bin lock
+  root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  bin="$(command -v har 2>/dev/null || echo "${root}/node_modules/.bin/har")"
+  [ -x "$bin" ] || return 0
+
+  lock="${TMPDIR:-/tmp}/har-control-sync.$(id -u)"
+  : > "${lock}.pending"
+  mkdir "$lock" 2>/dev/null || return 0
+  (
+    trap "" HUP
+    trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+    cd "$root" || exit 0
+    while [ -f "${lock}.pending" ]; do
+      rm -f "${lock}.pending"
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 120 "$bin" control sync || true
+      else
+        "$bin" control sync || true
+      fi
+    done
+  # Redirected as a whole, not per command: a background job that keeps the inherited
+  # stdout open makes any caller reading that pipe wait for it.
+  ) >/dev/null 2>&1 &
+}
+
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -474,10 +503,12 @@ for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PR
 }
 fs.writeFileSync(process.argv[1], JSON.stringify(entry, null, 2) + "\n");
 ' "$file"
+  har_notify_control
 }
 
 remove_slot_registry() {
   rm -f "$(slot_registry_file "$1")"
+  har_notify_control
 }
 
 # Exit 0 when the worktree has uncommitted or untracked changes.

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -427,6 +427,35 @@ try {
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
 #             SLOT_STATUS, SLOT_LAST_ERROR, SLOT_WORK_UNIT_ID, SLOT_ATTEMPT_ID
+# Mission Control re-reads slot state only when something syncs, and a sync takes
+# about twenty seconds — too long to make a slot change wait for it. Detached, and
+# coalesced so a run of slot changes leaves one sync going, then one more if needed.
+har_notify_control() {
+  local root bin lock
+  root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  bin="$(command -v har 2>/dev/null || echo "${root}/node_modules/.bin/har")"
+  [ -x "$bin" ] || return 0
+
+  lock="${TMPDIR:-/tmp}/har-control-sync.$(id -u)"
+  : > "${lock}.pending"
+  mkdir "$lock" 2>/dev/null || return 0
+  (
+    trap "" HUP
+    trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+    cd "$root" || exit 0
+    while [ -f "${lock}.pending" ]; do
+      rm -f "${lock}.pending"
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 120 "$bin" control sync || true
+      else
+        "$bin" control sync || true
+      fi
+    done
+  # Redirected as a whole, not per command: a background job that keeps the inherited
+  # stdout open makes any caller reading that pipe wait for it.
+  ) >/dev/null 2>&1 &
+}
+
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -456,10 +485,12 @@ for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PR
 }
 fs.writeFileSync(process.argv[1], JSON.stringify(entry, null, 2) + "\n");
 ' "$file"
+  har_notify_control
 }
 
 remove_slot_registry() {
   rm -f "$(slot_registry_file "$1")"
+  har_notify_control
 }
 
 # Exit 0 when the worktree has uncommitted or untracked changes.

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -95,6 +95,35 @@ try {
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
 #             SLOT_STATUS, SLOT_LAST_ERROR, SLOT_WORK_UNIT_ID, SLOT_ATTEMPT_ID
+# Mission Control re-reads slot state only when something syncs, and a sync takes
+# about twenty seconds — too long to make a slot change wait for it. Detached, and
+# coalesced so a run of slot changes leaves one sync going, then one more if needed.
+har_notify_control() {
+  local root bin lock
+  root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  bin="$(command -v har 2>/dev/null || echo "${root}/node_modules/.bin/har")"
+  [ -x "$bin" ] || return 0
+
+  lock="${TMPDIR:-/tmp}/har-control-sync.$(id -u)"
+  : > "${lock}.pending"
+  mkdir "$lock" 2>/dev/null || return 0
+  (
+    trap "" HUP
+    trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+    cd "$root" || exit 0
+    while [ -f "${lock}.pending" ]; do
+      rm -f "${lock}.pending"
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 120 "$bin" control sync || true
+      else
+        "$bin" control sync || true
+      fi
+    done
+  # Redirected as a whole, not per command: a background job that keeps the inherited
+  # stdout open makes any caller reading that pipe wait for it.
+  ) >/dev/null 2>&1 &
+}
+
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -124,10 +153,12 @@ for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PR
 }
 fs.writeFileSync(process.argv[1], JSON.stringify(entry, null, 2) + "\n");
 ' "$file"
+  har_notify_control
 }
 
 remove_slot_registry() {
   rm -f "$(slot_registry_file "$1")"
+  har_notify_control
 }
 
 # Exit 0 when the worktree has uncommitted or untracked changes.

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -445,6 +445,35 @@ try {
 #   optional: SLOT_SUFFIX, SLOT_WORKTREE_PATH, SLOT_BRANCH, SLOT_BASE_BRANCH,
 #             SLOT_BASE_COMMIT, SLOT_PORTS_JSON, SLOT_PREVIEW_URLS_JSON,
 #             SLOT_STATUS, SLOT_LAST_ERROR, SLOT_WORK_UNIT_ID, SLOT_ATTEMPT_ID
+# Mission Control re-reads slot state only when something syncs, and a sync takes
+# about twenty seconds — too long to make a slot change wait for it. Detached, and
+# coalesced so a run of slot changes leaves one sync going, then one more if needed.
+har_notify_control() {
+  local root bin lock
+  root="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  bin="$(command -v har 2>/dev/null || echo "${root}/node_modules/.bin/har")"
+  [ -x "$bin" ] || return 0
+
+  lock="${TMPDIR:-/tmp}/har-control-sync.$(id -u)"
+  : > "${lock}.pending"
+  mkdir "$lock" 2>/dev/null || return 0
+  (
+    trap "" HUP
+    trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+    cd "$root" || exit 0
+    while [ -f "${lock}.pending" ]; do
+      rm -f "${lock}.pending"
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 120 "$bin" control sync || true
+      else
+        "$bin" control sync || true
+      fi
+    done
+  # Redirected as a whole, not per command: a background job that keeps the inherited
+  # stdout open makes any caller reading that pipe wait for it.
+  ) >/dev/null 2>&1 &
+}
+
 write_slot_registry() {
   local file
   file="$(slot_registry_file "$SLOT_AGENT_ID")"
@@ -474,10 +503,12 @@ for (const [key, env] of [["ports", "SLOT_PORTS_JSON"], ["previewUrls", "SLOT_PR
 }
 fs.writeFileSync(process.argv[1], JSON.stringify(entry, null, 2) + "\n");
 ' "$file"
+  har_notify_control
 }
 
 remove_slot_registry() {
   rm -f "$(slot_registry_file "$1")"
+  har_notify_control
 }
 
 # Exit 0 when the worktree has uncommitted or untracked changes.

--- a/tests/agent-slots-bash.test.ts
+++ b/tests/agent-slots-bash.test.ts
@@ -47,4 +47,41 @@ describe('bash agent slot limits', () => {
     expect(out).toContain('./.har/launch.sh 2');
     expect(out.indexOf('har env launch')).toBeLessThan(out.indexOf('./.har/launch.sh'));
   });
+
+  // A sync takes about twenty seconds. Waiting on it would make every slot change
+  // pay for the dashboard, which is what detaching the nudge exists to avoid.
+  it('a slot change returns without waiting on the control sync', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-notify-'));
+    const harDir = path.join(dir, '.har');
+    const binDir = path.join(dir, 'bin');
+    fs.mkdirSync(harDir, { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(harDir, 'harness.env'), 'export HARNESS_PROJECT_NAME=demo\n');
+
+    // Stands in for a slow CLI, and leaves a trace so we know it was reached at all.
+    const witness = path.join(dir, 'witness');
+    fs.writeFileSync(
+      path.join(binDir, 'har'),
+      `#!/usr/bin/env bash\nsleep 5\necho ran >> "${witness}"\n`,
+    );
+    fs.chmodSync(path.join(binDir, 'har'), 0o755);
+
+    const script = [
+      `export PATH="${binDir}:$PATH"`,
+      `SCRIPT_DIR="${harDir}"`,
+      `source "${harDir}/harness.env"`,
+      `source "${AGENT_SLOT}"`,
+      'mkdir -p "$(dirname "$(slot_registry_file 2)")"',
+      'echo "{}" > "$(slot_registry_file 2)"',
+      'remove_slot_registry 2',
+    ].join('; ');
+
+    const started = Date.now();
+    execSync(`bash -c '${script}'`, { encoding: 'utf8' });
+    const elapsed = Date.now() - started;
+
+    expect(fs.existsSync(path.join(harDir, 'slots', 'agent-2.json'))).toBe(false);
+    expect(elapsed).toBeLessThan(3000);
+    expect(fs.existsSync(witness)).toBe(false); // still running, deliberately not awaited
+  });
 });


### PR DESCRIPTION
## The problem

Mission Control reads slot state from the slot registry, and nothing re-reads that
registry on its own. So a slot torn down through `./.har/teardown.sh` kept showing
as **Active** on the dashboard — with its worktree path, its branch and its drift
counts, all of them gone from disk — until some unrelated `har` command happened to
sync. Observed on a real teardown: still Active twenty minutes later, worktree
removed, branch deleted.

`launch.sh` has the mirror image of the same gap: a freshly created slot stays
invisible, or shows the previous occupant's data, until the same thing happens.

## The fix

`har_notify_control()` in `agent-slot.sh`, called from **both** registry mutations —
`write_slot_registry` and `remove_slot_registry`. Putting it at the mutation rather
than in `teardown.sh` means launch is covered too, and a future caller that changes
slot state inherits the behaviour instead of having to remember it.

Four properties the implementation has to have, each one learned the hard way:

**Detached.** A sync takes about twenty seconds; a slot change takes one. Awaiting it
would make every slot change pay for the dashboard. Measured: `har control sync`
returns 0 after ~23s — it is slow, not stuck. An earlier draft of this patch called
it synchronously and turned a 1-second teardown into a 25-second one.

**Redirected as a whole, not per command.** `( ... ) >/dev/null 2>&1 &` rather than
redirecting the command inside the subshell. A background job that keeps the
inherited stdout open makes any caller reading that pipe wait for it — so
`./.har/teardown.sh 2 | tail` blocked for the full sync even though the job was
backgrounded. This one is invisible until you pipe the script's output, which is
exactly what the new test does.

**Coalesced.** A lock directory plus a pending marker: concurrent slot changes leave
one sync running and queue at most one more. Five removals in a row now launch two
syncs instead of five.

**Degrades quietly.** Bounded by `timeout` where that command exists, resolves the CLI
through `node_modules/.bin` when it is a dev dependency rather than on `PATH`, and
returns without doing anything when neither is available.

## Test

`tests/agent-slots-bash.test.ts` gains one case: a slot change returns without waiting
on a deliberately slow stand-in CLI. It fails if the sync is made synchronous, and it
fails if the redirection moves back onto the inner command — both verified by
reverting each change in turn and watching it go red at ~5.3s.

## Scope

Applied to the three templates and to the three dogfooded copies, which stay
byte-identical to the templates they track. `dist/` is gitignored and regenerated at
build. Full suite: 485 passing; the 6 failures in `slot-registry`, `control-repo-path`
and `hooks` are pre-existing and load-dependent — the same suites fail on `main` with
this branch stashed.
