### PR TITLE
feat(control): allow per-repo portal opt-out on register

### DIFF
--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -211,7 +211,7 @@ are internal hook workers invoked by Git, not day-to-day commands.
 ```bash
 har control up [--build] [-d|--detach|--no-detach]
 har control down
-har control register [--repo .] [--api-url <url>] [--dry-run] [--force]
+har control register [--repo .] [--api-url <url>] [--dry-run] [--force] [--portal|--no-portal]
 har control unregister [--repo .] [--api-url <url>] [--yes] [--delete-worktrees] [--dry-run] [--json]
 har control reset [--yes] [--no-scrub-local] [--keep-registry] [--api-url <url>] [--dry-run] [--json]
 har control sync [--select] [--api-url <url>] [--dry-run] [--json] [--cloud] [--full]
@@ -225,6 +225,8 @@ one it picked. With `--api-key` it stores that ingest token; without it, HAR
 opens browser SSO and saves the resulting token.
 `sync --select` interactively chooses repositories; `--full` ignores the portal
 watermark and resends the complete payload.
+`register --no-portal` keeps the repo on local Mission Control only (skips hosted
+portal sync even when logged in); `--portal` re-enables portal sync for that repo.
 
 `unregister` removes the repository from Mission Control and `~/.har/repos.json`.
 Interactively it lists session worktrees and asks whether to delete them; pass

--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -32,7 +32,12 @@ import {
   resetMissionControlFromCli,
 } from '../../core/control-reset';
 import { error, header, info, success, warn } from '../../utils/logging';
-import { listRegisteredRepos, recordRepoForControlSync } from '../../core/control-registry';
+import {
+  isRepoPortalSyncEnabled,
+  listRegisteredRepos,
+  recordRepoForControlSync,
+  setRepoPortalSync,
+} from '../../core/control-registry';
 import { finishCommand } from '../finish-command';
 
 export const controlCommand = {
@@ -71,6 +76,11 @@ export const controlCommand = {
               type: 'boolean',
               default: false,
               describe: 'Re-register even if previously unregistered',
+            })
+            .option('portal', {
+              type: 'boolean',
+              describe:
+                'Sync this repo to the hosted portal when logged in. Use --no-portal to keep it local-only.',
             }),
         handleRegister,
       )
@@ -233,6 +243,7 @@ async function handleRegister(argv: {
   apiUrl?: string;
   dryRun: boolean;
   force: boolean;
+  portal?: boolean;
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
   header('har control register');
@@ -241,6 +252,10 @@ async function handleRegister(argv: {
   try {
     if (!argv.dryRun) {
       recordRepoForControlSync(repoPath);
+      // Only persist when the user passed --portal / --no-portal (undefined = leave as-is).
+      if (argv.portal !== undefined) {
+        setRepoPortalSync(repoPath, argv.portal);
+      }
     }
     // Explicit register always clears a prior unregister blocklist entry.
     await syncRepoWithControl({
@@ -253,6 +268,9 @@ async function handleRegister(argv: {
       info('Dry run — no API call made');
     } else {
       success('Registered and synced with Mission Control');
+      if (!isRepoPortalSyncEnabled(repoPath)) {
+        info('Local-only — skipped hosted portal sync');
+      }
     }
   } catch (err: unknown) {
     error((err as Error).message);

--- a/src/core/control-registry.ts
+++ b/src/core/control-registry.ts
@@ -6,6 +6,8 @@ import { canonicalizeControlRepoPath, resolveMainWorkingTree } from './control-r
 
 interface ControlRegistry {
   repos: string[];
+  /** Paths that stay on local Mission Control only (skip hosted portal sync). */
+  portalOptOut?: string[];
 }
 
 function getRegistryPath(): string {
@@ -15,11 +17,19 @@ function getRegistryPath(): string {
   return path.join(os.homedir(), '.har', 'repos.json');
 }
 
+function normalizeRegistry(raw: Partial<ControlRegistry> | null | undefined): ControlRegistry {
+  const repos = Array.isArray(raw?.repos) ? raw.repos.filter((p): p is string => typeof p === 'string') : [];
+  const portalOptOut = Array.isArray(raw?.portalOptOut)
+    ? raw.portalOptOut.filter((p): p is string => typeof p === 'string')
+    : undefined;
+  return portalOptOut && portalOptOut.length > 0 ? { repos, portalOptOut } : { repos };
+}
+
 function readRegistry(): ControlRegistry {
   const registryPath = getRegistryPath();
   try {
     if (!fs.existsSync(registryPath)) return { repos: [] };
-    return JSON.parse(fs.readFileSync(registryPath, 'utf8')) as ControlRegistry;
+    return normalizeRegistry(JSON.parse(fs.readFileSync(registryPath, 'utf8')) as ControlRegistry);
   } catch {
     return { repos: [] };
   }
@@ -28,12 +38,39 @@ function readRegistry(): ControlRegistry {
 function writeRegistry(registry: ControlRegistry): void {
   const registryPath = getRegistryPath();
   fs.mkdirSync(path.dirname(registryPath), { recursive: true });
-  fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2) + '\n');
+  const normalized = normalizeRegistry(registry);
+  fs.writeFileSync(registryPath, JSON.stringify(normalized, null, 2) + '\n');
 }
 
 function registryChanged(before: string[], after: string[]): boolean {
   if (before.length !== after.length) return true;
   return before.some((repoPath, index) => repoPath !== after[index]);
+}
+
+function pathEqualsCanonical(entry: string, resolved: string): boolean {
+  try {
+    return canonicalizeControlRepoPath(entry) === resolved;
+  } catch {
+    return path.resolve(entry) === resolved;
+  }
+}
+
+function prunePortalOptOut(registry: ControlRegistry, keptRepos: string[]): string[] | undefined {
+  const kept = new Set(keptRepos);
+  const next: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of registry.portalOptOut ?? []) {
+    let canonical: string;
+    try {
+      canonical = canonicalizeControlRepoPath(entry);
+    } catch {
+      canonical = path.resolve(entry);
+    }
+    if (!kept.has(canonical) || seen.has(canonical)) continue;
+    seen.add(canonical);
+    next.push(canonical);
+  }
+  return next.length > 0 ? next : undefined;
 }
 
 /** Remember a repo so Mission Control can sync it when the dashboard starts. */
@@ -51,19 +88,53 @@ export function recordRepoForControlSync(repoPath: string): void {
   writeRegistry(registry);
 }
 
+/**
+ * Whether this repo may sync to the hosted portal when credentials exist.
+ * Default is enabled; only paths listed in `portalOptOut` are skipped.
+ */
+export function isRepoPortalSyncEnabled(repoPath: string): boolean {
+  const resolved = canonicalizeControlRepoPath(repoPath);
+  const registry = readRegistry();
+  return !(registry.portalOptOut ?? []).some((entry) => pathEqualsCanonical(entry, resolved));
+}
+
+/**
+ * Persist whether a registered repo should sync to the hosted portal.
+ * `enabled: false` opts out; `true` clears a prior opt-out.
+ */
+export function setRepoPortalSync(repoPath: string, enabled: boolean): void {
+  const resolved = canonicalizeControlRepoPath(repoPath);
+  const registry = readRegistry();
+  const current = registry.portalOptOut ?? [];
+  const without = current.filter((entry) => !pathEqualsCanonical(entry, resolved));
+
+  if (enabled) {
+    if (without.length === current.length) return;
+    writeRegistry({
+      repos: registry.repos,
+      ...(without.length > 0 ? { portalOptOut: without } : {}),
+    });
+    return;
+  }
+
+  if (without.length !== current.length) return; // already opted out
+  writeRegistry({
+    repos: registry.repos,
+    portalOptOut: [...without, resolved],
+  });
+}
+
 /** Drop a repo from the local sync registry (does not touch Mission Control DB). */
 export function removeRegisteredRepo(repoPath: string): boolean {
   const resolved = canonicalizeControlRepoPath(repoPath);
   const registry = readRegistry();
-  const next = registry.repos.filter((entry) => {
-    try {
-      return canonicalizeControlRepoPath(entry) !== resolved;
-    } catch {
-      return path.resolve(entry) !== resolved;
-    }
-  });
+  const next = registry.repos.filter((entry) => !pathEqualsCanonical(entry, resolved));
   if (next.length === registry.repos.length) return false;
-  writeRegistry({ repos: next });
+  const portalOptOut = prunePortalOptOut(registry, next);
+  writeRegistry({
+    repos: next,
+    ...(portalOptOut ? { portalOptOut } : {}),
+  });
   return true;
 }
 
@@ -82,8 +153,17 @@ export function listRegisteredRepos(): string[] {
     kept.push(canonical);
   }
 
-  if (registryChanged(registry.repos, kept)) {
-    writeRegistry({ repos: kept });
+  const prunedOptOut = prunePortalOptOut(registry, kept);
+  const optOutBefore = registry.portalOptOut ?? [];
+  const optOutChanged =
+    (prunedOptOut?.length ?? 0) !== optOutBefore.length ||
+    (prunedOptOut ?? []).some((p, i) => p !== optOutBefore[i]);
+
+  if (registryChanged(registry.repos, kept) || optOutChanged) {
+    writeRegistry({
+      repos: kept,
+      ...(prunedOptOut ? { portalOptOut: prunedOptOut } : {}),
+    });
   }
 
   return kept;
@@ -97,7 +177,7 @@ export function getControlRegistryPath(): string {
 export function clearRegisteredRepos(): number {
   const registry = readRegistry();
   const count = registry.repos.length;
-  if (count === 0) return 0;
+  if (count === 0 && !(registry.portalOptOut?.length)) return 0;
   writeRegistry({ repos: [] });
   return count;
 }

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -20,6 +20,7 @@ import {
   PortalTarget,
 } from './control-config';
 import {
+  isRepoPortalSyncEnabled,
   listRegisteredRepos,
   recordRepoForControlSync,
   removeRegisteredRepo,
@@ -621,6 +622,8 @@ async function syncRepoWithPortal(
   options: ControlSyncOptions & { repoPath: string },
   controlApiUrl: string,
 ): Promise<void> {
+  if (!isRepoPortalSyncEnabled(options.repoPath)) return;
+
   const portal = getPortalTarget();
   if (!portal) return;
 
@@ -891,6 +894,7 @@ export async function syncRunWithControlAsync(repoPath: string, run: RunRecord):
 
   const portal = getPortalTarget();
   if (!portal) return;
+  if (!isRepoPortalSyncEnabled(canonical)) return;
 
   try {
     if (!(await isControlApiReachable(portal.url))) return;

--- a/tests/control-registry.test.ts
+++ b/tests/control-registry.test.ts
@@ -4,9 +4,11 @@ import * as path from 'path';
 import {
   clearRegisteredRepos,
   getControlRegistryPath,
+  isRepoPortalSyncEnabled,
   listRegisteredRepos,
   recordRepoForControlSync,
   removeRegisteredRepo,
+  setRepoPortalSync,
 } from '../src/core/control-registry';
 import { canonicalizeControlRepoPath } from '../src/core/control-repo-path';
 
@@ -92,5 +94,63 @@ describe('control registry', () => {
     expect(listRegisteredRepos()).toEqual([]);
     expect(clearRegisteredRepos()).toBe(0);
   });
-});
 
+  it('defaults portal sync to enabled', () => {
+    recordRepoForControlSync(FIXTURE);
+    expect(isRepoPortalSyncEnabled(FIXTURE)).toBe(true);
+  });
+
+  it('persists portal opt-out and re-enable', () => {
+    recordRepoForControlSync(FIXTURE);
+    setRepoPortalSync(FIXTURE, false);
+    expect(isRepoPortalSyncEnabled(FIXTURE)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).portalOptOut).toEqual([
+      FIXTURE_CANONICAL,
+    ]);
+
+    setRepoPortalSync(FIXTURE, true);
+    expect(isRepoPortalSyncEnabled(FIXTURE)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).portalOptOut).toBeUndefined();
+  });
+
+  it('recordRepoForControlSync does not clear an existing portal opt-out', () => {
+    recordRepoForControlSync(FIXTURE);
+    setRepoPortalSync(FIXTURE, false);
+    recordRepoForControlSync(FIXTURE);
+    expect(isRepoPortalSyncEnabled(FIXTURE)).toBe(false);
+  });
+
+  it('removeRegisteredRepo drops portal opt-out for that path', () => {
+    recordRepoForControlSync(FIXTURE);
+    setRepoPortalSync(FIXTURE, false);
+    removeRegisteredRepo(FIXTURE);
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).portalOptOut).toBeUndefined();
+  });
+
+  it('listRegisteredRepos prunes portal opt-out for missing repos', () => {
+    fs.mkdirSync(path.dirname(registryPath), { recursive: true });
+    fs.writeFileSync(
+      registryPath,
+      JSON.stringify(
+        {
+          repos: [path.resolve(FIXTURE), '/tmp/missing-har-repo'],
+          portalOptOut: ['/tmp/missing-har-repo', path.resolve(FIXTURE)],
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(listRegisteredRepos()).toEqual([FIXTURE_CANONICAL]);
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8')).portalOptOut).toEqual([
+      FIXTURE_CANONICAL,
+    ]);
+  });
+
+  it('clearRegisteredRepos clears portal opt-out', () => {
+    recordRepoForControlSync(FIXTURE);
+    setRepoPortalSync(FIXTURE, false);
+    clearRegisteredRepos();
+    expect(JSON.parse(fs.readFileSync(registryPath, 'utf8'))).toEqual({ repos: [] });
+  });
+});

--- a/tests/control-sync-portal-optout.test.ts
+++ b/tests/control-sync-portal-optout.test.ts
@@ -1,0 +1,122 @@
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+jest.mock('../src/core/portal-credentials', () => ({ readPortalCredentials: jest.fn(() => null) }));
+jest.mock('../src/core/runs', () => ({ listRuns: jest.fn(() => []) }));
+jest.mock('../src/core/slot-status', () => ({
+  collectEnvironmentStatus: () => ({ slots: [], generatedAt: '2026-01-01T00:00:00.000Z' }),
+}));
+jest.mock('../src/core/validations', () => ({ listValidations: () => [] }));
+jest.mock('../src/core/work-units', () => ({
+  listWorkUnits: () => [],
+  listWorkAttempts: () => [],
+  listValidationBindings: () => [],
+}));
+jest.mock('../src/core/usage-harvest', () => ({
+  harvestUsageForSlot: () => [],
+  harvestEventsForSlot: () => [],
+}));
+jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => false }));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => null,
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { syncReposWithControl } from '../src/core/control-sync';
+import { setRepoPortalSync } from '../src/core/control-registry';
+import { listRuns } from '../src/core/runs';
+import type { RunRecord } from '../src/harness/schema';
+
+const realFetch = global.fetch;
+const mockedListRuns = listRuns as jest.MockedFunction<typeof listRuns>;
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  };
+}
+
+describe('portal opt-out during sync', () => {
+  const calls: { url: string; body: Record<string, unknown> }[] = [];
+  let stateDir: string;
+  let registryPath: string;
+
+  beforeEach(() => {
+    calls.length = 0;
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-portal-optout-'));
+    registryPath = path.join(stateDir, 'repos.json');
+    process.env.HAR_CONTROL_REGISTRY_PATH = registryPath;
+    process.env.HAR_PORTAL_SYNC_STATE_PATH = path.join(stateDir, 'state.json');
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_test';
+
+    fs.writeFileSync(registryPath, JSON.stringify({ repos: ['/repos/local-only'] }, null, 2));
+
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(
+      async (url: string, init?: RequestInit) => {
+        const method = init?.method ?? 'GET';
+        const body = init?.body ? JSON.parse(String(init.body)) : {};
+        if (method === 'POST') calls.push({ url: String(url), body });
+
+        if (String(url).endsWith('/api/repos') && method === 'POST') {
+          return jsonResponse({ id: 'local-repo-1' });
+        }
+        if (String(url).endsWith('/api/repos') && method === 'GET') {
+          return jsonResponse([]);
+        }
+        return jsonResponse({});
+      },
+    );
+
+    mockedListRuns.mockReturnValue([
+      {
+        runId: '00000000-0000-4000-8000-000000000001',
+        repoPath: '/repos/local-only',
+        stageId: 'verify',
+        status: 'pass',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        trigger: 'cli',
+      } satisfies RunRecord,
+    ]);
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_CONTROL_REGISTRY_PATH;
+    delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+    delete process.env.HAR_PORTAL_URL;
+    delete process.env.HAR_PORTAL_TOKEN;
+    mockedListRuns.mockReturnValue([]);
+    (global as unknown as { fetch: unknown }).fetch = realFetch;
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('skips portal POSTs when the repo is opted out', async () => {
+    setRepoPortalSync('/repos/local-only', false);
+
+    const result = await syncReposWithControl({ repoPaths: ['/repos/local-only'] });
+    expect(result.failed).toBe(0);
+
+    expect(calls.some((c) => c.url.endsWith('/api/repos'))).toBe(true);
+    expect(calls.filter((c) => c.url === 'https://portal.example.com/api/sync')).toHaveLength(0);
+    expect(calls.filter((c) => c.url === 'https://portal.example.com/api/otel')).toHaveLength(0);
+  });
+
+  it('sends to the portal again after --portal re-enables sync', async () => {
+    setRepoPortalSync('/repos/local-only', false);
+    setRepoPortalSync('/repos/local-only', true);
+
+    await syncReposWithControl({ repoPaths: ['/repos/local-only'] });
+
+    expect(calls.filter((c) => c.url === 'https://portal.example.com/api/sync').length).toBeGreaterThan(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `har control register --no-portal` / `--portal` so logged-in users can keep specific repos on local Mission Control only
- Persist the preference in user-local `~/.har/repos.json` (`portalOptOut`) — not in the committed harness
- Gate portal sync (register, sync, auto-sync, per-run) while leaving local MC sync unchanged

## Test plan
- [x] `har env verify 1 --full` passed in session worktree
- [ ] `har control register --no-portal` with portal credentials → local MC only, message “Local-only — skipped hosted portal sync”
- [ ] Activity-edge sync does not undo the opt-out
- [ ] `har control register --portal` re-enables portal POSTs for that repo


Made with [Cursor](https://cursor.com)