### PR TITLE
feat(control): add replayable agent trajectories

### DIFF
--- a/control/prisma/schema.prisma
+++ b/control/prisma/schema.prisma
@@ -22,6 +22,7 @@ model Repository {
   sessionUsage    AgentSessionUsage[]
   sessionEvents   AgentSessionEvent[]
   sessionSpans    AgentSessionSpan[]
+  trajectoryRecords AgentTrajectoryRecord[]
   workUnits       WorkUnit[]
   workAttempts    WorkAttempt[]
   validationBindings ValidationBinding[]
@@ -133,6 +134,39 @@ model AgentSessionSpan {
 
   @@unique([repositoryId, traceId, spanId])
   @@index([repositoryId, agentId, startTime])
+}
+
+model AgentTrajectoryRecord {
+  id                String     @id @default(uuid())
+  repositoryId      String
+  repository        Repository @relation(fields: [repositoryId], references: [id], onDelete: Cascade)
+  version           Int        @default(1)
+  source            String
+  sourceEventId     String
+  contentKey        String
+  sessionKey        String
+  agentId           Int
+  agentTool         String
+  eventType         String
+  sequence          Int
+  eventTimestamp    DateTime
+  payload           Json
+  contentKind       String
+  contentDisclosure String
+  contentLabel      String?
+  traceId           String?
+  spanId            String?
+  parentSpanId      String?
+  generationId      String?
+  toolCallId        String?
+  correlationId     String?
+  workUnitId        String?
+  attemptId         String?
+  createdAt         DateTime   @default(now())
+
+  @@unique([repositoryId, source, sourceEventId, contentKey])
+  @@index([repositoryId, agentId, sessionKey, agentTool, sequence, eventTimestamp, source])
+  @@index([repositoryId, agentId, sessionKey, agentTool, createdAt])
 }
 
 model Run {

--- a/control/src/app/api/repos/[id]/slots/[slotId]/trajectory/route.ts
+++ b/control/src/app/api/repos/[id]/slots/[slotId]/trajectory/route.ts
@@ -1,0 +1,69 @@
+import { AgentToolSchema } from '@har/schemas';
+import { NextResponse } from 'next/server';
+import {
+  cursorForTrajectory,
+  decodeTrajectoryCursor,
+  listTrajectoryAfter,
+  listTrajectoryHistory,
+  serializeTrajectoryPage,
+  serializeTrajectoryRecord,
+} from '@/server/trajectory-ledger';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string; slotId: string }> },
+) {
+  const { id, slotId } = await params;
+  const url = new URL(request.url);
+  const sessionKey = url.searchParams.get('sessionKey')?.trim();
+  const parsedTool = AgentToolSchema.safeParse(url.searchParams.get('agentTool'));
+  const agentId = Number(slotId);
+  if (!sessionKey) {
+    return NextResponse.json({ error: 'sessionKey is required' }, { status: 400 });
+  }
+  if (!parsedTool.success) {
+    return NextResponse.json({ error: 'agentTool is invalid' }, { status: 400 });
+  }
+  if (!Number.isInteger(agentId) || agentId < 1) {
+    return NextResponse.json({ error: 'slotId is invalid' }, { status: 400 });
+  }
+
+  const before = url.searchParams.get('before') ?? undefined;
+  const after = url.searchParams.get('after') ?? undefined;
+  const requestedLimit = Number(url.searchParams.get('limit') ?? 100);
+  try {
+    if (before && after) {
+      return NextResponse.json({ error: 'before and after are mutually exclusive' }, { status: 400 });
+    }
+    if (before) decodeTrajectoryCursor(before);
+    if (after) decodeTrajectoryCursor(after);
+    const limit = Math.max(
+      1,
+      Math.min(Number.isFinite(requestedLimit) ? requestedLimit : 100, after ? 999 : 200),
+    );
+    const scope = { repositoryId: id, agentId, sessionKey, agentTool: parsedTool.data };
+    if (after) {
+      const rows = await listTrajectoryAfter(scope, after, limit + 1);
+      const records = rows.slice(0, limit);
+      const latest = records.at(-1);
+      return NextResponse.json({
+        records: records.map(serializeTrajectoryRecord),
+        hasMore: rows.length > limit,
+        nextBefore: null,
+        latest: latest ? cursorForTrajectory(latest) : after,
+        nextAfter: rows.length > limit && latest ? cursorForTrajectory(latest) : null,
+      });
+    }
+    const page = await listTrajectoryHistory(
+      scope,
+      {
+        before,
+        limit,
+      },
+    );
+    return NextResponse.json(serializeTrajectoryPage(page));
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/control/src/app/api/repos/[id]/slots/[slotId]/trajectory/stream/route.ts
+++ b/control/src/app/api/repos/[id]/slots/[slotId]/trajectory/stream/route.ts
@@ -1,0 +1,132 @@
+import { AgentToolSchema } from '@har/schemas';
+import type { AgentTrajectoryRecord } from '@prisma/client';
+import {
+  cursorForTrajectory,
+  decodeTrajectoryCursor,
+  listTrajectoryAfter,
+  subscribeToTrajectory,
+  type TrajectoryScope,
+} from '@/server/trajectory-ledger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const encoder = new TextEncoder();
+
+function trajectoryMessage(record: Awaited<ReturnType<typeof listTrajectoryAfter>>[number]): Uint8Array {
+  const cursor = cursorForTrajectory(record);
+  return encoder.encode(
+    `id: ${cursor}\nevent: trajectory\ndata: ${JSON.stringify(record)}\n\n`,
+  );
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string; slotId: string }> },
+) {
+  const { id, slotId } = await params;
+  const url = new URL(request.url);
+  const sessionKey = url.searchParams.get('sessionKey')?.trim();
+  const parsedTool = AgentToolSchema.safeParse(url.searchParams.get('agentTool'));
+  const agentId = Number(slotId);
+  const after =
+    request.headers.get('last-event-id') ??
+    url.searchParams.get('after') ??
+    undefined;
+
+  if (!sessionKey) return new Response('sessionKey is required', { status: 400 });
+  if (!parsedTool.success) return new Response('agentTool is invalid', { status: 400 });
+  if (!Number.isInteger(agentId) || agentId < 1) {
+    return new Response('slotId is invalid', { status: 400 });
+  }
+  if (after) {
+    try {
+      decodeTrajectoryCursor(after);
+    } catch (error: unknown) {
+      return new Response(error instanceof Error ? error.message : String(error), { status: 400 });
+    }
+  }
+
+  const scope: TrajectoryScope = {
+    repositoryId: id,
+    agentId,
+    sessionKey,
+    agentTool: parsedTool.data,
+  };
+  let cleanup = () => {};
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      const pending: AgentTrajectoryRecord[] = [];
+      let replaying = true;
+      const seen = new Set<string>();
+
+      const send = (record: AgentTrajectoryRecord) => {
+        if (closed || seen.has(record.id)) return;
+        seen.add(record.id);
+        controller.enqueue(trajectoryMessage(record));
+      };
+      const unsubscribe = subscribeToTrajectory(scope, (record) => {
+        if (replaying) pending.push(record);
+        else send(record);
+      });
+      const heartbeat = setInterval(() => {
+        if (!closed) controller.enqueue(encoder.encode(': heartbeat\n\n'));
+      }, 15_000);
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(heartbeat);
+        unsubscribe();
+        try {
+          controller.close();
+        } catch {
+          // The client may already have closed the stream.
+        }
+      };
+      cleanup = close;
+      request.signal.addEventListener('abort', close, { once: true });
+
+      void (async () => {
+        try {
+          if (after) {
+            let replayCursor = after;
+            while (!closed) {
+              const records = await listTrajectoryAfter(scope, replayCursor);
+              for (const record of records) send(record);
+              if (records.length < 1_000) break;
+              replayCursor = cursorForTrajectory(records[records.length - 1]);
+            }
+          }
+          replaying = false;
+          for (const record of pending) send(record);
+          controller.enqueue(encoder.encode(': connected\n\n'));
+        } catch (error: unknown) {
+          if (!closed) {
+            controller.enqueue(
+              encoder.encode(
+                `event: error\ndata: ${JSON.stringify({
+                  message: error instanceof Error ? error.message : String(error),
+                })}\n\n`,
+              ),
+            );
+          }
+          close();
+        }
+      })();
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -4,12 +4,15 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { SessionEventsTable } from '@/components/session-events-table';
 import { SessionTimeline } from '@/components/session-timeline';
+import { TrajectoryViewer } from '@/components/trajectory-viewer';
 import { ValidationPipeline } from '@/components/validation-pipeline';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
 import { eventModel } from '@/lib/session-event-detail';
 import { formatModelId, formatCostUsd, modelTotalsFromBreakdown, modelsFromBreakdown, type UsageModelTotals } from '@/lib/usage-models';
 import { getRepository } from '@/server/repositories';
 import { listSessionEventsForSlot } from '@/server/session-events';
+import { getSlotTrajectoryData } from '@/server/trajectory-ledger';
 import { listSessionUsageForSlot } from '@/server/usage';
 import { getValidationStages } from '@/server/validation-stages';
 import { prisma } from '@/lib/db';
@@ -37,7 +40,7 @@ export default async function SlotDetailPage({
   const slot = repo.slots.find((s) => s.slotId === slotId);
   if (!slot) notFound();
 
-  const [usageRows, validation, events, verifyRuns] = await Promise.all([
+  const [usageRows, validation, events, verifyRuns, trajectory] = await Promise.all([
     listSessionUsageForSlot(id, slotId),
     getValidationStages(id, { agentId: slotId }),
     listSessionEventsForSlot(id, slotId),
@@ -46,6 +49,7 @@ export default async function SlotDetailPage({
       orderBy: { startedAt: 'desc' },
       take: 20,
     }),
+    getSlotTrajectoryData(id, slotId),
   ]);
 
   const modelsByUsageKey = new Map<string, string[]>();
@@ -225,27 +229,42 @@ export default async function SlotDetailPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Session events</CardTitle>
+          <CardTitle>Agent activity</CardTitle>
           <CardDescription>
-            Filter by Activity / Tools / Files / Prompts / Errors / Logs. Activity hides raw log
-            noise and keeps the spans that explain what the agent did.
+            Follow the assembled trajectory, or inspect the raw session-event table for debugging.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <SessionEventsTable
-            events={events.map((ev) => ({
-              id: ev.id,
-              eventName: ev.eventName,
-              sessionKey: ev.sessionKey,
-              agentTool: ev.agentTool,
-              promptText: ev.promptText,
-              responseText: ev.responseText,
-              attributes: ev.attributes,
-              rawTruncated: ev.rawTruncated,
-              source: ev.source,
-              timestamp: ev.timestamp,
-            }))}
-          />
+          <Tabs defaultValue="trajectory">
+            <TabsList>
+              <TabsTrigger value="trajectory">Trajectory</TabsTrigger>
+              <TabsTrigger value="raw-events">Raw events</TabsTrigger>
+            </TabsList>
+            <TabsContent value="trajectory" className="mt-4">
+              <TrajectoryViewer
+                repositoryId={id}
+                agentId={slotId}
+                streams={trajectory.streams}
+                initialPage={trajectory.initialPage}
+              />
+            </TabsContent>
+            <TabsContent value="raw-events" className="mt-4">
+              <SessionEventsTable
+                events={events.map((ev) => ({
+                  id: ev.id,
+                  eventName: ev.eventName,
+                  sessionKey: ev.sessionKey,
+                  agentTool: ev.agentTool,
+                  promptText: ev.promptText,
+                  responseText: ev.responseText,
+                  attributes: ev.attributes,
+                  rawTruncated: ev.rawTruncated,
+                  source: ev.source,
+                  timestamp: ev.timestamp,
+                }))}
+              />
+            </TabsContent>
+          </Tabs>
         </CardContent>
       </Card>
 

--- a/control/src/components/trajectory-viewer.tsx
+++ b/control/src/components/trajectory-viewer.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { formatAgentToolLabel } from '@/lib/agent-tool';
+import {
+  assembleTrajectory,
+  mergeTrajectoryRecords,
+  safeTrajectoryBody,
+  sequenceGap,
+  type SerializedTrajectoryPage,
+  type SerializedTrajectoryRecord,
+  type TrajectoryNode,
+  type TrajectoryStream,
+} from '@/lib/trajectory';
+
+type LiveStatus = 'live' | 'reconnecting' | 'offline';
+
+function streamKey(stream: TrajectoryStream): string {
+  return JSON.stringify([stream.sessionKey, stream.agentTool]);
+}
+
+function endpoint(
+  repositoryId: string,
+  agentId: number,
+  stream: TrajectoryStream,
+  suffix = '',
+): string {
+  const params = new URLSearchParams({
+    sessionKey: stream.sessionKey,
+    agentTool: stream.agentTool,
+  });
+  return `/api/repos/${encodeURIComponent(repositoryId)}/slots/${agentId}/trajectory${suffix}?${params}`;
+}
+
+function bodyText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value && typeof value === 'object' && 'stringValue' in value) {
+    const stringValue = (value as { stringValue?: unknown }).stringValue;
+    if (typeof stringValue === 'string') return stringValue;
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+function disclosureCopy(record: SerializedTrajectoryRecord): string {
+  if (record.contentDisclosure === 'withheld') {
+    const payload = record.payload && typeof record.payload === 'object'
+      ? record.payload as { disclosure?: { withheld?: unknown } }
+      : null;
+    const reason = payload?.disclosure?.withheld;
+    return typeof reason === 'string' && reason
+      ? `Content withheld: ${reason}.`
+      : 'Content withheld by the producer.';
+  }
+  if (record.contentDisclosure === 'metadata_only') return 'Metadata only; no content was recorded.';
+  if (record.contentDisclosure === 'truncated') return 'Truncated content';
+  if (record.contentDisclosure === 'redacted') return 'Redacted content';
+  if (record.contentDisclosure === 'masked') return 'Masked content';
+  return 'Recorded content';
+}
+
+function statusVariant(status: TrajectoryNode['status']) {
+  return status === 'error' ? 'destructive' as const : status === 'completed' ? 'secondary' as const : 'outline' as const;
+}
+
+function TrajectoryBlock({ node }: { node: TrajectoryNode }) {
+  const expandable = node.kind === 'tool' || node.kind === 'subagent';
+  if (expandable) {
+    return (
+      <Card className="border-l-4 border-l-muted-foreground/30">
+        <Collapsible>
+          <CardHeader className="space-y-1 p-0">
+            <CollapsibleTrigger className="group flex w-full flex-wrap items-center gap-2 p-3 text-left">
+              <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
+              <span className="text-sm font-semibold">{node.title}</span>
+              <Badge variant="outline" className="text-[10px]">{node.kind}</Badge>
+              {node.status ? (
+                <Badge variant={statusVariant(node.status)} className="text-[10px]">{node.status}</Badge>
+              ) : null}
+              <time className="ml-auto text-[10px] text-muted-foreground" dateTime={node.startedAt}>
+                {new Date(node.startedAt).toLocaleString()}
+              </time>
+            </CollapsibleTrigger>
+            {node.note ? <p className="px-3 pb-2 text-xs text-muted-foreground">{node.note}</p> : null}
+          </CardHeader>
+          <CollapsibleContent>
+            <CardContent className="space-y-2 p-3 pt-0">
+              {node.records.map((record) => {
+                const body = safeTrajectoryBody(record);
+                return (
+                  <div key={record.id} className="rounded-md border bg-muted/20 p-2">
+                    <div className="mb-1 flex flex-wrap items-center gap-2 text-xs">
+                      <span className="font-medium">{record.contentLabel || record.eventType}</span>
+                      <Badge variant="outline" className="text-[10px]">{record.contentDisclosure}</Badge>
+                    </div>
+                    {body == null ? (
+                      <p className="text-xs italic text-muted-foreground">{disclosureCopy(record)}</p>
+                    ) : (
+                      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words text-xs">{bodyText(body)}</pre>
+                    )}
+                  </div>
+                );
+              })}
+            </CardContent>
+          </CollapsibleContent>
+        </Collapsible>
+      </Card>
+    );
+  }
+
+  const content = (
+    <Card className="border-l-4 border-l-muted-foreground/30">
+      <CardHeader className="space-y-1 p-3 pb-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <CardTitle className="text-sm">{node.title}</CardTitle>
+          <Badge variant="outline" className="text-[10px]">{node.kind}</Badge>
+          {node.status ? (
+            <Badge variant={statusVariant(node.status)} className="text-[10px]">{node.status}</Badge>
+          ) : null}
+          <time className="ml-auto text-[10px] text-muted-foreground" dateTime={node.startedAt}>
+            {new Date(node.startedAt).toLocaleString()}
+          </time>
+        </div>
+        {node.note ? <p className="text-xs text-muted-foreground">{node.note}</p> : null}
+      </CardHeader>
+      <CardContent className="space-y-2 p-3 pt-0">
+        {node.records.map((record) => {
+          const body = safeTrajectoryBody(record);
+          return (
+            <div key={record.id}>
+              {body == null ? (
+                <p className="text-xs italic text-muted-foreground">{disclosureCopy(record)}</p>
+              ) : (
+                <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 p-2 text-xs">
+                  {bodyText(body)}
+                </pre>
+              )}
+              {record.contentDisclosure !== 'full' ? (
+                <Badge variant="outline" className="mt-1 text-[10px]">{record.contentDisclosure}</Badge>
+              ) : null}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+  return content;
+}
+
+export function TrajectoryViewer({
+  repositoryId,
+  agentId,
+  streams,
+  initialPage,
+}: {
+  repositoryId: string;
+  agentId: number;
+  streams: TrajectoryStream[];
+  initialPage: SerializedTrajectoryPage;
+}) {
+  const initialStream = streams[0] ?? null;
+  const [selectedKey, setSelectedKey] = useState(initialStream ? streamKey(initialStream) : '');
+  const [loadedKey, setLoadedKey] = useState(selectedKey);
+  const [records, setRecords] = useState(initialPage.records);
+  const [before, setBefore] = useState(initialPage.nextBefore);
+  const [hasMore, setHasMore] = useState(initialPage.hasMore);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [connectionSeed, setConnectionSeed] = useState(0);
+  const [status, setStatus] = useState<LiveStatus>(
+    typeof navigator !== 'undefined' && !navigator.onLine ? 'offline' : 'reconnecting',
+  );
+  const recordsRef = useRef(records);
+  const cursorRef = useRef(initialPage.latest);
+  const appendChain = useRef(Promise.resolve());
+  const selected = streams.find((stream) => streamKey(stream) === selectedKey) ?? null;
+  const nodes = useMemo(() => assembleTrajectory(records), [records]);
+
+  const replaceRecords = (next: SerializedTrajectoryRecord[]) => {
+    recordsRef.current = next;
+    setRecords(next);
+  };
+
+  useEffect(() => {
+    const online = () => setStatus('reconnecting');
+    const offline = () => setStatus('offline');
+    window.addEventListener('online', online);
+    window.addEventListener('offline', offline);
+    return () => {
+      window.removeEventListener('online', online);
+      window.removeEventListener('offline', offline);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selected || loadedKey !== selectedKey) return;
+    const url = new URL(endpoint(repositoryId, agentId, selected, '/stream'), window.location.origin);
+    if (cursorRef.current) url.searchParams.set('after', cursorRef.current);
+    const source = new EventSource(url);
+    source.onopen = () => setStatus('live');
+    source.onerror = () => setStatus(navigator.onLine ? 'reconnecting' : 'offline');
+    source.addEventListener('trajectory', (event) => {
+      const message = event as MessageEvent<string>;
+      appendChain.current = appendChain.current.then(async () => {
+        const incoming = JSON.parse(message.data) as SerializedTrajectoryRecord;
+        if (sequenceGap(recordsRef.current, incoming) && cursorRef.current) {
+          let after: string | null = cursorRef.current;
+          do {
+            const repairUrl = new URL(endpoint(repositoryId, agentId, selected), window.location.origin);
+            repairUrl.searchParams.set('after', after);
+            repairUrl.searchParams.set('limit', '999');
+            const response = await fetch(repairUrl);
+            if (!response.ok) throw new Error(`Gap repair failed (${response.status})`);
+            const page = await response.json() as SerializedTrajectoryPage;
+            replaceRecords(mergeTrajectoryRecords(recordsRef.current, page.records));
+            cursorRef.current = page.latest ?? after;
+            after = page.nextAfter ?? null;
+          } while (after);
+        }
+        replaceRecords(mergeTrajectoryRecords(recordsRef.current, [incoming]));
+        cursorRef.current = message.lastEventId || cursorRef.current;
+      }).catch(() => setStatus(navigator.onLine ? 'reconnecting' : 'offline'));
+    });
+    return () => source.close();
+  }, [agentId, connectionSeed, loadedKey, repositoryId, selected, selectedKey]);
+
+  const chooseStream = async (key: string) => {
+    const stream = streams.find((item) => streamKey(item) === key);
+    if (!stream) return;
+    setLoadedKey('');
+    setSelectedKey(key);
+    setStatus(navigator.onLine ? 'reconnecting' : 'offline');
+    replaceRecords([]);
+    const response = await fetch(endpoint(repositoryId, agentId, stream));
+    if (!response.ok) {
+      setStatus('offline');
+      return;
+    }
+    const page = await response.json() as SerializedTrajectoryPage;
+    replaceRecords(page.records);
+    setBefore(page.nextBefore);
+    setHasMore(page.hasMore);
+    cursorRef.current = page.latest;
+    setLoadedKey(key);
+    setConnectionSeed((value) => value + 1);
+  };
+
+  const loadOlder = async () => {
+    if (!selected || !before) return;
+    setLoadingOlder(true);
+    try {
+      const url = new URL(endpoint(repositoryId, agentId, selected), window.location.origin);
+      url.searchParams.set('before', before);
+      const response = await fetch(url);
+      if (!response.ok) return;
+      const page = await response.json() as SerializedTrajectoryPage;
+      replaceRecords(mergeTrajectoryRecords(page.records, recordsRef.current));
+      setBefore(page.nextBefore);
+      setHasMore(page.hasMore);
+    } finally {
+      setLoadingOlder(false);
+    }
+  };
+
+  if (streams.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No trajectory records yet. New OTEL-hook or harvested agent facts will appear here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        {streams.length > 1 ? (
+          <Select value={selectedKey} onValueChange={(value) => void chooseStream(value)}>
+            <SelectTrigger className="max-w-md" aria-label="Select trajectory session and agent">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {streams.map((stream) => (
+                <SelectItem key={streamKey(stream)} value={streamKey(stream)}>
+                  {formatAgentToolLabel(stream.agentTool)} · {stream.sessionKey}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <p className="truncate text-xs text-muted-foreground">
+            {formatAgentToolLabel(streams[0].agentTool)} · {streams[0].sessionKey}
+          </p>
+        )}
+        <Badge variant="outline" aria-label={`Trajectory connection ${status}`}>
+          <span className={`mr-1.5 h-2 w-2 rounded-full ${status === 'live' ? 'bg-emerald-500' : status === 'offline' ? 'bg-destructive' : 'bg-amber-500'}`} />
+          {status}
+        </Badge>
+      </div>
+      {hasMore && before ? (
+        <Button variant="outline" size="sm" disabled={loadingOlder} onClick={() => void loadOlder()}>
+          {loadingOlder ? 'Loading…' : 'Load older'}
+        </Button>
+      ) : null}
+      {nodes.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No records in this trajectory stream.</p>
+      ) : (
+        <div className="space-y-2" aria-label="Agent trajectory timeline">
+          {nodes.map((node) => <TrajectoryBlock key={node.id} node={node} />)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/control/src/lib/schemas.test.ts
+++ b/control/src/lib/schemas.test.ts
@@ -1,11 +1,35 @@
 import { describe, it, expect } from 'vitest';
 import {
+  AgentTrajectoryRecordSchema,
   DeleteWorktreesInputSchema,
   RegisterRepoInputSchema,
   ResetMissionControlInputSchema,
   RunRecordSchema,
   SyncWorkUnitsInputSchema,
 } from '@har/schemas';
+
+describe('AgentTrajectoryRecordSchema', () => {
+  it('accepts an immutable v1 content fact and all canonical sources', () => {
+    const base = {
+      version: 1,
+      sourceEventId: 'event-42',
+      contentKey: 'response:abc123',
+      sessionKey: 'session-1',
+      agentId: 2,
+      agentTool: 'cursor',
+      eventType: 'generation.end',
+      sequence: 7,
+      timestamp: '2026-08-14T10:00:00.000Z',
+      payload: { body: 'done' },
+      contentKind: 'response',
+      contentDisclosure: 'full',
+    };
+    for (const source of ['otel', 'harvest', 'har']) {
+      expect(AgentTrajectoryRecordSchema.parse({ ...base, source }).source).toBe(source);
+    }
+    expect(() => AgentTrajectoryRecordSchema.parse({ ...base, version: 2, source: 'otel' })).toThrow();
+  });
+});
 
 describe('RegisterRepoInputSchema', () => {
   it('parses minimal repo registration', () => {

--- a/control/src/lib/session-event-detail.test.ts
+++ b/control/src/lib/session-event-detail.test.ts
@@ -3,6 +3,7 @@ import {
   displayEventType,
   displayPromptText,
   eventDetailSummary,
+  eventToolName,
   isRedundantLogEvent,
   matchesSessionEventView,
   shortEventName,
@@ -94,5 +95,19 @@ describe('event views', () => {
     expect(matchesSessionEventView(logMirror, 'activity')).toBe(false);
     expect(matchesSessionEventView(logMirror, 'logs')).toBe(true);
     expect(matchesSessionEventView(toolSpan, 'tools')).toBe(true);
+  });
+
+  it('classifies canonical otelhook events and standard tool names', () => {
+    const tool = {
+      eventName: 'tool.start',
+      attributes: { 'gen_ai.tool.name': 'shell' },
+    };
+    const prompt = { eventName: 'prompt.submitted' };
+    const generation = { eventName: 'generation.end' };
+
+    expect(eventToolName(tool.attributes)).toBe('shell');
+    expect(matchesSessionEventView(tool, 'tools')).toBe(true);
+    expect(matchesSessionEventView(prompt, 'prompts')).toBe(true);
+    expect(matchesSessionEventView(generation, 'activity')).toBe(true);
   });
 });

--- a/control/src/lib/session-event-detail.ts
+++ b/control/src/lib/session-event-detail.ts
@@ -74,6 +74,13 @@ const ACTIVITY_TYPES = new Set([
   'generation',
   'SessionStart',
   'SessionEnd',
+  'prompt.submitted',
+  'generation.start',
+  'generation.end',
+  'tool.start',
+  'tool.end',
+  'session.start',
+  'session.end',
 ]);
 
 /** Friendlier type label for log bodies like “Tool call: Read”. */
@@ -118,10 +125,13 @@ export function matchesSessionEventView(
   );
   const isPrompt =
     name === 'UserPromptSubmit' ||
+    name === 'prompt.submitted' ||
     Boolean(displayPromptText(event.promptText)) ||
     promptFromAttrs;
   const isTool =
     /ToolUse|ShellExecution|MCPExecution/i.test(name) ||
+    name === 'tool.start' ||
+    name === 'tool.end' ||
     Boolean(eventToolName(event.attributes)) ||
     /^Tool(Call|Result):/i.test(logEventKind(event.rawTruncated) ?? '');
   const isFile = /ReadFile|FileEdit/i.test(name);
@@ -219,7 +229,12 @@ export function displayPromptText(promptText: string | null | undefined): string
 export function eventToolName(attributes: unknown): string | null {
   const attrs = asAttrMap(attributes);
   if (!attrs) return null;
-  return attrString(attrs, 'gen_ai.client.tool_name', 'gen_ai.client.mcp_tool');
+  return attrString(
+    attrs,
+    'gen_ai.tool.name',
+    'gen_ai.client.tool_name',
+    'gen_ai.client.mcp_tool',
+  );
 }
 
 export function eventModel(attributes: unknown): string | null {
@@ -258,7 +273,12 @@ export function eventDetailSummary(
     const fromMessages = textFromGenAiMessages(inputMessages);
     if (fromMessages) return fromMessages;
 
-    const tool = attrString(attrs, 'gen_ai.client.tool_name', 'gen_ai.client.mcp_tool');
+    const tool = attrString(
+      attrs,
+      'gen_ai.tool.name',
+      'gen_ai.client.tool_name',
+      'gen_ai.client.mcp_tool',
+    );
     if (tool) return tool;
   }
 
@@ -283,7 +303,12 @@ export function summarizeEventAttributes(attributes: unknown): string[] {
   if (!attrs) return [];
   const lines: string[] = [];
 
-  const tool = attrString(attrs, 'gen_ai.client.tool_name', 'gen_ai.client.mcp_tool');
+  const tool = attrString(
+    attrs,
+    'gen_ai.tool.name',
+    'gen_ai.client.tool_name',
+    'gen_ai.client.mcp_tool',
+  );
   if (tool) lines.push(`tool: ${tool}`);
 
   const command = attrString(attrs, 'gen_ai.client.command');

--- a/control/src/lib/trajectory.test.ts
+++ b/control/src/lib/trajectory.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assembleTrajectory,
+  mergeTrajectoryRecords,
+  safeTrajectoryBody,
+  type SerializedTrajectoryRecord,
+} from './trajectory';
+
+function record(
+  id: string,
+  overrides: Partial<SerializedTrajectoryRecord> = {},
+): SerializedTrajectoryRecord {
+  return {
+    id,
+    repositoryId: 'repo-1',
+    version: 1,
+    source: 'otel',
+    sourceEventId: id,
+    contentKey: `content-${id}`,
+    sessionKey: 'session-1',
+    agentId: 3,
+    agentTool: 'cursor',
+    eventType: 'event',
+    sequence: 1,
+    eventTimestamp: '2026-08-14T10:00:00.000Z',
+    payload: {},
+    contentKind: 'event',
+    contentDisclosure: 'full',
+    contentLabel: null,
+    traceId: null,
+    spanId: null,
+    parentSpanId: null,
+    generationId: null,
+    toolCallId: null,
+    correlationId: null,
+    workUnitId: null,
+    attemptId: null,
+    createdAt: '2026-08-14T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('trajectory assembler', () => {
+  it('deduplicates row ids and applies canonical ordering', () => {
+    const later = record('later', { sequence: 2 });
+    const first = record('first', { contentKey: 'a' });
+    const second = record('second', { contentKey: 'b' });
+
+    expect(mergeTrajectoryRecords([later, second], [first, later]).map((item) => item.id)).toEqual([
+      'first',
+      'second',
+      'later',
+    ]);
+  });
+
+  it('pairs tool boundaries by explicit otelhook call id and keeps unmatched starts running', () => {
+    const start = record('start', {
+      eventType: 'tool.start',
+      contentKind: 'tool_input',
+      contentLabel: 'Read file',
+      payload: { attributes: { 'otelhook.tool.call.id': 'call-7' }, body: '/tmp/file' },
+    });
+    const end = record('end', {
+      sequence: 2,
+      eventType: 'tool.end',
+      contentKind: 'tool_output',
+      payload: { attributes: { 'otelhook.tool.call.id': 'call-7' }, body: 'contents' },
+    });
+    const running = record('running', {
+      sequence: 3,
+      eventType: 'tool.start',
+      contentKind: 'tool_input',
+      correlationId: 'fallback-8',
+    });
+
+    const nodes = assembleTrajectory([end, running, start]);
+    expect(nodes[0]).toMatchObject({
+      kind: 'tool',
+      title: 'Read file',
+      status: 'completed',
+      records: [{ id: 'start' }, { id: 'end' }],
+    });
+    expect(nodes[1]).toMatchObject({
+      kind: 'tool',
+      status: 'running',
+      note: expect.stringContaining('no explicit call id'),
+    });
+  });
+
+  it('uses canonical tool call ids and preserves failed outcomes', () => {
+    const start = record('start', {
+      eventType: 'tool.start',
+      toolCallId: 'call-8',
+    });
+    const end = record('end', {
+      sequence: 2,
+      eventType: 'tool.end',
+      toolCallId: 'call-8',
+      payload: { attributes: { 'otelhook.outcome': 'error' } },
+    });
+    expect(assembleTrajectory([end, start])[0]).toMatchObject({
+      kind: 'tool',
+      status: 'error',
+      records: [{ id: 'start' }, { id: 'end' }],
+    });
+  });
+
+  it('does not claim a correlation when an end has no matching start', () => {
+    const [node] = assembleTrajectory([
+      record('end', { eventType: 'subagent.end', contentKind: 'metadata' }),
+    ]);
+    expect(node).toMatchObject({
+      kind: 'subagent',
+      status: 'unmatched',
+      note: expect.stringContaining('No matching start'),
+    });
+  });
+
+  it('classifies messages and preserves disclosure without exposing protected bodies', () => {
+    const withheld = record('reasoning', {
+      eventType: 'generation.end',
+      contentKind: 'reasoning',
+      contentDisclosure: 'withheld',
+      payload: { body: 'secret reasoning', disclosure: { withheld: 'policy' } },
+    });
+    const metadataOnly = record('prompt', {
+      contentKind: 'prompt',
+      contentDisclosure: 'metadata_only',
+      payload: { body: 'secret prompt' },
+    });
+    const truncated = record('response', {
+      contentKind: 'response',
+      contentDisclosure: 'truncated',
+      payload: { responseText: 'partial answer', body: 'fallback' },
+    });
+
+    expect(assembleTrajectory([withheld, metadataOnly, truncated]).map((node) => node.kind)).toEqual([
+      'prompt',
+      'reasoning',
+      'response',
+    ]);
+    expect(safeTrajectoryBody(withheld)).toBeNull();
+    expect(safeTrajectoryBody(metadataOnly)).toBeNull();
+    expect(safeTrajectoryBody(truncated)).toBe('partial answer');
+  });
+});

--- a/control/src/lib/trajectory.ts
+++ b/control/src/lib/trajectory.ts
@@ -1,0 +1,292 @@
+export type TrajectoryDisclosure =
+  | 'full'
+  | 'redacted'
+  | 'masked'
+  | 'truncated'
+  | 'withheld'
+  | 'metadata_only';
+
+export interface SerializedTrajectoryRecord {
+  id: string;
+  repositoryId: string;
+  version: number;
+  source: string;
+  sourceEventId: string;
+  contentKey: string;
+  sessionKey: string;
+  agentId: number;
+  agentTool: string;
+  eventType: string;
+  sequence: number;
+  eventTimestamp: string;
+  payload: unknown;
+  contentKind: string;
+  contentDisclosure: TrajectoryDisclosure;
+  contentLabel: string | null;
+  traceId: string | null;
+  spanId: string | null;
+  parentSpanId: string | null;
+  generationId: string | null;
+  toolCallId: string | null;
+  correlationId: string | null;
+  workUnitId: string | null;
+  attemptId: string | null;
+  createdAt: string;
+}
+
+export interface TrajectoryStream {
+  sessionKey: string;
+  agentTool: string;
+  latestTimestamp: string;
+}
+
+export interface SerializedTrajectoryPage {
+  records: SerializedTrajectoryRecord[];
+  hasMore: boolean;
+  nextBefore: string | null;
+  latest: string | null;
+  nextAfter?: string | null;
+}
+
+export type TrajectoryNodeKind =
+  | 'prompt'
+  | 'response'
+  | 'reasoning'
+  | 'tool'
+  | 'subagent'
+  | 'error'
+  | 'metadata'
+  | 'event';
+
+export interface TrajectoryNode {
+  id: string;
+  kind: TrajectoryNodeKind;
+  title: string;
+  status?: 'running' | 'completed' | 'error' | 'unmatched';
+  startedAt: string;
+  endedAt?: string;
+  records: SerializedTrajectoryRecord[];
+  note?: string;
+}
+
+const TOOL_CALL_ID_KEYS = [
+  'otelhook.tool.call.id',
+  'otelhook.tool_call.id',
+  'gen_ai.tool.call.id',
+  'tool.call.id',
+  'tool_call_id',
+  'toolCallId',
+];
+const SUBAGENT_ID_KEYS = [
+  'otelhook.subagent.id',
+  'subagent.id',
+  'subagent_id',
+  'subagentId',
+];
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function trajectoryAttributes(record: SerializedTrajectoryRecord): Record<string, unknown> {
+  return asObject(asObject(record.payload)?.attributes) ?? {};
+}
+
+function attributeString(record: SerializedTrajectoryRecord, keys: string[]): string | null {
+  const attributes = trajectoryAttributes(record);
+  for (const key of keys) {
+    const value = attributes[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+    if (typeof value === 'number') return String(value);
+  }
+  return null;
+}
+
+export function compareSerializedTrajectory(
+  left: SerializedTrajectoryRecord,
+  right: SerializedTrajectoryRecord,
+): number {
+  return (
+    left.sequence - right.sequence ||
+    left.eventTimestamp.localeCompare(right.eventTimestamp) ||
+    left.source.localeCompare(right.source) ||
+    left.sourceEventId.localeCompare(right.sourceEventId) ||
+    left.contentKey.localeCompare(right.contentKey) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+export function mergeTrajectoryRecords(
+  ...groups: SerializedTrajectoryRecord[][]
+): SerializedTrajectoryRecord[] {
+  const byId = new Map<string, SerializedTrajectoryRecord>();
+  for (const record of groups.flat()) byId.set(record.id, record);
+  return [...byId.values()].sort(compareSerializedTrajectory);
+}
+
+function pairingKey(
+  record: SerializedTrajectoryRecord,
+  kind: 'tool' | 'subagent',
+): { key: string; confidence: 'explicit' | 'fallback' } {
+  if (kind === 'tool' && record.toolCallId) {
+    return { key: `explicit:${record.toolCallId}`, confidence: 'explicit' };
+  }
+  const explicit = attributeString(record, kind === 'tool' ? TOOL_CALL_ID_KEYS : SUBAGENT_ID_KEYS);
+  if (explicit) return { key: `explicit:${explicit}`, confidence: 'explicit' };
+  if (record.correlationId) return { key: `correlation:${record.correlationId}`, confidence: 'fallback' };
+  return { key: `event:${record.sourceEventId}`, confidence: 'fallback' };
+}
+
+function contentTitle(record: SerializedTrajectoryRecord, fallback: string): string {
+  return record.contentLabel?.trim() ||
+    attributeString(record, [
+      'otelhook.tool.name',
+      'gen_ai.tool.name',
+      'tool.name',
+      'otelhook.subagent.name',
+      'subagent.name',
+    ]) ||
+    fallback;
+}
+
+function eventOutcome(record: SerializedTrajectoryRecord): string | null {
+  return attributeString(record, ['otelhook.outcome', 'gen_ai.tool.outcome', 'outcome']);
+}
+
+function simpleKind(record: SerializedTrajectoryRecord): TrajectoryNodeKind {
+  const content = record.contentKind.toLowerCase();
+  const event = record.eventType.toLowerCase();
+  if (content === 'prompt' || content === 'user' || event.includes('prompt')) return 'prompt';
+  if (content === 'response' || content === 'assistant' || event.includes('response')) return 'response';
+  if (content.includes('reasoning')) return 'reasoning';
+  if (event.includes('error') || event.includes('fail') || content.includes('error')) return 'error';
+  if (
+    event.includes('compaction') ||
+    event.includes('session') ||
+    event.includes('generation') ||
+    content.includes('metadata')
+  ) return 'metadata';
+  return 'event';
+}
+
+function nodeForRecord(record: SerializedTrajectoryRecord): TrajectoryNode {
+  const kind = simpleKind(record);
+  const titles: Record<TrajectoryNodeKind, string> = {
+    prompt: 'User prompt',
+    response: 'Assistant response',
+    reasoning: 'Reasoning',
+    tool: 'Tool call',
+    subagent: 'Subagent',
+    error: 'Error',
+    metadata: record.eventType,
+    event: record.eventType,
+  };
+  return {
+    id: record.id,
+    kind,
+    title: contentTitle(record, titles[kind]),
+    status: kind === 'error' ? 'error' : undefined,
+    startedAt: record.eventTimestamp,
+    records: [record],
+  };
+}
+
+function isBoundary(record: SerializedTrajectoryRecord, kind: 'tool' | 'subagent', side: 'start' | 'end') {
+  const event = record.eventType.toLowerCase().replaceAll('_', '.');
+  return event.includes(kind) && (
+    event.endsWith(`.${side}`) ||
+    event.includes(`.${side}.`) ||
+    event.endsWith(`${kind}${side}`)
+  );
+}
+
+export function assembleTrajectory(records: SerializedTrajectoryRecord[]): TrajectoryNode[] {
+  const ordered = mergeTrajectoryRecords(records);
+  const nodes: TrajectoryNode[] = [];
+  const open = new Map<string, TrajectoryNode[]>();
+
+  for (const record of ordered) {
+    const boundaryKind = isBoundary(record, 'tool', 'start') || isBoundary(record, 'tool', 'end')
+      ? 'tool'
+      : isBoundary(record, 'subagent', 'start') || isBoundary(record, 'subagent', 'end')
+        ? 'subagent'
+        : null;
+    if (!boundaryKind) {
+      nodes.push(nodeForRecord(record));
+      continue;
+    }
+
+    const start = isBoundary(record, boundaryKind, 'start');
+    const { key, confidence } = pairingKey(record, boundaryKind);
+    const mapKey = `${boundaryKind}:${key}`;
+    if (start) {
+      const node: TrajectoryNode = {
+        id: record.id,
+        kind: boundaryKind,
+        title: contentTitle(record, boundaryKind === 'tool' ? 'Tool call' : 'Subagent'),
+        status: 'running',
+        startedAt: record.eventTimestamp,
+        records: [record],
+        note: confidence === 'fallback'
+          ? 'Pairing uses correlation or event identity because no explicit call id was recorded.'
+          : undefined,
+      };
+      nodes.push(node);
+      const queue = open.get(mapKey) ?? [];
+      queue.push(node);
+      open.set(mapKey, queue);
+      continue;
+    }
+
+    const matched = open.get(mapKey)?.shift();
+    if (matched) {
+      matched.records.push(record);
+      matched.endedAt = record.eventTimestamp;
+      const outcome = eventOutcome(record)?.toLowerCase();
+      matched.status =
+        record.eventType.toLowerCase().includes('error') ||
+        outcome === 'error' ||
+        outcome === 'timeout' ||
+        outcome === 'denied'
+          ? 'error'
+          : 'completed';
+    } else {
+      nodes.push({
+        id: record.id,
+        kind: boundaryKind,
+        title: contentTitle(record, boundaryKind === 'tool' ? 'Tool result' : 'Subagent result'),
+        status: 'unmatched',
+        startedAt: record.eventTimestamp,
+        endedAt: record.eventTimestamp,
+        records: [record],
+        note: 'No matching start record was available; this result is shown independently.',
+      });
+    }
+  }
+
+  return nodes.sort((left, right) => {
+    const first = compareSerializedTrajectory(left.records[0], right.records[0]);
+    return first || left.id.localeCompare(right.id);
+  });
+}
+
+export function safeTrajectoryBody(record: SerializedTrajectoryRecord): unknown | null {
+  if (record.contentDisclosure === 'withheld' || record.contentDisclosure === 'metadata_only') {
+    return null;
+  }
+  const payload = asObject(record.payload);
+  if (!payload) return null;
+  if (record.contentKind === 'prompt' && payload.promptText != null) return payload.promptText;
+  if (record.contentKind === 'response' && payload.responseText != null) return payload.responseText;
+  return payload.body ?? payload.raw ?? null;
+}
+
+export function sequenceGap(
+  records: SerializedTrajectoryRecord[],
+  incoming: SerializedTrajectoryRecord,
+): boolean {
+  const latestSequence = records.reduce((maximum, record) => Math.max(maximum, record.sequence), -1);
+  return latestSequence >= 0 && incoming.sequence > latestSequence + 1;
+}

--- a/control/src/server/otel-ingest.test.ts
+++ b/control/src/server/otel-ingest.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { extractPromptText, type AttrMap } from './otel-ingest';
+import {
+  canonicalizeOtelLogRecord,
+  extractLogRecords,
+  extractPromptText,
+  extractResponseText,
+  type AttrMap,
+} from './otel-ingest';
 
 describe('extractPromptText', () => {
   it('reads gen_ai.prompt style attributes (existing behavior)', () => {
@@ -56,5 +62,109 @@ describe('extractPromptText', () => {
       'otelhook.content.kind': 'Prompt',
     };
     expect(extractPromptText(attrs, undefined, 'hello there')).toBe('hello there');
+  });
+});
+
+describe('extractResponseText', () => {
+  it('symmetrically reads generation response facts', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'generation.end',
+      'otelhook.content.kind': 'response',
+    };
+    expect(extractResponseText(attrs, undefined, 'completed answer')).toBe('completed answer');
+  });
+
+  it('does not misclassify reasoning as a response', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'generation.end',
+      'otelhook.content.kind': 'reasoning',
+    };
+    expect(extractResponseText(attrs, undefined, 'private chain')).toBeNull();
+  });
+});
+
+describe('canonical OTLP log facts', () => {
+  it('prefers record event names and canonical event ids, types, and sequences', () => {
+    const [record] = extractLogRecords({
+      resourceLogs: [{
+        resource: { attributes: [] },
+        scopeLogs: [{
+          logRecords: [{
+            eventName: 'sdk.log.name',
+            traceId: 'trace-1',
+            spanId: 'span-1',
+            timeUnixNano: '1786701600000000000',
+            attributes: [
+              { key: 'otelhook.event.id', value: { stringValue: 'evt-9' } },
+              { key: 'otelhook.event.type', value: { stringValue: 'tool.end' } },
+              { key: 'otelhook.event.sequence', value: { intValue: '42' } },
+              { key: 'otelhook.content.kind', value: { stringValue: 'tool_output' } },
+              { key: 'otelhook.content.disclosure', value: { stringValue: 'redact' } },
+              { key: 'otelhook.content.body_truncated', value: { boolValue: true } },
+              { key: 'otelhook.generation.id', value: { stringValue: 'generation-1' } },
+              { key: 'gen_ai.tool.call.id', value: { stringValue: 'tool-call-1' } },
+            ],
+            body: { stringValue: '{"ok":true}' },
+          }],
+        }],
+      }],
+    });
+
+    expect(record.eventName).toBe('sdk.log.name');
+    expect(canonicalizeOtelLogRecord(record)).toMatchObject({
+      eventType: 'tool.end',
+      sequence: 42,
+      sourceEventId: 'evt-9',
+      contentKind: 'tool_output',
+      contentDisclosure: 'truncated',
+      generationId: 'generation-1',
+      toolCallId: 'tool-call-1',
+      correlationId: 'tool-call-1',
+      payload: { body: { stringValue: '{"ok":true}' } },
+    });
+    expect(record).toMatchObject({ traceId: 'trace-1', spanId: 'span-1' });
+  });
+
+  it('keeps reasoning disclosure metadata without exposing a withheld body', () => {
+    const canonical = canonicalizeOtelLogRecord({
+      resource: {},
+      eventName: 'log',
+      attributes: {
+        'otelhook.event.type': 'generation.end',
+        'otelhook.event.id': 'evt-10',
+        'otelhook.content.kind': 'reasoning',
+        'otelhook.content.withheld': 'policy',
+      },
+      timestamp: new Date('2026-08-14T10:00:00.000Z'),
+      body: null,
+      bodyText: null,
+      sequence: 3,
+    });
+    expect(canonical).toMatchObject({
+      contentKind: 'reasoning',
+      contentDisclosure: 'withheld',
+      payload: {
+        body: null,
+        disclosure: { withheld: 'policy' },
+      },
+    });
+  });
+
+  it('preserves redacted disclosure when a safe body is exported', () => {
+    const canonical = canonicalizeOtelLogRecord({
+      resource: {},
+      eventName: 'otelhook.generation.end',
+      attributes: {
+        'otelhook.event.type': 'generation.end',
+        'otelhook.event.id': 'evt-11',
+        'otelhook.content.kind': 'response',
+        'otelhook.content.disclosure': 'redact',
+      },
+      timestamp: new Date('2026-08-14T10:00:00.000Z'),
+      body: { stringValue: 'safe redacted answer' },
+      bodyText: 'safe redacted answer',
+      sequence: 4,
+    });
+    expect(canonical.contentDisclosure).toBe('redacted');
   });
 });

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -1,7 +1,15 @@
 import { createRequire } from 'node:module';
 import type { Prisma } from '@prisma/client';
-import type { AgentSessionUsage, AgentTool } from '@har/schemas';
+import {
+  AgentTrajectoryRecordSchema,
+  type AgentSessionUsage,
+  type AgentTool,
+} from '@har/schemas';
 import { prisma } from '@/lib/db';
+import {
+  appendTrajectoryRecord,
+  stableTrajectoryKey,
+} from '@/server/trajectory-ledger';
 import { upsertSessionUsage } from '@/server/usage';
 import {
   isWorkspaceUnderPath,
@@ -619,7 +627,7 @@ export function extractPromptText(attributes: AttrMap, eventName?: string, bodyT
   return null;
 }
 
-function extractResponseText(
+export function extractResponseText(
   attributes: AttrMap,
   eventName?: string,
   bodyText?: string | null,
@@ -640,6 +648,16 @@ function extractResponseText(
     if (unwrapped) return unwrapped;
   }
   if (String(eventName ?? '').toLowerCase().includes('assistant') && bodyText?.trim()) {
+    return bodyText.trim();
+  }
+  const otelHookEventType = String(attributes['otelhook.event.type'] ?? '').toLowerCase();
+  const otelHookContentKind = String(attributes['otelhook.content.kind'] ?? '').toLowerCase();
+  if (
+    otelHookEventType === 'generation.end' &&
+    (otelHookContentKind === 'response' || otelHookContentKind === 'output') &&
+    !attributes['otelhook.content.withheld'] &&
+    bodyText?.trim()
+  ) {
     return bodyText.trim();
   }
   return null;
@@ -907,7 +925,7 @@ export async function ingestOtelMetricsBody(
   };
 }
 
-function otelTimeToDate(value: unknown): Date {
+function otelTimeToDate(value: unknown, fallback = new Date()): Date {
   if (typeof value === 'string' || typeof value === 'number') {
     const n = Number(value);
     if (Number.isFinite(n) && n > 0) {
@@ -917,7 +935,7 @@ function otelTimeToDate(value: unknown): Date {
       return new Date(n);
     }
   }
-  return new Date();
+  return fallback;
 }
 
 function bodyToText(body: unknown): string | null {
@@ -928,16 +946,20 @@ function bodyToText(body: unknown): string | null {
   return null;
 }
 
-interface ParsedLogRecord {
+export interface ParsedLogRecord {
   resource: AttrMap;
   eventName: string;
   attributes: AttrMap;
   timestamp: Date;
+  body: unknown;
   bodyText: string | null;
   sequence: number;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
 }
 
-function extractLogRecords(payload: unknown): ParsedLogRecord[] {
+export function extractLogRecords(payload: unknown): ParsedLogRecord[] {
   const out: ParsedLogRecord[] = [];
   if (!payload || typeof payload !== 'object') return out;
 
@@ -968,7 +990,9 @@ function extractLogRecords(payload: unknown): ParsedLogRecord[] {
         const record = lr as Record<string, unknown>;
         const attributes = attrsFromOtel(record.attributes);
         const eventName = String(
-          attributes['event.name'] ??
+          record.eventName ??
+            record.event_name ??
+            attributes['event.name'] ??
             attributes.event_name ??
             attributes['log.event'] ??
             record.name ??
@@ -984,14 +1008,137 @@ function extractLogRecords(payload: unknown): ParsedLogRecord[] {
           resource,
           eventName,
           attributes,
-          timestamp: otelTimeToDate(ts),
+          timestamp: otelTimeToDate(ts, new Date(0)),
+          body: record.body ?? null,
           bodyText: bodyToText(record.body),
-          sequence: Number(attributes['har.sequence'] ?? attributes.sequence ?? seq),
+          sequence: Number(
+            attributes['otelhook.event.sequence'] ??
+              attributes['har.sequence'] ??
+              attributes.sequence ??
+              seq,
+          ),
+          traceId: record.traceId || record.trace_id
+            ? String(record.traceId ?? record.trace_id)
+            : undefined,
+          spanId: record.spanId || record.span_id
+            ? String(record.spanId ?? record.span_id)
+            : undefined,
+          parentSpanId: record.parentSpanId || record.parent_span_id
+            ? String(record.parentSpanId ?? record.parent_span_id)
+            : undefined,
         });
       }
     }
   }
   return out;
+}
+
+function canonicalContentDisclosure(attributes: AttrMap, bodyText: string | null) {
+  const explicit = String(attributes['otelhook.content.disclosure'] ?? '').toLowerCase();
+  if (attributes['otelhook.content.withheld']) return 'withheld' as const;
+  if (
+    attributes['otelhook.content.truncated'] ||
+    attributes['otelhook.content.body_truncated']
+  ) return 'truncated' as const;
+  if (explicit === 'redact' || explicit === 'redacted') return 'redacted' as const;
+  if (explicit === 'mask' || explicit === 'masked') return 'masked' as const;
+  if (explicit === 'raw' || explicit === 'full') return 'full' as const;
+  if (explicit === 'truncated' || explicit === 'withheld' || explicit === 'metadata_only') {
+    return explicit;
+  }
+  return bodyText == null ? 'metadata_only' as const : 'full' as const;
+}
+
+function canonicalContentKind(attributes: AttrMap): string {
+  return String(attributes['otelhook.content.kind'] ?? 'event').trim().toLowerCase() || 'event';
+}
+
+export function canonicalEventType(record: ParsedLogRecord): string {
+  return String(record.attributes['otelhook.event.type'] ?? record.eventName).trim() || 'log';
+}
+
+export function canonicalSequence(record: ParsedLogRecord): number {
+  return Number.isFinite(record.sequence) && record.sequence >= 0
+    ? Math.floor(record.sequence)
+    : 0;
+}
+
+function canonicalSourceEventId(record: ParsedLogRecord, eventType: string, sequence: number): string {
+  const explicit = String(record.attributes['otelhook.event.id'] ?? '').trim();
+  if (explicit) return explicit;
+  return stableTrajectoryKey({
+    eventType,
+    sequence,
+    timestamp: record.timestamp.toISOString(),
+    traceId: record.traceId ?? null,
+    spanId: record.spanId ?? null,
+    resource: record.resource,
+  });
+}
+
+function canonicalContentKey(record: ParsedLogRecord, contentKind: string): string {
+  const explicitHash = String(record.attributes['otelhook.content.hash'] ?? '').trim();
+  const ordinal = record.attributes['otelhook.content.ordinal'];
+  return stableTrajectoryKey({
+    contentKind,
+    hash: explicitHash || null,
+    label: record.attributes['otelhook.content.label'] ?? null,
+    ordinal: ordinal ?? null,
+    body: explicitHash ? null : record.body,
+    withheld: record.attributes['otelhook.content.withheld'] ?? null,
+    truncated: record.attributes['otelhook.content.truncated'] ?? null,
+  });
+}
+
+export function canonicalizeOtelLogRecord(record: ParsedLogRecord) {
+  const eventType = canonicalEventType(record);
+  const sequence = canonicalSequence(record);
+  const contentKind = canonicalContentKind(record.attributes);
+  const contentDisclosure = canonicalContentDisclosure(record.attributes, record.bodyText);
+  const generationId =
+    String(record.attributes['otelhook.generation.id'] ?? '').trim() || undefined;
+  const toolCallId =
+    String(
+      record.attributes['gen_ai.tool.call.id'] ??
+        record.attributes['tool.call.id'] ??
+        record.attributes.tool_call_id ??
+        '',
+    ).trim() || undefined;
+  return {
+    eventType,
+    sequence,
+    contentKind,
+    contentDisclosure,
+    sourceEventId: canonicalSourceEventId(record, eventType, sequence),
+    contentKey: canonicalContentKey(record, contentKind),
+    contentLabel: String(record.attributes['otelhook.content.label'] ?? '').trim() || undefined,
+    correlationId:
+      String(
+        record.attributes['otelhook.correlation.id'] ??
+          record.attributes['correlation.id'] ??
+          record.attributes['gen_ai.conversation.id'] ??
+          toolCallId ??
+          generationId ??
+          '',
+      ).trim() || undefined,
+    generationId,
+    toolCallId,
+    payload: {
+      body: record.body,
+      attributes: record.attributes,
+      resource: record.resource,
+      recordEventName: record.eventName,
+      disclosure: {
+        status: contentDisclosure,
+        withheld: record.attributes['otelhook.content.withheld'] ?? null,
+        truncated: record.attributes['otelhook.content.truncated'] ?? null,
+        bodyTruncated: record.attributes['otelhook.content.body_truncated'] ?? null,
+        characterLength: record.attributes['otelhook.content.character_length'] ?? null,
+        byteLength: record.attributes['otelhook.content.byte_length'] ?? null,
+        originalDisclosure: record.attributes['otelhook.content.disclosure'] ?? null,
+      },
+    },
+  };
 }
 
 export async function ingestOtelLogsJson(payload: unknown): Promise<OtelIngestResult> {
@@ -1009,20 +1156,50 @@ export async function ingestOtelLogsJson(payload: unknown): Promise<OtelIngestRe
       continue;
     }
     const { context } = resolved;
+    const canonical = canonicalizeOtelLogRecord(record);
+    const { eventType, sequence } = canonical;
 
-    const promptText = extractPromptText(record.attributes, record.eventName, record.bodyText);
+    const promptText = extractPromptText(record.attributes, eventType, record.bodyText);
     const responseText = extractResponseText(
       record.attributes,
-      record.eventName,
+      eventType,
       record.bodyText,
+    );
+
+    await appendTrajectoryRecord(
+      context.repositoryId,
+      AgentTrajectoryRecordSchema.parse({
+        version: 1,
+        source: 'otel',
+        sourceEventId: canonical.sourceEventId,
+        contentKey: canonical.contentKey,
+        sessionKey: context.sessionKey,
+        agentId: context.agentId,
+        agentTool: context.agentTool,
+        eventType,
+        sequence,
+        timestamp: record.timestamp.toISOString(),
+        payload: canonical.payload,
+        contentKind: canonical.contentKind,
+        contentDisclosure: canonical.contentDisclosure,
+        contentLabel: canonical.contentLabel,
+        traceId: record.traceId,
+        spanId: record.spanId,
+        parentSpanId: record.parentSpanId,
+        generationId: canonical.generationId,
+        toolCallId: canonical.toolCallId,
+        correlationId: canonical.correlationId,
+        workUnitId: context.workUnitId,
+        attemptId: context.attemptId,
+      }),
     );
 
     await upsertSessionEvent(context.repositoryId, {
       sessionKey: context.sessionKey,
       agentId: context.agentId,
       agentTool: context.agentTool,
-      eventName: record.eventName,
-      sequence: Number.isFinite(record.sequence) ? Math.floor(record.sequence) : accepted + 1,
+      eventName: eventType,
+      sequence,
       timestamp: record.timestamp,
       attributes: record.attributes as Prisma.InputJsonValue,
       promptText,

--- a/control/src/server/session-events.ts
+++ b/control/src/server/session-events.ts
@@ -1,5 +1,10 @@
 import type { Prisma } from '@prisma/client';
+import { AgentTrajectoryRecordSchema } from '@har/schemas';
 import { prisma } from '@/lib/db';
+import {
+  appendTrajectoryRecord,
+  stableTrajectoryKey,
+} from '@/server/trajectory-ledger';
 
 export interface SessionEventInput {
   sessionKey: string;
@@ -80,6 +85,52 @@ export async function listSessionEventsForRepo(repositoryId: string) {
 export async function syncSessionEvents(repositoryId: string, events: SessionEventInput[]) {
   let synced = 0;
   for (const event of events) {
+    const payload = {
+      attributes: event.attributes ?? {},
+      promptText: event.promptText ?? null,
+      responseText: event.responseText ?? null,
+      raw: event.rawTruncated ?? null,
+    };
+    const source = event.source === 'otel' ? 'otel' : 'harvest';
+    const sourceEventId = stableTrajectoryKey({
+      sessionKey: event.sessionKey,
+      agentTool: event.agentTool,
+      eventName: event.eventName,
+      sequence: event.sequence,
+      timestamp: event.timestamp.toISOString(),
+    });
+    const facts = [
+      ...(event.promptText ? [{ kind: 'prompt', content: event.promptText }] : []),
+      ...(event.responseText ? [{ kind: 'response', content: event.responseText }] : []),
+      ...(!event.promptText && !event.responseText
+        ? [{ kind: 'event', content: event.rawTruncated ?? event.attributes ?? null }]
+        : []),
+    ];
+    for (const fact of facts) {
+      await appendTrajectoryRecord(
+        repositoryId,
+        AgentTrajectoryRecordSchema.parse({
+          version: 1,
+          source,
+          sourceEventId,
+          contentKey: stableTrajectoryKey({
+            kind: fact.kind,
+            content: fact.content,
+          }),
+          sessionKey: event.sessionKey,
+          agentId: event.agentId,
+          agentTool: event.agentTool,
+          eventType: event.eventName,
+          sequence: event.sequence,
+          timestamp: event.timestamp.toISOString(),
+          payload,
+          contentKind: fact.kind,
+          contentDisclosure: event.rawTruncated ? 'truncated' : 'full',
+          workUnitId: event.workUnitId,
+          attemptId: event.attemptId,
+        }),
+      );
+    }
     await upsertSessionEvent(repositoryId, event);
     synced += 1;
   }

--- a/control/src/server/trajectory-ledger.test.ts
+++ b/control/src/server/trajectory-ledger.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareTrajectoryOrder,
+  cursorForTrajectory,
+  decodeTrajectoryCursor,
+  stableTrajectoryKey,
+} from './trajectory-ledger';
+
+describe('trajectory ledger ordering', () => {
+  it('round-trips opaque cursors and orders content facts deterministically', () => {
+    const first = {
+      sequence: 8,
+      eventTimestamp: new Date('2026-08-14T10:00:00.000Z'),
+      source: 'otel',
+      sourceEventId: 'event-1',
+      contentKey: 'prompt',
+      id: 'row-a',
+    };
+    const second = { ...first, contentKey: 'response', id: 'row-b' };
+    const firstCursor = decodeTrajectoryCursor(cursorForTrajectory(first));
+    const secondCursor = decodeTrajectoryCursor(cursorForTrajectory(second));
+
+    expect(firstCursor).toMatchObject({
+      sequence: 8,
+      sourceEventId: 'event-1',
+      contentKey: 'prompt',
+    });
+    expect(compareTrajectoryOrder(firstCursor, secondCursor)).toBeLessThan(0);
+  });
+
+  it('hashes object keys independently of insertion order', () => {
+    expect(stableTrajectoryKey({ kind: 'prompt', body: 'hello' })).toBe(
+      stableTrajectoryKey({ body: 'hello', kind: 'prompt' }),
+    );
+  });
+
+  it('rejects malformed cursors', () => {
+    expect(() => decodeTrajectoryCursor('not-a-cursor')).toThrow('Invalid trajectory cursor');
+  });
+});

--- a/control/src/server/trajectory-ledger.ts
+++ b/control/src/server/trajectory-ledger.ts
@@ -1,0 +1,350 @@
+import type { AgentTrajectoryRecord as CanonicalTrajectoryRecord } from '@har/schemas';
+import { Prisma, type AgentTrajectoryRecord } from '@prisma/client';
+import { createHash } from 'node:crypto';
+import { prisma } from '@/lib/db';
+import type {
+  SerializedTrajectoryPage,
+  SerializedTrajectoryRecord,
+  TrajectoryStream,
+} from '@/lib/trajectory';
+
+export interface TrajectoryCursor {
+  sequence: number;
+  timestamp: string;
+  source: string;
+  sourceEventId: string;
+  contentKey: string;
+  id: string;
+}
+
+export interface TrajectoryScope {
+  repositoryId: string;
+  agentId: number;
+  sessionKey: string;
+  agentTool: string;
+}
+
+export interface TrajectoryPage {
+  records: AgentTrajectoryRecord[];
+  hasMore: boolean;
+  nextBefore: string | null;
+  latest: string | null;
+}
+
+export interface AppendTrajectoryResult {
+  record: AgentTrajectoryRecord;
+  inserted: boolean;
+}
+
+export interface SlotTrajectoryData {
+  streams: TrajectoryStream[];
+  initialPage: SerializedTrajectoryPage;
+}
+
+type TrajectoryListener = (record: AgentTrajectoryRecord) => void;
+
+const globalBus = globalThis as unknown as {
+  trajectoryListeners?: Set<TrajectoryListener>;
+};
+const listeners = (globalBus.trajectoryListeners ??= new Set());
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+export function stableTrajectoryKey(value: unknown): string {
+  return createHash('sha256').update(stableJson(value)).digest('hex');
+}
+
+export function cursorForTrajectory(record: Pick<
+  AgentTrajectoryRecord,
+  'sequence' | 'eventTimestamp' | 'source' | 'sourceEventId' | 'contentKey' | 'id'
+>): string {
+  return Buffer.from(
+    JSON.stringify({
+      sequence: record.sequence,
+      timestamp: record.eventTimestamp.toISOString(),
+      source: record.source,
+      sourceEventId: record.sourceEventId,
+      contentKey: record.contentKey,
+      id: record.id,
+    } satisfies TrajectoryCursor),
+  ).toString('base64url');
+}
+
+export function decodeTrajectoryCursor(value: string): TrajectoryCursor {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as Partial<TrajectoryCursor>;
+    if (
+      !Number.isInteger(parsed.sequence) ||
+      typeof parsed.timestamp !== 'string' ||
+      !Number.isFinite(new Date(parsed.timestamp).getTime()) ||
+      typeof parsed.source !== 'string' ||
+      typeof parsed.sourceEventId !== 'string' ||
+      typeof parsed.contentKey !== 'string' ||
+      typeof parsed.id !== 'string'
+    ) {
+      throw new Error('invalid fields');
+    }
+    return parsed as TrajectoryCursor;
+  } catch {
+    throw new Error('Invalid trajectory cursor');
+  }
+}
+
+export function compareTrajectoryOrder(
+  left: TrajectoryCursor,
+  right: TrajectoryCursor,
+): number {
+  return (
+    left.sequence - right.sequence ||
+    left.timestamp.localeCompare(right.timestamp) ||
+    left.source.localeCompare(right.source) ||
+    left.sourceEventId.localeCompare(right.sourceEventId) ||
+    left.contentKey.localeCompare(right.contentKey) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function cursorWhere(cursor: TrajectoryCursor, direction: 'before' | 'after'): Prisma.AgentTrajectoryRecordWhereInput {
+  const operator = direction === 'before' ? 'lt' : 'gt';
+  const timestamp = new Date(cursor.timestamp);
+  return {
+    OR: [
+      { sequence: { [operator]: cursor.sequence } },
+      { sequence: cursor.sequence, eventTimestamp: { [operator]: timestamp } },
+      {
+        sequence: cursor.sequence,
+        eventTimestamp: timestamp,
+        source: { [operator]: cursor.source },
+      },
+      {
+        sequence: cursor.sequence,
+        eventTimestamp: timestamp,
+        source: cursor.source,
+        sourceEventId: { [operator]: cursor.sourceEventId },
+      },
+      {
+        sequence: cursor.sequence,
+        eventTimestamp: timestamp,
+        source: cursor.source,
+        sourceEventId: cursor.sourceEventId,
+        contentKey: { [operator]: cursor.contentKey },
+      },
+      {
+        sequence: cursor.sequence,
+        eventTimestamp: timestamp,
+        source: cursor.source,
+        sourceEventId: cursor.sourceEventId,
+        contentKey: cursor.contentKey,
+        id: { [operator]: cursor.id },
+      },
+    ],
+  };
+}
+
+const ascendingOrder = [
+  { sequence: 'asc' },
+  { eventTimestamp: 'asc' },
+  { source: 'asc' },
+  { sourceEventId: 'asc' },
+  { contentKey: 'asc' },
+  { id: 'asc' },
+] satisfies Prisma.AgentTrajectoryRecordOrderByWithRelationInput[];
+
+const descendingOrder = ascendingOrder.map((field) => {
+  const key = Object.keys(field)[0] as keyof typeof field;
+  return { [key]: 'desc' };
+}) as Prisma.AgentTrajectoryRecordOrderByWithRelationInput[];
+
+function scopeWhere(scope: TrajectoryScope): Prisma.AgentTrajectoryRecordWhereInput {
+  return {
+    repositoryId: scope.repositoryId,
+    agentId: scope.agentId,
+    sessionKey: scope.sessionKey,
+    agentTool: scope.agentTool,
+  };
+}
+
+export async function appendTrajectoryRecord(
+  repositoryId: string,
+  input: CanonicalTrajectoryRecord,
+): Promise<AppendTrajectoryResult> {
+  try {
+    const record = await prisma.agentTrajectoryRecord.create({
+      data: {
+        repositoryId,
+        version: input.version,
+        source: input.source,
+        sourceEventId: input.sourceEventId,
+        contentKey: input.contentKey,
+        sessionKey: input.sessionKey,
+        agentId: input.agentId,
+        agentTool: input.agentTool,
+        eventType: input.eventType,
+        sequence: input.sequence,
+        eventTimestamp: new Date(input.timestamp),
+        payload: input.payload as Prisma.InputJsonValue,
+        contentKind: input.contentKind,
+        contentDisclosure: input.contentDisclosure,
+        contentLabel: input.contentLabel,
+        traceId: input.traceId,
+        spanId: input.spanId,
+        parentSpanId: input.parentSpanId,
+        generationId: input.generationId,
+        toolCallId: input.toolCallId,
+        correlationId: input.correlationId,
+        workUnitId: input.workUnitId,
+        attemptId: input.attemptId,
+      },
+    });
+    for (const listener of listeners) {
+      try {
+        listener(record);
+      } catch {
+        // A disconnected subscriber must not turn a durable insert into a failure.
+      }
+    }
+    return { record, inserted: true };
+  } catch (error: unknown) {
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002') {
+      throw error;
+    }
+    const record = await prisma.agentTrajectoryRecord.findUniqueOrThrow({
+      where: {
+        repositoryId_source_sourceEventId_contentKey: {
+          repositoryId,
+          source: input.source,
+          sourceEventId: input.sourceEventId,
+          contentKey: input.contentKey,
+        },
+      },
+    });
+    return { record, inserted: false };
+  }
+}
+
+export async function listTrajectoryHistory(
+  scope: TrajectoryScope,
+  options: { before?: string; limit?: number } = {},
+): Promise<TrajectoryPage> {
+  const limit = Math.max(1, Math.min(options.limit ?? 100, 200));
+  const before = options.before ? decodeTrajectoryCursor(options.before) : null;
+  const rows = await prisma.agentTrajectoryRecord.findMany({
+    where: {
+      ...scopeWhere(scope),
+      ...(before ? { AND: [cursorWhere(before, 'before')] } : {}),
+    },
+    orderBy: descendingOrder,
+    take: limit + 1,
+  });
+  const hasMore = rows.length > limit;
+  const records = rows.slice(0, limit).reverse();
+  return {
+    records,
+    hasMore,
+    nextBefore: hasMore && records[0] ? cursorForTrajectory(records[0]) : null,
+    latest: records.at(-1) ? cursorForTrajectory(records.at(-1)!) : null,
+  };
+}
+
+export async function listTrajectoryAfter(
+  scope: TrajectoryScope,
+  after: string,
+  limit = 1_000,
+): Promise<AgentTrajectoryRecord[]> {
+  const cursor = decodeTrajectoryCursor(after);
+  return prisma.agentTrajectoryRecord.findMany({
+    where: { ...scopeWhere(scope), AND: [cursorWhere(cursor, 'after')] },
+    orderBy: ascendingOrder,
+    take: Math.max(1, Math.min(limit, 1_000)),
+  });
+}
+
+export function serializeTrajectoryRecord(
+  record: AgentTrajectoryRecord,
+): SerializedTrajectoryRecord {
+  return {
+    ...record,
+    eventTimestamp: record.eventTimestamp.toISOString(),
+    createdAt: record.createdAt.toISOString(),
+    payload: record.payload,
+    contentDisclosure: record.contentDisclosure as SerializedTrajectoryRecord['contentDisclosure'],
+  };
+}
+
+export function serializeTrajectoryPage(page: TrajectoryPage): SerializedTrajectoryPage {
+  return {
+    ...page,
+    records: page.records.map(serializeTrajectoryRecord),
+  };
+}
+
+export async function listTrajectoryStreams(
+  repositoryId: string,
+  agentId: number,
+): Promise<TrajectoryStream[]> {
+  const groups = await prisma.agentTrajectoryRecord.groupBy({
+    by: ['sessionKey', 'agentTool'],
+    where: { repositoryId, agentId },
+    _max: { eventTimestamp: true },
+  });
+  return groups.flatMap((group) => group._max.eventTimestamp
+    ? [{
+        sessionKey: group.sessionKey,
+        agentTool: group.agentTool,
+        latestTimestamp: group._max.eventTimestamp.toISOString(),
+      }]
+    : []).sort((left, right) => (
+      right.latestTimestamp.localeCompare(left.latestTimestamp) ||
+      left.sessionKey.localeCompare(right.sessionKey) ||
+      left.agentTool.localeCompare(right.agentTool)
+    ));
+}
+
+export async function getSlotTrajectoryData(
+  repositoryId: string,
+  agentId: number,
+  limit = 100,
+): Promise<SlotTrajectoryData> {
+  const streams = await listTrajectoryStreams(repositoryId, agentId);
+  const latest = streams[0];
+  if (!latest) {
+    return {
+      streams: [],
+      initialPage: { records: [], hasMore: false, nextBefore: null, latest: null },
+    };
+  }
+  const page = await listTrajectoryHistory({
+    repositoryId,
+    agentId,
+    sessionKey: latest.sessionKey,
+    agentTool: latest.agentTool,
+  }, { limit });
+  return { streams, initialPage: serializeTrajectoryPage(page) };
+}
+
+export function subscribeToTrajectory(
+  scope: TrajectoryScope,
+  listener: TrajectoryListener,
+): () => void {
+  const scoped: TrajectoryListener = (record) => {
+    if (
+      record.repositoryId === scope.repositoryId &&
+      record.agentId === scope.agentId &&
+      record.sessionKey === scope.sessionKey &&
+      record.agentTool === scope.agentTool
+    ) {
+      listener(record);
+    }
+  };
+  listeners.add(scoped);
+  return () => listeners.delete(scoped);
+}

--- a/control/tests/frontend/trajectory-viewer.spec.js
+++ b/control/tests/frontend/trajectory-viewer.spec.js
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { test, expect } = require('@playwright/test');
+
+test.describe('Slot trajectory viewer', () => {
+  test('keeps trajectory and raw events available side by side', async ({ page }) => {
+    await page.goto('/worktrees');
+    const slotLink = page.locator('tbody a[href*="/slots/"]').first();
+    if (!(await slotLink.isVisible().catch(() => false))) {
+      test.skip(true, 'No slot fixture exists — no trajectory page to open');
+    }
+
+    await page.goto(await slotLink.getAttribute('href'));
+    const trajectoryTab = page.getByRole('tab', { name: 'Trajectory' });
+    const rawTab = page.getByRole('tab', { name: 'Raw events' });
+    await expect(trajectoryTab).toBeVisible();
+    await expect(rawTab).toBeVisible();
+
+    const panel = page.getByRole('tabpanel');
+    await expect(
+      panel.getByLabel('Agent trajectory timeline')
+        .or(panel.getByText(/no trajectory records yet|no records in this trajectory stream/i)),
+    ).toBeVisible();
+
+    const selector = panel.getByLabel('Select trajectory session and agent');
+    if (await selector.isVisible().catch(() => false)) {
+      await expect(selector).toBeEnabled();
+    }
+
+    await rawTab.click();
+    await expect(
+      page.getByText(/no otel session events yet/i).or(page.getByRole('table')),
+    ).toBeVisible();
+  });
+});

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -656,6 +656,61 @@ export type AgentTool = z.infer<typeof AgentToolSchema>;
 export const UsageSourceSchema = z.enum(['otel', 'harvest']);
 export type UsageSource = z.infer<typeof UsageSourceSchema>;
 
+/** Durable origin of an immutable agent trajectory fact. */
+export const AgentTrajectorySourceSchema = z.enum(['otel', 'harvest', 'har']);
+export type AgentTrajectorySource = z.infer<typeof AgentTrajectorySourceSchema>;
+
+/** How much of the original content is present in payload. */
+export const AgentTrajectoryContentDisclosureSchema = z.enum([
+  'full',
+  'redacted',
+  'masked',
+  'truncated',
+  'withheld',
+  'metadata_only',
+]);
+export type AgentTrajectoryContentDisclosure = z.infer<
+  typeof AgentTrajectoryContentDisclosureSchema
+>;
+
+/**
+ * Version 1 of the canonical, append-only agent trajectory fact.
+ *
+ * `sourceEventId` identifies the producer event while `contentKey` identifies
+ * one content fact within it. Multiple facts may therefore share an event id
+ * and sequence without overwriting each other.
+ */
+export const AgentTrajectoryRecordV1Schema = z
+  .object({
+    version: z.literal(1),
+    source: AgentTrajectorySourceSchema,
+    sourceEventId: z.string().min(1),
+    contentKey: z.string().min(1),
+    sessionKey: z.string().min(1),
+    agentId: z.number().int().min(HAR_AGENT_SLOT_MIN),
+    agentTool: AgentToolSchema,
+    eventType: z.string().min(1),
+    sequence: z.number().int().nonnegative(),
+    timestamp: z.string(),
+    payload: z.record(z.unknown()),
+    contentKind: z.string().min(1),
+    contentDisclosure: AgentTrajectoryContentDisclosureSchema,
+    contentLabel: z.string().optional(),
+    traceId: z.string().optional(),
+    spanId: z.string().optional(),
+    parentSpanId: z.string().optional(),
+    generationId: z.string().optional(),
+    toolCallId: z.string().optional(),
+    correlationId: z.string().optional(),
+    workUnitId: WorkUnitIdSchema.optional(),
+    attemptId: WorkAttemptIdSchema.optional(),
+  })
+  .passthrough();
+
+export const AgentTrajectoryRecordSchema = AgentTrajectoryRecordV1Schema;
+export type AgentTrajectoryRecordV1 = z.infer<typeof AgentTrajectoryRecordV1Schema>;
+export type AgentTrajectoryRecord = AgentTrajectoryRecordV1;
+
 /** Per-session agent token/cost aggregates for Mission Control. */
 export const AgentSessionUsageSchema = z.object({
   sessionKey: z.string().min(1),


### PR DESCRIPTION
## Summary
- persist versioned, append-only trajectory records before existing event and usage projections
- preserve otel-hook event IDs, canonical sequences, content facts, disclosure state, and trace/tool/generation correlation
- add cursor history and replaying SSE APIs with duplicate-safe, out-of-order assembly
- add a live slot trajectory viewer for prompts, responses, reasoning, tools, subagents, errors, and metadata while retaining raw events
- route harvested events through the same ledger and recognize canonical otel-hook activity names

## Related
- Implements the first end-to-end vertical slice of #203
- Claude final-response capture: https://github.com/os-factory/otel-hook/pull/34

## Test plan
- [x] `har env verify 3 --full`
- [x] 90 unit tests passed
- [x] 15 browser tests passed (4 fixture-dependent tests skipped)
- [x] lint, typecheck, health, and Docker smoke build passed
- [x] manually ingested a synthetic prompt → tool → response/reasoning OTLP flow
- [x] verified a subsequent SSE event appeared without reloading the slot page

Made with [Cursor](https://cursor.com)