### PR TITLE
docs: rename Enterprise nav to Teams and move page to /teams

### DIFF
--- a/docs/.har/CLAUDE.agent.md
+++ b/docs/.har/CLAUDE.agent.md
@@ -44,7 +44,7 @@ When you change the landing page or another route:
 1. Add or update a Playwright spec under `tests/frontend/`
 2. Update `tests/frontend/visual-proof.spec.cjs` if the route/assertion changed
 3. Run `har env verify ${AGENT_ID} --full`
-4. In the session handoff, link the **after** screenshots (and **before** when present)
+4. In the session handoff, **always** link the **after** screenshots (and **before** when present) from the **session work dir** — not the main checkout (`docs/.har/artifacts/…` in the repo root stays stale)
 
 ## Definition of done
 
@@ -53,13 +53,15 @@ When you change the landing page or another route:
 - [ ] UI changes have Playwright coverage; screenshot artifacts prove the result
 - [ ] Changes committed **in the session worktree**
 - [ ] User got the preview URL http://localhost:${FE_PORT}
+- [ ] Session handoff lists Playwright **after** screenshot paths from the work dir (`.har/artifacts/browser-e2e/screenshots/after/`)
 - [ ] Present session handoff and **wait** before `complete`, push, or PR
 
 ### Session handoff
 
 After full verify and commit, stop. Include summary, session branch
-(`.har/slots/agent-${AGENT_ID}.json`), preview URL, and screenshot artifact paths.
-Never autonomously run `complete`, push, or open a PR. Prefer **Complete + open a PR**
+(`.har/slots/agent-${AGENT_ID}.json`), preview URL, and **Playwright after-screenshots**
+(under `<work-dir>/.har/artifacts/browser-e2e/screenshots/after/` — always list the
+PNG paths; the main checkout copy is not updated). Never autonomously run `complete`, push, or open a PR. Prefer **Complete + open a PR**
 when `gh`/GitHub MCP is available.
 
 Quick loop: `./.har/verify.sh ${AGENT_ID}` (check + health only).

--- a/docs/.har/README.md
+++ b/docs/.har/README.md
@@ -75,8 +75,9 @@ cd docs
 | **before** | End of `launch` (baseline) | `.har/artifacts/browser-e2e/screenshots/before/` |
 | **after** | Full verify / `browser-e2e` | `.har/artifacts/browser-e2e/screenshots/after/` |
 
-UI change tasks must add or update specs under `tests/frontend/` and include
-these artifact paths in the session handoff. See `stages/PLAYWRIGHT.md`.
+UI change tasks must add or update specs under `tests/frontend/` and **always**
+include Playwright screenshot paths from the **session work dir** in the session
+handoff (not the main checkout — see `CLAUDE.agent.md`). See `stages/PLAYWRIGHT.md`.
 
 ## Readiness layers
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -76,7 +76,10 @@ Commit in the session worktree. Run JSON stays in the main checkout `.har/runs/`
 ### Session handoff (required)
 
 After full verify and commit, stop. Include summary, session branch
-(`.har/slots/agent-<id>.json`), and preview URLs. Wait — never autonomously
+(`.har/slots/agent-<id>.json`), preview URLs, and **Playwright after-screenshots**
+from full verify (paths under the **session work dir**, not the main checkout —
+e.g. `<work-dir>/.har/artifacts/browser-e2e/screenshots/after/*.png`; list or link
+every PNG so UI changes are reviewable without hunting the worktree). Wait — never autonomously
 complete, teardown, push, or open a PR. **Default:** when `gh`/GitHub MCP is available,
 recommend **Complete + open a PR** (still needs approval). Alternatives: **Complete only**,
 or **Something else**. Without PR tooling, recommend **Complete only** and give the

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -36,6 +36,7 @@ const redirects = Object.fromEntries(
 );
 // The docs landing was consolidated into the Introduction; send /docs there.
 redirects['/docs'] = '/docs/getting-started/introduction/';
+redirects['/enterprise'] = '/teams/';
 
 export default defineConfig({
 	site: 'https://harproject.dev',

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -29,7 +29,7 @@ const { minimal = false } = Astro.props;
           </a>
         </div>
       </div>
-      <div class="footer-col"><strong>Product</strong><a href="/#why">What HAR gives you</a><a href="/#workflow">How HAR works</a><a href="/#control">Mission Control</a><a href="/enterprise">Enterprise</a></div>
+      <div class="footer-col"><strong>Product</strong><a href="/#why">What HAR gives you</a><a href="/#workflow">How HAR works</a><a href="/#control">Mission Control</a><a href="/teams/">Teams</a></div>
       <div class="footer-col"><strong>Resources</strong><a href="/docs">Documentation</a><a href="/docs/getting-started/quick-start/">Quick start</a><a href="https://www.npmjs.com/package/@osfactory/har">npm</a></div>
       <div class="footer-col"><strong>Project</strong><a href="https://github.com/os-factory/har">GitHub</a><a href="https://github.com/os-factory/har/blob/main/CONTRIBUTING.md">Contributing</a><a href="https://github.com/os-factory/har/blob/main/LICENSE">Apache-2.0</a></div>
     </div>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -2,7 +2,7 @@
 import ThemeToggle from './ThemeToggle.astro';
 
 interface Props {
-  active?: 'home' | 'plugins' | 'enterprise';
+  active?: 'home' | 'plugins' | 'teams';
   solid?: boolean;
 }
 
@@ -18,7 +18,7 @@ const homePrefix = active === 'home' ? '' : '/';
       <nav class="desktop-nav" aria-label="Primary navigation">
         <a href="/docs">Docs</a>
         <a href="/plugins/" class:list={{ active: active === 'plugins' }} aria-current={active === 'plugins' ? 'page' : undefined}>Plugins</a>
-        <a href="/enterprise" class:list={{ active: active === 'enterprise' }} aria-current={active === 'enterprise' ? 'page' : undefined}>Enterprise</a>
+        <a href="/teams/" class:list={{ active: active === 'teams' }} aria-current={active === 'teams' ? 'page' : undefined}>Teams</a>
       </nav>
       <div class="nav-actions">
         <a class="nav-link" href="https://github.com/os-factory/har">GitHub <span aria-hidden="true">↗</span></a>
@@ -33,7 +33,7 @@ const homePrefix = active === 'home' ? '' : '/';
   <div class="mobile-menu" id="mobile-menu" data-mobile-menu>
     <a href="/docs">Documentation</a>
     <a href="/plugins/">Plugins</a>
-    <a href="/enterprise">Enterprise</a>
+    <a href="/teams/">Teams</a>
     <a href="https://github.com/os-factory/har">GitHub</a>
   </div>
 </header>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -263,7 +263,7 @@ const heroRunTotal = formatHeroRunTotal();
 >
 <input type="hidden" name="access_key" value="9650ee0d-81c2-4edb-9cab-69920938f8ab" />
 <input type="hidden" name="subject" value="HAR team features registration" />
-<input type="hidden" name="form_type" value="enterprise" />
+<input type="hidden" name="form_type" value="teams" />
 <input type="hidden" name="source" value="landing-page-teams" />
 <input type="hidden" name="interests" value="hosted cloud, centralized observability, shared mission control" />
 <input type="checkbox" name="botcheck" class="hidden" hidden tabindex="-1" autocomplete="off" />

--- a/docs/src/pages/teams.astro
+++ b/docs/src/pages/teams.astro
@@ -7,9 +7,9 @@ import Footer from '../components/Footer.astro';
   title="HAR for teams"
   description="Run a fleet of coding agents across your whole organization, in one shared place. See what every agent costs down to the ticket, check what each run shipped, and help everyone work like your best engineers. Built on the open HAR core you already run."
   bodyClass="home-page"
-  canonicalPath="/enterprise/"
+  canonicalPath="/teams/"
 >
-  <Header active="enterprise" />
+  <Header active="teams" />
   <main>
 <section class="hero blueprint-surface">
 <div class="container hero-grid">
@@ -157,9 +157,9 @@ import Footer from '../components/Footer.astro';
   method="POST"
 >
 <input type="hidden" name="access_key" value="9650ee0d-81c2-4edb-9cab-69920938f8ab" />
-<input type="hidden" name="subject" value="HAR Enterprise early access request" />
-<input type="hidden" name="form_type" value="enterprise" />
-<input type="hidden" name="source" value="enterprise-page" />
+<input type="hidden" name="subject" value="HAR Teams early access request" />
+<input type="hidden" name="form_type" value="teams" />
+<input type="hidden" name="source" value="teams-page" />
 <input type="hidden" name="interests" value="ticket-level cost attribution, verifiable proof, gemba team analytics, alerts, shared workspaces" />
 <input type="checkbox" name="botcheck" class="hidden" hidden tabindex="-1" autocomplete="off" />
 <label class="sr-only" for="enterprise-email">Work email</label>

--- a/docs/src/scripts/site.ts
+++ b/docs/src/scripts/site.ts
@@ -106,7 +106,7 @@ for (const form of document.querySelectorAll<HTMLFormElement>('[data-newsletter-
         window.posthog?.capture(
           form.matches('[data-newsletter-form]')
             ? 'newsletter_subscription_completed'
-            : 'enterprise_interest_submitted',
+            : 'teams_interest_submitted',
         );
         form.reset();
         if (status) status.textContent = successMessage;

--- a/docs/tests/frontend/teams.spec.cjs
+++ b/docs/tests/frontend/teams.spec.cjs
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-test.describe('Enterprise page', () => {
+test.describe('Teams page', () => {
   test.beforeEach(async ({ page }) => {
     await page.route(
       /(?:posthog|googletagmanager|google-analytics|youtube|youtu\.be|web3forms|doubleclick)/i,
@@ -9,19 +9,27 @@ test.describe('Enterprise page', () => {
   });
 
   test('loads with hero and request-access form', async ({ page }) => {
-    await page.goto('/enterprise/');
+    await page.goto('/teams/');
     await expect(page.locator('body')).toBeVisible();
     await expect(page.locator('h1')).toContainText(
       'Bring visibility, control, and governance to every agent across your org.',
     );
-    await expect(page.getByRole('link', { name: 'Enterprise' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Teams' }).first()).toBeVisible();
     await expect(page.getByRole('textbox', { name: 'Work email' })).toBeVisible();
     await expect(page.locator('img[data-dashboard-zoom]')).toBeVisible();
   });
 
+  test('redirects legacy /enterprise/ URL to /teams/', async ({ page }) => {
+    await page.goto('/enterprise/');
+    await expect(page).toHaveURL(/\/teams\/$/);
+    await expect(page.locator('h1')).toContainText(
+      'Bring visibility, control, and governance to every agent across your org.',
+    );
+  });
+
   test('opens dashboard screenshot in zoom modal on mobile', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('/enterprise/');
+    await page.goto('/teams/');
 
     const trigger = page.locator('img[data-dashboard-zoom]');
     await expect(trigger).toBeVisible();

--- a/docs/tests/frontend/visual-proof.spec.cjs
+++ b/docs/tests/frontend/visual-proof.spec.cjs
@@ -63,15 +63,15 @@ test.describe('Visual proof screenshots', () => {
     expect(file).toBeTruthy();
   });
 
-  test('enterprise page full-page shot', async ({ page }, testInfo) => {
+  test('teams page full-page shot', async ({ page }, testInfo) => {
     test.setTimeout(90_000);
-    await page.goto('/enterprise/', { waitUntil: 'domcontentloaded' });
+    await page.goto('/teams/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('h1')).toContainText(
       'Bring visibility, control, and governance to every agent across your org.',
     );
     await page.locator('.hero').waitFor({ state: 'visible' });
     await page.waitForTimeout(800);
-    const file = await capturePageScreenshot(page, testInfo, 'enterprise');
+    const file = await capturePageScreenshot(page, testInfo, 'teams');
     expect(file).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Renames the marketing site nav/footer label from **Enterprise** to **Teams** and moves the dedicated page to `/teams/`.
- Adds an Astro redirect so legacy `/enterprise` links continue to work and land on `/teams/`.
- Updates Playwright coverage (including a redirect test) and visual-proof screenshots for the new route.

## Test plan
- [x] `har env verify 2 --full` (docs harness)
- [x] Playwright: Teams page loads, nav shows **Teams**, `/enterprise/` redirects to `/teams/`
- [ ] Preview: http://localhost:4331/teams/ and confirm `/enterprise` redirects


Made with [Cursor](https://cursor.com)