### PR TITLE
feat: related links on work units (#217)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,11 @@ Follow [`.cursor/rules/har-workflow.mdc`](.cursor/rules/har-workflow.mdc) and
 dir, full-verify before done, then present a session handoff and wait for approval.
 When the task names a tracker issue or ticket, bind at launch with a short
 `--work-id`, plus `--work-source`, `--work-url`, and `--work-title` when known.
+Add secondary links (GitHub issue, PR, Bitbucket) with repeatable
+`--work-link source|url|label` at launch, or later via
+`har env work-link --work-id <id> --link …` / MCP `har_add_work_unit_link`. Bind the
+planning tracker (Jira/Linear) as `--work-url`; attach code-host links as related
+links. Include any remaining links in session handoff until attached.
 Default recommendation is complete + open a PR when tooling is available (still
 requires approval); never run `complete`, push, or PR autonomously.
 

--- a/control/prisma/schema.prisma
+++ b/control/prisma/schema.prisma
@@ -201,6 +201,7 @@ model WorkUnit {
   sourceUrl        String?
   title            String?
   parentWorkUnitId String?
+  relatedLinks     Json?
   outcome          Json?
   sourceCreatedAt  DateTime
   sourceUpdatedAt  DateTime

--- a/control/src/app/factory/[id]/page.tsx
+++ b/control/src/app/factory/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type { WorkUnitRelatedLink } from '@har/schemas';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { WorkUnitEvidenceTable } from '@/components/work-unit-evidence-table';
@@ -62,6 +63,8 @@ export default async function WorkUnitPage({
     validations: unit.validations,
   });
 
+  const relatedLinks = (unit.relatedLinks as WorkUnitRelatedLink[] | null) ?? [];
+
   return (
     <div className="min-w-0 space-y-6 overflow-x-hidden px-4 py-4 md:px-6 md:py-6">
       <div>
@@ -73,17 +76,33 @@ export default async function WorkUnitPage({
           <Badge variant="secondary">{status}</Badge>
         </div>
         <p className="font-mono text-xs text-muted-foreground">{unit.workUnitId}</p>
-        {unit.sourceUrl ? (
-          <p className="mt-1 text-sm">
-            <a
-              href={unit.sourceUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="text-primary underline-offset-2 hover:underline"
-            >
-              Source
-            </a>
-          </p>
+        {(unit.sourceUrl || relatedLinks.length > 0) ? (
+          <ul className="mt-2 space-y-1 text-sm">
+            {unit.sourceUrl ? (
+              <li>
+                <a
+                  href={unit.sourceUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline-offset-2 hover:underline"
+                >
+                  {unit.source ?? 'Source'}
+                </a>
+              </li>
+            ) : null}
+            {relatedLinks.map((link) => (
+              <li key={link.url}>
+                <a
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline-offset-2 hover:underline"
+                >
+                  {link.label ?? link.source}
+                </a>
+              </li>
+            ))}
+          </ul>
         ) : null}
       </div>
 

--- a/control/src/lib/schemas.test.ts
+++ b/control/src/lib/schemas.test.ts
@@ -59,6 +59,25 @@ describe('SyncWorkUnitsInputSchema', () => {
     });
     expect(result.attempts[0].workUnitId).toBe(result.workUnits[0].workUnitId);
   });
+
+  it('parses work units with related links', () => {
+    const result = SyncWorkUnitsInputSchema.parse({
+      workUnits: [{
+        workUnitId: 'widget-123',
+        source: 'jira',
+        sourceUrl: 'https://company.atlassian.net/browse/WIDGET-123',
+        relatedLinks: [{
+          source: 'github',
+          url: 'https://github.com/acme/widget/issues/123',
+          label: 'GitHub mirror',
+        }],
+        createdAt: '2026-07-23T20:00:00.000Z',
+        updatedAt: '2026-07-23T20:00:00.000Z',
+      }],
+      attempts: [],
+    });
+    expect(result.workUnits[0].relatedLinks).toHaveLength(1);
+  });
 });
 
 describe('RunRecordSchema', () => {

--- a/control/src/server/work-units.ts
+++ b/control/src/server/work-units.ts
@@ -20,6 +20,9 @@ export async function syncWorkUnits(repositoryId: string, input: unknown) {
         sourceUrl: unit.sourceUrl,
         title: unit.title,
         parentWorkUnitId: unit.parentWorkUnitId,
+        relatedLinks: unit.relatedLinks
+          ? (unit.relatedLinks as Prisma.InputJsonValue)
+          : undefined,
         outcome: unit.outcome
           ? (unit.outcome as Prisma.InputJsonValue)
           : undefined,
@@ -31,6 +34,9 @@ export async function syncWorkUnits(repositoryId: string, input: unknown) {
         sourceUrl: unit.sourceUrl,
         title: unit.title,
         parentWorkUnitId: unit.parentWorkUnitId,
+        relatedLinks: unit.relatedLinks
+          ? (unit.relatedLinks as Prisma.InputJsonValue)
+          : undefined,
         outcome: unit.outcome
           ? (unit.outcome as Prisma.InputJsonValue)
           : Prisma.DbNull,

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -112,7 +112,10 @@ har env preflight 1 [--json]
 har env launch 1 [--no-worktree] [--claude] [--resume]
   [--work-id <id>] [--work-source <name>] [--work-url <url>]
   [--work-title <title>] [--parent-work-id <id>]
+  [--work-link <source|url|label> ...]
 har env recover 1
+har env work-link --work-id <id> [--link <source|url|label>]
+  [--source <name> --url <url> [--label <text>]]
 ```
 
 Every `launch` creates a **new** session from the current HEAD of `--repo` (the
@@ -127,8 +130,9 @@ launch — it is not a way to replace an active session.
 
 Work metadata is optional and backward compatible. Bind when the task names a
 tracker issue or ticket: pass a short repo-scoped `--work-id`, plus `--work-source`,
-`--work-url`, and `--work-title` when known. A fresh bound launch creates an
-immutable attempt UUID; `--resume` preserves the failed session's attempt.
+`--work-url`, and `--work-title` when known. Add secondary links with repeatable
+`--work-link source|url|label`, or later with `har env work-link`. A fresh bound
+launch creates an immutable attempt UUID; `--resume` preserves the failed session's attempt.
 
 A worktree only materializes what is in `HEAD`. Preflight and launch warn when
 untracked (not gitignored) paths will be missing from the session worktree —

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -18,11 +18,13 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 | Tool | Inputs | Result |
 | --- | --- | --- |
 | `har_preflight_environment` | `agentId` | Readiness, blockers, warnings (including untracked worktree paths), and whether launch is safe |
-| `har_launch_environment` | `agentId`, optional `worktree`, `claude`, `resume`, `workUnitId`, `source`, `sourceUrl`, `title`, `parentWorkUnitId` | Work directory, branch, work/attempt IDs, URLs, and normalized stage result |
+| `har_launch_environment` | `agentId`, optional `worktree`, `claude`, `resume`, `workUnitId`, `source`, `sourceUrl`, `title`, `parentWorkUnitId`, `relatedLinks` | Work directory, branch, work/attempt IDs, URLs, and normalized stage result |
 
 Pass `workUnitId`, `source`, and `sourceUrl` when the task names a tracker issue or
 ticket (short repo-scoped id such as `widget-123`, not a provider-prefixed composite).
-Omit them for ad-hoc work with no tracker identity.
+Use `relatedLinks` or `har_add_work_unit_link` for secondary URLs (GitHub PR, mirrored
+issue, Bitbucket). Omit work metadata for ad-hoc work with no tracker identity.
+| `har_add_work_unit_link` | `workUnitId`, `source`, `url`, optional `label` | Append a related external link to an existing work unit |
 | `har_recover_environment` | `agentId` | Resumed failed or partial launch |
 | `har_get_status` | optional `agentId` | Slot, process, worktree, branch, and dirty state |
 | `har_get_logs` | `agentId`, optional `service` | Recent service output |

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -251,12 +251,22 @@ export const WorkUnitIdSchema = z
 
 export const WorkAttemptIdSchema = z.string().uuid();
 
+/** Secondary external link (PR, mirrored issue, alternate tracker). Append-only on the work unit. */
+export const WorkUnitRelatedLinkSchema = z.object({
+  source: z.string().min(1).max(64),
+  url: z.string().url(),
+  label: z.string().min(1).max(128).optional(),
+});
+
+export type WorkUnitRelatedLink = z.infer<typeof WorkUnitRelatedLinkSchema>;
+
 export const WorkUnitMetadataSchema = z.object({
   workUnitId: WorkUnitIdSchema,
   source: z.string().min(1).max(64).optional(),
   sourceUrl: z.string().url().optional(),
   title: z.string().min(1).max(256).optional(),
   parentWorkUnitId: WorkUnitIdSchema.optional(),
+  relatedLinks: z.array(WorkUnitRelatedLinkSchema).optional(),
 });
 
 export type WorkUnitMetadata = z.infer<typeof WorkUnitMetadataSchema>;

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -31,6 +31,8 @@ import {
 } from '../../core/run-service';
 import { checkLaunchGuard } from '../../core/slot-launch-guard';
 import { listRuns, getRun } from '../../core/runs';
+import { addWorkUnitLinks, parseWorkLinkSpec } from '../../core/work-units';
+import { resolveHarnessRoot } from '../../harness/manifest';
 import { collectEnvironmentStatus } from '../../core/slot-status';
 import { handleCommitGateOnboarding } from '../../core/commit-gate-onboarding';
 import { readOnboardingPreferences } from '../../core/onboarding-preferences';
@@ -43,6 +45,22 @@ import {
   LAUNCH_EPILOG,
   LAUNCH_RESUME_DESCRIBE,
 } from '../help-text';
+
+const workLinkOptions = (y: Argv) =>
+  y
+    .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+    .option('work-id', {
+      type: 'string',
+      demandOption: true,
+      describe: 'Repo-scoped work unit id (same as --work-id at launch)',
+    })
+    .option('link', {
+      type: 'string',
+      describe: 'Link as source|url or source|url|label',
+    })
+    .option('source', { type: 'string', describe: 'Tracker provider (e.g. github, jira)' })
+    .option('url', { type: 'string', describe: 'Canonical URL for the link' })
+    .option('label', { type: 'string', describe: 'Optional display label' });
 
 export const envCommand = {
   command: 'env <subcommand>',
@@ -269,8 +287,20 @@ export const envCommand = {
               type: 'string',
               describe: 'Optional parent work unit identifier',
             })
+            .option('work-link', {
+              type: 'array',
+              string: true,
+              describe:
+                'Additional tracker link: source|url or source|url|label (repeatable)',
+            })
             .epilog(LAUNCH_EPILOG),
         handleLaunch,
+      )
+      .command(
+        'work-link',
+        'Append a related external link to an existing work unit',
+        workLinkOptions,
+        handleWorkLink,
       )
       .command(
         'recover <id>',
@@ -852,6 +882,7 @@ export async function handleLaunch(argv: {
   workUrl?: string;
   workTitle?: string;
   parentWorkId?: string;
+  workLink?: string[];
 }): Promise<void> {
   const repo = path.resolve(argv.repo);
   const agentId = validateAgentId(argv.id, repo);
@@ -878,6 +909,7 @@ export async function handleLaunch(argv: {
     sourceUrl: argv.workUrl,
     title: argv.workTitle,
     parentWorkUnitId: argv.parentWorkId,
+    relatedLinks: argv.workLink?.map(parseWorkLinkSpec),
     capture: false,
   });
   if (result.blocked) {
@@ -897,6 +929,34 @@ export async function handleLaunch(argv: {
     if (result.branch) info(`Branch: ${result.branch}`);
   }
   return finishCommand(result.code);
+}
+
+export async function handleWorkLink(argv: {
+  repo: string;
+  workId: string;
+  link?: string;
+  source?: string;
+  url?: string;
+  label?: string;
+}): Promise<void> {
+  if (!argv.link && !(argv.source && argv.url)) {
+    error('Provide --link or both --source and --url');
+    return finishCommand(1);
+  }
+
+  const harnessRoot = resolveHarnessRoot(path.resolve(argv.repo));
+  const links = argv.link
+    ? [parseWorkLinkSpec(argv.link)]
+    : [{ source: argv.source!, url: argv.url!, label: argv.label }];
+
+  try {
+    const record = addWorkUnitLinks(harnessRoot, argv.workId, links);
+    success(`Added link to work unit ${record.workUnitId}`);
+    return finishCommand(0);
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    return finishCommand(1);
+  }
 }
 
 export async function handleRecover(argv: { id?: number; repo: string }): Promise<void> {

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -240,6 +240,7 @@ export class RunService {
         sourceUrl: options.sourceUrl,
         title: options.title,
         parentWorkUnitId: options.parentWorkUnitId,
+        relatedLinks: options.relatedLinks,
       });
       createWorkAttempt(harnessRoot, {
         attemptId,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,6 +6,7 @@ import type {
   StageResult,
   ValidationRecord,
   VerificationResult,
+  WorkUnitRelatedLink,
 } from '../harness/schema';
 import { z } from 'zod';
 
@@ -56,6 +57,7 @@ export interface LaunchOptions {
   sourceUrl?: string;
   title?: string;
   parentWorkUnitId?: string;
+  relatedLinks?: WorkUnitRelatedLink[];
 }
 
 export interface PreflightOptions {

--- a/src/core/work-units.ts
+++ b/src/core/work-units.ts
@@ -12,6 +12,8 @@ import {
   WorkUnitOutcome,
   WorkUnitRecord,
   WorkUnitRecordSchema,
+  WorkUnitRelatedLink,
+  WorkUnitRelatedLinkSchema,
 } from '../harness/schema';
 import { markDirty } from './sync-context';
 
@@ -67,6 +69,36 @@ function listRecords<T>(
   return records;
 }
 
+/** Parse `source|url` or `source|url|label` from CLI `--work-link`. */
+export function parseWorkLinkSpec(spec: string): WorkUnitRelatedLink {
+  const parts = spec.split('|');
+  if (parts.length < 2) {
+    throw new Error(
+      `Invalid work link "${spec}" — use source|url or source|url|label (example: github|https://github.com/org/repo/pull/42|PR #42)`,
+    );
+  }
+  const [source, url, ...labelParts] = parts;
+  const label = labelParts.length > 0 ? labelParts.join('|') : undefined;
+  return WorkUnitRelatedLinkSchema.parse({ source, url, label });
+}
+
+export function mergeRelatedLinks(
+  existing: WorkUnitRelatedLink[] | undefined,
+  incoming: WorkUnitRelatedLink[] | undefined,
+  primaryUrl?: string,
+): WorkUnitRelatedLink[] | undefined {
+  if (!incoming?.length) return existing?.length ? existing : undefined;
+  const seen = new Set<string>();
+  const merged: WorkUnitRelatedLink[] = [];
+  for (const link of [...(existing ?? []), ...incoming]) {
+    if (primaryUrl && link.url === primaryUrl) continue;
+    if (seen.has(link.url)) continue;
+    seen.add(link.url);
+    merged.push(link);
+  }
+  return merged.length > 0 ? merged : undefined;
+}
+
 export function findWorkUnit(
   harnessRoot: string,
   workUnitId: string,
@@ -107,13 +139,19 @@ export function upsertWorkUnit(
     }
   }
   const now = new Date().toISOString();
+  const sourceUrl = existing?.sourceUrl ?? metadata.sourceUrl;
   const record = WorkUnitRecordSchema.parse({
     ...existing,
     workUnitId: metadata.workUnitId,
     source: existing?.source ?? metadata.source,
-    sourceUrl: existing?.sourceUrl ?? metadata.sourceUrl,
+    sourceUrl,
     title: existing?.title ?? metadata.title,
     parentWorkUnitId: existing?.parentWorkUnitId ?? metadata.parentWorkUnitId,
+    relatedLinks: mergeRelatedLinks(
+      existing?.relatedLinks,
+      metadata.relatedLinks,
+      sourceUrl,
+    ),
     version: 1,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
@@ -121,6 +159,28 @@ export function upsertWorkUnit(
   });
   writeRecord(
     hashedRecordPath(harnessRoot, WORK_UNITS_DIR, metadata.workUnitId),
+    record,
+  );
+  markDirty(harnessRoot);
+  return record;
+}
+
+export function addWorkUnitLinks(
+  harnessRoot: string,
+  workUnitId: string,
+  links: WorkUnitRelatedLink[],
+): WorkUnitRecord {
+  const existing = findWorkUnit(harnessRoot, workUnitId);
+  if (!existing) throw new Error(`Unknown work unit: ${workUnitId}`);
+  const parsed = links.map((link) => WorkUnitRelatedLinkSchema.parse(link));
+  const relatedLinks = mergeRelatedLinks(existing.relatedLinks, parsed, existing.sourceUrl);
+  const record = WorkUnitRecordSchema.parse({
+    ...existing,
+    relatedLinks,
+    updatedAt: new Date().toISOString(),
+  });
+  writeRecord(
+    hashedRecordPath(harnessRoot, WORK_UNITS_DIR, workUnitId),
     record,
   );
   markDirty(harnessRoot);

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -78,6 +78,23 @@ export const LaunchEnvironmentInputSchema = z.object({
   sourceUrl: z.string().url().optional(),
   title: z.string().min(1).max(256).optional(),
   parentWorkUnitId: z.string().min(1).max(128).optional(),
+  relatedLinks: z
+    .array(
+      z.object({
+        source: z.string().min(1).max(64),
+        url: z.string().url(),
+        label: z.string().min(1).max(128).optional(),
+      }),
+    )
+    .optional(),
+});
+
+export const AddWorkUnitLinkInputSchema = z.object({
+  repo: z.string().default('.'),
+  workUnitId: z.string().min(1).max(128),
+  source: z.string().min(1).max(64),
+  url: z.string().url(),
+  label: z.string().min(1).max(128).optional(),
 });
 
 export const LaunchEnvironmentOutputSchema = ShellRunOutputSchema.extend({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -22,6 +22,8 @@ import {
   teardownEnvironment,
 } from '../core/run-service';
 import { getRun, listRuns } from '../core/runs';
+import { addWorkUnitLinks } from '../core/work-units';
+import { resolveHarnessRoot } from '../harness/manifest';
 import {
   agentIdJsonProperty,
   objectJsonSchema,
@@ -30,6 +32,7 @@ import {
 } from './schema-tools';
 import { validateAgentId } from '../utils/validation';
 import {
+  AddWorkUnitLinkInputSchema,
   CompleteEnvironmentInputSchema,
   CompleteEnvironmentOutputSchema,
   DescribeProjectOutputSchema,
@@ -104,8 +107,40 @@ export const HAR_MCP_TOOLS: Tool[] = [
           type: 'string',
           description: 'Optional parent work unit identifier.',
         },
+        relatedLinks: {
+          type: 'array',
+          description:
+            'Additional tracker links (append-only). Each item: source, url, optional label.',
+          items: {
+            type: 'object',
+            properties: {
+              source: { type: 'string' },
+              url: { type: 'string' },
+              label: { type: 'string' },
+            },
+            required: ['source', 'url'],
+          },
+        },
       },
       ['agentId'],
+    ),
+  },
+  {
+    name: 'har_add_work_unit_link',
+    description:
+      'Append a related external link (PR, mirrored issue, alternate tracker) to an existing work unit.',
+    inputSchema: objectJsonSchema(
+      {
+        repo: repoJsonProperty,
+        workUnitId: {
+          type: 'string',
+          description: 'Repo-scoped work unit id bound at launch.',
+        },
+        source: { type: 'string', description: 'Tracker provider (e.g. github, jira).' },
+        url: { type: 'string', description: 'Canonical URL for the link.' },
+        label: { type: 'string', description: 'Optional display label.' },
+      },
+      ['workUnitId', 'source', 'url'],
     ),
   },
   {
@@ -292,6 +327,7 @@ export async function handleMcpToolCall(
         sourceUrl: input.sourceUrl,
         title: input.title,
         parentWorkUnitId: input.parentWorkUnitId,
+        relatedLinks: input.relatedLinks,
         capture: true,
       });
       const parsed = LaunchEnvironmentOutputSchema.parse(result);
@@ -315,6 +351,7 @@ export async function handleMcpToolCall(
         sourceUrl: input.sourceUrl,
         title: input.title,
         parentWorkUnitId: input.parentWorkUnitId,
+        relatedLinks: input.relatedLinks,
         capture: true,
       });
       const parsed = LaunchEnvironmentOutputSchema.parse(result);
@@ -322,6 +359,29 @@ export async function handleMcpToolCall(
         ...jsonContent(parsed),
         ...(result.blocked ? { isError: true } : {}),
       };
+    }
+
+    case 'har_add_work_unit_link': {
+      const input = AddWorkUnitLinkInputSchema.parse({ ...args, repo });
+      const harnessRoot = resolveHarnessRoot(repo);
+      try {
+        const record = addWorkUnitLinks(harnessRoot, input.workUnitId, [
+          { source: input.source, url: input.url, label: input.label },
+        ]);
+        return jsonContent({
+          ok: true,
+          workUnitId: record.workUnitId,
+          relatedLinks: record.relatedLinks,
+        });
+      } catch (err) {
+        return {
+          ...jsonContent({
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+          isError: true,
+        };
+      }
     }
 
     case 'har_preflight_environment': {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -9,6 +9,7 @@ describe('HAR MCP tool schemas', () => {
       'har_describe_project',
       'har_init_harness',
       'har_launch_environment',
+      'har_add_work_unit_link',
       'har_recover_environment',
       'har_preflight_environment',
       'har_run_stage',

--- a/tests/work-units.test.ts
+++ b/tests/work-units.test.ts
@@ -2,12 +2,15 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  addWorkUnitLinks,
   bindValidationToAttempt,
   createWorkAttempt,
   decideWorkUnitOutcome,
+  findWorkUnit,
   listValidationBindings,
   listWorkAttempts,
   listWorkUnits,
+  parseWorkLinkSpec,
   upsertWorkUnit,
 } from '../src/core/work-units';
 import type { ValidationRecord } from '../src/harness/schema';
@@ -86,5 +89,41 @@ describe('durable work identity', () => {
         decidedAt: new Date().toISOString(),
       }),
     ).toThrow('completed work must reference');
+  });
+
+  it('merges append-only related links and dedupes by url', () => {
+    upsertWorkUnit(repo, {
+      workUnitId: 'har-217',
+      source: 'jira',
+      sourceUrl: 'https://company.atlassian.net/browse/HAR-217',
+      relatedLinks: [
+        { source: 'github', url: 'https://github.com/os-factory/har/issues/217' },
+      ],
+    });
+    addWorkUnitLinks(repo, 'har-217', [
+      { source: 'github', url: 'https://github.com/os-factory/har/pull/999', label: 'PR #999' },
+      { source: 'github', url: 'https://github.com/os-factory/har/pull/999' },
+    ]);
+
+    expect(findWorkUnit(repo, 'har-217')).toEqual(
+      expect.objectContaining({
+        relatedLinks: [
+          { source: 'github', url: 'https://github.com/os-factory/har/issues/217' },
+          {
+            source: 'github',
+            url: 'https://github.com/os-factory/har/pull/999',
+            label: 'PR #999',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('parses CLI work link specs', () => {
+    expect(parseWorkLinkSpec('github|https://github.com/org/repo/pull/1|PR #1')).toEqual({
+      source: 'github',
+      url: 'https://github.com/org/repo/pull/1',
+      label: 'PR #1',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add append-only `relatedLinks` on work units so teams can attach secondary tracker URLs (GitHub PR, mirrored issue, Bitbucket) alongside the primary `sourceUrl`
- CLI: repeatable `--work-link source|url|label` at launch; `har env work-link --work-id …` to add links at handoff time
- MCP: `relatedLinks` on launch + new `har_add_work_unit_link` tool
- Mission Control: work unit page lists primary source plus all related links

Closes #217

## Test plan
- [x] Full HAR verify passes (`har env verify 1 --full`)
- [x] Unit tests for merge/dedupe, link parsing, sync schema, MCP tool list
- [ ] After merge/deploy: `prisma db push` in `control/` for the new `relatedLinks` column
- [ ] Manual: launch with `--work-link`, add PR via `har env work-link`, confirm links in Factory UI


Made with [Cursor](https://cursor.com)