### PR TITLE
feat: warn when untracked files will be missing from session worktrees

### DIFF
--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -310,6 +310,49 @@ EOF
   fi
 }
 
+# Untracked (not ignored) paths stay in the main checkout when a session
+# worktree is created from HEAD. Advisory — never fails the launch.
+har_warn_untracked_worktree() {
+  case "${USE_WORKTREE:-${HARNESS_USE_WORKTREE:-true}}" in
+    true|TRUE|yes|YES|1) ;;
+    *) return 0 ;;
+  esac
+  local root="${REPO_ROOT:-}"
+  if [ -z "$root" ] && [ -n "${SCRIPT_DIR:-}" ]; then
+    root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  fi
+  [ -n "$root" ] || return 0
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  local paths=()
+  local entry
+  while IFS= read -r -d '' entry; do
+    paths+=("$entry")
+  done < <(git -C "$root" --literal-pathspecs ls-files --others --exclude-standard --directory -z 2>/dev/null || true)
+
+  local count="${#paths[@]}"
+  [ "$count" -gt 0 ] || return 0
+
+  local max=8
+  local listed=""
+  local i
+  for ((i = 0; i < count && i < max; i++)); do
+    [ -n "$listed" ] && listed+=", "
+    listed+="${paths[$i]}"
+  done
+  if [ "$count" -gt "$max" ]; then
+    listed+=" (+$((count - max)) more)"
+  fi
+
+  local noun="paths"
+  local them="They are"
+  if [ "$count" -eq 1 ]; then
+    noun="path"
+    them="It is"
+  fi
+  echo "WARN: ${count} untracked ${noun} will not appear in the session worktree: ${listed}. ${them} only in the main checkout — track them, or launch with --no-worktree." >&2
+}
+
 # har_launch_preflight <agent_id> [resume]
 # Exit 0 when ready; 2 when occupied (free the slot first) or not resumable; 1 on machine blockers.
 har_launch_preflight() {
@@ -346,6 +389,7 @@ har_launch_preflight() {
       fi
     done
   fi
+  har_warn_untracked_worktree
   return 0
 }
 

--- a/.har/manifest.json
+++ b/.har/manifest.json
@@ -16,7 +16,7 @@
     "README.md": "efa0dc01d6d3cf7a",
     "STAGES.md": "a4ac0935e883beab",
     "agent-cli.sh": "521a85e86297ebd2",
-    "agent-slot.sh": "30352581225b3200",
+    "agent-slot.sh": "67ef31bacf5143db",
     "docker-compose.agent.yml": "6991f134a3ba81f9",
     "harness.env": "28d0123c52801d59",
     "justfile": "6415e7c5452eb2f9",

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -320,6 +320,49 @@ har_regenerate_agent_env_file() {
   fi
 }
 
+# Untracked (not ignored) paths stay in the main checkout when a session
+# worktree is created from HEAD. Advisory — never fails the launch.
+har_warn_untracked_worktree() {
+  case "${USE_WORKTREE:-${HARNESS_USE_WORKTREE:-true}}" in
+    true|TRUE|yes|YES|1) ;;
+    *) return 0 ;;
+  esac
+  local root="${REPO_ROOT:-}"
+  if [ -z "$root" ] && [ -n "${SCRIPT_DIR:-}" ]; then
+    root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  fi
+  [ -n "$root" ] || return 0
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  local paths=()
+  local entry
+  while IFS= read -r -d '' entry; do
+    paths+=("$entry")
+  done < <(git -C "$root" --literal-pathspecs ls-files --others --exclude-standard --directory -z 2>/dev/null || true)
+
+  local count="${#paths[@]}"
+  [ "$count" -gt 0 ] || return 0
+
+  local max=8
+  local listed=""
+  local i
+  for ((i = 0; i < count && i < max; i++)); do
+    [ -n "$listed" ] && listed+=", "
+    listed+="${paths[$i]}"
+  done
+  if [ "$count" -gt "$max" ]; then
+    listed+=" (+$((count - max)) more)"
+  fi
+
+  local noun="paths"
+  local them="They are"
+  if [ "$count" -eq 1 ]; then
+    noun="path"
+    them="It is"
+  fi
+  echo "WARN: ${count} untracked ${noun} will not appear in the session worktree: ${listed}. ${them} only in the main checkout — track them, or launch with --no-worktree." >&2
+}
+
 # har_launch_preflight <agent_id> [resume]
 # Exit 0 when ready; 2 when occupied (free the slot first) or not resumable; 1 on machine blockers.
 # Sets FE_PORT/API_PORT/DEBUG_PORT when this harness uses PM2.
@@ -358,6 +401,7 @@ har_launch_preflight() {
       fi
     done
   fi
+  har_warn_untracked_worktree
   return 0
 }
 

--- a/control/.har/manifest.json
+++ b/control/.har/manifest.json
@@ -12,7 +12,7 @@
     "README.md": "3b1930416c414fa9",
     "STAGES.md": "029c2a037ed503c2",
     "agent-cli.sh": "7f0040b9508b1300",
-    "agent-slot.sh": "b1cf788a5f6cd28e",
+    "agent-slot.sh": "780c9eff0af6a56a",
     "attach.sh": "4755c9cfaf9abb45",
     "docker-compose.agent.yml": "5fb44636558e19b4",
     "ecosystem.agent.template.cjs": "ad305dbfcf6724e1",

--- a/docs/.har/agent-slot.sh
+++ b/docs/.har/agent-slot.sh
@@ -326,6 +326,49 @@ har_regenerate_agent_env_file() {
   fi
 }
 
+# Untracked (not ignored) paths stay in the main checkout when a session
+# worktree is created from HEAD. Advisory — never fails the launch.
+har_warn_untracked_worktree() {
+  case "${USE_WORKTREE:-${HARNESS_USE_WORKTREE:-true}}" in
+    true|TRUE|yes|YES|1) ;;
+    *) return 0 ;;
+  esac
+  local root="${REPO_ROOT:-}"
+  if [ -z "$root" ] && [ -n "${SCRIPT_DIR:-}" ]; then
+    root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  fi
+  [ -n "$root" ] || return 0
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  local paths=()
+  local entry
+  while IFS= read -r -d '' entry; do
+    paths+=("$entry")
+  done < <(git -C "$root" --literal-pathspecs ls-files --others --exclude-standard --directory -z 2>/dev/null || true)
+
+  local count="${#paths[@]}"
+  [ "$count" -gt 0 ] || return 0
+
+  local max=8
+  local listed=""
+  local i
+  for ((i = 0; i < count && i < max; i++)); do
+    [ -n "$listed" ] && listed+=", "
+    listed+="${paths[$i]}"
+  done
+  if [ "$count" -gt "$max" ]; then
+    listed+=" (+$((count - max)) more)"
+  fi
+
+  local noun="paths"
+  local them="They are"
+  if [ "$count" -eq 1 ]; then
+    noun="path"
+    them="It is"
+  fi
+  echo "WARN: ${count} untracked ${noun} will not appear in the session worktree: ${listed}. ${them} only in the main checkout — track them, or launch with --no-worktree." >&2
+}
+
 # har_launch_preflight <agent_id> [resume]
 # Exit 0 when ready; 2 when occupied (free the slot first) or not resumable; 1 on machine blockers.
 # Sets FE_PORT/API_PORT/DEBUG_PORT when this harness uses PM2.
@@ -364,6 +407,7 @@ har_launch_preflight() {
       fi
     done
   fi
+  har_warn_untracked_worktree
   return 0
 }
 

--- a/docs/.har/manifest.json
+++ b/docs/.har/manifest.json
@@ -12,7 +12,7 @@
     "README.md": "883a31ee9250b4bc",
     "STAGES.md": "a4ac0935e883beab",
     "agent-cli.sh": "20d5742ece791655",
-    "agent-slot.sh": "9bdfc739116fb951",
+    "agent-slot.sh": "6f6f7e6bdd5aa631",
     "attach.sh": "4755c9cfaf9abb45",
     "docker-compose.agent.yml": "383c6474797449f5",
     "ecosystem.agent.template.cjs": "265f52756dacc0f8",

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -42,7 +42,7 @@ With `--yes` and no `--agent-slots`, the profile template default is kept.
 | `maintain` | Validate, compare templates, and prepare or finalize an upgrade |
 | `add-plugin [plugin]` | Install a shipped plugin (registers stages) |
 | `add-stage [id]` | Register a custom stage (`--custom`), or deprecated plugin alias |
-| `preflight <id>` | Check ports, processes, Docker, and slot occupation |
+| `preflight <id>` | Check ports, processes, Docker, slot occupation, and untracked worktree paths |
 | `launch <id>` | Start a fresh session (new worktree from `--repo` HEAD) |
 | `recover <id>` | Resume a failed or partial launch |
 | `verify <id>` | Run quick or full verification |
@@ -123,6 +123,13 @@ Work metadata is optional and backward compatible. Bind when the task names a
 tracker issue or ticket: pass a short repo-scoped `--work-id`, plus `--work-source`,
 `--work-url`, and `--work-title` when known. A fresh bound launch creates an
 immutable attempt UUID; `--resume` preserves the failed session's attempt.
+
+A worktree only materializes what is in `HEAD`. Preflight and launch warn when
+untracked (not gitignored) paths will be missing from the session worktree —
+the count plus a few examples. Track them, or launch with `--no-worktree`. The
+check is skipped when `HARNESS_USE_WORKTREE=false` and for a `--no-worktree`
+launch. The same warning appears in `har env status --json`, MCP launch
+`stderr`, and `./.har/launch.sh`.
 
 ### Verify and finish
 

--- a/docs/src/content/docs/docs/reference/harness-files.md
+++ b/docs/src/content/docs/docs/reference/harness-files.md
@@ -39,6 +39,11 @@ Installed during `har onboard` / `har env init` (and refreshed on maintain):
 
 Legacy `AGENT.md` (singular) is migrated into `AGENTS.md` and removed. Do not create it.
 
+Keep instruction files **tracked**. A session worktree only materializes what is
+in `HEAD`, so an untracked `CLAUDE.md` or `.claude/` leaves every agent slot
+blind to the rules. `har env preflight` and `har env launch` warn when they
+find untracked paths; see [Launch and recovery](/docs/reference/cli/#launch-and-recovery).
+
 ## Generated local state
 
 These paths are normally gitignored:

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -17,7 +17,7 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 
 | Tool | Inputs | Result |
 | --- | --- | --- |
-| `har_preflight_environment` | `agentId` | Readiness, blockers, and whether launch is safe |
+| `har_preflight_environment` | `agentId` | Readiness, blockers, warnings (including untracked worktree paths), and whether launch is safe |
 | `har_launch_environment` | `agentId`, optional `worktree`, `claude`, `resume`, `workUnitId`, `source`, `sourceUrl`, `title`, `parentWorkUnitId` | Work directory, branch, work/attempt IDs, URLs, and normalized stage result |
 
 Pass `workUnitId`, `source`, and `sourceUrl` when the task names a tracker issue or

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -400,6 +400,8 @@ export const SlotReadinessSchema = z.object({
   remediations: z.array(z.string()),
   ports: z.record(z.number()).optional(),
   allocatedPorts: z.boolean().optional(),
+  /** A warning already states why this port was chosen — suppresses the generic note. */
+  portChoiceExplained: z.boolean().optional(),
   /** Non-blocking notices (e.g. har control up holds the default port but an alternate was picked). */
   warnings: z.array(z.string()).optional(),
 });

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -283,7 +283,7 @@ export const envCommand = {
       )
       .command(
         'preflight <id>',
-        'Check whether a slot can launch now (ports, PM2, Docker, occupied slot)',
+        'Check whether a slot can launch now (ports, PM2, Docker, occupied slot, untracked worktree paths)',
         (y: Argv) =>
           y
             .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
@@ -851,10 +851,13 @@ export async function handleLaunch(argv: {
   const agentId = validateAgentId(argv.id, repo);
 
   if (!argv.resume) {
-    const guard = checkLaunchGuard(repo, agentId, {});
+    const guard = checkLaunchGuard(repo, agentId, { worktree: argv.worktree });
     if (!guard.allowed && guard.blocked) {
       error(guard.reason ?? `Slot ${agentId} is occupied.`);
       return finishCommand(2);
+    }
+    for (const warning of guard.readiness?.warnings ?? []) {
+      warn(warning);
     }
   }
 

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -26,7 +26,7 @@ For a new unrelated task: checkout main (or your intended base) on the main
 repo checkout, free the slot (complete/teardown), then launch.`;
 
 export const HAR_ENV_EPILOG = `Environment lifecycle:
-  preflight <id>   dry-run: ports, PM2, Docker, occupied-slot gates
+  preflight <id>   dry-run: ports, PM2, Docker, occupied-slot gates, untracked paths
   launch <id>      fresh session worktree from the main checkout's current HEAD
   recover <id>     alias for launch --resume (failed/starting only)
   verify <id>      run checks (--full before declaring done)

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -166,6 +166,7 @@ export class RunService {
   async launchEnvironment(options: LaunchOptions): Promise<EnvironmentRunResult> {
     const guard = checkLaunchGuard(options.repoPath, options.agentId, {
       resume: options.resume,
+      worktree: options.worktree,
     });
     if (!guard.allowed) {
       const slot = guard.slot;
@@ -187,22 +188,26 @@ export class RunService {
       };
     }
 
-    let telemetryBanner = '';
+    // Readiness warnings are advisory, but a launch that passes the guard is the
+    // moment they matter most — they must not be dropped with the guard result.
+    let launchBanner = (guard.readiness?.warnings ?? [])
+      .map((warning) => `WARN: ${warning}\n`)
+      .join('');
     if (isTelemetryEnabled() && process.env.NODE_ENV !== 'test') {
       const ensured = await ensureTelemetryInfrastructure({ startIfNeeded: true });
       if (ensured.message) {
-        telemetryBanner += `${ensured.message}\nUsage from Cursor / Claude / Codex (@osfactory/otel-hook) will appear under Worktrees. Disable: har telemetry off\n`;
+        launchBanner += `${ensured.message}\nUsage from Cursor / Claude / Codex (@osfactory/otel-hook) will appear under Worktrees. Disable: har telemetry off\n`;
       }
       if (ensured.warning) {
-        telemetryBanner += `${ensured.warning}\n`;
+        launchBanner += `${ensured.warning}\n`;
       }
       try {
         const { ensureOtelHooks } = await import('./otel-hooks');
         const hooks = ensureOtelHooks({ setupAgents: true });
-        if (hooks.message) telemetryBanner += `${hooks.message}\n`;
-        if (hooks.warning) telemetryBanner += `${hooks.warning}\n`;
+        if (hooks.message) launchBanner += `${hooks.message}\n`;
+        if (hooks.warning) launchBanner += `${hooks.warning}\n`;
       } catch (err) {
-        telemetryBanner += `@osfactory/otel-hook setup skipped: ${err instanceof Error ? err.message : String(err)}\n`;
+        launchBanner += `@osfactory/otel-hook setup skipped: ${err instanceof Error ? err.message : String(err)}\n`;
       }
     }
 
@@ -307,8 +312,8 @@ export class RunService {
           });
         }
       }
-      if (telemetryBanner) {
-        envResult.stderr = `${telemetryBanner}${envResult.stderr ?? ''}`;
+      if (launchBanner) {
+        envResult.stderr = `${launchBanner}${envResult.stderr ?? ''}`;
       }
     }
     return envResult;

--- a/src/core/slot-launch-guard.ts
+++ b/src/core/slot-launch-guard.ts
@@ -1,4 +1,4 @@
-import { inspectSlotReadiness, formatPreflightReport } from './slot-preflight';
+import { inspectSlotReadiness, formatPreflightReport, type PreflightOptions } from './slot-preflight';
 import { checkLaunchGuard as checkOccupiedSlotGuard, type LaunchGuardOptions } from './slot-launch-guard-occupied';
 import type { AgentSlotStatus, SlotReadiness } from '../harness/schema';
 
@@ -16,7 +16,7 @@ export interface LaunchGuardResult {
 export function checkLaunchGuard(
   repoPath: string,
   agentId: number,
-  options: LaunchGuardOptions = {},
+  options: PreflightOptions = {},
 ): LaunchGuardResult {
   const readiness = inspectSlotReadiness(repoPath, agentId, options);
 

--- a/src/core/slot-preflight.ts
+++ b/src/core/slot-preflight.ts
@@ -22,6 +22,11 @@ import {
   slotPortLaneEnd,
 } from './slot-ports';
 import { readSlotRegistry, isSlotResumable } from './slot-registry';
+import {
+  formatUntrackedWorktreeWarning,
+  listUntrackedAbsentFromWorktree,
+  worktreeCheckEnabled,
+} from './worktree-untracked';
 import { execSync } from 'child_process';
 import { packageRunner } from '../utils/package-runner';
 
@@ -36,6 +41,10 @@ export interface PreflightOptions extends LaunchGuardOptions {
   dockerContainers?: DockerRow[];
   /** Test hook: override PM2 process list (pass [] to skip live pm2 jlist). */
   pm2Processes?: Pm2Process[];
+  /** Test hook: override the untracked-path scan (pass [] to skip the git call). */
+  untrackedPaths?: string[];
+  /** False for a `--no-worktree` launch — the slot runs in the repo root. */
+  worktree?: boolean;
 }
 
 interface Pm2Process {
@@ -109,6 +118,19 @@ function checkInfraPort(
     return { error: `No free ${varName} port in range ${scanStart}-${scanEnd}` };
   }
   return { port };
+}
+
+/**
+ * Repo-wide untracked-path scan. Identical for every slot — callers inspecting
+ * several slots should call this once and pass the result back through
+ * `PreflightOptions.untrackedPaths`.
+ */
+export function scanUntrackedWorktreePaths(
+  repoPath: string,
+  env: Record<string, string>,
+): string[] {
+  if (!worktreeCheckEnabled(env, undefined)) return [];
+  return listUntrackedAbsentFromWorktree(repoPath);
 }
 
 /**
@@ -196,6 +218,7 @@ export function inspectSlotReadiness(
   }
 
   let allocatedPorts = false;
+  let portChoiceExplained = false;
   if (usesPm2 && (options.allocatePorts ?? true)) {
     const alloc = allocateAppPorts(repoPath, agentId);
     if ('error' in alloc) {
@@ -216,7 +239,9 @@ export function inspectSlotReadiness(
         agentId,
         portStep(env),
       );
-      warnings.push(...controlDefaultPortWarnings(containers, feDefault, alloc.frontend));
+      const portWarnings = controlDefaultPortWarnings(containers, feDefault, alloc.frontend);
+      portChoiceExplained = portWarnings.length > 0;
+      warnings.push(...portWarnings);
 
       for (const [label, port] of Object.entries({ frontend: alloc.frontend, api: alloc.api })) {
         const control = controlContainerOnPort(containers, port);
@@ -275,6 +300,13 @@ export function inspectSlotReadiness(
     }
   }
 
+  if (worktreeCheckEnabled(env, options.worktree)) {
+    const untracked =
+      options.untrackedPaths ?? scanUntrackedWorktreePaths(repoPath, env);
+    const untrackedWarning = formatUntrackedWorktreeWarning(untracked);
+    if (untrackedWarning) warnings.push(untrackedWarning);
+  }
+
   const canLaunch = blockers.length === 0;
   return {
     canLaunch,
@@ -283,6 +315,7 @@ export function inspectSlotReadiness(
     remediations: [...new Set(remediations)],
     ports: Object.keys(ports).length > 0 ? ports : undefined,
     allocatedPorts: allocatedPorts || undefined,
+    portChoiceExplained: portChoiceExplained || undefined,
     warnings: warnings.length > 0 ? warnings : undefined,
   };
 }
@@ -300,7 +333,8 @@ export function formatPreflightReport(agentId: number, readiness: SlotReadiness)
         p.db !== undefined ? `db=${p.db}` : undefined,
       ].filter(Boolean);
       if (parts.length) lines.push(`  Ports: ${parts.join(' ')}`);
-      if (readiness.allocatedPorts && !readiness.warnings?.length) {
+      // Skip the generic note only when a warning already explains the chosen port.
+      if (readiness.allocatedPorts && !readiness.portChoiceExplained) {
         lines.push('  (alternate ports selected — defaults were busy)');
       }
     }
@@ -316,6 +350,10 @@ export function formatPreflightReport(agentId: number, readiness: SlotReadiness)
   for (const b of readiness.blockers) {
     lines.push(`  [${b.code}] ${b.message}`);
     if (b.remediation) lines.push(`    → ${b.remediation}`);
+  }
+  // Warnings are independent of the verdict — a blocked slot must not hide them.
+  for (const w of readiness.warnings ?? []) {
+    lines.push(`  WARN: ${w}`);
   }
   return lines.join('\n');
 }

--- a/src/core/slot-status.ts
+++ b/src/core/slot-status.ts
@@ -15,7 +15,7 @@ import { getAgentSlotIds } from '../harness/stages';
 import { computePreviewUrls } from './local-executor';
 import { listRuns, resolveAgentWorkDir } from './runs';
 import { readSlotRegistry } from './slot-registry';
-import { inspectSlotReadiness } from './slot-preflight';
+import { inspectSlotReadiness, scanUntrackedWorktreePaths } from './slot-preflight';
 import { packageRunner } from '../utils/package-runner';
 
 const BYPASS_WARNING_MS = 15 * 60 * 1000;
@@ -206,6 +206,7 @@ function collectSlotStatus(
   agentId: number,
   runs: RunRecord[],
   pm2Procs: Array<{ name?: string }> | undefined,
+  untrackedPaths?: string[],
 ): AgentSlotStatus {
   const env = readHarnessEnv(harnessRoot);
   const projectName = env.HARNESS_PROJECT_NAME ?? path.basename(harnessRoot);
@@ -256,6 +257,7 @@ function collectSlotStatus(
   const readiness = inspectSlotReadiness(harnessRoot, agentId, {
     allocatePorts: true,
     occupied: { active, dirty: drift.dirty },
+    untrackedPaths: untrackedPaths ?? scanUntrackedWorktreePaths(harnessRoot, env),
   });
 
   const resumeHint =
@@ -298,13 +300,15 @@ export function collectEnvironmentStatus(repoPath: string): EnvironmentStatus {
   const manifest = readManifest(harnessRoot);
   const slotIds = getAgentSlotIds(harnessRoot);
   const pm2Procs = listPm2Processes();
+  // Repo-wide and identical for every slot — scanned once, like pm2Procs above.
+  const untrackedPaths = scanUntrackedWorktreePaths(harnessRoot, readHarnessEnv(harnessRoot));
 
   return {
     repoPath: path.resolve(repoPath),
     harnessRoot,
     gitRemote: readGitRemote(harnessRoot),
     profile: manifest?.profile,
-    slots: slotIds.map((id) => collectSlotStatus(harnessRoot, id, runs, pm2Procs)),
+    slots: slotIds.map((id) => collectSlotStatus(harnessRoot, id, runs, pm2Procs, untrackedPaths)),
     generatedAt: new Date().toISOString(),
   };
 }

--- a/src/core/worktree-untracked.ts
+++ b/src/core/worktree-untracked.ts
@@ -1,0 +1,57 @@
+import { execSync } from 'child_process';
+import { resolveCheckoutRoot } from './hooks';
+
+const MAX_LISTED = 8;
+
+/**
+ * Paths present in the checkout but absent from a fresh `git worktree add`:
+ * untracked and not ignored. `--directory` collapses a fully untracked tree
+ * to one entry so a dirty `node_modules/` is a single line, not a walk.
+ * Returns `[]` outside a git checkout and never throws.
+ */
+export function listUntrackedAbsentFromWorktree(repoPath: string): string[] {
+  const toplevel = resolveCheckoutRoot(repoPath);
+  if (!toplevel) return [];
+  try {
+    const raw = execSync(
+      'git --literal-pathspecs ls-files --others --exclude-standard --directory -z',
+      {
+        cwd: toplevel,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'ignore'],
+        timeout: 10_000,
+        maxBuffer: 8 * 1024 * 1024,
+      },
+    );
+    return raw.split('\0').filter(Boolean).sort();
+  } catch {
+    return [];
+  }
+}
+
+/** One readiness warning: count plus a capped example list. */
+export function formatUntrackedWorktreeWarning(
+  paths: string[],
+  maxListed = MAX_LISTED,
+): string | undefined {
+  if (paths.length === 0) return undefined;
+  const shown = paths.slice(0, maxListed);
+  const omitted = paths.length - shown.length;
+  const listed = shown.join(', ') + (omitted > 0 ? ` (+${omitted} more)` : '');
+  const n = paths.length;
+  const noun = n === 1 ? 'path' : 'paths';
+  const them = n === 1 ? 'It is' : 'They are';
+  return (
+    `${n} untracked ${noun} will not appear in the session worktree: ${listed}. ` +
+    `${them} only in the main checkout — track them, or launch with --no-worktree.`
+  );
+}
+
+export function worktreeCheckEnabled(
+  env: Record<string, string>,
+  worktree?: boolean,
+): boolean {
+  if (worktree === false) return false;
+  if (worktree === true) return true;
+  return (env.HARNESS_USE_WORKTREE ?? 'true').toLowerCase() !== 'false';
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -123,7 +123,7 @@ export const HAR_MCP_TOOLS: Tool[] = [
   {
     name: 'har_preflight_environment',
     description:
-      'Readiness gate before launch: checks ports, foreign PM2, Docker conflicts, and occupied slot. Returns canLaunch with actionable blockers. Call before har_launch_environment.',
+      'Readiness gate before launch: checks ports, foreign PM2, Docker conflicts, occupied slot, and untracked paths that will be missing from a session worktree. Returns canLaunch with actionable blockers and warnings. Call before har_launch_environment.',
     inputSchema: objectJsonSchema(
       {
         repo: repoJsonProperty,

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -310,6 +310,49 @@ EOF
   fi
 }
 
+# Untracked (not ignored) paths stay in the main checkout when a session
+# worktree is created from HEAD. Advisory — never fails the launch.
+har_warn_untracked_worktree() {
+  case "${USE_WORKTREE:-${HARNESS_USE_WORKTREE:-true}}" in
+    true|TRUE|yes|YES|1) ;;
+    *) return 0 ;;
+  esac
+  local root="${REPO_ROOT:-}"
+  if [ -z "$root" ] && [ -n "${SCRIPT_DIR:-}" ]; then
+    root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  fi
+  [ -n "$root" ] || return 0
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  local paths=()
+  local entry
+  while IFS= read -r -d '' entry; do
+    paths+=("$entry")
+  done < <(git -C "$root" --literal-pathspecs ls-files --others --exclude-standard --directory -z 2>/dev/null || true)
+
+  local count="${#paths[@]}"
+  [ "$count" -gt 0 ] || return 0
+
+  local max=8
+  local listed=""
+  local i
+  for ((i = 0; i < count && i < max; i++)); do
+    [ -n "$listed" ] && listed+=", "
+    listed+="${paths[$i]}"
+  done
+  if [ "$count" -gt "$max" ]; then
+    listed+=" (+$((count - max)) more)"
+  fi
+
+  local noun="paths"
+  local them="They are"
+  if [ "$count" -eq 1 ]; then
+    noun="path"
+    them="It is"
+  fi
+  echo "WARN: ${count} untracked ${noun} will not appear in the session worktree: ${listed}. ${them} only in the main checkout — track them, or launch with --no-worktree." >&2
+}
+
 # har_launch_preflight <agent_id> [resume]
 # Exit 0 when ready; 2 when occupied (free the slot first) or not resumable; 1 on machine blockers.
 har_launch_preflight() {
@@ -346,6 +389,7 @@ har_launch_preflight() {
       fi
     done
   fi
+  har_warn_untracked_worktree
   return 0
 }
 

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -239,6 +239,49 @@ print_slot_occupied_warning() {
   echo "" >&2
 }
 
+# Untracked (not ignored) paths stay in the main checkout when a session
+# worktree is created from HEAD. Advisory — never fails the launch.
+har_warn_untracked_worktree() {
+  case "${USE_WORKTREE:-${HARNESS_USE_WORKTREE:-true}}" in
+    true|TRUE|yes|YES|1) ;;
+    *) return 0 ;;
+  esac
+  local root="${REPO_ROOT:-}"
+  if [ -z "$root" ] && [ -n "${SCRIPT_DIR:-}" ]; then
+    root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  fi
+  [ -n "$root" ] || return 0
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  local paths=()
+  local entry
+  while IFS= read -r -d '' entry; do
+    paths+=("$entry")
+  done < <(git -C "$root" --literal-pathspecs ls-files --others --exclude-standard --directory -z 2>/dev/null || true)
+
+  local count="${#paths[@]}"
+  [ "$count" -gt 0 ] || return 0
+
+  local max=8
+  local listed=""
+  local i
+  for ((i = 0; i < count && i < max; i++)); do
+    [ -n "$listed" ] && listed+=", "
+    listed+="${paths[$i]}"
+  done
+  if [ "$count" -gt "$max" ]; then
+    listed+=" (+$((count - max)) more)"
+  fi
+
+  local noun="paths"
+  local them="They are"
+  if [ "$count" -eq 1 ]; then
+    noun="path"
+    them="It is"
+  fi
+  echo "WARN: ${count} untracked ${noun} will not appear in the session worktree: ${listed}. ${them} only in the main checkout — track them, or launch with --no-worktree." >&2
+}
+
 git_common_dir() {
   local cwd="$1"
   local out

--- a/src/templates/har-boilerplate-ios/launch.sh
+++ b/src/templates/har-boilerplate-ios/launch.sh
@@ -56,6 +56,8 @@ if slot_is_occupied "$AGENT_ID"; then
   exit 2
 fi
 
+har_warn_untracked_worktree
+
 "$SCRIPT_DIR/setup-infra.sh"
 
 # Session worktree (default — use --no-worktree to work in repo root).

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -326,6 +326,49 @@ har_regenerate_agent_env_file() {
   fi
 }
 
+# Untracked (not ignored) paths stay in the main checkout when a session
+# worktree is created from HEAD. Advisory — never fails the launch.
+har_warn_untracked_worktree() {
+  case "${USE_WORKTREE:-${HARNESS_USE_WORKTREE:-true}}" in
+    true|TRUE|yes|YES|1) ;;
+    *) return 0 ;;
+  esac
+  local root="${REPO_ROOT:-}"
+  if [ -z "$root" ] && [ -n "${SCRIPT_DIR:-}" ]; then
+    root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  fi
+  [ -n "$root" ] || return 0
+  git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+
+  local paths=()
+  local entry
+  while IFS= read -r -d '' entry; do
+    paths+=("$entry")
+  done < <(git -C "$root" --literal-pathspecs ls-files --others --exclude-standard --directory -z 2>/dev/null || true)
+
+  local count="${#paths[@]}"
+  [ "$count" -gt 0 ] || return 0
+
+  local max=8
+  local listed=""
+  local i
+  for ((i = 0; i < count && i < max; i++)); do
+    [ -n "$listed" ] && listed+=", "
+    listed+="${paths[$i]}"
+  done
+  if [ "$count" -gt "$max" ]; then
+    listed+=" (+$((count - max)) more)"
+  fi
+
+  local noun="paths"
+  local them="They are"
+  if [ "$count" -eq 1 ]; then
+    noun="path"
+    them="It is"
+  fi
+  echo "WARN: ${count} untracked ${noun} will not appear in the session worktree: ${listed}. ${them} only in the main checkout — track them, or launch with --no-worktree." >&2
+}
+
 # har_launch_preflight <agent_id> [resume]
 # Exit 0 when ready; 2 when occupied (free the slot first) or not resumable; 1 on machine blockers.
 # Sets FE_PORT/API_PORT/DEBUG_PORT when this harness uses PM2.
@@ -364,6 +407,7 @@ har_launch_preflight() {
       fi
     done
   fi
+  har_warn_untracked_worktree
   return 0
 }
 

--- a/tests/agent-slots-bash.test.ts
+++ b/tests/agent-slots-bash.test.ts
@@ -84,4 +84,32 @@ describe('bash agent slot limits', () => {
     expect(elapsed).toBeLessThan(3000);
     expect(fs.existsSync(witness)).toBe(false); // still running, deliberately not awaited
   });
+
+  it('har_warn_untracked_worktree names untracked paths and stays quiet when ignored', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-untracked-warn-'));
+    execSync('git init -q', { cwd: repo });
+    execSync('git -c user.email=har@example.com -c user.name=har -c commit.gpgsign=false commit --allow-empty -qm init', {
+      cwd: repo,
+    });
+    fs.writeFileSync(path.join(repo, '.gitignore'), 'secret.env\n');
+    fs.writeFileSync(path.join(repo, 'CLAUDE.md'), '# rules\n');
+    fs.writeFileSync(path.join(repo, 'secret.env'), 'TOKEN=x\n');
+    execSync('git add .gitignore && git -c user.email=har@example.com -c user.name=har -c commit.gpgsign=false commit -qm ignore', {
+      cwd: repo,
+    });
+
+    const out = execSync(
+      `bash -c 'REPO_ROOT="${repo}"; USE_WORKTREE=true; source "${AGENT_SLOT}"; har_warn_untracked_worktree' 2>&1`,
+      { encoding: 'utf8' },
+    );
+    expect(out).toContain('WARN:');
+    expect(out).toContain('CLAUDE.md');
+    expect(out).not.toContain('secret.env');
+
+    const skipped = execSync(
+      `bash -c 'REPO_ROOT="${repo}"; USE_WORKTREE=false; source "${AGENT_SLOT}"; har_warn_untracked_worktree' 2>&1`,
+      { encoding: 'utf8' },
+    );
+    expect(skipped).toBe('');
+  });
 });

--- a/tests/slot-preflight.test.ts
+++ b/tests/slot-preflight.test.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { inspectSlotReadiness } from '../src/core/slot-preflight';
+import { formatPreflightReport, inspectSlotReadiness } from '../src/core/slot-preflight';
+import type { SlotReadiness } from '../src/harness/schema';
 import { allocateAppPorts, isPortInUse } from '../src/core/slot-ports';
 
 const tmpDirs: string[] = [];
@@ -15,6 +16,7 @@ function makeHarness(
     infraDb?: boolean;
     feBase?: number;
     apiBase?: number;
+    useWorktree?: boolean;
   } = {},
 ): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-preflight-'));
@@ -34,6 +36,9 @@ function makeHarness(
   if (options.infraDb) {
     lines.push('export HARNESS_INFRA_SERVICES="db"');
     lines.push('export HARNESS_DB_PORT_DEFAULT=15432');
+  }
+  if (options.useWorktree !== undefined) {
+    lines.push(`export HARNESS_USE_WORKTREE=${options.useWorktree}`);
   }
   fs.writeFileSync(path.join(harDir, 'harness.env'), lines.join('\n') + '\n');
   if (options.pm2) {
@@ -106,12 +111,77 @@ describe('inspectSlotReadiness', () => {
     expect(readiness.canLaunch).toBe(true);
   });
 
+  it('warns about untracked paths that will be missing from the session worktree', () => {
+    const repo = makeHarness();
+    const readiness = inspectSlotReadiness(repo, 1, {
+      untrackedPaths: ['CLAUDE.md'],
+    });
+    expect(readiness.canLaunch).toBe(true);
+    expect(readiness.warnings?.[0]).toContain('CLAUDE.md');
+  });
+
+  it('reports the warning even when the slot is blocked', () => {
+    const repo = makeHarness();
+    writeOccupiedSlot(repo, 1);
+    const readiness = inspectSlotReadiness(repo, 1, {
+      untrackedPaths: ['CLAUDE.md'],
+    });
+    expect(readiness.canLaunch).toBe(false);
+    expect(formatPreflightReport(1, readiness)).toContain('WARN: 1 untracked path');
+  });
+
+  it('skips the check when slots run in the repo root', () => {
+    const repo = makeHarness({ useWorktree: false });
+    const readiness = inspectSlotReadiness(repo, 1, {
+      untrackedPaths: ['CLAUDE.md'],
+    });
+    expect(readiness.warnings).toBeUndefined();
+  });
+
+  it('skips the check for a --no-worktree launch', () => {
+    const repo = makeHarness();
+    const readiness = inspectSlotReadiness(repo, 1, {
+      worktree: false,
+      untrackedPaths: ['CLAUDE.md'],
+    });
+    expect(readiness.warnings).toBeUndefined();
+  });
+
   it('allocates app ports for PM2 harnesses', () => {
     const repo = makeHarness({ pm2: true });
     const readiness = inspectSlotReadiness(repo, 2, { pm2Processes: [] });
     expect(readiness.canLaunch).toBe(true);
     expect(readiness.ports?.frontend).toBe(TEST_FE_BASE + 20);
     expect(readiness.ports?.api).toBe(TEST_API_BASE + 20);
+  });
+});
+
+describe('formatPreflightReport', () => {
+  const ready = (extra: Partial<SlotReadiness>): SlotReadiness => ({
+    canLaunch: true,
+    verdict: 'ready',
+    blockers: [],
+    remediations: [],
+    ports: { frontend: 3010 },
+    allocatedPorts: true,
+    ...extra,
+  });
+
+  it('drops the generic port note when a warning already explains the choice', () => {
+    const report = formatPreflightReport(
+      1,
+      ready({ portChoiceExplained: true, warnings: ['har control up holds port 3000.'] }),
+    );
+    expect(report).not.toContain('alternate ports selected');
+    expect(report).toContain('WARN: har control up holds port 3000.');
+  });
+
+  it('keeps the generic port note when only unrelated warnings are present', () => {
+    const report = formatPreflightReport(
+      1,
+      ready({ warnings: ['1 untracked path will not appear in the session worktree: notes.txt.'] }),
+    );
+    expect(report).toContain('alternate ports selected');
   });
 });
 

--- a/tests/worktree-untracked.test.ts
+++ b/tests/worktree-untracked.test.ts
@@ -1,0 +1,122 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  formatUntrackedWorktreeWarning,
+  listUntrackedAbsentFromWorktree,
+  worktreeCheckEnabled,
+} from '../src/core/worktree-untracked';
+
+const tmpDirs: string[] = [];
+
+function git(cwd: string, args: string): void {
+  execSync(
+    `git -c user.email=har@example.com -c user.name=har -c commit.gpgsign=false ${args}`,
+    { cwd, stdio: 'ignore' },
+  );
+}
+
+function write(repo: string, relPath: string, contents = 'x\n'): void {
+  const target = path.join(repo, relPath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, contents);
+}
+
+function makeRepo(files: Record<string, string> = {}, tracked: string[] = []): string {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-worktree-untracked-'));
+  tmpDirs.push(repo);
+  git(repo, 'init -q');
+  write(repo, 'tracked.txt');
+  for (const [relPath, contents] of Object.entries(files)) {
+    write(repo, relPath, contents);
+  }
+  git(
+    repo,
+    'add tracked.txt' + (tracked.length ? ' ' + tracked.map((p) => `"${p}"`).join(' ') : ''),
+  );
+  git(repo, 'commit -qm init');
+  return repo;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('listUntrackedAbsentFromWorktree', () => {
+  it('returns nothing outside a git checkout', () => {
+    const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'har-not-a-repo-')));
+    tmpDirs.push(dir);
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# rules\n');
+    const previousCeiling = process.env.GIT_CEILING_DIRECTORIES;
+    process.env.GIT_CEILING_DIRECTORIES = dir;
+    try {
+      expect(listUntrackedAbsentFromWorktree(dir)).toEqual([]);
+    } finally {
+      if (previousCeiling === undefined) delete process.env.GIT_CEILING_DIRECTORIES;
+      else process.env.GIT_CEILING_DIRECTORIES = previousCeiling;
+    }
+  });
+
+  it('lists untracked files and collapses an untracked directory', () => {
+    const repo = makeRepo({
+      'CLAUDE.md': '# rules\n',
+      '.claude/skills/review/SKILL.md': '# skill\n',
+    });
+    expect(listUntrackedAbsentFromWorktree(repo)).toEqual(['.claude/', 'CLAUDE.md']);
+  });
+
+  it('does not list tracked or gitignored paths', () => {
+    const repo = makeRepo(
+      {
+        '.gitignore': 'node_modules/\n.env\n*.md\n!README.md\n',
+        'README.md': '# app\n',
+        'CLAUDE.md': '# rules\n',
+        '.env': 'TOKEN=abc\n',
+        'notes.txt': 'scratch\n',
+        'node_modules/left-pad/readme.md': 'x\n',
+      },
+      ['.gitignore', 'README.md'],
+    );
+    expect(listUntrackedAbsentFromWorktree(repo)).toEqual(['notes.txt']);
+  });
+
+  it('does not list tracked context files', () => {
+    const repo = makeRepo({ 'CLAUDE.md': '# rules\n' }, ['CLAUDE.md']);
+    expect(listUntrackedAbsentFromWorktree(repo)).toEqual([]);
+  });
+});
+
+describe('formatUntrackedWorktreeWarning', () => {
+  it('returns undefined when there is nothing to report', () => {
+    expect(formatUntrackedWorktreeWarning([])).toBeUndefined();
+  });
+
+  it('names the count, paths, and the way out', () => {
+    const warning = formatUntrackedWorktreeWarning(['CLAUDE.md', '.claude/']);
+    expect(warning).toContain('2 untracked paths will not appear in the session worktree');
+    expect(warning).toContain('CLAUDE.md, .claude/');
+    expect(warning).toContain('They are only in the main checkout');
+    expect(warning).toContain('--no-worktree');
+  });
+
+  it('stays singular for one path and caps the listed remainder', () => {
+    expect(formatUntrackedWorktreeWarning(['.env'])).toContain('1 untracked path will not appear');
+    expect(formatUntrackedWorktreeWarning(['.env'])).toContain('It is only in the main checkout');
+    const many = Array.from({ length: 10 }, (_, i) => `note-${i}.txt`);
+    const warning = formatUntrackedWorktreeWarning(many, 8);
+    expect(warning).toContain('10 untracked paths');
+    expect(warning).toContain('(+2 more)');
+  });
+});
+
+describe('worktreeCheckEnabled', () => {
+  it('follows the harness default and the per-launch override', () => {
+    expect(worktreeCheckEnabled({})).toBe(true);
+    expect(worktreeCheckEnabled({ HARNESS_USE_WORKTREE: 'false' })).toBe(false);
+    expect(worktreeCheckEnabled({}, false)).toBe(false);
+    expect(worktreeCheckEnabled({ HARNESS_USE_WORKTREE: 'false' }, true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #205. A session worktree is `git worktree add` from `HEAD`, so untracked files stay in the main checkout and the agent never sees them.
- One git command, no filename lists: `git ls-files --others --exclude-standard --directory`. Gitignore is the denylist. The warning is a count plus a few examples.
- The warning is on the path agents actually use — `har env launch`, MCP launch `stderr`, and `./.har/launch.sh` — not only `har env preflight`. Skipped for `--no-worktree` / `HARNESS_USE_WORKTREE=false`.
- Keeps `portChoiceExplained` so unrelated warnings do not hide the “alternate ports” note.

This is the simpler alternative to #171 (no agent-context / local-config classifier, no extra `harness.env` knobs, no second-pass directory walk).

## Test plan

- [x] `har env verify 4 --full` (typecheck, build, unit tests, lint, docs-drift)
- [ ] `har env preflight <id>` in a checkout with an untracked `CLAUDE.md` shows the warning and still exits 0
- [ ] `har env launch <id>` prints the warning before creating the worktree
- [ ] `./.har/launch.sh <id>` prints the same `WARN:` line
- [ ] `--no-worktree` / `HARNESS_USE_WORKTREE=false` stays quiet
- [ ] gitignored paths (`.env`, `node_modules/`) are not listed


Made with [Cursor](https://cursor.com)