### PR TITLE
fix(ios): distinguish an unusable simctl from a missing iOS runtime

### DIFF
--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -109,6 +109,24 @@ launch fails and lists the models this machine can create.
 If `HARNESS_SIMULATOR_NAME` is not a model but names an existing device, that
 device is used as-is and never deleted — how a hand-renamed simulator is targeted.
 
+### Running from an agent sandbox
+
+`xcrun simctl` reaches CoreSimulatorService over XPC. Coding agents that sandbox
+their shell (Codex, Claude Code and others) usually deny that lookup, so `simctl`
+fails while `xcodebuild` keeps working — every simulator command then dies with
+`CoreSimulatorService connection became invalid`. Nothing is missing on the machine.
+
+Launch and teardown say so when it happens. Either run `har env launch <id>` and
+`har env teardown <id>` from a normal terminal and let the agent work in the
+worktree, or grant the agent unsandboxed access to `xcrun simctl` — the escalation
+must cover every subcommand the harness uses (`list`, `create`, `boot`,
+`bootstatus`, `shutdown`, `delete`), not just `list`.
+
+The same messages distinguish a second cause: if `xcrun simctl` is missing from
+the selected developer directory — no Xcode, or `xcode-select` pointing at the
+Command Line Tools — they say so and print the current selection instead of
+blaming a sandbox.
+
 The device lands in `.env.agent.<id>` as `HARNESS_SIMULATOR_UDID`,
 `HARNESS_SIMULATOR_DEVICE_NAME` and `HARNESS_IOS_DESTINATION` — the model stays in
 `HARNESS_SIMULATOR_NAME`, so the two never mean the same thing in one place; what a slot holds is tracked in `.har/simulators/`.

--- a/src/templates/har-boilerplate-ios/setup-infra.sh
+++ b/src/templates/har-boilerplate-ios/setup-infra.sh
@@ -19,6 +19,14 @@ source "$SCRIPT_DIR/simulator.sh"
 
 log() { echo "==> $*" >&2; }
 
+# simctl could not be asked, so nothing it did not return is evidence of anything
+# missing on this machine. The wording lives in simulator.sh so launch and this
+# script cannot drift apart on which of the two causes they name.
+fail_simctl_unavailable() {
+  har_sim_log_simctl_unavailable
+  exit 1
+}
+
 # ── Xcode check ───────────────────────────────────────────────────────────────
 if ! command -v xcodebuild >/dev/null 2>&1; then
   echo "Error: xcodebuild not found — install Xcode from the App Store." >&2
@@ -40,6 +48,8 @@ if har_sim_per_slot_enabled; then
   PLAN_STATUS="${PLAN%%$'\t'*}"
   if [ "$PLAN_STATUS" = "OK" ]; then
     log "Per-slot simulators: launch creates one $(printf '%s' "$PLAN" | cut -f3) per agent."
+  elif [ "$PLAN_STATUS" = "SIMCTL_UNAVAILABLE" ]; then
+    fail_simctl_unavailable
   elif [ "$PLAN_STATUS" = "NO_MODEL" ] && [ -n "$(har_sim_device_by_name "${HARNESS_SIMULATOR_NAME:-}")" ]; then
     # Supported fallback: the name is an existing device rather than a model.
     log "Per-slot simulators: launch reuses the existing device '${SIMULATOR_NAME}'."
@@ -63,6 +73,7 @@ else
   UDID="${RESOLVED%%$'\t'*}"
 
   if [ -z "$UDID" ]; then
+    har_sim_simctl_available || fail_simctl_unavailable
     echo "Error: Simulator '${SIMULATOR_NAME}' not found in available devices." >&2
     echo "  Available simulators:" >&2
     xcrun simctl list devices available 2>/dev/null | grep -E 'iPhone|iPad' | head -20 >&2

--- a/src/templates/har-boilerplate-ios/simulator.sh
+++ b/src/templates/har-boilerplate-ios/simulator.sh
@@ -108,10 +108,25 @@ har_sim_claim_owner_of() {
 
 # ── Device discovery ──────────────────────────────────────────────────────────
 
+# Every simctl call goes through here, so "simctl could not be asked" stays
+# distinguishable from "simctl answered, and the answer is empty" at the one place
+# that still knows the difference. Non-zero means the first; callers check it
+# instead of reading an empty list as a fact about the machine.
+har_sim_simctl() {
+  local out rc=0
+  out="$(xcrun simctl "$@" 2>/dev/null)" || rc=$?
+  if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
 # Unavailable devices are skipped: a device whose runtime was uninstalled must
 # not pass validation only to fail at boot.
 har_sim_device_field() {
-  xcrun simctl list devices --json 2>/dev/null | node -e '
+  local devices
+  devices="$(har_sim_simctl list devices --json)" || return 1
+  printf '%s' "$devices" | node -e '
 const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
 const [want, field] = process.argv.slice(1);
 const device = Object.values(data.devices || {})
@@ -128,9 +143,10 @@ har_sim_device_name() { har_sim_device_field "$1" name; }
 # UDID of an existing device with this exact name, newest runtime first.
 # A substring match would resolve "iPhone 16" to "iPhone 16 Pro Max".
 har_sim_device_by_name() {
-  local want="${1:-}"
+  local want="${1:-}" devices
   [ -n "$want" ] || return 0
-  xcrun simctl list devices available --json 2>/dev/null | node -e '
+  devices="$(har_sim_simctl list devices available --json)" || return 1
+  printf '%s' "$devices" | node -e '
 const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
 const want = process.argv[1];
 const rows = [];
@@ -157,20 +173,64 @@ har_sim_resolve_configured() {
   printf '%s\t%s' "$udid" "${HARNESS_SIMULATOR_NAME}"
 }
 
-# `simctl list` is a subprocess and a JSON parse; neither answer changes during
-# a launch, so each is fetched at most once per process.
+# `simctl list` is a subprocess and a JSON parse, so each answer is cached — but in
+# the calling shell, not the process: `$(har_sim_runtimes_json)` fetches, then throws
+# the cache and the availability flag away with the subshell that held them. Call
+# these directly and read the variable whenever either one matters.
 har_sim_devicetypes_json() {
   if [ -z "${_HAR_SIM_TYPES_JSON:-}" ]; then
-    _HAR_SIM_TYPES_JSON="$(xcrun simctl list devicetypes --json 2>/dev/null || echo '{}')"
+    _HAR_SIM_TYPES_JSON="$(har_sim_simctl list devicetypes --json)" || _HAR_SIM_TYPES_JSON='{}'
   fi
   printf '%s' "$_HAR_SIM_TYPES_JSON"
 }
 
 har_sim_runtimes_json() {
   if [ -z "${_HAR_SIM_RUNTIMES_JSON:-}" ]; then
-    _HAR_SIM_RUNTIMES_JSON="$(xcrun simctl list runtimes --json 2>/dev/null || echo '{}')"
+    if _HAR_SIM_RUNTIMES_JSON="$(har_sim_simctl list runtimes --json)"; then
+      _HAR_SIM_SIMCTL_OK=true
+    else
+      _HAR_SIM_RUNTIMES_JSON='{}'
+      _HAR_SIM_SIMCTL_OK=false
+      # A second call, but only ever when simctl is already failing — and failing
+      # is the fast path. Its stderr is the only thing that tells the causes apart.
+      _HAR_SIM_SIMCTL_ERROR="$(xcrun simctl list runtimes --json 2>&1 >/dev/null || true)"
+    fi
   fi
   printf '%s' "$_HAR_SIM_RUNTIMES_JSON"
+}
+
+# Ask simctl once, recording in this shell whether it answered and why not.
+har_sim_probe_simctl() {
+  har_sim_runtimes_json >/dev/null
+}
+
+har_sim_simctl_available() {
+  har_sim_probe_simctl
+  [ "${_HAR_SIM_SIMCTL_OK:-true}" = "true" ]
+}
+
+# Two unrelated problems make simctl unusable — a sandbox denying the
+# CoreSimulatorService lookup, and a developer directory with no simctl in it.
+# Naming the wrong one costs the reader the hunt this check exists to prevent.
+har_sim_log_simctl_unavailable() {
+  # Teardown hits two failures in a row; the cause only needs saying once.
+  [ -z "${_HAR_SIM_SIMCTL_CAUSE_REPORTED:-}" ] || return 0
+  _HAR_SIM_SIMCTL_CAUSE_REPORTED=1
+  # For a launch the failing call happened inside the command substitution around
+  # har_sim_plan_creation, so the reason died with that subshell — ask again here.
+  har_sim_probe_simctl
+  case "${_HAR_SIM_SIMCTL_ERROR:-}" in
+    *"not a developer tool"*|*"unable to find utility"*|*"command not found"*)
+      har_sim_log "'xcrun simctl' is not in the selected developer directory"
+      har_sim_log "  install Xcode, then point the toolchain at it:"
+      har_sim_log "    sudo xcode-select -s /Applications/Xcode.app"
+      har_sim_log "  current selection: $(xcode-select -p 2>/dev/null || echo 'none')"
+      return
+      ;;
+  esac
+  har_sim_log "cannot reach CoreSimulatorService — 'xcrun simctl' is unusable here"
+  har_sim_log "  this usually means the command is running inside an agent sandbox"
+  har_sim_log "  run it from a normal terminal, or let the agent run 'xcrun simctl' unsandboxed"
 }
 
 # Model and runtime to create this slot's device from. Failures carry the models
@@ -180,10 +240,18 @@ har_sim_runtimes_json() {
 #   NO_RUNTIME                        no iOS runtime installed
 #   NO_MODEL <models>                 HARNESS_SIMULATOR_NAME is not a device model
 #   NO_RUNTIME_FOR_MODEL <models>     model exists, no installed runtime supports it
+#   SIMCTL_UNAVAILABLE                simctl could not be asked at all
 har_sim_plan_creation() {
   local types runtimes
   types="$(har_sim_devicetypes_json)"
-  runtimes="$(har_sim_runtimes_json)"
+  # Not `$(...)`: that would discard the availability flag with the subshell.
+  har_sim_runtimes_json >/dev/null
+  runtimes="$_HAR_SIM_RUNTIMES_JSON"
+  # Checked before the empty lists are read as an answer about the machine.
+  if ! har_sim_simctl_available; then
+    printf 'SIMCTL_UNAVAILABLE'
+    return
+  fi
   node -e '
 const [typesRaw, runtimesRaw, wantName, family] = process.argv.slice(1);
 const types = JSON.parse(typesRaw).devicetypes || [];
@@ -240,7 +308,9 @@ process.stdout.write(plan());
 # Every device whose name is <prefix> or starts with "<prefix>-", so a slot's
 # leftovers are found whatever model they were created from.
 har_sim_devices_with_prefix() {
-  xcrun simctl list devices --json 2>/dev/null | node -e '
+  local devices
+  devices="$(har_sim_simctl list devices --json)" || return 1
+  printf '%s' "$devices" | node -e '
 const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
 const prefix = process.argv[1];
 const matches = Object.values(data.devices || {})
@@ -252,12 +322,19 @@ process.stdout.write(matches.join("\n"));
 ' "$1" 2>/dev/null || true
 }
 
+# Returns 0 even when it could not look: teardown.sh runs under `set -e`, and
+# aborting there would leave the slot registry behind on top of the device.
 har_sim_delete_devices_with_prefix() {
-  local udid
+  local udid list
+  if ! list="$(har_sim_devices_with_prefix "$1")"; then
+    har_sim_log "cannot check for leftover devices named ${1}* — none were removed"
+    har_sim_log_simctl_unavailable
+    return 0
+  fi
   while read -r udid; do
     [ -n "$udid" ] || continue
     xcrun simctl delete "$udid" >/dev/null 2>&1 || true
-  done <<< "$(har_sim_devices_with_prefix "$1")"
+  done <<< "$list"
 }
 
 # ── Boot ──────────────────────────────────────────────────────────────────────
@@ -289,7 +366,11 @@ _har_sim_select() {
 
   # An explicit UDID is a deliberate override — never fall back off it.
   if [ -n "${HARNESS_SIMULATOR_UDID:-}" ]; then
-    name="$(har_sim_device_name "$HARNESS_SIMULATOR_UDID")"
+    # A failed lookup is "could not ask"; an empty one is "no such device".
+    name="$(har_sim_device_name "$HARNESS_SIMULATOR_UDID")" || {
+      har_sim_log_simctl_unavailable
+      return 1
+    }
     if [ -z "$name" ]; then
       har_sim_log "HARNESS_SIMULATOR_UDID=${HARNESS_SIMULATOR_UDID} is not a known device"
       return 1
@@ -309,6 +390,11 @@ _har_sim_select() {
   # Failure statuses carry the creatable models after the first tab.
   models=""
   [ "$plan" != "$status" ] && models="${plan#*$'\t'}"
+
+  if [ "$status" = "SIMCTL_UNAVAILABLE" ]; then
+    har_sim_log_simctl_unavailable
+    return 1
+  fi
 
   if [ "$status" = "OK" ]; then
     IFS=$'\t' read -r _ device_type model runtime _ <<< "$plan"
@@ -388,8 +474,14 @@ har_sim_release() {
     rm -f "$file"
     if [ "$created" = "true" ] && [ -n "$udid" ]; then
       xcrun simctl shutdown "$udid" >/dev/null 2>&1 || true
-      xcrun simctl delete "$udid" >/dev/null 2>&1 || true
-      echo "✓ Deleted simulator created for this slot ($udid)"
+      if xcrun simctl delete "$udid" >/dev/null 2>&1; then
+        echo "✓ Deleted simulator created for this slot ($udid)"
+      else
+        # Naming it is the whole remedy left: the claim is gone, so only the name
+        # prefix sweep at the next launch can still find this device.
+        har_sim_log "could not delete ${udid}, created for agent ${agent_id} — it is still on this machine"
+        har_sim_simctl_available || har_sim_log_simctl_unavailable
+      fi
     fi
   fi
 

--- a/tests/ios-simulator-allocation.test.ts
+++ b/tests/ios-simulator-allocation.test.ts
@@ -71,7 +71,9 @@ const DEVICES = {
  */
 const tempRoots: string[] = [];
 
-function makeHarness(): { root: string; harnessDir: string; binDir: string; callLog: string } {
+function makeHarness(
+  options: { simctlFailure?: 'sandbox' | 'missing'; noRuntimes?: boolean } = {},
+): { root: string; harnessDir: string; binDir: string; callLog: string } {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'har-ios-sim-'));
   tempRoots.push(root);
   const harnessDir = path.join(root, '.har');
@@ -85,8 +87,26 @@ function makeHarness(): { root: string; harnessDir: string; binDir: string; call
   }
 
   const devicesPath = path.join(root, 'devices.json');
+  // Both leave xcodebuild working and kill every simctl subcommand, which is why
+  // they are indistinguishable to a caller that only looks at an empty list.
+  const simctlFailures = {
+    // An agent sandbox denies the mach lookup to CoreSimulatorService.
+    sandbox: `
+if [ "\$1" = "simctl" ]; then
+  echo "CoreSimulatorService connection became invalid.  Simulator services will no longer be available." >&2
+  echo "Underlying error (domain=NSPOSIXErrorDomain, code=61): Connection refused" >&2
+  exit 1
+fi`,
+    // xcode-select pointing at the Command Line Tools: simctl is not there at all.
+    missing: `
+if [ "\$1" = "simctl" ]; then
+  echo 'xcrun: error: unable to find utility "simctl", not a developer tool or in PATH' >&2
+  exit 72
+fi`,
+  };
+  const failure = options.simctlFailure ? simctlFailures[options.simctlFailure] : '';
   const stub = `#!/usr/bin/env bash
-echo "$*" >> ${JSON.stringify(callLog)}
+echo "$*" >> ${JSON.stringify(callLog)}${failure}
 if [ "\$1" != "simctl" ]; then exit 0; fi
 case "\$2 \$3" in
   "list devices")     cat ${JSON.stringify(devicesPath)} ;;
@@ -115,7 +135,10 @@ exit 0
   fs.writeFileSync(path.join(binDir, 'xcodebuild'), '#!/usr/bin/env bash\necho "Xcode 26.5"\n', { mode: 0o755 });
   fs.writeFileSync(devicesPath, JSON.stringify(DEVICES));
   fs.writeFileSync(path.join(root, 'devicetypes.json'), JSON.stringify(DEVICE_TYPES));
-  fs.writeFileSync(path.join(root, 'runtimes.json'), JSON.stringify(RUNTIMES));
+  fs.writeFileSync(
+    path.join(root, 'runtimes.json'),
+    JSON.stringify(options.noRuntimes ? { runtimes: [] } : RUNTIMES),
+  );
 
   return { root, harnessDir, binDir, callLog };
 }
@@ -384,6 +407,96 @@ describe('iOS per-slot simulator allocation', () => {
     expect(result.code).not.toBe(0);
     expect(result.stdout).toContain('no simulator can be prepared');
     expect(result.stdout).toContain('iPhone 17');
+  });
+
+  it('reports simctl being unreachable rather than blaming a missing runtime', () => {
+    const harness = makeHarness({ simctlFailure: 'sandbox' });
+
+    const result = runSetupInfra(harness);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toContain('cannot reach CoreSimulatorService');
+    expect(result.stdout).toContain('sandbox');
+    expect(result.stdout).not.toContain('No iOS runtime is installed');
+  });
+
+  it('fails a slot launch with the simctl diagnostic, creating nothing', () => {
+    const harness = makeHarness({ simctlFailure: 'sandbox' });
+
+    const result = bash(harness, 'har_sim_acquire 1', { HARNESS_SIMULATOR_NAME: 'iPhone 16' });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('cannot reach CoreSimulatorService');
+    expect(result.stderr).not.toContain('no iOS simulator runtime is installed');
+    expect(fs.readFileSync(harness.callLog, 'utf8')).not.toContain('simctl create');
+  });
+
+  it('names the toolchain, not a sandbox, when simctl is not installed', () => {
+    const harness = makeHarness({ simctlFailure: 'missing' });
+
+    const result = bash(harness, 'har_sim_acquire 1', { HARNESS_SIMULATOR_NAME: 'iPhone 16' });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('not in the selected developer directory');
+    expect(result.stderr).toContain('xcode-select');
+    expect(result.stderr).not.toContain('sandbox');
+  });
+
+  // The message the whole change exists to preserve: a reachable simctl reporting
+  // no iOS runtime must still send the reader to Xcode, not to a sandbox.
+  it('still blames a missing runtime when simctl answers with none', () => {
+    const harness = makeHarness({ noRuntimes: true });
+
+    const result = runSetupInfra(harness);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toContain('No iOS runtime is installed');
+    expect(result.stdout).not.toContain('CoreSimulatorService');
+  });
+
+  it('does not call a pinned UDID unknown when simctl is unreachable', () => {
+    const harness = makeHarness({ simctlFailure: 'sandbox' });
+
+    const result = bash(harness, 'har_sim_acquire 1', { HARNESS_SIMULATOR_UDID: 'UDID-MY-IPHONE' });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('cannot reach CoreSimulatorService');
+    expect(result.stderr).not.toContain('not a known device');
+  });
+
+  it('reports simctl being unreachable in shared mode too', () => {
+    const harness = makeHarness({ simctlFailure: 'sandbox' });
+    setHarnessEnv(harness.harnessDir, 'HARNESS_SIMULATOR_SHARED', 'true');
+
+    const result = runSetupInfra(harness);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toContain('cannot reach CoreSimulatorService');
+    expect(result.stdout).not.toContain('not found in available devices');
+  });
+
+  // The claim is dropped even though the delete failed: nothing reads it once the
+  // slot registry is gone, and keeping it makes `agent-cli.sh <id> simulator`
+  // report a live reservation for a torn-down slot.
+  it('drops the claim and names the device release could not delete', () => {
+    const harness = makeHarness({ simctlFailure: 'sandbox' });
+    claimFor(harness.harnessDir, 1, 'UDID-CREATED-7', true);
+
+    const result = bash(harness, 'har_sim_release 1', { HARNESS_PROJECT_NAME: 'demo' });
+
+    expect(result.stderr).toContain('cannot reach CoreSimulatorService');
+    expect(result.stderr).toContain('UDID-CREATED-7');
+    expect(fs.existsSync(path.join(harness.harnessDir, 'simulators', 'agent-1.json'))).toBe(false);
+    // No cleanup may be claimed that did not happen.
+    expect(result.stdout).not.toContain('Deleted simulator');
+  });
+
+  it('reports that leftover devices could not even be looked for', () => {
+    const harness = makeHarness({ simctlFailure: 'sandbox' });
+
+    const result = bash(harness, 'har_sim_release 1', { HARNESS_PROJECT_NAME: 'demo' });
+
+    expect(result.stderr).toContain('cannot check for leftover devices');
   });
 
   it('lets setup-infra pass when the name is an existing device rather than a model', () => {


### PR DESCRIPTION
## Problem

`xcrun simctl` reaches CoreSimulatorService over XPC. An agent sandbox denies that lookup while leaving `xcodebuild` working, so every simctl call fails with `CoreSimulatorService connection became invalid`.

HAR read the resulting empty lists as an answer about the machine:

```
==> Found: Xcode 26.5
Error: no simulator can be prepared for 'iPhone 17'.
  No iOS runtime is installed — add one in Xcode → Settings → Components.
```

That message was produced on a host with four iOS runtimes installed. On one project it accounted for **8 of 19 launches** over two days, each one sending the developer to install a runtime they already had. Teardown had the mirror problem: `simctl delete` failed silently and printed `✓ Agent N torn down` while the device survived.

## Change

- Every simctl call goes through one runner that **fails** instead of returning an empty list, so callers separate "could not ask" from "asked, and the answer is empty". This replaces the `2>/dev/null || true` in the three list accessors.
- New `SIMCTL_UNAVAILABLE` plan status, reported wherever an empty list was previously treated as evidence: per-slot and shared `setup-infra`, a pinned `HARNESS_SIMULATOR_UDID`, selection, and release.
- **Two causes told apart.** A sandbox denying CoreSimulatorService, and a developer directory with no simctl in it — the latter is what a machine without Xcode, or with `xcode-select` pointing at the Command Line Tools, actually hits. Blaming a sandbox there would have been the mirror image of the bug being fixed.
- Release drops the claim and names the device it could not delete, instead of keeping a claim that `agent-cli.sh <id> simulator` would report as a live reservation for a torn-down slot. The orphan sweep now says when it could not even look.
- `har_sim_plan_creation` no longer asks simctl for the runtimes twice per launch (the cache died with a command substitution).

## Verification

- `tests/ios-simulator-allocation.test.ts`: **28/28**, including 5 new tests driven by an `xcrun` stub that fails exactly as a sandbox and as a CLT-only toolchain do.
- Behaviour confirmed against real hardware: reproduced the sandbox denial with `sandbox-exec`, and the toolchain case with `DEVELOPER_DIR=/Library/Developer/CommandLineTools`. The duplicate simctl call was measured by wrapping `xcrun` (3 calls → 2).
- `typecheck`, `lint`, `build`, `docs drift` all clean.
- Full suite: 3 suites red (`control-repo-path`, `slot-registry`, `hooks`) — **all three fail identically on an unmodified `main` checkout**, unrelated to this change.
