### PR TITLE
feat(control): replayable trajectory ledger and split-pane viewer

### DIFF
--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/control",
-  "version": "0.42.0",
+  "version": "0.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "0.42.0",
+      "version": "0.57.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -66,7 +66,7 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "0.42.0",
+      "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/control/src/app/api/repos/[id]/slots/[slotId]/trajectory/route.ts
+++ b/control/src/app/api/repos/[id]/slots/[slotId]/trajectory/route.ts
@@ -3,35 +3,58 @@ import { NextResponse } from 'next/server';
 import {
   cursorForTrajectory,
   decodeTrajectoryCursor,
+  deleteTrajectoryScope,
   listTrajectoryAfter,
+  listTrajectoryExport,
   listTrajectoryHistory,
   serializeTrajectoryPage,
   serializeTrajectoryRecord,
 } from '@/server/trajectory-ledger';
+
+function parseScope(request: Request, id: string, slotId: string) {
+  const url = new URL(request.url);
+  const sessionKey = url.searchParams.get('sessionKey')?.trim();
+  const parsedTool = AgentToolSchema.safeParse(url.searchParams.get('agentTool'));
+  const agentId = Number(slotId);
+  if (!sessionKey) {
+    return { ok: false as const, response: NextResponse.json({ error: 'sessionKey is required' }, { status: 400 }) };
+  }
+  if (!parsedTool.success) {
+    return { ok: false as const, response: NextResponse.json({ error: 'agentTool is invalid' }, { status: 400 }) };
+  }
+  if (!Number.isInteger(agentId) || agentId < 1) {
+    return { ok: false as const, response: NextResponse.json({ error: 'slotId is invalid' }, { status: 400 }) };
+  }
+  return {
+    ok: true as const,
+    url,
+    scope: { repositoryId: id, agentId, sessionKey, agentTool: parsedTool.data },
+  };
+}
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string; slotId: string }> },
 ) {
   const { id, slotId } = await params;
-  const url = new URL(request.url);
-  const sessionKey = url.searchParams.get('sessionKey')?.trim();
-  const parsedTool = AgentToolSchema.safeParse(url.searchParams.get('agentTool'));
-  const agentId = Number(slotId);
-  if (!sessionKey) {
-    return NextResponse.json({ error: 'sessionKey is required' }, { status: 400 });
-  }
-  if (!parsedTool.success) {
-    return NextResponse.json({ error: 'agentTool is invalid' }, { status: 400 });
-  }
-  if (!Number.isInteger(agentId) || agentId < 1) {
-    return NextResponse.json({ error: 'slotId is invalid' }, { status: 400 });
-  }
+  const parsed = parseScope(request, id, slotId);
+  if (!parsed.ok) return parsed.response;
+  const { url, scope } = parsed;
 
   const before = url.searchParams.get('before') ?? undefined;
   const after = url.searchParams.get('after') ?? undefined;
   const requestedLimit = Number(url.searchParams.get('limit') ?? 100);
   try {
+    if (url.searchParams.get('format') === 'jsonl') {
+      const records = await listTrajectoryExport(scope);
+      const body = records.map((record) => JSON.stringify(serializeTrajectoryRecord(record))).join('\n');
+      return new NextResponse(body ? `${body}\n` : '', {
+        headers: {
+          'Content-Type': 'application/x-ndjson; charset=utf-8',
+          'Content-Disposition': `attachment; filename="trajectory-${scope.sessionKey}.jsonl"`,
+        },
+      });
+    }
     if (before && after) {
       return NextResponse.json({ error: 'before and after are mutually exclusive' }, { status: 400 });
     }
@@ -41,7 +64,6 @@ export async function GET(
       1,
       Math.min(Number.isFinite(requestedLimit) ? requestedLimit : 100, after ? 999 : 200),
     );
-    const scope = { repositoryId: id, agentId, sessionKey, agentTool: parsedTool.data };
     if (after) {
       const rows = await listTrajectoryAfter(scope, after, limit + 1);
       const records = rows.slice(0, limit);
@@ -54,14 +76,24 @@ export async function GET(
         nextAfter: rows.length > limit && latest ? cursorForTrajectory(latest) : null,
       });
     }
-    const page = await listTrajectoryHistory(
-      scope,
-      {
-        before,
-        limit,
-      },
-    );
+    const page = await listTrajectoryHistory(scope, { before, limit });
     return NextResponse.json(serializeTrajectoryPage(page));
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; slotId: string }> },
+) {
+  const { id, slotId } = await params;
+  const parsed = parseScope(request, id, slotId);
+  if (!parsed.ok) return parsed.response;
+  const { scope } = parsed;
+  try {
+    return NextResponse.json(await deleteTrajectoryScope(scope));
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ error: message }, { status: 400 });

--- a/control/src/app/globals.css
+++ b/control/src/app/globals.css
@@ -33,6 +33,12 @@
     --sidebar-accent-foreground: 215 26% 9%;
     --sidebar-border: 218 17% 84%;
     --sidebar-ring: 124 11% 30%;
+    /* Trajectory roles: olive user, ink-teal assistant, earth tool */
+    --trajectory-user: 124 11% 30%;
+    --trajectory-assistant: 200 28% 36%;
+    --trajectory-tool: 32 42% 38%;
+    --trajectory-system: 219 8% 42%;
+    --trajectory-error: 0 72% 42%;
   }
 
   .dark {
@@ -64,6 +70,11 @@
     --sidebar-accent-foreground: 45 31% 95%;
     --sidebar-border: 213 20% 16%;
     --sidebar-ring: 149 42% 64%;
+    --trajectory-user: 149 42% 64%;
+    --trajectory-assistant: 198 48% 72%;
+    --trajectory-tool: 36 55% 62%;
+    --trajectory-system: 214 8% 62%;
+    --trajectory-error: 0 62% 62%;
   }
 }
 

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -231,7 +231,7 @@ export default async function SlotDetailPage({
         <CardHeader>
           <CardTitle>Agent activity</CardTitle>
           <CardDescription>
-            Follow the assembled trajectory, or inspect the raw session-event table for debugging.
+            Follow the assembled trajectory, or inspect raw session events. Start/end bookends are hidden by default.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -231,7 +231,7 @@ export default async function SlotDetailPage({
         <CardHeader>
           <CardTitle>Agent activity</CardTitle>
           <CardDescription>
-            Follow the assembled trajectory, or inspect raw session events. Start/end bookends are hidden by default.
+            Follow the assembled trajectory, or inspect raw session events. Tool and generation start/end pairs are hidden by default.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/control/src/app/settings/page.tsx
+++ b/control/src/app/settings/page.tsx
@@ -1,10 +1,12 @@
 import { ResetMissionControlButton } from '@/components/reset-mission-control-button';
+import { trajectoryPolicy } from '@/lib/trajectory-privacy';
 import { listRepositories } from '@/server/repositories';
 
 export const dynamic = 'force-dynamic';
 
 export default async function SettingsPage() {
   const repos = await listRepositories();
+  const policy = trajectoryPolicy();
 
   return (
     <div className="flex flex-col gap-4 py-4 md:gap-6 md:py-6">
@@ -14,6 +16,21 @@ export default async function SettingsPage() {
           Local Mission Control preferences and destructive maintenance
         </p>
       </div>
+
+      <section className="mx-4 space-y-2 rounded-lg border p-4 md:mx-6 md:p-6">
+        <h3 className="text-lg font-semibold">Trajectory storage</h3>
+        <p className="max-w-2xl text-sm text-muted-foreground">
+          Agent trajectories stay in this local SQLite database. Exporting a session downloads
+          JSONL to your machine; nothing is sent to HAR Cloud unless you run a remote Mission
+          Control. Set <code>HAR_TRAJECTORY_RETENTION_DAYS</code> to expire old ledger rows
+          (0 keeps them). <code>HAR_TRAJECTORY_MAX_PAYLOAD_BYTES</code> caps stored tool/prompt
+          bodies.
+        </p>
+        <p className="text-sm">
+          Retention: {policy.retentionDays > 0 ? `${policy.retentionDays} days` : 'unlimited'} ·
+          Payload cap: {Math.round(policy.maxPayloadBytes / 1024)} KiB
+        </p>
+      </section>
 
       <section className="mx-4 space-y-4 rounded-lg border border-destructive/30 bg-destructive/[0.03] p-4 md:mx-6 md:p-6">
         <div className="space-y-1">

--- a/control/src/components/session-events-table.tsx
+++ b/control/src/components/session-events-table.tsx
@@ -7,9 +7,12 @@ import {
   type SessionEventRow,
 } from '@/components/columns/session-event-columns';
 import { SessionEventPreview } from '@/components/session-event-preview';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import {
   countSessionEventViews,
+  isStartEndBoundaryEvent,
   matchesSessionEventView,
   SESSION_EVENT_VIEWS,
   type SessionEventView,
@@ -17,14 +20,21 @@ import {
 
 export function SessionEventsTable({ events }: { events: SessionEventRow[] }) {
   const [view, setView] = useState<SessionEventView>('activity');
+  const [hideStartEnd, setHideStartEnd] = useState(true);
   const [selected, setSelected] = useState<SessionEventRow | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
 
-  const counts = useMemo(() => countSessionEventViews(events), [events]);
+  const scoped = useMemo(
+    () => hideStartEnd
+      ? events.filter((event) => !isStartEndBoundaryEvent(event.eventName))
+      : events,
+    [events, hideStartEnd],
+  );
+  const counts = useMemo(() => countSessionEventViews(scoped), [scoped]);
 
   const visible = useMemo(
-    () => events.filter((event) => matchesSessionEventView(event, view)),
-    [events, view],
+    () => scoped.filter((event) => matchesSessionEventView(event, view)),
+    [scoped, view],
   );
 
   if (events.length === 0) {
@@ -62,9 +72,24 @@ export function SessionEventsTable({ events }: { events: SessionEventRow[] }) {
             </ToggleGroupItem>
           ))}
         </ToggleGroup>
-        <p className="text-xs text-muted-foreground">
-          Showing {visible.length} of {events.length}. Click a row for attributes.
-        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="hide-start-end"
+              checked={hideStartEnd}
+              onCheckedChange={(value) => setHideStartEnd(value === true)}
+              aria-label="Hide start/end events"
+            />
+            <Label htmlFor="hide-start-end" className="text-xs font-normal text-muted-foreground">
+              Hide start/end events
+            </Label>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Showing {visible.length} of {scoped.length}
+            {hideStartEnd && scoped.length !== events.length ? ` (${events.length - scoped.length} hidden)` : ''}.
+            {' '}Click a row for attributes.
+          </p>
+        </div>
       </div>
 
       <DataTable

--- a/control/src/components/trajectory-viewer.tsx
+++ b/control/src/components/trajectory-viewer.tsx
@@ -306,10 +306,39 @@ export function TrajectoryViewer({
             {formatAgentToolLabel(streams[0].agentTool)} · {streams[0].sessionKey}
           </p>
         )}
-        <Badge variant="outline" aria-label={`Trajectory connection ${status}`}>
-          <span className={`mr-1.5 h-2 w-2 rounded-full ${status === 'live' ? 'bg-emerald-500' : status === 'offline' ? 'bg-destructive' : 'bg-amber-500'}`} />
-          {status}
-        </Badge>
+        <div className="flex flex-wrap items-center gap-2">
+          {selected ? (
+            <>
+              <Button variant="outline" size="sm" asChild>
+                <a href={endpoint(repositoryId, agentId, selected, '') + '&format=jsonl'} download>
+                  Export JSONL
+                </a>
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  if (!window.confirm('Delete this session trajectory from local Mission Control? Usage totals are kept.')) {
+                    return;
+                  }
+                  void fetch(endpoint(repositoryId, agentId, selected), { method: 'DELETE' }).then((response) => {
+                    if (!response.ok) return;
+                    replaceRecords([]);
+                    setBefore(null);
+                    setHasMore(false);
+                    cursorRef.current = null;
+                  });
+                }}
+              >
+                Delete session
+              </Button>
+            </>
+          ) : null}
+          <Badge variant="outline" aria-label={`Trajectory connection ${status}`}>
+            <span className={`mr-1.5 h-2 w-2 rounded-full ${status === 'live' ? 'bg-emerald-500' : status === 'offline' ? 'bg-destructive' : 'bg-amber-500'}`} />
+            {status}
+          </Badge>
+        </div>
       </div>
       {hasMore && before ? (
         <Button variant="outline" size="sm" disabled={loadingOlder} onClick={() => void loadOlder()}>

--- a/control/src/components/trajectory-viewer.tsx
+++ b/control/src/components/trajectory-viewer.tsx
@@ -1,15 +1,10 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { ChevronRight } from 'lucide-react';
+import { Clock, Download, MessageSquare, Search, Trash2, Wrench } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -17,19 +12,39 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { cn } from '@/lib/utils';
 import {
   assembleTrajectory,
+  countTrajectoryCalls,
+  countTrajectoryTurns,
+  formatDurationMs,
   mergeTrajectoryRecords,
+  nodeDurationMs,
+  nodeMatchesQuery,
+  previewTrajectoryNode,
   safeTrajectoryBody,
   sequenceGap,
+  sessionDurationMs,
+  trajectoryOverviewPlacement,
+  trajectoryRoleLabel,
   type SerializedTrajectoryPage,
   type SerializedTrajectoryRecord,
+  type TrajectoryLane,
   type TrajectoryNode,
+  type TrajectoryNodeKind,
   type TrajectoryStream,
 } from '@/lib/trajectory';
 
 type LiveStatus = 'live' | 'reconnecting' | 'offline';
+
+const LANE_ORDER: Array<Exclude<TrajectoryLane, 'other'>> = ['input', 'model', 'tools'];
+const LANE_LABEL: Record<Exclude<TrajectoryLane, 'other'>, string> = {
+  input: 'Input',
+  model: 'Model',
+  tools: 'Tools',
+};
 
 function streamKey(stream: TrajectoryStream): string {
   return JSON.stringify([stream.sessionKey, stream.agentTool]);
@@ -49,11 +64,21 @@ function endpoint(
 }
 
 function bodyText(value: unknown): string {
-  if (typeof value === 'string') return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if ((trimmed.startsWith('{') || trimmed.startsWith('[')) && trimmed.length > 1) {
+      try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2);
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
   if (value && typeof value === 'object' && 'stringValue' in value) {
     const stringValue = (value as { stringValue?: unknown }).stringValue;
-    if (typeof stringValue === 'string') return stringValue;
+    if (typeof stringValue === 'string') return bodyText(stringValue);
   }
   return JSON.stringify(value, null, 2);
 }
@@ -75,92 +100,314 @@ function disclosureCopy(record: SerializedTrajectoryRecord): string {
   return 'Recorded content';
 }
 
-function statusVariant(status: TrajectoryNode['status']) {
-  return status === 'error' ? 'destructive' as const : status === 'completed' ? 'secondary' as const : 'outline' as const;
+function roleTone(kind: TrajectoryNodeKind): string {
+  switch (kind) {
+    case 'prompt':
+      return 'text-[hsl(var(--trajectory-user))] bg-[hsl(var(--trajectory-user)/0.14)]';
+    case 'response':
+    case 'reasoning':
+      return 'text-[hsl(var(--trajectory-assistant))] bg-[hsl(var(--trajectory-assistant)/0.14)]';
+    case 'tool':
+    case 'subagent':
+      return 'text-[hsl(var(--trajectory-tool))] bg-[hsl(var(--trajectory-tool)/0.16)]';
+    case 'error':
+      return 'text-[hsl(var(--trajectory-error))] bg-[hsl(var(--trajectory-error)/0.14)]';
+    default:
+      return 'text-[hsl(var(--trajectory-system))] bg-[hsl(var(--trajectory-system)/0.14)]';
+  }
 }
 
-function TrajectoryBlock({ node }: { node: TrajectoryNode }) {
-  const expandable = node.kind === 'tool' || node.kind === 'subagent';
-  if (expandable) {
+function laneBarClass(lane: Exclude<TrajectoryLane, 'other'>): string {
+  if (lane === 'input') return 'bg-[hsl(var(--trajectory-user))]';
+  if (lane === 'model') return 'bg-[hsl(var(--trajectory-assistant))]';
+  return 'bg-[hsl(var(--trajectory-tool))]';
+}
+
+function roleDotClass(kind: TrajectoryNodeKind): string {
+  switch (kind) {
+    case 'prompt':
+      return 'bg-[hsl(var(--trajectory-user))]';
+    case 'response':
+    case 'reasoning':
+      return 'bg-[hsl(var(--trajectory-assistant))]';
+    case 'tool':
+    case 'subagent':
+      return 'bg-[hsl(var(--trajectory-tool))]';
+    case 'error':
+      return 'bg-[hsl(var(--trajectory-error))]';
+    default:
+      return 'bg-[hsl(var(--trajectory-system))]';
+  }
+}
+
+function statusLabel(status: TrajectoryNode['status']): string | null {
+  if (!status) return null;
+  if (status === 'running') return 'Running';
+  if (status === 'completed') return 'Completed';
+  if (status === 'unmatched') return 'Unmatched';
+  return 'Error';
+}
+
+function turnIndex(nodes: TrajectoryNode[], nodeId: string): number | null {
+  let turn = 0;
+  for (const node of nodes) {
+    if (node.kind === 'prompt') turn += 1;
+    if (node.id === nodeId) return node.kind === 'prompt' || turn > 0 ? Math.max(turn, 1) : null;
+  }
+  return null;
+}
+
+function payloadRecord(node: TrajectoryNode): SerializedTrajectoryRecord {
+  return node.records[0];
+}
+
+function resultRecord(node: TrajectoryNode): SerializedTrajectoryRecord | null {
+  return node.records.length > 1 ? node.records[node.records.length - 1] : null;
+}
+
+function RecordBody({ record }: { record: SerializedTrajectoryRecord }) {
+  const body = safeTrajectoryBody(record);
+  if (body == null) {
+    return <p className="text-xs italic text-muted-foreground">{disclosureCopy(record)}</p>;
+  }
+  return (
+    <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md border bg-background/80 p-2 font-mono text-[11px] leading-relaxed">
+      {bodyText(body)}
+    </pre>
+  );
+}
+
+function TrajectoryOverview({
+  nodes,
+  selectedId,
+  onSelect,
+}: {
+  nodes: TrajectoryNode[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const placements = useMemo(() => trajectoryOverviewPlacement(nodes), [nodes]);
+  if (placements.length === 0) return null;
+
+  return (
+    <div className="space-y-1.5 rounded-md border bg-muted/30 px-3 py-2" aria-label="Trajectory overview">
+      {LANE_ORDER.map((lane) => {
+        const bars = placements.filter((item) => item.lane === lane);
+        return (
+          <div key={lane} className="grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-2">
+            <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              {LANE_LABEL[lane]}
+            </span>
+            <div className="relative h-3.5 overflow-hidden rounded-sm bg-background/70">
+              {bars.map((bar) => (
+                <button
+                  key={bar.id}
+                  type="button"
+                  title={nodes.find((node) => node.id === bar.id)?.title}
+                  aria-label={`${LANE_LABEL[lane]} ${nodes.find((node) => node.id === bar.id)?.title ?? bar.id}`}
+                  aria-pressed={selectedId === bar.id}
+                  onClick={() => onSelect(bar.id)}
+                  className={cn(
+                    'absolute top-0.5 h-2.5 rounded-sm transition-opacity',
+                    laneBarClass(lane),
+                    selectedId === bar.id ? 'opacity-100 ring-1 ring-ring' : 'opacity-80 hover:opacity-100',
+                  )}
+                  style={{ left: `${bar.left}%`, width: `${bar.width}%` }}
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function TrajectoryLog({
+  nodes,
+  selectedId,
+  onSelect,
+}: {
+  nodes: TrajectoryNode[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  let turn = 0;
+
+  return (
+    <ol className="relative space-y-0" aria-label="Agent trajectory timeline">
+      <span aria-hidden className="absolute bottom-2 left-[11px] top-2 w-px bg-border" />
+      {nodes.map((node) => {
+        if (node.kind === 'prompt') turn += 1;
+        const currentTurn = turn;
+        const preview = previewTrajectoryNode(node);
+        const duration = nodeDurationMs(node);
+        const selected = selectedId === node.id;
+        return (
+          <li key={node.id} className="relative">
+            {node.kind === 'prompt' ? (
+              <span className="absolute -left-0.5 top-2 z-10 rounded border border-primary/30 bg-primary/10 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-primary">
+                Turn {currentTurn}
+              </span>
+            ) : null}
+            <button
+              type="button"
+              aria-pressed={selected}
+              onClick={() => onSelect(node.id)}
+              className={cn(
+                'flex w-full gap-3 rounded-md px-2 py-2 text-left transition-colors',
+                node.kind === 'prompt' ? 'mt-5' : '',
+                selected ? 'bg-primary/10' : 'hover:bg-muted/60',
+              )}
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  'mt-1.5 h-2 w-2 shrink-0 rounded-full ring-2 ring-background',
+                  roleDotClass(node.kind),
+                )}
+              />
+              <span className="min-w-0 flex-1 space-y-1">
+                <span className="flex flex-wrap items-center gap-2">
+                  <span className={cn('rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wider', roleTone(node.kind))}>
+                    {trajectoryRoleLabel(node.kind)}
+                  </span>
+                  <span className="truncate text-sm font-medium">{node.title}</span>
+                  {duration != null ? (
+                    <span className="ml-auto shrink-0 text-[10px] tabular-nums text-muted-foreground">
+                      {formatDurationMs(duration)}
+                    </span>
+                  ) : (
+                    <time className="ml-auto shrink-0 text-[10px] tabular-nums text-muted-foreground" dateTime={node.startedAt}>
+                      {new Date(node.startedAt).toLocaleTimeString()}
+                    </time>
+                  )}
+                </span>
+                {preview ? (
+                  <span className="line-clamp-2 font-mono text-[11px] leading-relaxed text-muted-foreground">
+                    {preview}
+                  </span>
+                ) : node.note ? (
+                  <span className="line-clamp-2 text-[11px] italic text-muted-foreground">{node.note}</span>
+                ) : null}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function TrajectoryInspector({
+  node,
+  nodes,
+}: {
+  node: TrajectoryNode | null;
+  nodes: TrajectoryNode[];
+}) {
+  if (!node) {
     return (
-      <Card className="border-l-4 border-l-muted-foreground/30">
-        <Collapsible>
-          <CardHeader className="space-y-1 p-0">
-            <CollapsibleTrigger className="group flex w-full flex-wrap items-center gap-2 p-3 text-left">
-              <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
-              <span className="text-sm font-semibold">{node.title}</span>
-              <Badge variant="outline" className="text-[10px]">{node.kind}</Badge>
-              {node.status ? (
-                <Badge variant={statusVariant(node.status)} className="text-[10px]">{node.status}</Badge>
-              ) : null}
-              <time className="ml-auto text-[10px] text-muted-foreground" dateTime={node.startedAt}>
-                {new Date(node.startedAt).toLocaleString()}
-              </time>
-            </CollapsibleTrigger>
-            {node.note ? <p className="px-3 pb-2 text-xs text-muted-foreground">{node.note}</p> : null}
-          </CardHeader>
-          <CollapsibleContent>
-            <CardContent className="space-y-2 p-3 pt-0">
-              {node.records.map((record) => {
-                const body = safeTrajectoryBody(record);
-                return (
-                  <div key={record.id} className="rounded-md border bg-muted/20 p-2">
-                    <div className="mb-1 flex flex-wrap items-center gap-2 text-xs">
-                      <span className="font-medium">{record.contentLabel || record.eventType}</span>
-                      <Badge variant="outline" className="text-[10px]">{record.contentDisclosure}</Badge>
-                    </div>
-                    {body == null ? (
-                      <p className="text-xs italic text-muted-foreground">{disclosureCopy(record)}</p>
-                    ) : (
-                      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words text-xs">{bodyText(body)}</pre>
-                    )}
-                  </div>
-                );
-              })}
-            </CardContent>
-          </CollapsibleContent>
-        </Collapsible>
-      </Card>
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        Select an event to inspect payload, result, and timing.
+      </div>
     );
   }
 
-  const content = (
-    <Card className="border-l-4 border-l-muted-foreground/30">
-      <CardHeader className="space-y-1 p-3 pb-2">
+  const payload = payloadRecord(node);
+  const result = resultRecord(node);
+  const duration = nodeDurationMs(node);
+  const turn = turnIndex(nodes, node.id);
+  const step = nodes.findIndex((item) => item.id === node.id) + 1;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" aria-label="Trajectory inspector">
+      <div className="space-y-2 border-b px-3 py-3">
         <div className="flex flex-wrap items-center gap-2">
-          <CardTitle className="text-sm">{node.title}</CardTitle>
-          <Badge variant="outline" className="text-[10px]">{node.kind}</Badge>
-          {node.status ? (
-            <Badge variant={statusVariant(node.status)} className="text-[10px]">{node.status}</Badge>
-          ) : null}
-          <time className="ml-auto text-[10px] text-muted-foreground" dateTime={node.startedAt}>
-            {new Date(node.startedAt).toLocaleString()}
-          </time>
+          <span className={cn('rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wider', roleTone(node.kind))}>
+            {trajectoryRoleLabel(node.kind)}
+          </span>
+          <h3 className="text-sm font-semibold">{node.title}</h3>
         </div>
-        {node.note ? <p className="text-xs text-muted-foreground">{node.note}</p> : null}
-      </CardHeader>
-      <CardContent className="space-y-2 p-3 pt-0">
-        {node.records.map((record) => {
-          const body = safeTrajectoryBody(record);
-          return (
-            <div key={record.id}>
-              {body == null ? (
-                <p className="text-xs italic text-muted-foreground">{disclosureCopy(record)}</p>
-              ) : (
-                <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 p-2 text-xs">
-                  {bodyText(body)}
-                </pre>
-              )}
-              {record.contentDisclosure !== 'full' ? (
-                <Badge variant="outline" className="mt-1 text-[10px]">{record.contentDisclosure}</Badge>
+        <p className="text-[11px] text-muted-foreground">
+          {turn ? `Turn ${turn}` : 'Session'}
+          {step ? ` · Step ${step}` : ''}
+          {statusLabel(node.status) ? ` · ${statusLabel(node.status)}` : ''}
+        </p>
+      </div>
+      <Tabs defaultValue="summary" className="flex min-h-0 flex-1 flex-col">
+        <TabsList className="mx-3 mt-3 h-8 w-auto justify-start self-start">
+          <TabsTrigger value="summary" className="px-2 text-xs">Summary</TabsTrigger>
+          <TabsTrigger value="payload" className="px-2 text-xs">Payload</TabsTrigger>
+          <TabsTrigger value="result" className="px-2 text-xs">Result</TabsTrigger>
+          <TabsTrigger value="timing" className="px-2 text-xs">Timing</TabsTrigger>
+        </TabsList>
+        <div className="min-h-0 flex-1 overflow-auto px-3 py-3">
+          <TabsContent value="summary" className="mt-0 space-y-3">
+            <dl className="grid grid-cols-[5.5rem_minmax(0,1fr)] gap-x-2 gap-y-1.5 text-xs">
+              <dt className="text-muted-foreground">Kind</dt>
+              <dd className="font-medium">{node.kind}</dd>
+              <dt className="text-muted-foreground">Status</dt>
+              <dd>{statusLabel(node.status) ?? '—'}</dd>
+              <dt className="text-muted-foreground">Disclosure</dt>
+              <dd>{payload.contentDisclosure}{result && result.contentDisclosure !== payload.contentDisclosure ? ` → ${result.contentDisclosure}` : ''}</dd>
+              {payload.toolCallId ? (
+                <>
+                  <dt className="text-muted-foreground">Call id</dt>
+                  <dd className="truncate font-mono text-[11px]">{payload.toolCallId}</dd>
+                </>
               ) : null}
-            </div>
-          );
-        })}
-      </CardContent>
-    </Card>
+            </dl>
+            {node.note ? <p className="text-xs text-muted-foreground">{node.note}</p> : null}
+            {node.records.map((record) => (
+              record.contentDisclosure !== 'full' ? (
+                <p key={record.id} className="text-xs italic text-muted-foreground">{disclosureCopy(record)}</p>
+              ) : null
+            ))}
+          </TabsContent>
+          <TabsContent value="payload" className="mt-0 space-y-2">
+            <p className="text-[11px] text-muted-foreground">{payload.contentLabel || payload.eventType}</p>
+            <RecordBody record={payload} />
+          </TabsContent>
+          <TabsContent value="result" className="mt-0 space-y-2">
+            {result ? (
+              <>
+                <p className="text-[11px] text-muted-foreground">{result.contentLabel || result.eventType}</p>
+                <RecordBody record={result} />
+              </>
+            ) : (
+              <p className="text-xs italic text-muted-foreground">
+                {node.kind === 'tool' || node.kind === 'subagent'
+                  ? 'No result record yet.'
+                  : 'This event has a single record; see Payload.'}
+              </p>
+            )}
+          </TabsContent>
+          <TabsContent value="timing" className="mt-0">
+            <dl className="grid grid-cols-[5.5rem_minmax(0,1fr)] gap-x-2 gap-y-1.5 text-xs">
+              <dt className="text-muted-foreground">Started</dt>
+              <dd>
+                <time dateTime={node.startedAt}>{new Date(node.startedAt).toLocaleString()}</time>
+              </dd>
+              <dt className="text-muted-foreground">Ended</dt>
+              <dd>
+                {node.endedAt
+                  ? <time dateTime={node.endedAt}>{new Date(node.endedAt).toLocaleString()}</time>
+                  : '—'}
+              </dd>
+              <dt className="text-muted-foreground">Duration</dt>
+              <dd>{duration != null ? formatDurationMs(duration) : '—'}</dd>
+              <dt className="text-muted-foreground">Sequence</dt>
+              <dd className="font-mono text-[11px]">
+                {node.records[0].sequence}
+                {node.records.length > 1 ? ` → ${node.records[node.records.length - 1].sequence}` : ''}
+              </dd>
+            </dl>
+          </TabsContent>
+        </div>
+      </Tabs>
+    </div>
   );
-  return content;
 }
 
 export function TrajectoryViewer({
@@ -182,6 +429,8 @@ export function TrajectoryViewer({
   const [hasMore, setHasMore] = useState(initialPage.hasMore);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [connectionSeed, setConnectionSeed] = useState(0);
+  const [query, setQuery] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [status, setStatus] = useState<LiveStatus>(
     typeof navigator !== 'undefined' && !navigator.onLine ? 'offline' : 'reconnecting',
   );
@@ -190,6 +439,14 @@ export function TrajectoryViewer({
   const appendChain = useRef(Promise.resolve());
   const selected = streams.find((stream) => streamKey(stream) === selectedKey) ?? null;
   const nodes = useMemo(() => assembleTrajectory(records), [records]);
+  const visibleNodes = useMemo(() => nodes.filter((node) => nodeMatchesQuery(node, query)), [nodes, query]);
+  const selectedNode = visibleNodes.find((node) => node.id === selectedId)
+    ?? visibleNodes.find((node) => node.kind === 'prompt')
+    ?? visibleNodes[0]
+    ?? null;
+  const duration = sessionDurationMs(nodes);
+  const turns = countTrajectoryTurns(nodes);
+  const calls = countTrajectoryCalls(nodes);
 
   const replaceRecords = (next: SerializedTrajectoryRecord[]) => {
     recordsRef.current = next;
@@ -244,6 +501,7 @@ export function TrajectoryViewer({
     if (!stream) return;
     setLoadedKey('');
     setSelectedKey(key);
+    setSelectedId(null);
     setStatus(navigator.onLine ? 'reconnecting' : 'offline');
     replaceRecords([]);
     const response = await fetch(endpoint(repositoryId, agentId, stream));
@@ -287,7 +545,7 @@ export function TrajectoryViewer({
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
         {streams.length > 1 ? (
           <Select value={selectedKey} onValueChange={(value) => void chooseStream(value)}>
             <SelectTrigger className="max-w-md" aria-label="Select trajectory session and agent">
@@ -307,10 +565,28 @@ export function TrajectoryViewer({
           </p>
         )}
         <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+            <span className="inline-flex items-center gap-1" aria-label={`Duration ${duration != null ? formatDurationMs(duration) : 'unknown'}`}>
+              <Clock className="h-3 w-3" />
+              <span className="font-medium text-foreground">{duration != null ? formatDurationMs(duration) : '—'}</span>
+              Duration
+            </span>
+            <span className="inline-flex items-center gap-1" aria-label={`${turns} turns`}>
+              <MessageSquare className="h-3 w-3" />
+              <span className="font-medium text-foreground">{turns}</span>
+              Turns
+            </span>
+            <span className="inline-flex items-center gap-1" aria-label={`${calls} calls`}>
+              <Wrench className="h-3 w-3" />
+              <span className="font-medium text-foreground">{calls}</span>
+              Calls
+            </span>
+          </div>
           {selected ? (
             <>
               <Button variant="outline" size="sm" asChild>
                 <a href={endpoint(repositoryId, agentId, selected, '') + '&format=jsonl'} download>
+                  <Download className="mr-1.5 h-3.5 w-3.5" />
                   Export JSONL
                 </a>
               </Button>
@@ -326,10 +602,12 @@ export function TrajectoryViewer({
                     replaceRecords([]);
                     setBefore(null);
                     setHasMore(false);
+                    setSelectedId(null);
                     cursorRef.current = null;
                   });
                 }}
               >
+                <Trash2 className="mr-1.5 h-3.5 w-3.5" />
                 Delete session
               </Button>
             </>
@@ -340,16 +618,49 @@ export function TrajectoryViewer({
           </Badge>
         </div>
       </div>
+
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search the trajectory…"
+          aria-label="Search trajectory"
+          className="h-8 pl-8 text-sm"
+        />
+      </div>
+
       {hasMore && before ? (
         <Button variant="outline" size="sm" disabled={loadingOlder} onClick={() => void loadOlder()}>
           {loadingOlder ? 'Loading…' : 'Load older'}
         </Button>
       ) : null}
+
       {nodes.length === 0 ? (
         <p className="text-sm text-muted-foreground">No records in this trajectory stream.</p>
+      ) : visibleNodes.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No events match this search.</p>
       ) : (
-        <div className="space-y-2" aria-label="Agent trajectory timeline">
-          {nodes.map((node) => <TrajectoryBlock key={node.id} node={node} />)}
+        <div className="space-y-3">
+          <TrajectoryOverview
+            nodes={visibleNodes}
+            selectedId={selectedNode?.id ?? null}
+            onSelect={setSelectedId}
+          />
+          <div className="overflow-hidden rounded-lg border">
+            <div className="grid min-h-[28rem] lg:grid-cols-[minmax(0,1fr)_minmax(17rem,22rem)]">
+              <div className="min-h-0 overflow-auto border-b p-2 lg:border-b-0 lg:border-r">
+                <TrajectoryLog
+                  nodes={visibleNodes}
+                  selectedId={selectedNode?.id ?? null}
+                  onSelect={setSelectedId}
+                />
+              </div>
+              <div className="min-h-0 overflow-hidden bg-muted/20">
+                <TrajectoryInspector node={selectedNode} nodes={visibleNodes} />
+              </div>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/control/src/components/trajectory-viewer.tsx
+++ b/control/src/components/trajectory-viewer.tsx
@@ -245,18 +245,12 @@ function TrajectoryLog({
         const selected = selectedId === node.id;
         return (
           <li key={node.id} className="relative">
-            {node.kind === 'prompt' ? (
-              <span className="absolute -left-0.5 top-2 z-10 rounded border border-primary/30 bg-primary/10 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-primary">
-                Turn {currentTurn}
-              </span>
-            ) : null}
             <button
               type="button"
               aria-pressed={selected}
               onClick={() => onSelect(node.id)}
               className={cn(
                 'flex w-full gap-3 rounded-md px-2 py-2 text-left transition-colors',
-                node.kind === 'prompt' ? 'mt-5' : '',
                 selected ? 'bg-primary/10' : 'hover:bg-muted/60',
               )}
             >
@@ -269,6 +263,11 @@ function TrajectoryLog({
               />
               <span className="min-w-0 flex-1 space-y-1">
                 <span className="flex flex-wrap items-center gap-2">
+                  {node.kind === 'prompt' ? (
+                    <span className="rounded border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                      Turn {currentTurn}
+                    </span>
+                  ) : null}
                   <span className={cn('rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wider', roleTone(node.kind))}>
                     {trajectoryRoleLabel(node.kind)}
                   </span>

--- a/control/src/lib/session-event-detail.test.ts
+++ b/control/src/lib/session-event-detail.test.ts
@@ -128,7 +128,8 @@ describe('event views', () => {
     expect(isStartEndBoundaryEvent('tool.start')).toBe(true);
     expect(isStartEndBoundaryEvent('tool.end')).toBe(true);
     expect(isStartEndBoundaryEvent('generation.start')).toBe(true);
-    expect(isStartEndBoundaryEvent('session.end')).toBe(true);
+    expect(isStartEndBoundaryEvent('session.start')).toBe(false);
+    expect(isStartEndBoundaryEvent('session.end')).toBe(false);
     expect(isStartEndBoundaryEvent('prompt.submitted')).toBe(false);
     expect(isStartEndBoundaryEvent('span.tool Read')).toBe(false);
     expect(isStartEndBoundaryEvent('span.gen_ai.client.hook.PreToolUse')).toBe(false);

--- a/control/src/lib/session-event-detail.test.ts
+++ b/control/src/lib/session-event-detail.test.ts
@@ -46,6 +46,18 @@ describe('displayPromptText', () => {
 });
 
 describe('eventDetailSummary', () => {
+  it('does not surface secret-bearing attributes as visible content', () => {
+    expect(eventDetailSummary({
+      authorization: 'Bearer leaked',
+      'gen_ai.request.api_key': 'sk-secret',
+      'gen_ai.client.tool_name': 'Read',
+    })).toBe('Read');
+    expect(summarizeEventAttributes({
+      authorization: 'Bearer leaked',
+      'gen_ai.client.tool_name': 'Read',
+    })).toEqual(['tool: Read']);
+  });
+
   it('prefers command / file / error from attributes', () => {
     expect(
       eventDetailSummary({

--- a/control/src/lib/session-event-detail.test.ts
+++ b/control/src/lib/session-event-detail.test.ts
@@ -5,6 +5,7 @@ import {
   eventDetailSummary,
   eventToolName,
   isRedundantLogEvent,
+  isStartEndBoundaryEvent,
   matchesSessionEventView,
   shortEventName,
   summarizeEventAttributes,
@@ -121,5 +122,15 @@ describe('event views', () => {
     expect(matchesSessionEventView(tool, 'tools')).toBe(true);
     expect(matchesSessionEventView(prompt, 'prompts')).toBe(true);
     expect(matchesSessionEventView(generation, 'activity')).toBe(true);
+  });
+
+  it('identifies start/end lifecycle bookends without hiding span or prompt rows', () => {
+    expect(isStartEndBoundaryEvent('tool.start')).toBe(true);
+    expect(isStartEndBoundaryEvent('tool.end')).toBe(true);
+    expect(isStartEndBoundaryEvent('generation.start')).toBe(true);
+    expect(isStartEndBoundaryEvent('session.end')).toBe(true);
+    expect(isStartEndBoundaryEvent('prompt.submitted')).toBe(false);
+    expect(isStartEndBoundaryEvent('span.tool Read')).toBe(false);
+    expect(isStartEndBoundaryEvent('span.gen_ai.client.hook.PreToolUse')).toBe(false);
   });
 });

--- a/control/src/lib/session-event-detail.ts
+++ b/control/src/lib/session-event-detail.ts
@@ -43,11 +43,12 @@ export function isRedundantLogEvent(eventName: string, rawTruncated?: string | n
 }
 
 /**
- * Lifecycle bookends (`tool.start` / `tool.end`, `generation.start`, …).
- * The paired end (or a span row) already represents the same call.
+ * Redundant tool/generation bookends (`tool.start` / `tool.end`, `generation.start`, …).
+ * Session start/end stay visible — they frame the run.
  */
 export function isStartEndBoundaryEvent(eventName: string): boolean {
   const name = shortEventName(eventName).toLowerCase().replaceAll('_', '.');
+  if (name.includes('session')) return false;
   return /(^|\.)(start|end)$/.test(name);
 }
 

--- a/control/src/lib/session-event-detail.ts
+++ b/control/src/lib/session-event-detail.ts
@@ -42,6 +42,15 @@ export function isRedundantLogEvent(eventName: string, rawTruncated?: string | n
   return /Hook event:\s*\w+/i.test(rawTruncated ?? '');
 }
 
+/**
+ * Lifecycle bookends (`tool.start` / `tool.end`, `generation.start`, …).
+ * The paired end (or a span row) already represents the same call.
+ */
+export function isStartEndBoundaryEvent(eventName: string): boolean {
+  const name = shortEventName(eventName).toLowerCase().replaceAll('_', '.');
+  return /(^|\.)(start|end)$/.test(name);
+}
+
 /** Views for the session events table (replaces a blunt “hide log mirrors” toggle). */
 export type SessionEventView =
   | 'activity'

--- a/control/src/lib/session-event-detail.ts
+++ b/control/src/lib/session-event-detail.ts
@@ -4,6 +4,8 @@
  * dedicated prompt/response columns.
  */
 
+import { isSecretAttributeKey } from '@/lib/trajectory-privacy';
+
 type AttrMap = Record<string, unknown>;
 
 function asString(value: unknown): string | null {
@@ -19,6 +21,7 @@ function asAttrMap(attributes: unknown): AttrMap | null {
 
 function attrString(attrs: AttrMap, ...keys: string[]): string | null {
   for (const key of keys) {
+    if (isSecretAttributeKey(key)) continue;
     const value = asString(attrs[key]);
     if (value) return value;
   }

--- a/control/src/lib/trajectory-privacy.test.ts
+++ b/control/src/lib/trajectory-privacy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  boundTrajectoryPayload,
+  hidesTrajectoryContent,
+  isSecretAttributeKey,
+  payloadByteLength,
+  redactSecretAttributes,
+  trajectoryPolicy,
+  visibleContentFromPayload,
+} from './trajectory-privacy';
+
+describe('secret attribute keys', () => {
+  it('redacts credential leaves without treating token counters as secrets', () => {
+    expect(isSecretAttributeKey('authorization')).toBe(true);
+    expect(isSecretAttributeKey('gen_ai.request.api_key')).toBe(true);
+    expect(isSecretAttributeKey('openai.access_token')).toBe(true);
+    expect(isSecretAttributeKey('gen_ai.usage.input_tokens')).toBe(false);
+    expect(isSecretAttributeKey('otelhook.content.hash')).toBe(false);
+    expect(redactSecretAttributes({
+      authorization: 'Bearer secret',
+      'gen_ai.usage.input_tokens': 12,
+    })).toEqual({
+      authorization: '[redacted]',
+      'gen_ai.usage.input_tokens': 12,
+    });
+  });
+});
+
+describe('trajectory policy', () => {
+  it('defaults to a 64KiB payload cap and unlimited retention', () => {
+    expect(trajectoryPolicy({})).toEqual({
+      maxPayloadBytes: 65_536,
+      retentionDays: 0,
+    });
+    expect(trajectoryPolicy({
+      HAR_TRAJECTORY_MAX_PAYLOAD_BYTES: '2048',
+      HAR_TRAJECTORY_RETENTION_DAYS: '14',
+    })).toEqual({
+      maxPayloadBytes: 2048,
+      retentionDays: 14,
+    });
+  });
+});
+
+describe('payload bounds and disclosure', () => {
+  it('drops withheld bodies and secret attributes before persistence', () => {
+    const bounded = boundTrajectoryPayload({
+      body: 'should never be stored',
+      promptText: 'also secret',
+      attributes: { authorization: 'Bearer abc', 'gen_ai.tool.name': 'Read' },
+    }, 'withheld');
+    expect(bounded.contentDisclosure).toBe('withheld');
+    expect(bounded.payload.body).toBeNull();
+    expect(bounded.payload.promptText).toBeNull();
+    expect(bounded.payload.attributes).toEqual({
+      authorization: '[redacted]',
+      'gen_ai.tool.name': 'Read',
+    });
+    expect(visibleContentFromPayload(bounded.payload, 'prompt', bounded.contentDisclosure)).toEqual({
+      promptText: null,
+      responseText: null,
+      raw: null,
+    });
+  });
+
+  it('omits binary bodies instead of storing them as text', () => {
+    const bounded = boundTrajectoryPayload({
+      body: Buffer.from([0, 1, 2, 3]),
+      attributes: {},
+    }, 'full');
+    expect(bounded.contentDisclosure).toBe('metadata_only');
+    expect(bounded.payload.body).toBeNull();
+    expect(bounded.payload.binaryOmitted).toBe(true);
+  });
+
+  it('truncates oversized tool payloads and marks disclosure', () => {
+    const bounded = boundTrajectoryPayload({
+      body: 'x'.repeat(8_000),
+      attributes: {},
+    }, 'full', 1_024);
+    expect(bounded.contentDisclosure).toBe('truncated');
+    expect(payloadByteLength(bounded.payload)).toBeLessThanOrEqual(1_024);
+    expect(String(bounded.payload.body)).toMatch(/…$/);
+  });
+
+  it('does not expose withheld or metadata-only content as visible text', () => {
+    expect(hidesTrajectoryContent('withheld')).toBe(true);
+    expect(visibleContentFromPayload({
+      body: 'hidden',
+      promptText: 'hidden prompt',
+    }, 'prompt', 'metadata_only')).toEqual({
+      promptText: null,
+      responseText: null,
+      raw: null,
+    });
+  });
+});

--- a/control/src/lib/trajectory-privacy.ts
+++ b/control/src/lib/trajectory-privacy.ts
@@ -1,0 +1,170 @@
+import type { AgentTrajectoryContentDisclosure } from '@har/schemas';
+
+export const DEFAULT_TRAJECTORY_MAX_PAYLOAD_BYTES = 65_536;
+
+const SECRET_LEAF =
+  /^(authorization|api[_-]?key|password|passwd|secret|cookie|set-cookie|private[_-]?key|access[_-]?token|refresh[_-]?token|x-api-key|bearer)$/i;
+
+export interface TrajectoryPolicy {
+  maxPayloadBytes: number;
+  retentionDays: number;
+}
+
+export function parseEnvInt(value: string | undefined, fallback: number, min = 0): number {
+  if (value == null || value.trim() === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.floor(parsed));
+}
+
+export function trajectoryPolicy(
+  env: Record<string, string | undefined> = process.env,
+): TrajectoryPolicy {
+  return {
+    maxPayloadBytes: parseEnvInt(
+      env.HAR_TRAJECTORY_MAX_PAYLOAD_BYTES,
+      DEFAULT_TRAJECTORY_MAX_PAYLOAD_BYTES,
+      1_024,
+    ),
+    retentionDays: parseEnvInt(env.HAR_TRAJECTORY_RETENTION_DAYS, 0, 0),
+  };
+}
+
+export function isSecretAttributeKey(key: string): boolean {
+  const leaf = key.split('.').pop() ?? key;
+  return SECRET_LEAF.test(leaf);
+}
+
+export function redactSecretAttributes(
+  attributes: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    out[key] = isSecretAttributeKey(key) ? '[redacted]' : value;
+  }
+  return out;
+}
+
+export function isBinaryBody(value: unknown): boolean {
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) return true;
+  if (value instanceof Uint8Array) return true;
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as { bytes?: unknown; type?: unknown };
+    if (record.bytes instanceof Uint8Array) return true;
+    if (typeof record.type === 'string' && record.type.toLowerCase().startsWith('application/octet')) {
+      return true;
+    }
+  }
+  return typeof value === 'string' && value.includes('\u0000');
+}
+
+export function payloadByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value) ?? 'null', 'utf8');
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const buffer = Buffer.from(value, 'utf8');
+  if (buffer.byteLength <= maxBytes) return value;
+  return `${buffer.subarray(0, Math.max(0, maxBytes - 3)).toString('utf8')}…`;
+}
+
+function truncateUnknown(value: unknown, maxBytes: number): unknown {
+  if (typeof value === 'string') return truncateUtf8(value, maxBytes);
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as { stringValue?: unknown };
+    if (typeof record.stringValue === 'string') {
+      return { ...record, stringValue: truncateUtf8(record.stringValue, maxBytes) };
+    }
+  }
+  const serialized = JSON.stringify(value) ?? 'null';
+  if (Buffer.byteLength(serialized, 'utf8') <= maxBytes) return value;
+  return truncateUtf8(serialized, maxBytes);
+}
+
+export function hidesTrajectoryContent(
+  disclosure: AgentTrajectoryContentDisclosure | string,
+): boolean {
+  return disclosure === 'withheld' || disclosure === 'metadata_only';
+}
+
+export interface BoundTrajectoryPayload {
+  payload: Record<string, unknown>;
+  contentDisclosure: AgentTrajectoryContentDisclosure;
+}
+
+/**
+ * Drop withheld/binary bodies, redact secret attributes, and cap stored JSON.
+ * Disclosure is upgraded to truncated/metadata_only when content is removed.
+ */
+export function boundTrajectoryPayload(
+  payload: Record<string, unknown>,
+  disclosure: AgentTrajectoryContentDisclosure,
+  maxPayloadBytes = DEFAULT_TRAJECTORY_MAX_PAYLOAD_BYTES,
+): BoundTrajectoryPayload {
+  const attributes = payload.attributes && typeof payload.attributes === 'object' && !Array.isArray(payload.attributes)
+    ? redactSecretAttributes(payload.attributes as Record<string, unknown>)
+    : payload.attributes;
+
+  let next: Record<string, unknown> = { ...payload, attributes };
+  let nextDisclosure = disclosure;
+
+  if (hidesTrajectoryContent(nextDisclosure)) {
+    next = { ...next, body: null, promptText: null, responseText: null, raw: null };
+  } else if (isBinaryBody(next.body)) {
+    next = { ...next, body: null, binaryOmitted: true };
+    nextDisclosure = 'metadata_only';
+  }
+
+  if (payloadByteLength(next) > maxPayloadBytes) {
+    const budget = Math.max(256, Math.floor(maxPayloadBytes / 3));
+    next = {
+      ...next,
+      body: next.body == null ? null : truncateUnknown(next.body, budget),
+      promptText: typeof next.promptText === 'string' ? truncateUtf8(next.promptText, budget) : next.promptText,
+      responseText: typeof next.responseText === 'string' ? truncateUtf8(next.responseText, budget) : next.responseText,
+      raw: typeof next.raw === 'string' ? truncateUtf8(next.raw, budget) : next.raw,
+    };
+    if (nextDisclosure === 'full' || nextDisclosure === 'redacted' || nextDisclosure === 'masked') {
+      nextDisclosure = 'truncated';
+    }
+  }
+
+  return { payload: next, contentDisclosure: nextDisclosure };
+}
+
+export function visibleContentFromPayload(
+  payload: Record<string, unknown>,
+  contentKind: string,
+  disclosure: string,
+): { promptText: string | null; responseText: string | null; raw: string | null } {
+  if (hidesTrajectoryContent(disclosure)) {
+    return { promptText: null, responseText: null, raw: null };
+  }
+  const bodyText = bodyToVisibleText(payload.body);
+  const promptText =
+    stringOrNull(payload.promptText) ??
+    (contentKind === 'prompt' ? bodyText : null);
+  const responseText =
+    stringOrNull(payload.responseText) ??
+    (contentKind === 'response' ? bodyText : null);
+  return {
+    promptText,
+    responseText,
+    raw: stringOrNull(payload.raw) ?? bodyText,
+  };
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function bodyToVisibleText(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as { stringValue?: unknown };
+    if (typeof record.stringValue === 'string' && record.stringValue.trim()) {
+      return record.stringValue;
+    }
+  }
+  return null;
+}

--- a/control/src/lib/trajectory.test.ts
+++ b/control/src/lib/trajectory.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   assembleTrajectory,
+  formatDurationMs,
   mergeTrajectoryRecords,
   safeTrajectoryBody,
+  trajectoryOverviewPlacement,
+  trajectoryRoleLabel,
   type SerializedTrajectoryRecord,
 } from './trajectory';
 
@@ -142,5 +145,70 @@ describe('trajectory assembler', () => {
     expect(safeTrajectoryBody(withheld)).toBeNull();
     expect(safeTrajectoryBody(metadataOnly)).toBeNull();
     expect(safeTrajectoryBody(truncated)).toBe('partial answer');
+    expect(safeTrajectoryBody(record('wrapped', {
+      contentKind: 'prompt',
+      payload: { body: { stringValue: 'unwrap me' } },
+    }))).toBe('unwrap me');
+  });
+
+  it('omits span-only mirror records from the assembled timeline', () => {
+    const nodes = assembleTrajectory([
+      record('prompt', {
+        eventType: 'prompt.submitted',
+        contentKind: 'prompt',
+        payload: { promptText: 'read the file' },
+      }),
+      record('span', {
+        sequence: 2,
+        eventType: 'span.tool',
+        contentKind: 'span',
+        contentLabel: 'Read',
+      }),
+      record('start', {
+        sequence: 3,
+        eventType: 'tool.start',
+        toolCallId: 'call-9',
+        contentLabel: 'Read',
+      }),
+      record('end', {
+        sequence: 4,
+        eventType: 'tool.end',
+        toolCallId: 'call-9',
+      }),
+    ]);
+    expect(nodes.map((node) => node.kind)).toEqual(['prompt', 'tool']);
+    expect(nodes.some((node) => node.records.some((item) => item.id === 'span'))).toBe(false);
+  });
+
+  it('drops empty session and generation bookends but keeps message-bearing generation ends', () => {
+    const nodes = assembleTrajectory([
+      record('session-start', { eventType: 'session.start', contentKind: 'metadata' }),
+      record('prompt', { sequence: 2, eventType: 'prompt.submitted', contentKind: 'prompt' }),
+      record('gen-start', { sequence: 3, eventType: 'generation.start', contentKind: 'metadata' }),
+      record('gen-end', {
+        sequence: 4,
+        eventType: 'generation.end',
+        contentKind: 'response',
+        payload: { responseText: 'done' },
+      }),
+      record('session-end', { sequence: 5, eventType: 'session.end', contentKind: 'metadata' }),
+    ]);
+    expect(nodes.map((node) => node.kind)).toEqual(['prompt', 'response']);
+  });
+
+  it('places input, model, and tool nodes on overview lanes', () => {
+    const nodes = assembleTrajectory([
+      record('prompt', { eventType: 'prompt.submitted', contentKind: 'prompt', sequence: 1 }),
+      record('response', { eventType: 'response', contentKind: 'response', sequence: 2 }),
+      record('start', { eventType: 'tool.start', toolCallId: 'c', sequence: 3 }),
+      record('end', { eventType: 'tool.end', toolCallId: 'c', sequence: 4 }),
+    ]);
+    expect(nodes.map((node) => trajectoryRoleLabel(node.kind))).toEqual(['USER', 'ASSISTANT', 'TOOL']);
+    expect(trajectoryOverviewPlacement(nodes).map((item) => item.lane)).toEqual([
+      'input',
+      'model',
+      'tools',
+    ]);
+    expect(formatDurationMs(21)).toBe('21 ms');
   });
 });

--- a/control/src/lib/trajectory.test.ts
+++ b/control/src/lib/trajectory.test.ts
@@ -180,7 +180,7 @@ describe('trajectory assembler', () => {
     expect(nodes.some((node) => node.records.some((item) => item.id === 'span'))).toBe(false);
   });
 
-  it('drops empty session and generation bookends but keeps message-bearing generation ends', () => {
+  it('keeps session start/end and message-bearing generation ends, but drops empty generation bookends', () => {
     const nodes = assembleTrajectory([
       record('session-start', { eventType: 'session.start', contentKind: 'metadata' }),
       record('prompt', { sequence: 2, eventType: 'prompt.submitted', contentKind: 'prompt' }),
@@ -193,7 +193,12 @@ describe('trajectory assembler', () => {
       }),
       record('session-end', { sequence: 5, eventType: 'session.end', contentKind: 'metadata' }),
     ]);
-    expect(nodes.map((node) => node.kind)).toEqual(['prompt', 'response']);
+    expect(nodes.map((node) => node.title)).toEqual([
+      'Session started',
+      'User prompt',
+      'Assistant response',
+      'Session ended',
+    ]);
   });
 
   it('places input, model, and tool nodes on overview lanes', () => {

--- a/control/src/lib/trajectory.ts
+++ b/control/src/lib/trajectory.ts
@@ -139,8 +139,16 @@ function pairingKey(
   return { key: `event:${record.sourceEventId}`, confidence: 'fallback' };
 }
 
+function sessionBookendTitle(record: SerializedTrajectoryRecord): string | null {
+  const event = record.eventType.toLowerCase().replaceAll('_', '.');
+  if (event === 'session.start' || event.endsWith('.session.start')) return 'Session started';
+  if (event === 'session.end' || event.endsWith('.session.end')) return 'Session ended';
+  return null;
+}
+
 function contentTitle(record: SerializedTrajectoryRecord, fallback: string): string {
   return record.contentLabel?.trim() ||
+    sessionBookendTitle(record) ||
     attributeString(record, [
       'otelhook.tool.name',
       'gen_ai.tool.name',
@@ -207,10 +215,12 @@ export function isSpanMirrorRecord(record: SerializedTrajectoryRecord): boolean 
     record.eventType.toLowerCase().startsWith('span.');
 }
 
-/** Session/generation start-end rows with no message body — noise next to paired tools. */
+/** Generation start/end with no message body — noise next to paired tools. Session bookends stay. */
 export function isEmptyLifecycleBookend(record: SerializedTrajectoryRecord): boolean {
   const event = record.eventType.toLowerCase().replaceAll('_', '.');
-  if (event.includes('tool') || event.includes('subagent')) return false;
+  if (event.includes('tool') || event.includes('subagent') || event.includes('session')) {
+    return false;
+  }
   if (!/(^|\.)(start|end)$/.test(event)) return false;
   const kind = record.contentKind.toLowerCase();
   return !['prompt', 'response', 'reasoning', 'user', 'assistant'].includes(kind);

--- a/control/src/lib/trajectory.ts
+++ b/control/src/lib/trajectory.ts
@@ -202,8 +202,164 @@ function isBoundary(record: SerializedTrajectoryRecord, kind: 'tool' | 'subagent
   );
 }
 
+export function isSpanMirrorRecord(record: SerializedTrajectoryRecord): boolean {
+  return record.contentKind.toLowerCase() === 'span' ||
+    record.eventType.toLowerCase().startsWith('span.');
+}
+
+/** Session/generation start-end rows with no message body — noise next to paired tools. */
+export function isEmptyLifecycleBookend(record: SerializedTrajectoryRecord): boolean {
+  const event = record.eventType.toLowerCase().replaceAll('_', '.');
+  if (event.includes('tool') || event.includes('subagent')) return false;
+  if (!/(^|\.)(start|end)$/.test(event)) return false;
+  const kind = record.contentKind.toLowerCase();
+  return !['prompt', 'response', 'reasoning', 'user', 'assistant'].includes(kind);
+}
+
+function unwrapTrajectoryValue(value: unknown): unknown {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as { stringValue?: unknown };
+    if (typeof record.stringValue === 'string') return record.stringValue;
+  }
+  return value;
+}
+
+export type TrajectoryLane = 'input' | 'model' | 'tools' | 'other';
+
+export function trajectoryLane(kind: TrajectoryNodeKind): TrajectoryLane {
+  if (kind === 'prompt') return 'input';
+  if (kind === 'response' || kind === 'reasoning') return 'model';
+  if (kind === 'tool' || kind === 'subagent') return 'tools';
+  return 'other';
+}
+
+export function trajectoryRoleLabel(kind: TrajectoryNodeKind): string {
+  switch (kind) {
+    case 'prompt':
+      return 'USER';
+    case 'response':
+      return 'ASSISTANT';
+    case 'reasoning':
+      return 'REASON';
+    case 'tool':
+      return 'TOOL';
+    case 'subagent':
+      return 'AGENT';
+    case 'error':
+      return 'ERROR';
+    default:
+      return 'SYSTEM';
+  }
+}
+
+export function nodeDurationMs(node: TrajectoryNode): number | null {
+  if (!node.endedAt) return null;
+  const ms = new Date(node.endedAt).getTime() - new Date(node.startedAt).getTime();
+  return Number.isFinite(ms) && ms >= 0 ? ms : null;
+}
+
+export function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+export function sessionDurationMs(nodes: TrajectoryNode[]): number | null {
+  if (nodes.length === 0) return null;
+  const starts = nodes.map((node) => new Date(node.startedAt).getTime());
+  const ends = nodes.map((node) => new Date(node.endedAt ?? node.startedAt).getTime());
+  const ms = Math.max(...ends) - Math.min(...starts);
+  return Number.isFinite(ms) && ms >= 0 ? ms : null;
+}
+
+export function countTrajectoryTurns(nodes: TrajectoryNode[]): number {
+  return nodes.filter((node) => node.kind === 'prompt').length;
+}
+
+export function countTrajectoryCalls(nodes: TrajectoryNode[]): number {
+  return nodes.filter((node) => node.kind === 'tool' || node.kind === 'subagent').length;
+}
+
+export function previewTrajectoryNode(node: TrajectoryNode): string {
+  for (const record of node.records) {
+    const body = safeTrajectoryBody(record);
+    if (body == null) continue;
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    const compact = text.replace(/\s+/g, ' ').trim();
+    if (compact) return compact.length > 160 ? `${compact.slice(0, 157)}…` : compact;
+  }
+  return node.note ?? '';
+}
+
+export function nodeMatchesQuery(node: TrajectoryNode, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  const haystack = [
+    node.title,
+    node.kind,
+    trajectoryRoleLabel(node.kind),
+    node.note ?? '',
+    previewTrajectoryNode(node),
+    ...node.records.flatMap((record) => [record.eventType, record.contentLabel ?? '']),
+  ].join(' ').toLowerCase();
+  return haystack.includes(needle);
+}
+
+export interface TrajectoryLanePlacement {
+  id: string;
+  lane: Exclude<TrajectoryLane, 'other'>;
+  left: number;
+  width: number;
+}
+
+export function trajectoryOverviewPlacement(nodes: TrajectoryNode[]): TrajectoryLanePlacement[] {
+  const visible = nodes.filter((node) => trajectoryLane(node.kind) !== 'other');
+  if (visible.length === 0) return [];
+
+  const times = visible.flatMap((node) => [
+    new Date(node.startedAt).getTime(),
+    new Date(node.endedAt ?? node.startedAt).getTime(),
+  ]);
+  const minTime = Math.min(...times);
+  const maxTime = Math.max(...times);
+  const useTime = Number.isFinite(minTime) && Number.isFinite(maxTime) && maxTime - minTime >= 400;
+
+  if (useTime) {
+    const span = Math.max(maxTime - minTime, 1);
+    return visible.map((node) => {
+      const start = new Date(node.startedAt).getTime();
+      const end = new Date(node.endedAt ?? node.startedAt).getTime();
+      return {
+        id: node.id,
+        lane: trajectoryLane(node.kind) as Exclude<TrajectoryLane, 'other'>,
+        left: ((start - minTime) / span) * 100,
+        width: Math.max(((Math.max(end, start) - start) / span) * 100, 1.6),
+      };
+    });
+  }
+
+  const sequences = visible.flatMap((node) => node.records.map((record) => record.sequence));
+  const minSeq = Math.min(...sequences);
+  const maxSeq = Math.max(...sequences);
+  const span = Math.max(maxSeq - minSeq, 1);
+  return visible.map((node) => {
+    const start = node.records[0].sequence;
+    const end = node.records[node.records.length - 1].sequence;
+    return {
+      id: node.id,
+      lane: trajectoryLane(node.kind) as Exclude<TrajectoryLane, 'other'>,
+      left: ((start - minSeq) / span) * 100,
+      width: Math.max(((Math.max(end, start) - start + 1) / span) * 100, 2.4),
+    };
+  });
+}
+
 export function assembleTrajectory(records: SerializedTrajectoryRecord[]): TrajectoryNode[] {
-  const ordered = mergeTrajectoryRecords(records);
+  const ordered = mergeTrajectoryRecords(records).filter((record) =>
+    !isSpanMirrorRecord(record) && !isEmptyLifecycleBookend(record),
+  );
   const nodes: TrajectoryNode[] = [];
   const open = new Map<string, TrajectoryNode[]>();
 
@@ -278,9 +434,13 @@ export function safeTrajectoryBody(record: SerializedTrajectoryRecord): unknown 
   }
   const payload = asObject(record.payload);
   if (!payload) return null;
-  if (record.contentKind === 'prompt' && payload.promptText != null) return payload.promptText;
-  if (record.contentKind === 'response' && payload.responseText != null) return payload.responseText;
-  return payload.body ?? payload.raw ?? null;
+  if (record.contentKind === 'prompt' && payload.promptText != null) {
+    return unwrapTrajectoryValue(payload.promptText);
+  }
+  if (record.contentKind === 'response' && payload.responseText != null) {
+    return unwrapTrajectoryValue(payload.responseText);
+  }
+  return unwrapTrajectoryValue(payload.body ?? payload.raw ?? null);
 }
 
 export function sequenceGap(

--- a/control/src/server/otel-ingest.test.ts
+++ b/control/src/server/otel-ingest.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   canonicalizeOtelLogRecord,
+  canonicalizeOtelSpan,
+  canonicalSpanSequence,
   extractLogRecords,
   extractPromptText,
   extractResponseText,
@@ -72,6 +74,15 @@ describe('extractResponseText', () => {
       'otelhook.content.kind': 'response',
     };
     expect(extractResponseText(attrs, undefined, 'completed answer')).toBe('completed answer');
+  });
+
+  it('withholds the body when otelhook.content.withheld is set', () => {
+    const attrs: AttrMap = {
+      'otelhook.event.type': 'generation.end',
+      'otelhook.content.kind': 'response',
+      'otelhook.content.withheld': 'privacy-policy',
+    };
+    expect(extractResponseText(attrs, 'otelhook.generation.end', 'secret answer')).toBeNull();
   });
 
   it('does not misclassify reasoning as a response', () => {
@@ -150,6 +161,80 @@ describe('canonical OTLP log facts', () => {
     });
   });
 
+  it('canonicalizes a prompt → generation → tool → response sequence without inventing order', () => {
+    const [prompt, tool, response] = extractLogRecords({
+      resourceLogs: [{
+        resource: { attributes: [] },
+        scopeLogs: [{
+          logRecords: [
+            {
+              eventName: 'otelhook.prompt.submitted',
+              attributes: [
+                { key: 'otelhook.event.id', value: { stringValue: 'evt-prompt' } },
+                { key: 'otelhook.event.type', value: { stringValue: 'prompt.submitted' } },
+                { key: 'otelhook.event.sequence', value: { intValue: '1' } },
+                { key: 'otelhook.content.kind', value: { stringValue: 'prompt' } },
+              ],
+              body: { stringValue: 'fix the flaky test' },
+            },
+            {
+              eventName: 'otelhook.tool.start',
+              attributes: [
+                { key: 'otelhook.event.id', value: { stringValue: 'evt-tool' } },
+                { key: 'otelhook.event.type', value: { stringValue: 'tool.start' } },
+                { key: 'otelhook.event.sequence', value: { intValue: '2' } },
+                { key: 'otelhook.content.kind', value: { stringValue: 'tool_input' } },
+                { key: 'gen_ai.tool.name', value: { stringValue: 'Read' } },
+              ],
+              body: { stringValue: 'tests/flaky.test.ts' },
+            },
+            {
+              eventName: 'otelhook.generation.end',
+              attributes: [
+                { key: 'otelhook.event.id', value: { stringValue: 'evt-response' } },
+                { key: 'otelhook.event.type', value: { stringValue: 'generation.end' } },
+                { key: 'otelhook.event.sequence', value: { intValue: '3' } },
+                { key: 'otelhook.content.kind', value: { stringValue: 'response' } },
+              ],
+              body: { stringValue: 'updated the assertion' },
+            },
+          ],
+        }],
+      }],
+    }).map((record) => canonicalizeOtelLogRecord(record));
+
+    expect(prompt).toMatchObject({ eventType: 'prompt.submitted', sequence: 1, contentKind: 'prompt' });
+    expect(tool).toMatchObject({ eventType: 'tool.start', sequence: 2, contentKind: 'tool_input' });
+    expect(response).toMatchObject({ eventType: 'generation.end', sequence: 3, contentKind: 'response' });
+    expect(prompt.sequence).toBeLessThan(tool.sequence);
+    expect(tool.sequence).toBeLessThan(response.sequence);
+  });
+
+  it('does not persist withheld bodies or secret attributes on the canonical payload', () => {
+    const canonical = canonicalizeOtelLogRecord({
+      resource: {},
+      eventName: 'log',
+      attributes: {
+        'otelhook.event.type': 'generation.end',
+        'otelhook.event.id': 'evt-secret',
+        'otelhook.content.kind': 'response',
+        'otelhook.content.withheld': 'privacy-policy',
+        authorization: 'Bearer leaked-token',
+        'gen_ai.tool.name': 'Read',
+      },
+      timestamp: new Date('2026-08-14T10:00:00.000Z'),
+      body: { stringValue: 'should not be stored' },
+      bodyText: 'should not be stored',
+      sequence: 9,
+    });
+    expect(canonical.contentDisclosure).toBe('withheld');
+    expect(canonical.payload.body).toBeNull();
+    expect(canonical.payload.attributes).toMatchObject({
+      authorization: '[redacted]',
+      'gen_ai.tool.name': 'Read',
+    });
+  });
+
   it('preserves redacted disclosure when a safe body is exported', () => {
     const canonical = canonicalizeOtelLogRecord({
       resource: {},
@@ -166,5 +251,37 @@ describe('canonical OTLP log facts', () => {
       sequence: 4,
     });
     expect(canonical.contentDisclosure).toBe('redacted');
+  });
+});
+
+describe('canonical OTLP span facts', () => {
+  it('uses producer sequence when present and never a span-id hash', () => {
+    expect(canonicalSpanSequence({
+      'otelhook.event.sequence': 6,
+      sequence: 99,
+    })).toBe(6);
+    expect(canonicalSpanSequence({})).toBe(0);
+    expect(canonicalSpanSequence({ sequence: 'not-a-number' })).toBe(0);
+
+    const canonical = canonicalizeOtelSpan({
+      resource: {},
+      traceId: 'trace-1',
+      spanId: 'deadbeefcafebabe',
+      parentSpanId: null,
+      name: 'gen_ai.client.generation',
+      startTime: new Date('2026-08-14T10:00:00.000Z'),
+      endTime: new Date('2026-08-14T10:00:01.000Z'),
+      attributes: {
+        'otelhook.event.sequence': 12,
+        authorization: 'Bearer leaked',
+        'gen_ai.client.prompt.text': 'hello',
+      },
+    });
+    expect(canonical.sequence).toBe(12);
+    expect(canonical.sourceEventId).toBe('span:trace-1:deadbeefcafebabe');
+    expect(canonical.sequence).not.toBe(
+      Math.abs(Number.parseInt('deadbeefcafebabe'.replace(/\D/g, '').slice(-8) || '0', 16)),
+    );
+    expect(canonical.payload.attributes).toMatchObject({ authorization: '[redacted]' });
   });
 });

--- a/control/src/server/otel-ingest.test.ts
+++ b/control/src/server/otel-ingest.test.ts
@@ -3,6 +3,7 @@ import {
   canonicalizeOtelLogRecord,
   canonicalizeOtelSpan,
   canonicalSpanSequence,
+  detectAgentTool,
   extractLogRecords,
   extractPromptText,
   extractResponseText,
@@ -283,5 +284,13 @@ describe('canonical OTLP span facts', () => {
       Math.abs(Number.parseInt('deadbeefcafebabe'.replace(/\D/g, '').slice(-8) || '0', 16)),
     );
     expect(canonical.payload.attributes).toMatchObject({ authorization: '[redacted]' });
+  });
+});
+
+describe('detectAgentTool', () => {
+  it('reads otelhook provider and agent name before defaulting', () => {
+    expect(detectAgentTool({ 'otelhook.provider.id': 'claude-code' })).toBe('claude_code');
+    expect(detectAgentTool({ 'otelhook.agent.name': 'claude-code' })).toBe('claude_code');
+    expect(detectAgentTool({ 'gen_ai.client.name': 'cursor' })).toBe('cursor');
   });
 });

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -1,5 +1,4 @@
 import { createRequire } from 'node:module';
-import type { Prisma } from '@prisma/client';
 import {
   AgentTrajectoryRecordSchema,
   type AgentSessionUsage,
@@ -12,11 +11,15 @@ import {
 } from '@/server/trajectory-ledger';
 import { upsertSessionUsage } from '@/server/usage';
 import {
+  boundTrajectoryPayload,
+  hidesTrajectoryContent,
+  redactSecretAttributes,
+} from '@/lib/trajectory-privacy';
+import {
   isWorkspaceUnderPath,
   normalizeOtelPath,
   pickBestRepoPathMatch,
   pickPathForWorkspaceId,
-  shouldPersistOtelUsage,
 } from '@/server/otel-workspace';
 
 const nodeRequire = createRequire(__filename);
@@ -684,11 +687,6 @@ async function maybeSetDerivedPurpose(
   });
 }
 
-function shouldPersistUsage(usage: AgentSessionUsage): boolean {
-  // Model-only / zero-token rows are not real usage — keep events/spans, skip usage table.
-  return shouldPersistOtelUsage(usage);
-}
-
 function applyHooksUsageFromAttrs(usage: AgentSessionUsage, attributes: AttrMap): void {
   const input = Number(
     attributes['gen_ai.usage.input_tokens'] ?? attributes['gen_ai.usage.prompt_tokens'] ?? 0,
@@ -1124,8 +1122,8 @@ export function canonicalizeOtelLogRecord(record: ParsedLogRecord) {
     generationId,
     toolCallId,
     payload: {
-      body: record.body,
-      attributes: record.attributes,
+      body: hidesTrajectoryContent(contentDisclosure) ? null : record.body,
+      attributes: redactSecretAttributes(record.attributes),
       resource: record.resource,
       recordEventName: record.eventName,
       disclosure: {
@@ -1141,8 +1139,55 @@ export function canonicalizeOtelLogRecord(record: ParsedLogRecord) {
   };
 }
 
+export function canonicalSpanSequence(attributes: AttrMap): number {
+  const raw =
+    attributes['otelhook.event.sequence'] ??
+    attributes['har.sequence'] ??
+    attributes.sequence;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 0;
+}
+
+export function canonicalizeOtelSpan(span: ParsedSpan) {
+  const sequence = canonicalSpanSequence(span.attributes);
+  const promptText = extractPromptText(span.attributes, span.name);
+  const responseText = extractResponseText(span.attributes, span.name);
+  const contentKind = promptText ? 'prompt' : responseText ? 'response' : 'span';
+  const withheld = Boolean(span.attributes['otelhook.content.withheld']);
+  const contentDisclosure = withheld
+    ? 'withheld' as const
+    : promptText || responseText
+      ? 'full' as const
+      : 'metadata_only' as const;
+  const bounded = boundTrajectoryPayload({
+    attributes: redactSecretAttributes(span.attributes),
+    body: hidesTrajectoryContent(contentDisclosure) ? null : promptText ?? responseText,
+    promptText: contentDisclosure === 'full' ? promptText : null,
+    responseText: contentDisclosure === 'full' ? responseText : null,
+    span: {
+      name: span.name,
+      startTime: span.startTime.toISOString(),
+      endTime: span.endTime?.toISOString() ?? null,
+    },
+  }, contentDisclosure);
+  return {
+    eventType: `span.${span.name}`,
+    sequence,
+    sourceEventId: `span:${span.traceId}:${span.spanId}`,
+    contentKey: stableTrajectoryKey({
+      kind: contentKind,
+      traceId: span.traceId,
+      spanId: span.spanId,
+    }),
+    contentKind,
+    contentDisclosure: bounded.contentDisclosure,
+    payload: bounded.payload,
+    promptText: contentDisclosure === 'full' ? promptText : null,
+    responseText: contentDisclosure === 'full' ? responseText : null,
+  };
+}
+
 export async function ingestOtelLogsJson(payload: unknown): Promise<OtelIngestResult> {
-  const { upsertSessionEvent } = await import('@/server/session-events');
   const records = extractLogRecords(payload);
   let accepted = 0;
   let dropped = 0;
@@ -1158,13 +1203,7 @@ export async function ingestOtelLogsJson(payload: unknown): Promise<OtelIngestRe
     const { context } = resolved;
     const canonical = canonicalizeOtelLogRecord(record);
     const { eventType, sequence } = canonical;
-
     const promptText = extractPromptText(record.attributes, eventType, record.bodyText);
-    const responseText = extractResponseText(
-      record.attributes,
-      eventType,
-      record.bodyText,
-    );
 
     await appendTrajectoryRecord(
       context.repositoryId,
@@ -1179,7 +1218,14 @@ export async function ingestOtelLogsJson(payload: unknown): Promise<OtelIngestRe
         eventType,
         sequence,
         timestamp: record.timestamp.toISOString(),
-        payload: canonical.payload,
+        payload: {
+          ...canonical.payload,
+          session: {
+            workDir: context.workDir,
+            branch: context.branch,
+            suffix: context.suffix,
+          },
+        },
         contentKind: canonical.contentKind,
         contentDisclosure: canonical.contentDisclosure,
         contentLabel: canonical.contentLabel,
@@ -1194,41 +1240,7 @@ export async function ingestOtelLogsJson(payload: unknown): Promise<OtelIngestRe
       }),
     );
 
-    await upsertSessionEvent(context.repositoryId, {
-      sessionKey: context.sessionKey,
-      agentId: context.agentId,
-      agentTool: context.agentTool,
-      eventName: eventType,
-      sequence,
-      timestamp: record.timestamp,
-      attributes: record.attributes as Prisma.InputJsonValue,
-      promptText,
-      responseText,
-      rawTruncated: record.bodyText,
-      source: 'otel',
-      workUnitId: context.workUnitId,
-      attemptId: context.attemptId,
-    });
-
     await maybeSetDerivedPurpose(context.repositoryId, context.agentId, promptText);
-
-    const usage = emptyUsage({
-      sessionKey: context.sessionKey,
-      agentId: context.agentId,
-      agentTool: context.agentTool,
-      workDir: context.workDir,
-      branch: context.branch,
-      suffix: context.suffix,
-      workUnitId: context.workUnitId,
-      attemptId: context.attemptId,
-    });
-    applyHooksUsageFromAttrs(usage, record.attributes);
-    usage.tokensTotal =
-      usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead + usage.tokensCacheCreation;
-    if (shouldPersistUsage(usage)) {
-      await upsertSessionUsage(context.repositoryId, usage);
-    }
-
     accepted += 1;
   }
 
@@ -1335,83 +1347,40 @@ export async function ingestOtelTracesJson(payload: unknown): Promise<OtelIngest
       continue;
     }
     const { context } = resolved;
+    const canonical = canonicalizeOtelSpan(span);
 
-    await prisma.agentSessionSpan.upsert({
-      where: {
-        repositoryId_traceId_spanId: {
-          repositoryId: context.repositoryId,
-          traceId: span.traceId,
-          spanId: span.spanId,
-        },
-      },
-      create: {
-        repositoryId: context.repositoryId,
+    await appendTrajectoryRecord(
+      context.repositoryId,
+      AgentTrajectoryRecordSchema.parse({
+        version: 1,
+        source: 'otel',
+        sourceEventId: canonical.sourceEventId,
+        contentKey: canonical.contentKey,
         sessionKey: context.sessionKey,
         agentId: context.agentId,
         agentTool: context.agentTool,
-        workUnitId: context.workUnitId,
-        attemptId: context.attemptId,
+        eventType: canonical.eventType,
+        sequence: canonical.sequence,
+        timestamp: span.startTime.toISOString(),
+        payload: {
+          ...canonical.payload,
+          session: {
+            workDir: context.workDir,
+            branch: context.branch,
+            suffix: context.suffix,
+          },
+        },
+        contentKind: canonical.contentKind,
+        contentDisclosure: canonical.contentDisclosure,
         traceId: span.traceId,
         spanId: span.spanId,
-        parentSpanId: span.parentSpanId,
-        name: span.name,
-        startTime: span.startTime,
-        endTime: span.endTime,
-        attributes: span.attributes as Prisma.InputJsonValue,
-      },
-      update: {
-        name: span.name,
-        endTime: span.endTime,
+        parentSpanId: span.parentSpanId ?? undefined,
         workUnitId: context.workUnitId,
         attemptId: context.attemptId,
-        attributes: span.attributes as Prisma.InputJsonValue,
-      },
-    });
+      }),
+    );
 
-    // Also fold key spans into the event timeline for UI without a separate spans section.
-    const { upsertSessionEvent } = await import('@/server/session-events');
-    const promptText = extractPromptText(span.attributes, span.name);
-    const responseText = extractResponseText(span.attributes, span.name);
-    await upsertSessionEvent(context.repositoryId, {
-      sessionKey: context.sessionKey,
-      agentId: context.agentId,
-      agentTool: context.agentTool,
-      eventName: `span.${span.name}`,
-      sequence: Math.abs(
-        Number.parseInt(span.spanId.replace(/\D/g, '').slice(-8) || '0', 16) || accepted + 1,
-      ),
-      timestamp: span.startTime,
-      attributes: {
-        ...span.attributes,
-        traceId: span.traceId,
-        spanId: span.spanId,
-      } as Prisma.InputJsonValue,
-      promptText,
-      responseText,
-      source: 'otel',
-      workUnitId: context.workUnitId,
-      attemptId: context.attemptId,
-    });
-
-    await maybeSetDerivedPurpose(context.repositoryId, context.agentId, promptText);
-
-    const usage = emptyUsage({
-      sessionKey: context.sessionKey,
-      agentId: context.agentId,
-      agentTool: context.agentTool,
-      workDir: context.workDir,
-      branch: context.branch,
-      suffix: context.suffix,
-      workUnitId: context.workUnitId,
-      attemptId: context.attemptId,
-    });
-    applyHooksUsageFromAttrs(usage, span.attributes);
-    usage.tokensTotal =
-      usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead + usage.tokensCacheCreation;
-    if (shouldPersistUsage(usage)) {
-      await upsertSessionUsage(context.repositoryId, usage);
-    }
-
+    await maybeSetDerivedPurpose(context.repositoryId, context.agentId, canonical.promptText);
     accepted += 1;
   }
 

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -175,9 +175,12 @@ function extractPointsFromResourceMetrics(payload: unknown): Array<{
   return results;
 }
 
-function detectAgentTool(resource: AttrMap, serviceName?: string): AgentTool | null {
+export function detectAgentTool(resource: AttrMap, serviceName?: string): AgentTool | null {
   const candidates = [
     String(resource['har.agent_tool'] ?? ''),
+    String(resource['otelhook.provider.id'] ?? ''),
+    String(resource['otelhook.agent.name'] ?? ''),
+    String(resource['otelhook.provider'] ?? ''),
     String(resource['gen_ai.client.name'] ?? ''),
     serviceName ?? String(resource['service.name'] ?? ''),
   ]

--- a/control/src/server/session-events.ts
+++ b/control/src/server/session-events.ts
@@ -1,10 +1,7 @@
 import type { Prisma } from '@prisma/client';
 import { AgentTrajectoryRecordSchema } from '@har/schemas';
 import { prisma } from '@/lib/db';
-import {
-  appendTrajectoryRecord,
-  stableTrajectoryKey,
-} from '@/server/trajectory-ledger';
+import { boundTrajectoryPayload } from '@/lib/trajectory-privacy';
 
 export interface SessionEventInput {
   sessionKey: string;
@@ -83,14 +80,9 @@ export async function listSessionEventsForRepo(repositoryId: string) {
 }
 
 export async function syncSessionEvents(repositoryId: string, events: SessionEventInput[]) {
+  const { appendTrajectoryRecord, stableTrajectoryKey } = await import('@/server/trajectory-ledger');
   let synced = 0;
   for (const event of events) {
-    const payload = {
-      attributes: event.attributes ?? {},
-      promptText: event.promptText ?? null,
-      responseText: event.responseText ?? null,
-      raw: event.rawTruncated ?? null,
-    };
     const source = event.source === 'otel' ? 'otel' : 'harvest';
     const sourceEventId = stableTrajectoryKey({
       sessionKey: event.sessionKey,
@@ -103,10 +95,17 @@ export async function syncSessionEvents(repositoryId: string, events: SessionEve
       ...(event.promptText ? [{ kind: 'prompt', content: event.promptText }] : []),
       ...(event.responseText ? [{ kind: 'response', content: event.responseText }] : []),
       ...(!event.promptText && !event.responseText
-        ? [{ kind: 'event', content: event.rawTruncated ?? event.attributes ?? null }]
+        ? [{ kind: 'event', content: event.rawTruncated ?? null }]
         : []),
     ];
     for (const fact of facts) {
+      const bounded = boundTrajectoryPayload({
+        attributes: event.attributes ?? {},
+        promptText: event.promptText ?? null,
+        responseText: event.responseText ?? null,
+        raw: event.rawTruncated ?? null,
+        body: fact.content,
+      }, event.rawTruncated ? 'truncated' : 'full');
       await appendTrajectoryRecord(
         repositoryId,
         AgentTrajectoryRecordSchema.parse({
@@ -115,7 +114,7 @@ export async function syncSessionEvents(repositoryId: string, events: SessionEve
           sourceEventId,
           contentKey: stableTrajectoryKey({
             kind: fact.kind,
-            content: fact.content,
+            content: fact.kind === 'event' ? event.rawTruncated ?? event.eventName : fact.content,
           }),
           sessionKey: event.sessionKey,
           agentId: event.agentId,
@@ -123,15 +122,14 @@ export async function syncSessionEvents(repositoryId: string, events: SessionEve
           eventType: event.eventName,
           sequence: event.sequence,
           timestamp: event.timestamp.toISOString(),
-          payload,
+          payload: bounded.payload,
           contentKind: fact.kind,
-          contentDisclosure: event.rawTruncated ? 'truncated' : 'full',
+          contentDisclosure: bounded.contentDisclosure,
           workUnitId: event.workUnitId,
           attemptId: event.attemptId,
         }),
       );
     }
-    await upsertSessionEvent(repositoryId, event);
     synced += 1;
   }
   return { synced };

--- a/control/src/server/trajectory-ledger.test.ts
+++ b/control/src/server/trajectory-ledger.test.ts
@@ -38,3 +38,14 @@ describe('trajectory ledger ordering', () => {
     expect(() => decodeTrajectoryCursor('not-a-cursor')).toThrow('Invalid trajectory cursor');
   });
 });
+
+describe('trajectory retention policy', () => {
+  it('treats zero days as keep-forever so expire is a no-op without a cutoff', async () => {
+    const previous = process.env.HAR_TRAJECTORY_RETENTION_DAYS;
+    process.env.HAR_TRAJECTORY_RETENTION_DAYS = '0';
+    const { expireTrajectoryRecords } = await import('./trajectory-ledger');
+    await expect(expireTrajectoryRecords()).resolves.toBe(0);
+    if (previous == null) delete process.env.HAR_TRAJECTORY_RETENTION_DAYS;
+    else process.env.HAR_TRAJECTORY_RETENTION_DAYS = previous;
+  });
+});

--- a/control/src/server/trajectory-ledger.ts
+++ b/control/src/server/trajectory-ledger.ts
@@ -2,11 +2,13 @@ import type { AgentTrajectoryRecord as CanonicalTrajectoryRecord } from '@har/sc
 import { Prisma, type AgentTrajectoryRecord } from '@prisma/client';
 import { createHash } from 'node:crypto';
 import { prisma } from '@/lib/db';
+import { boundTrajectoryPayload, trajectoryPolicy } from '@/lib/trajectory-privacy';
 import type {
   SerializedTrajectoryPage,
   SerializedTrajectoryRecord,
   TrajectoryStream,
 } from '@/lib/trajectory';
+import { projectTrajectoryRecord } from '@/server/trajectory-projections';
 
 export interface TrajectoryCursor {
   sequence: number;
@@ -173,10 +175,16 @@ function scopeWhere(scope: TrajectoryScope): Prisma.AgentTrajectoryRecordWhereIn
   };
 }
 
+const globalRetention = globalThis as unknown as {
+  trajectoryRetentionAt?: number;
+};
+
 export async function appendTrajectoryRecord(
   repositoryId: string,
   input: CanonicalTrajectoryRecord,
 ): Promise<AppendTrajectoryResult> {
+  const { maxPayloadBytes } = trajectoryPolicy();
+  const bounded = boundTrajectoryPayload(input.payload, input.contentDisclosure, maxPayloadBytes);
   try {
     const record = await prisma.agentTrajectoryRecord.create({
       data: {
@@ -191,9 +199,9 @@ export async function appendTrajectoryRecord(
         eventType: input.eventType,
         sequence: input.sequence,
         eventTimestamp: new Date(input.timestamp),
-        payload: input.payload as Prisma.InputJsonValue,
+        payload: bounded.payload as Prisma.InputJsonValue,
         contentKind: input.contentKind,
-        contentDisclosure: input.contentDisclosure,
+        contentDisclosure: bounded.contentDisclosure,
         contentLabel: input.contentLabel,
         traceId: input.traceId,
         spanId: input.spanId,
@@ -205,6 +213,8 @@ export async function appendTrajectoryRecord(
         attemptId: input.attemptId,
       },
     });
+    await projectTrajectoryRecord(record);
+    await maybeExpireTrajectoryRecords();
     for (const listener of listeners) {
       try {
         listener(record);
@@ -329,6 +339,57 @@ export async function getSlotTrajectoryData(
     agentTool: latest.agentTool,
   }, { limit });
   return { streams, initialPage: serializeTrajectoryPage(page) };
+}
+
+export async function listTrajectoryExport(
+  scope: TrajectoryScope,
+): Promise<AgentTrajectoryRecord[]> {
+  return prisma.agentTrajectoryRecord.findMany({
+    where: scopeWhere(scope),
+    orderBy: ascendingOrder,
+  });
+}
+
+export async function deleteTrajectoryScope(scope: TrajectoryScope): Promise<{ deleted: number }> {
+  const result = await prisma.agentTrajectoryRecord.deleteMany({ where: scopeWhere(scope) });
+  await prisma.agentSessionEvent.deleteMany({
+    where: {
+      repositoryId: scope.repositoryId,
+      agentId: scope.agentId,
+      sessionKey: scope.sessionKey,
+      agentTool: scope.agentTool,
+    },
+  });
+  await prisma.agentSessionSpan.deleteMany({
+    where: {
+      repositoryId: scope.repositoryId,
+      agentId: scope.agentId,
+      sessionKey: scope.sessionKey,
+      agentTool: scope.agentTool,
+    },
+  });
+  return { deleted: result.count };
+}
+
+export async function expireTrajectoryRecords(now = new Date()): Promise<number> {
+  const { retentionDays } = trajectoryPolicy();
+  if (retentionDays <= 0) return 0;
+  const cutoff = new Date(now.getTime() - retentionDays * 86_400_000);
+  const result = await prisma.agentTrajectoryRecord.deleteMany({
+    where: { createdAt: { lt: cutoff } },
+  });
+  await prisma.agentSessionEvent.deleteMany({ where: { createdAt: { lt: cutoff } } });
+  await prisma.agentSessionSpan.deleteMany({ where: { createdAt: { lt: cutoff } } });
+  return result.count;
+}
+
+async function maybeExpireTrajectoryRecords(): Promise<void> {
+  const { retentionDays } = trajectoryPolicy();
+  if (retentionDays <= 0) return;
+  const last = globalRetention.trajectoryRetentionAt ?? 0;
+  if (Date.now() - last < 60_000) return;
+  globalRetention.trajectoryRetentionAt = Date.now();
+  await expireTrajectoryRecords();
 }
 
 export function subscribeToTrajectory(

--- a/control/src/server/trajectory-projections.test.ts
+++ b/control/src/server/trajectory-projections.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentTrajectoryRecord } from '@prisma/client';
+import {
+  eventInputFromTrajectoryRecord,
+  usageFromTrajectoryRecord,
+} from './trajectory-projections';
+
+function record(overrides: Partial<AgentTrajectoryRecord> = {}): AgentTrajectoryRecord {
+  return {
+    id: 'row-1',
+    repositoryId: 'repo-1',
+    version: 1,
+    source: 'otel',
+    sourceEventId: 'evt-1',
+    contentKey: 'prompt',
+    sessionKey: 'session-1',
+    agentId: 2,
+    agentTool: 'cursor',
+    eventType: 'prompt.submitted',
+    sequence: 4,
+    eventTimestamp: new Date('2026-08-14T10:00:00.000Z'),
+    payload: {
+      body: 'refactor auth',
+      attributes: {
+        authorization: 'Bearer leaked',
+        'gen_ai.usage.input_tokens': 11,
+        'gen_ai.request.model': 'grok-4.5',
+      },
+      session: { workDir: '/tmp/work', branch: 'feat/x', suffix: 'abcd' },
+    },
+    contentKind: 'prompt',
+    contentDisclosure: 'full',
+    contentLabel: null,
+    traceId: null,
+    spanId: null,
+    parentSpanId: null,
+    generationId: null,
+    toolCallId: null,
+    correlationId: null,
+    workUnitId: null,
+    attemptId: null,
+    createdAt: new Date('2026-08-14T10:00:01.000Z'),
+    ...overrides,
+  };
+}
+
+describe('trajectory projections', () => {
+  it('projects event columns from ledger content and redacts secrets', () => {
+    const event = eventInputFromTrajectoryRecord(record());
+    expect(event).toMatchObject({
+      eventName: 'prompt.submitted',
+      sequence: 4,
+      promptText: 'refactor auth',
+      source: 'otel',
+    });
+    expect(event.attributes).toMatchObject({
+      authorization: '[redacted]',
+      'gen_ai.usage.input_tokens': 11,
+    });
+  });
+
+  it('never copies withheld bodies into event projections', () => {
+    const event = eventInputFromTrajectoryRecord(record({
+      contentDisclosure: 'withheld',
+      payload: { body: 'secret reasoning', attributes: {} },
+    }));
+    expect(event.promptText).toBeNull();
+    expect(event.responseText).toBeNull();
+    expect(event.rawTruncated).toBeNull();
+  });
+
+  it('derives usage from ledger attributes when tokens are present', () => {
+    expect(usageFromTrajectoryRecord(record())).toMatchObject({
+      tokensInput: 11,
+      tokensTotal: 11,
+      workDir: '/tmp/work',
+      sources: ['otel'],
+      modelBreakdown: { 'grok-4.5': { tokensInput: 11 } },
+    });
+    expect(usageFromTrajectoryRecord(record({
+      payload: { attributes: { 'gen_ai.request.model': 'grok-4.5' } },
+    }))).toBeNull();
+  });
+});

--- a/control/src/server/trajectory-projections.ts
+++ b/control/src/server/trajectory-projections.ts
@@ -1,0 +1,144 @@
+import { Prisma, type AgentTrajectoryRecord } from '@prisma/client';
+import type { AgentSessionUsage } from '@har/schemas';
+import { prisma } from '@/lib/db';
+import { shouldPersistOtelUsage } from '@/server/otel-workspace';
+import { upsertSessionEvent } from '@/server/session-events';
+import { upsertSessionUsage } from '@/server/usage';
+import {
+  redactSecretAttributes,
+  visibleContentFromPayload,
+} from '@/lib/trajectory-privacy';
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function numberField(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+export function usageFromTrajectoryRecord(
+  record: AgentTrajectoryRecord,
+): AgentSessionUsage | null {
+  const payload = asObject(record.payload);
+  const attributes = asObject(payload?.attributes) ?? {};
+  const session = asObject(payload?.session);
+  const input = numberField(
+    attributes['gen_ai.usage.input_tokens'] ?? attributes['gen_ai.usage.prompt_tokens'],
+  );
+  const output = numberField(
+    attributes['gen_ai.usage.output_tokens'] ?? attributes['gen_ai.usage.completion_tokens'],
+  );
+  const cacheRead = numberField(attributes['gen_ai.usage.cache_read.input_tokens']);
+  const cacheCreate = numberField(attributes['gen_ai.usage.cache_creation.input_tokens']);
+  const model = String(
+    attributes['gen_ai.request.model'] ?? attributes['gen_ai.response.model'] ?? '',
+  ).trim();
+  const usage: AgentSessionUsage = {
+    sessionKey: record.sessionKey,
+    agentId: record.agentId,
+    agentTool: record.agentTool as AgentSessionUsage['agentTool'],
+    workDir: stringField(session?.workDir),
+    branch: stringField(session?.branch),
+    suffix: stringField(session?.suffix),
+    workUnitId: record.workUnitId ?? undefined,
+    attemptId: record.attemptId ?? undefined,
+    tokensInput: input,
+    tokensOutput: output,
+    tokensCacheRead: cacheRead,
+    tokensCacheCreation: cacheCreate,
+    tokensTotal: input + output + cacheRead + cacheCreate,
+    costUsd: null,
+    sources: [record.source === 'harvest' ? 'harvest' : 'otel'],
+    firstSeenAt: record.eventTimestamp.toISOString(),
+    lastSeenAt: record.eventTimestamp.toISOString(),
+    modelBreakdown: model
+      ? {
+          [model]: {
+            tokensInput: input,
+            tokensOutput: output,
+            tokensCacheRead: cacheRead,
+            tokensCacheCreation: cacheCreate,
+            tokensTotal: input + output + cacheRead + cacheCreate,
+          },
+        }
+      : undefined,
+  };
+  return shouldPersistOtelUsage(usage) ? usage : null;
+}
+
+export function eventInputFromTrajectoryRecord(record: AgentTrajectoryRecord) {
+  const payload = asObject(record.payload) ?? {};
+  const attributes = asObject(payload.attributes) ?? {};
+  const visible = visibleContentFromPayload(
+    payload,
+    record.contentKind,
+    record.contentDisclosure,
+  );
+  return {
+    sessionKey: record.sessionKey,
+    agentId: record.agentId,
+    agentTool: record.agentTool,
+    eventName: record.eventType,
+    sequence: record.sequence,
+    timestamp: record.eventTimestamp,
+    attributes: redactSecretAttributes(attributes) as Prisma.InputJsonValue,
+    promptText: visible.promptText,
+    responseText: visible.responseText,
+    rawTruncated: visible.raw,
+    source: record.source === 'harvest' ? 'harvest' : 'otel',
+    workUnitId: record.workUnitId ?? undefined,
+    attemptId: record.attemptId ?? undefined,
+  };
+}
+
+export async function projectTrajectoryRecord(record: AgentTrajectoryRecord): Promise<void> {
+  await upsertSessionEvent(record.repositoryId, eventInputFromTrajectoryRecord(record));
+
+  if (record.traceId && record.spanId) {
+    const payload = asObject(record.payload);
+    const span = asObject(payload?.span);
+    const attributes = asObject(payload?.attributes) ?? {};
+    const startTime = span?.startTime ? new Date(String(span.startTime)) : record.eventTimestamp;
+    const endTime = span?.endTime ? new Date(String(span.endTime)) : null;
+    await prisma.agentSessionSpan.upsert({
+      where: {
+        repositoryId_traceId_spanId: {
+          repositoryId: record.repositoryId,
+          traceId: record.traceId,
+          spanId: record.spanId,
+        },
+      },
+      create: {
+        repositoryId: record.repositoryId,
+        sessionKey: record.sessionKey,
+        agentId: record.agentId,
+        agentTool: record.agentTool,
+        workUnitId: record.workUnitId,
+        attemptId: record.attemptId,
+        traceId: record.traceId,
+        spanId: record.spanId,
+        parentSpanId: record.parentSpanId,
+        name: stringField(span?.name) ?? record.eventType.replace(/^span\./, ''),
+        startTime: Number.isFinite(startTime.getTime()) ? startTime : record.eventTimestamp,
+        endTime: endTime && Number.isFinite(endTime.getTime()) ? endTime : null,
+        attributes: redactSecretAttributes(attributes) as Prisma.InputJsonValue,
+      },
+      update: {
+        parentSpanId: record.parentSpanId,
+        endTime: endTime && Number.isFinite(endTime.getTime()) ? endTime : undefined,
+        attributes: redactSecretAttributes(attributes) as Prisma.InputJsonValue,
+      },
+    });
+  }
+
+  const usage = usageFromTrajectoryRecord(record);
+  if (usage) await upsertSessionUsage(record.repositoryId, usage);
+}

--- a/control/tests/frontend/home.spec.js
+++ b/control/tests/frontend/home.spec.js
@@ -50,7 +50,7 @@ test.describe('Factory and operations', () => {
     await expect(filter).toBeVisible();
 
     await filter.click();
-    const options = page.getByRole('option');
+    const options = page.getByRole('listbox').getByRole('option');
     const optionCount = await options.count();
     if (optionCount <= 1) {
       test.skip(true, 'Only the All repositories option is available');

--- a/control/tests/frontend/settings-reset.spec.js
+++ b/control/tests/frontend/settings-reset.spec.js
@@ -5,6 +5,7 @@ test.describe('Settings reset', () => {
     await page.goto('/settings');
 
     await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Trajectory storage' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Danger zone' })).toBeVisible();
 
     const openButton = page.getByRole('button', { name: /clear all data/i });

--- a/control/tests/frontend/trajectory-viewer.spec.js
+++ b/control/tests/frontend/trajectory-viewer.spec.js
@@ -15,24 +15,33 @@ test.describe('Slot trajectory viewer', () => {
     await expect(trajectoryTab).toBeVisible();
     await expect(rawTab).toBeVisible();
 
-    const panel = page.getByRole('tabpanel');
+    const panel = page.getByRole('tabpanel', { name: 'Trajectory' });
     await expect(
-      panel.getByLabel('Agent trajectory timeline')
-        .or(panel.getByText(/no trajectory records yet|no records in this trajectory stream/i)),
+      page.getByLabel('Agent trajectory timeline')
+        .or(page.getByText(/no trajectory records yet|no records in this trajectory stream/i)),
     ).toBeVisible();
 
     const selector = panel.getByLabel('Select trajectory session and agent');
     if (await selector.isVisible().catch(() => false)) {
       await expect(selector).toBeEnabled();
     }
-    const exportLink = panel.getByRole('link', { name: /export jsonl/i });
+    const exportLink = page.getByRole('link', { name: /export jsonl/i });
     if (await exportLink.isVisible().catch(() => false)) {
       await expect(exportLink).toHaveAttribute('href', /format=jsonl/);
+    }
+    const overview = page.getByLabel('Trajectory overview');
+    if (await overview.isVisible().catch(() => false)) {
+      await expect(page.getByLabel('Trajectory inspector')).toBeVisible();
+      await expect(page.getByLabel(/turns/i)).toBeVisible();
     }
 
     await rawTab.click();
     await expect(
       page.getByText(/no otel session events yet/i).or(page.getByRole('table')),
     ).toBeVisible();
+    const hideStartEnd = page.getByLabel('Hide start/end events');
+    if (await hideStartEnd.isVisible().catch(() => false)) {
+      await expect(hideStartEnd).toBeChecked();
+    }
   });
 });

--- a/control/tests/frontend/trajectory-viewer.spec.js
+++ b/control/tests/frontend/trajectory-viewer.spec.js
@@ -25,6 +25,10 @@ test.describe('Slot trajectory viewer', () => {
     if (await selector.isVisible().catch(() => false)) {
       await expect(selector).toBeEnabled();
     }
+    const exportLink = panel.getByRole('link', { name: /export jsonl/i });
+    if (await exportLink.isVisible().catch(() => false)) {
+      await expect(exportLink).toHaveAttribute('href', /format=jsonl/);
+    }
 
     await rawTab.click();
     await expect(

--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -194,6 +194,24 @@ When telemetry is on:
 **Privacy:** prompt text is included by default and stays in local Mission Control (SQLite).
 Opt out with `har telemetry on --no-prompts` or disable everything with `har telemetry off`.
 
+### Trajectory ledger
+
+The slot **Trajectory** tab is assembled from an append-only ledger, not from the
+usage/event tables. OTLP ingest and harvest write canonical facts first; event,
+span, and usage rows are projections of those facts.
+
+| Concern | Behavior |
+|---|---|
+| Order | Producer `sequence`, then event timestamp, then source / event id / content key. Ingestion order is not canonical. |
+| Duplicates | The same `(source, sourceEventId, contentKey)` is stored once. Replayed OTLP does not create a second row. |
+| Late arrival | Out-of-order facts keep their sequence. The live viewer repairs gaps after reconnect instead of appending blindly. |
+| Partial content | `contentDisclosure` records `full`, `redacted`, `masked`, `truncated`, `withheld`, or `metadata_only`. Withheld and metadata-only bodies are not rendered. |
+| Secrets | Attribute leaves such as `authorization` or `api_key` are stored as `[redacted]` and never used as prompt/response text. |
+| Size | Bodies over `HAR_TRAJECTORY_MAX_PAYLOAD_BYTES` (default 64 KiB) are truncated. Binary tool payloads are omitted. |
+| Retention | `HAR_TRAJECTORY_RETENTION_DAYS=0` (default) keeps rows. A positive value expires ledger, event, and span rows older than that. Usage totals stay. |
+| Export / delete | The slot viewer can download the session as local JSONL or delete that session's trajectory. Factory reset still wipes the whole database. |
+| Local vs remote | Default Mission Control is local SQLite. Export is a local download. Hosted / Cloud sync does not receive these bodies unless you point agents at a remote Mission Control instance. |
+
 ## Local development
 
 Mission Control's source has its own harness:

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/schemas",
-  "version": "0.42.0",
+  "version": "0.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "0.42.0",
+      "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.0.73",

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -691,6 +691,14 @@ export type AgentTrajectoryContentDisclosure = z.infer<
  * `sourceEventId` identifies the producer event while `contentKey` identifies
  * one content fact within it. Multiple facts may therefore share an event id
  * and sequence without overwriting each other.
+ *
+ * Ordering is deterministic: `sequence`, then occurrence `timestamp`, then
+ * `source`, `sourceEventId`, `contentKey`, and the storage row id. Duplicate
+ * OTLP/harvest delivery is idempotent on `(source, sourceEventId, contentKey)`.
+ * Late or out-of-order facts keep their producer sequence; clients merge by
+ * that order rather than ingestion time. Partial content is represented by
+ * `contentDisclosure` (`truncated` / `redacted` / `withheld` / `metadata_only`)
+ * instead of guessed bodies.
  */
 export const AgentTrajectoryRecordV1Schema = z
   .object({


### PR DESCRIPTION
<img width="2359" height="933" alt="image" src="https://github.com/user-attachments/assets/8c16eefc-724b-4f48-94ab-bd86a2ae020f" />

## Summary
- Persist a host-owned append-only trajectory ledger, then project event/span/usage rows from those writes (no span-ID sequences, payload bounds, secret redaction, retention/export/delete).
- Add a Mission Control trajectory workspace: duration/turns/calls, Input/Model/Tools overview, chronological log, and a Summary/Payload/Result/Timing inspector in HAR colors.
- Hide redundant tool/generation start–end pairs by default; keep the user prompt plus session start/end as the run envelope.

Closes #203. HAR-native capture (Phase 5) remains a follow-up.

## Test plan
- [x] Open a slot with OTEL traffic and confirm the Trajectory tab shows Session started → user prompt → paired tools → Session ended
- [x] Select a tool and check Payload vs Result vs Timing
- [x] Confirm Raw events hides `tool.start`/`tool.end` by default and still shows the session envelope; uncheck to see bookends
- [x] Export JSONL and delete session (usage totals remain)
- [x] Confirm Turn N sits beside the USER tag, not on the timeline rail


Made with [Cursor](https://cursor.com)