### PR TITLE
fix(telemetry): pin otel-hook 0.2.0

### DIFF
--- a/src/core/otel-hooks.ts
+++ b/src/core/otel-hooks.ts
@@ -6,7 +6,7 @@ import { getControlApiUrl } from './control-config';
 import { getTelemetrySignals, isTelemetryEnabled } from './telemetry-config';
 
 /** Pinned npm package for reproducible installs (replaces Python opentelemetry-hooks). */
-export const OTEL_HOOKS_PACKAGE = '@osfactory/otel-hook@0.1.2';
+export const OTEL_HOOKS_PACKAGE = '@osfactory/otel-hook@0.2.0';
 
 /** Providers HAR registers with `otel-hook setup --provider`. */
 export const OTEL_HOOKS_PROVIDERS = [

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -17,11 +17,18 @@ import {
 } from '../src/core/telemetry-env';
 import {
   buildOtelHooksConfig,
+  OTEL_HOOKS_PACKAGE,
   pruneLegacyCursorHookEvents,
   rewriteHookCommandsToWrapper,
   writeOtelHooksConfig,
   writeOtelHooksWrapper,
 } from '../src/core/otel-hooks';
+
+describe('otel-hook package pin', () => {
+  it('installs the release with Claude response content support', () => {
+    expect(OTEL_HOOKS_PACKAGE).toBe('@osfactory/otel-hook@0.2.0');
+  });
+});
 
 describe('telemetry preference', () => {
   const originalEnv = process.env.HAR_TELEMETRY;


### PR DESCRIPTION
## Summary
- pin HAR-managed telemetry hooks to `@osfactory/otel-hook@0.2.0`
- ensure new sessions install the release containing Claude final-response capture
- add a regression assertion for the managed package pin

## Test plan
- [x] `har env verify 1 --full`

Follow-up to #203 and #207.

Made with [Cursor](https://cursor.com)