### PR TITLE
docs: link plugin authoring to os-factory/har-plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,6 +365,10 @@ Add or modify subcommands in the matching file under `src/cli/commands/` (`env.t
 2. Rebuild (`npm run build`) — plugins are **discovered from disk** (no `PLUGIN_IDS` edit)
 3. Test with `har env add-plugin <name>` on a fixture
 
+For **external / community plugins**, start from the
+[os-factory/har-plugin](https://github.com/os-factory/har-plugin) template repository
+(`har env add-plugin github:os-factory/har-plugin`).
+
 Optional: install from a path, npm package, or git URL:
 `har env add-plugin ./my-plugin`, `har env add-plugin @org/har-cypress`, `har env add-plugin github:org/repo`.
 

--- a/docs/src/content/docs/docs/guides/plugins.md
+++ b/docs/src/content/docs/docs/guides/plugins.md
@@ -209,6 +209,12 @@ See [Stages and artifacts](/docs/guides/stages/) and `.har/STAGES.md`.
 
 HAR is open source. Anyone can ship a verification plugin without changing HAR core.
 
+**Start from the official boilerplate** (GitHub template + npm package layout):
+
+- Repository: [os-factory/har-plugin](https://github.com/os-factory/har-plugin) (*Use this template*)
+- Authoring guide: [docs/AUTHORING.md](https://github.com/os-factory/har-plugin/blob/main/docs/AUTHORING.md)
+- Try the example: `har env add-plugin github:os-factory/har-plugin --skip-ci`
+
 **1. Author a bundle** — a directory with:
 
 - `template.manifest.json` (required) — `id`, `stages` (or legacy `stage` + `stageId`),
@@ -216,8 +222,9 @@ HAR is open source. Anyone can ship a verification plugin without changing HAR c
 - Stage script(s) under `.har/stages/`
 - Optional: `package.fragment.json`, CI workflow, smoke fixtures, adaptation guide
 
-Use an existing plugin under the HAR repo’s `src/templates/plugins/` (e.g. Playwright
-or Gitleaks) as the template. Manifests prefer `stages: [...]` for one or more stages.
+Rename the example `id` / stage, implement the script, run `npm run check-manifest`.
+You can also copy an existing bundled plugin under HAR’s `src/templates/plugins/`
+(e.g. Playwright or Gitleaks). Manifests prefer `stages: [...]` for one or more stages.
 
 **2. Distribute**
 

--- a/docs/src/content/docs/docs/guides/plugins.md
+++ b/docs/src/content/docs/docs/guides/plugins.md
@@ -212,6 +212,7 @@ HAR is open source. Anyone can ship a verification plugin without changing HAR c
 **Start from the official boilerplate** (GitHub template + npm package layout):
 
 - Repository: [os-factory/har-plugin](https://github.com/os-factory/har-plugin) (*Use this template*)
+- Agent guide (fit + examples): [AGENTS.md](https://github.com/os-factory/har-plugin/blob/main/AGENTS.md)
 - Authoring guide: [docs/AUTHORING.md](https://github.com/os-factory/har-plugin/blob/main/docs/AUTHORING.md)
 - Try the example: `har env add-plugin github:os-factory/har-plugin --skip-ci`
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -229,7 +229,7 @@ const heroRunTotal = formatHeroRunTotal();
 <a class="what-cell what-cell-link" href="/docs/guides/plugins/#your-own-checks">
 <svg class="what-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
 <h3>Your own checks</h3>
-<p>Custom stages for project-only checks, or publish a plugin via path, npm, or git — no core change required.</p>
+<p>Custom stages for project-only checks, or publish a plugin from the <code>os-factory/har-plugin</code> template via path, npm, or git.</p>
 </a>
 <div class="stack-group-link-bar plugin-link-bar">
 <a class="stack-group-link" href="/plugins/">Explore the plugin marketplace <span aria-hidden="true">→</span></a>

--- a/docs/src/pages/plugins/index.astro
+++ b/docs/src/pages/plugins/index.astro
@@ -57,9 +57,9 @@ import trivyMark from '../../assets/logo-trivy.svg?raw';
 <span class="plugin-card-category">Custom stages · Community plugins · Any stack</span>
 </div>
 </div>
-<p>Project-specific checks stay custom stages. Reusable checks ship as your own plugin — install with a path, npm package, or git URL, or contribute upstream to HAR.</p>
+<p>Project-specific checks stay custom stages. Reusable checks ship as your own plugin — start from <code>os-factory/har-plugin</code>, then install via path, npm, or git.</p>
 <div class="plugin-card-foot">
-<code>add-plugin ./my-plugin</code>
+<code>github:os-factory/har-plugin</code>
 <span class="plugin-card-stage">Docs <span aria-hidden="true">→</span></span>
 </div>
 </a>

--- a/docs/tests/frontend/smoke.spec.cjs
+++ b/docs/tests/frontend/smoke.spec.cjs
@@ -24,7 +24,7 @@ test.describe('Frontend smoke', () => {
     await page.locator('a.plugin-card', { hasText: 'Gitleaks' }).click();
     await expect(page).toHaveURL(/\/plugins\/gitleaks\/$/);
     await expect(page.locator('h1')).toContainText('Gitleaks');
-    await expect(page.locator('.install-cmd')).toContainText('har env add-plugin gitleaks');
+    await expect(page.locator('.install-command')).toContainText('har env add-plugin gitleaks');
   });
 
   test('docs introduction is reachable', async ({ page }) => {

--- a/docs/tests/frontend/teams.spec.cjs
+++ b/docs/tests/frontend/teams.spec.cjs
@@ -37,7 +37,8 @@ test.describe('Teams page', () => {
     const modal = page.locator('[data-dashboard-image-modal]');
     await expect(modal).toBeHidden();
 
-    await trigger.click();
+    // Play control sits over the image center; hit a corner so zoom opens.
+    await trigger.click({ position: { x: 12, y: 12 } });
 
     await expect(modal).toBeVisible();
     await expect(page.getByRole('dialog', { name: 'Dashboard screenshot' })).toBeVisible();


### PR DESCRIPTION
## Summary
- Link the plugins guide, marketplace “Your own checks” card, landing copy, and CONTRIBUTING to the [os-factory/har-plugin](https://github.com/os-factory/har-plugin) template (including `AGENTS.md` / authoring docs).
- Fix Playwright smoke selectors for plugin detail install command and teams mobile zoom click.

## Test plan
- [x] `har env verify 1 --full` on docs harness (browser-e2e + visual-proof)
- [ ] Spot-check `/plugins/` and `/docs/guides/plugins/#publish-your-own-plugin` on the preview / after deploy


Made with [Cursor](https://cursor.com)