### PR TITLE
feat(control): forward the trajectory ledger to a hosted portal

### DIFF
--- a/control/src/app/api/repos/[id]/spans/route.ts
+++ b/control/src/app/api/repos/[id]/spans/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { listSessionSpansForRepo } from '@/server/session-spans';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const url = new URL(request.url);
+  const since = url.searchParams.get('since');
+  const requestedLimit = Number(url.searchParams.get('limit'));
+  const spans = await listSessionSpansForRepo(id, {
+    since,
+    ...(Number.isFinite(requestedLimit) && requestedLimit > 0
+      ? { limit: requestedLimit }
+      : {}),
+  });
+  return NextResponse.json({
+    spans: spans.map((span) => ({
+      ...span,
+      startTime: span.startTime.toISOString(),
+      endTime: span.endTime?.toISOString() ?? null,
+      createdAt: span.createdAt.toISOString(),
+    })),
+  });
+}

--- a/control/src/app/api/repos/[id]/trajectory/route.ts
+++ b/control/src/app/api/repos/[id]/trajectory/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import {
+  listTrajectoryForRepo,
+  serializeTrajectoryForEgress,
+} from '@/server/trajectory-ledger';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const url = new URL(request.url);
+  const since = url.searchParams.get('since');
+  const requestedLimit = Number(url.searchParams.get('limit'));
+  const records = await listTrajectoryForRepo(id, {
+    since,
+    ...(Number.isFinite(requestedLimit) && requestedLimit > 0
+      ? { limit: requestedLimit }
+      : {}),
+  });
+  return NextResponse.json({ records: records.map(serializeTrajectoryForEgress) });
+}

--- a/control/src/server/session-spans.ts
+++ b/control/src/server/session-spans.ts
@@ -1,0 +1,21 @@
+import type { AgentSessionSpan } from '@prisma/client';
+import { prisma } from '@/lib/db';
+
+const REPO_SPANS_LIMIT = 1_000;
+const REPO_SPANS_MAX_LIMIT = 5_000;
+
+export async function listSessionSpansForRepo(
+  repositoryId: string,
+  options: { since?: string | null; limit?: number } = {},
+): Promise<AgentSessionSpan[]> {
+  const limit = Math.max(1, Math.min(options.limit ?? REPO_SPANS_LIMIT, REPO_SPANS_MAX_LIMIT));
+  const since = options.since ? new Date(options.since) : null;
+  return prisma.agentSessionSpan.findMany({
+    where: {
+      repositoryId,
+      ...(since && Number.isFinite(since.getTime()) ? { createdAt: { gt: since } } : {}),
+    },
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    take: limit,
+  });
+}

--- a/control/src/server/trajectory-egress.test.ts
+++ b/control/src/server/trajectory-egress.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const trajectoryFindMany = vi.fn();
+const spanFindMany = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    agentTrajectoryRecord: {
+      findMany: (...args: unknown[]) => trajectoryFindMany(...args),
+    },
+    agentSessionSpan: {
+      findMany: (...args: unknown[]) => spanFindMany(...args),
+    },
+  },
+}));
+
+import { listTrajectoryForRepo, serializeTrajectoryForEgress } from './trajectory-ledger';
+import { listSessionSpansForRepo } from './session-spans';
+
+function record(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'row-1',
+    repositoryId: 'repo-1',
+    version: 1,
+    source: 'otel',
+    sourceEventId: 'evt-1',
+    contentKey: 'prompt',
+    sessionKey: 'feat/x',
+    agentId: 1,
+    agentTool: 'claude_code',
+    eventType: 'claude_code.user_prompt',
+    sequence: 3,
+    eventTimestamp: new Date('2026-01-01T00:00:00.000Z'),
+    payload: { promptText: 'hello', attributes: {} },
+    contentKind: 'prompt',
+    contentDisclosure: 'full',
+    contentLabel: null,
+    traceId: null,
+    spanId: null,
+    parentSpanId: null,
+    generationId: null,
+    toolCallId: null,
+    correlationId: null,
+    workUnitId: null,
+    attemptId: null,
+    createdAt: new Date('2026-01-02T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('listTrajectoryForRepo', () => {
+  beforeEach(() => trajectoryFindMany.mockReset());
+
+  it('reads in storage order so a late fact is not stranded behind the watermark', async () => {
+    trajectoryFindMany.mockResolvedValue([]);
+    await listTrajectoryForRepo('repo-1');
+    expect(trajectoryFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { repositoryId: 'repo-1' },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      }),
+    );
+  });
+
+  it('filters on createdAt when a watermark is given', async () => {
+    trajectoryFindMany.mockResolvedValue([]);
+    await listTrajectoryForRepo('repo-1', { since: '2026-01-01T00:00:00.000Z' });
+    expect(trajectoryFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          repositoryId: 'repo-1',
+          createdAt: { gt: new Date('2026-01-01T00:00:00.000Z') },
+        },
+      }),
+    );
+  });
+
+  it('ignores an unparseable watermark rather than filtering everything out', async () => {
+    trajectoryFindMany.mockResolvedValue([]);
+    await listTrajectoryForRepo('repo-1', { since: 'not-a-date' });
+    expect(trajectoryFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { repositoryId: 'repo-1' } }),
+    );
+  });
+
+  it('caps the requested limit', async () => {
+    trajectoryFindMany.mockResolvedValue([]);
+    await listTrajectoryForRepo('repo-1', { limit: 999_999 });
+    expect(trajectoryFindMany).toHaveBeenCalledWith(expect.objectContaining({ take: 5_000 }));
+  });
+});
+
+describe('serializeTrajectoryForEgress', () => {
+  const previous = process.env.HAR_TRAJECTORY_MAX_PAYLOAD_BYTES;
+
+  beforeEach(() => {
+    if (previous == null) delete process.env.HAR_TRAJECTORY_MAX_PAYLOAD_BYTES;
+    else process.env.HAR_TRAJECTORY_MAX_PAYLOAD_BYTES = previous;
+  });
+
+  it('serializes timestamps as ISO strings', () => {
+    const serialized = serializeTrajectoryForEgress(record() as never);
+    expect(serialized.eventTimestamp).toBe('2026-01-01T00:00:00.000Z');
+    expect(serialized.createdAt).toBe('2026-01-02T00:00:00.000Z');
+  });
+
+  it('re-applies a tightened payload cap to already-stored content', () => {
+    process.env.HAR_TRAJECTORY_MAX_PAYLOAD_BYTES = '1024';
+    const stored = record({ payload: { promptText: 'x'.repeat(20_000), attributes: {} } });
+
+    const serialized = serializeTrajectoryForEgress(stored as never);
+
+    expect((serialized.payload as { promptText: string }).promptText.length).toBeLessThan(20_000);
+    expect(serialized.contentDisclosure).toBe('truncated');
+  });
+
+  it('redacts a secret attribute a newer policy recognizes', () => {
+    const stored = record({
+      payload: { attributes: { authorization: 'Bearer abc', 'tool.name': 'Read' } },
+    });
+
+    const serialized = serializeTrajectoryForEgress(stored as never);
+
+    const attributes = (serialized.payload as { attributes: Record<string, unknown> }).attributes;
+    expect(attributes.authorization).toBe('[redacted]');
+    expect(attributes['tool.name']).toBe('Read');
+  });
+
+  it('keeps a withheld body absent instead of promising content', () => {
+    const stored = record({
+      contentDisclosure: 'withheld',
+      payload: { promptText: 'secret', attributes: {} },
+    });
+
+    const serialized = serializeTrajectoryForEgress(stored as never);
+
+    expect(serialized.contentDisclosure).toBe('withheld');
+    expect((serialized.payload as { promptText: unknown }).promptText).toBeNull();
+  });
+
+  it('does not weaken a hidden disclosure into truncated', () => {
+    process.env.HAR_TRAJECTORY_MAX_PAYLOAD_BYTES = '1024';
+    const stored = record({
+      contentDisclosure: 'metadata_only',
+      payload: { promptText: 'x'.repeat(20_000), attributes: {} },
+    });
+
+    expect(serializeTrajectoryForEgress(stored as never).contentDisclosure).toBe('metadata_only');
+  });
+});
+
+describe('listSessionSpansForRepo', () => {
+  beforeEach(() => spanFindMany.mockReset());
+
+  it('reads spans in storage order, watermarked on createdAt', async () => {
+    spanFindMany.mockResolvedValue([]);
+    await listSessionSpansForRepo('repo-1', { since: '2026-01-01T00:00:00.000Z' });
+    expect(spanFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          repositoryId: 'repo-1',
+          createdAt: { gt: new Date('2026-01-01T00:00:00.000Z') },
+        },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      }),
+    );
+  });
+});

--- a/control/src/server/trajectory-ledger.ts
+++ b/control/src/server/trajectory-ledger.ts
@@ -350,6 +350,44 @@ export async function listTrajectoryExport(
   });
 }
 
+const REPO_TRAJECTORY_LIMIT = 1_000;
+const REPO_TRAJECTORY_MAX_LIMIT = 5_000;
+
+export async function listTrajectoryForRepo(
+  repositoryId: string,
+  options: { since?: string | null; limit?: number } = {},
+): Promise<AgentTrajectoryRecord[]> {
+  const limit = Math.max(
+    1,
+    Math.min(options.limit ?? REPO_TRAJECTORY_LIMIT, REPO_TRAJECTORY_MAX_LIMIT),
+  );
+  const since = options.since ? new Date(options.since) : null;
+  return prisma.agentTrajectoryRecord.findMany({
+    where: {
+      repositoryId,
+      ...(since && Number.isFinite(since.getTime()) ? { createdAt: { gt: since } } : {}),
+    },
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    take: limit,
+  });
+}
+
+export function serializeTrajectoryForEgress(
+  record: AgentTrajectoryRecord,
+): SerializedTrajectoryRecord {
+  const { maxPayloadBytes } = trajectoryPolicy();
+  const bounded = boundTrajectoryPayload(
+    (record.payload ?? {}) as Record<string, unknown>,
+    record.contentDisclosure as CanonicalTrajectoryRecord['contentDisclosure'],
+    maxPayloadBytes,
+  );
+  return {
+    ...serializeTrajectoryRecord(record),
+    payload: bounded.payload,
+    contentDisclosure: bounded.contentDisclosure,
+  };
+}
+
 export async function deleteTrajectoryScope(scope: TrajectoryScope): Promise<{ deleted: number }> {
   const result = await prisma.agentTrajectoryRecord.deleteMany({ where: scopeWhere(scope) });
   await prisma.agentSessionEvent.deleteMany({

--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -210,7 +210,35 @@ span, and usage rows are projections of those facts.
 | Size | Bodies over `HAR_TRAJECTORY_MAX_PAYLOAD_BYTES` (default 64 KiB) are truncated. Binary tool payloads are omitted. |
 | Retention | `HAR_TRAJECTORY_RETENTION_DAYS=0` (default) keeps rows. A positive value expires ledger, event, and span rows older than that. Usage totals stay. |
 | Export / delete | The slot viewer can download the session as local JSONL or delete that session's trajectory. Factory reset still wipes the whole database. |
-| Local vs remote | Default Mission Control is local SQLite. Export is a local download. Hosted / Cloud sync does not receive these bodies unless you point agents at a remote Mission Control instance. |
+| Local vs remote | Default Mission Control is local SQLite. Export is a local download. A hosted portal receives these bodies only after you opt in (see below). |
+
+#### Forwarding the ledger to a hosted portal
+
+`har control sync` pushes runs, slots and token counts to a hosted portal, but the
+ledger's prompts, tool arguments and tool results stay local until you say
+otherwise:
+
+```bash
+har control trajectory          # show the current setting
+har control trajectory on       # forward prompts / tool payloads
+har control trajectory off      # back to counts and events only (default)
+```
+
+`HAR_PORTAL_TRAJECTORY=on|off` overrides the stored choice for one sync, and
+telemetry must be on either way. What is forwarded goes through the same policy as
+what is stored: bodies are capped at `HAR_TRAJECTORY_MAX_PAYLOAD_BYTES`, secret
+attributes are `[redacted]`, and `contentDisclosure` travels with each record so a
+truncated or withheld body is labelled as such remotely instead of arriving as
+apparently-complete text. The policy is applied again on the way out, so tightening
+the cap also bounds records stored under a looser one.
+
+Forwarding is idempotent on `(source, sourceEventId, contentKey)` and watermarked
+independently of the event and run batches — enabling it later still sends the
+backlog rather than starting from that moment.
+
+Projected **spans** ride along with telemetry rather than with this opt-in: they
+carry call structure and timing, and their attributes were already redacted when
+the span was projected.
 
 ## Local development
 

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -217,6 +217,7 @@ har control reset [--yes] [--no-scrub-local] [--keep-registry] [--api-url <url>]
 har control sync [--select] [--api-url <url>] [--dry-run] [--json] [--cloud] [--full]
 har control watch [--repo .] [--interval 10] [--api-url <url>]
 har control login [--portal <url>] [--api-key <key>]
+har control trajectory [on|off]
 ```
 
 `login` resolves the portal from `--portal`, then `HAR_PORTAL_URL`, then the
@@ -227,6 +228,13 @@ opens browser SSO and saves the resulting token.
 watermark and resends the complete payload.
 `register --no-portal` keeps the repo on local Mission Control only (skips hosted
 portal sync even when logged in); `--portal` re-enables portal sync for that repo.
+
+`trajectory` controls whether sync forwards the trajectory ledger — agent prompts,
+tool arguments and tool results — to a hosted portal. Off by default: without it a
+portal receives runs, slots, token counts and events, and those bodies stay on this
+machine. Requires telemetry to be on, and `HAR_PORTAL_TRAJECTORY=on|off` overrides
+the stored choice. Forwarded content is capped and redacted by the same local policy
+that governs storage (see the Mission Control guide).
 
 `unregister` removes the repository from Mission Control and `~/.har/repos.json`.
 Interactively it lists session worktrees and asks whether to delete them; pass

--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -38,6 +38,11 @@ import {
   recordRepoForControlSync,
   setRepoPortalSync,
 } from '../../core/control-registry';
+import {
+  isTelemetryEnabled,
+  readTelemetryPreference,
+  writePortalTrajectoryPreference,
+} from '../../core/telemetry-config';
 import { finishCommand } from '../finish-command';
 
 export const controlCommand = {
@@ -172,9 +177,20 @@ export const controlCommand = {
             .option('json', { type: 'boolean', default: false }),
         handleReset,
       )
+      .command(
+        'trajectory [state]',
+        'Forward agent prompts, tool arguments and tool results to the hosted portal (off by default)',
+        (y: Argv) =>
+          y.positional('state', {
+            type: 'string',
+            choices: ['on', 'off'] as const,
+            describe: 'Omit to print the current setting',
+          }),
+        handleTrajectory,
+      )
       .demandCommand(
         1,
-        'Please specify a subcommand: up, down, register, unregister, sync, login, reset',
+        'Please specify a subcommand: up, down, register, unregister, sync, login, reset, trajectory',
       ),
   handler: () => {},
 };
@@ -578,5 +594,38 @@ async function handleLogin(argv: { apiKey?: string; portal?: string }): Promise<
   } catch (err) {
     error(`Login failed: ${(err as Error).message}`);
     return finishCommand(1);
+  }
+}
+
+async function handleTrajectory(argv: { state?: string }): Promise<void> {
+  header('har control trajectory');
+
+  if (!argv.state) {
+    const enabled = readTelemetryPreference().portalTrajectory === true;
+    info(`Trajectory forwarding: ${enabled ? 'on' : 'off'}`);
+    if (!enabled) {
+      info('Enable: har control trajectory on');
+    }
+    if (!isTelemetryEnabled()) {
+      warn('Telemetry is off, so nothing is forwarded regardless of this setting.');
+    }
+    return;
+  }
+
+  const enabled = argv.state === 'on';
+  writePortalTrajectoryPreference(enabled);
+
+  if (!enabled) {
+    success('Trajectory forwarding off — the portal receives token counts and events only.');
+    return;
+  }
+
+  success('Trajectory forwarding on.');
+  info(
+    'Prompts, tool arguments and tool results now sync to the hosted portal, ' +
+      'capped and redacted by the local policy (HAR_TRAJECTORY_MAX_PAYLOAD_BYTES).',
+  );
+  if (!isTelemetryEnabled()) {
+    warn('Telemetry is off, so nothing is forwarded yet — enable it with har telemetry on.');
   }
 }

--- a/src/core/control-persisted-trajectory.ts
+++ b/src/core/control-persisted-trajectory.ts
@@ -1,0 +1,173 @@
+import * as path from 'path';
+import type { AgentTrajectoryRecord } from '../harness/schema';
+import { AgentTrajectoryRecordSchema } from '../harness/schema';
+import { selectSince } from './portal-watermark';
+
+const FETCH_TIMEOUT_MS = 5000;
+
+export interface PersistedSpanRow {
+  sessionKey: string;
+  agentId: number;
+  agentTool: string;
+  workUnitId?: string | null;
+  attemptId?: string | null;
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string | null;
+  name: string;
+  startTime: string;
+  endTime?: string | null;
+  attributes?: Record<string, unknown> | null;
+  createdAt?: string | null;
+}
+
+export interface PortalSpan {
+  sessionKey: string;
+  agentId: number;
+  agentTool: string;
+  workUnitId?: string;
+  attemptId?: string;
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  startTime: string;
+  endTime?: string;
+  attributes?: Record<string, unknown>;
+}
+
+async function getJson<T>(url: string): Promise<T | null> {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveControlRepoId(apiUrl: string, repoPath: string): Promise<string | null> {
+  const repos = await getJson<{ id: string; path: string }[]>(`${apiUrl}/api/repos`);
+  if (!Array.isArray(repos)) return null;
+  const target = path.resolve(repoPath);
+  return repos.find((repo) => path.resolve(repo.path) === target)?.id ?? null;
+}
+
+function optional<T>(value: T | null | undefined): T | undefined {
+  return value == null ? undefined : value;
+}
+
+function toCanonicalRecord(row: Record<string, unknown>): Record<string, unknown> {
+  const canonical: Record<string, unknown> = {
+    version: row.version,
+    source: row.source,
+    sourceEventId: row.sourceEventId,
+    contentKey: row.contentKey,
+    sessionKey: row.sessionKey,
+    agentId: row.agentId,
+    agentTool: row.agentTool,
+    eventType: row.eventType,
+    sequence: row.sequence,
+    timestamp: row.eventTimestamp ?? row.timestamp,
+    payload: row.payload,
+    contentKind: row.contentKind,
+    contentDisclosure: row.contentDisclosure,
+  };
+  for (const key of [
+    'contentLabel',
+    'traceId',
+    'spanId',
+    'parentSpanId',
+    'generationId',
+    'toolCallId',
+    'correlationId',
+    'workUnitId',
+    'attemptId',
+  ]) {
+    if (row[key] != null) canonical[key] = row[key];
+  }
+  return canonical;
+}
+
+function toPortalSpan(row: PersistedSpanRow): PortalSpan {
+  return {
+    sessionKey: row.sessionKey,
+    agentId: row.agentId,
+    agentTool: row.agentTool,
+    ...(optional(row.workUnitId) !== undefined ? { workUnitId: row.workUnitId as string } : {}),
+    ...(optional(row.attemptId) !== undefined ? { attemptId: row.attemptId as string } : {}),
+    traceId: row.traceId,
+    spanId: row.spanId,
+    ...(optional(row.parentSpanId) !== undefined
+      ? { parentSpanId: row.parentSpanId as string }
+      : {}),
+    name: row.name,
+    startTime: row.startTime,
+    ...(optional(row.endTime) !== undefined ? { endTime: row.endTime as string } : {}),
+    ...(row.attributes ? { attributes: row.attributes } : {}),
+  };
+}
+
+export interface PersistedTrajectoryRequest {
+  records: { since: string | null } | false;
+  spans: { since: string | null } | false;
+}
+
+export interface PersistedTrajectory {
+  records: AgentTrajectoryRecord[];
+  spans: PortalSpan[];
+  recordsMaxSyncedAt: string | null;
+  spansMaxSyncedAt: string | null;
+}
+
+export async function fetchPersistedTrajectory(
+  repoPath: string,
+  apiUrl: string,
+  request: PersistedTrajectoryRequest,
+): Promise<PersistedTrajectory> {
+  const empty: PersistedTrajectory = {
+    records: [],
+    spans: [],
+    recordsMaxSyncedAt: null,
+    spansMaxSyncedAt: null,
+  };
+  if (!request.records && !request.spans) return empty;
+
+  const repoId = await resolveControlRepoId(apiUrl, repoPath);
+  if (!repoId) return empty;
+
+  const [trajectoryResponse, spansResponse] = await Promise.all([
+    request.records
+      ? getJson<{ records: (Record<string, unknown> & { createdAt?: string })[] }>(
+          `${apiUrl}/api/repos/${repoId}/trajectory`,
+        )
+      : null,
+    request.spans
+      ? getJson<{ spans: PersistedSpanRow[] }>(`${apiUrl}/api/repos/${repoId}/spans`)
+      : null,
+  ]);
+
+  const trajectory = selectSince(
+    trajectoryResponse?.records ?? [],
+    request.records ? request.records.since : null,
+    (row) => row.createdAt ?? null,
+  );
+  const spans = selectSince(
+    spansResponse?.spans ?? [],
+    request.spans ? request.spans.since : null,
+    (row) => row.createdAt ?? null,
+  );
+
+  return {
+    records: trajectory.selected.flatMap((row) => {
+      const parsed = AgentTrajectoryRecordSchema.safeParse(toCanonicalRecord(row));
+      return parsed.success ? [parsed.data] : [];
+    }),
+    spans: spans.selected.map(toPortalSpan),
+    recordsMaxSyncedAt: trajectory.maxSyncedAt,
+    spansMaxSyncedAt: spans.maxSyncedAt,
+  };
+}

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -36,11 +36,12 @@ import {
   listWorkUnits,
 } from './work-units';
 import { createRemoteExecutor } from './cloud-executor';
-import { isTelemetryEnabled } from './telemetry-config';
+import { isPortalTrajectoryEnabled, isTelemetryEnabled } from './telemetry-config';
 import { warn } from '../utils/logging';
 import { harvestEventsForSlot, harvestUsageForSlot, omitHarvestEventsWhenOtelPresent, omitHarvestWhenOtelPresent } from './usage-harvest';
 import { buildSessionKey } from './telemetry-env';
 import { fetchPersistedPortalTelemetry } from './control-persisted-usage';
+import { fetchPersistedTrajectory } from './control-persisted-trajectory';
 import { dedupePortalEvents, mergePortalUsage } from './portal-usage-merge';
 import { enrichUsageWithPricing } from '../harness/schema';
 import {
@@ -113,6 +114,14 @@ function rewindSince(since: string | null): string | null {
 
 function runsWatermarkTarget(target: string): string {
   return `runs:${target}`;
+}
+
+function trajectoryWatermarkTarget(target: string): string {
+  return `trajectory:${target}`;
+}
+
+function spansWatermarkTarget(target: string): string {
+  return `spans:${target}`;
 }
 
 /** Send run batches oldest-first, advancing the watermark (with the server repo
@@ -233,6 +242,33 @@ async function refreshPortalToken(target: PortalTarget): Promise<boolean> {
   return true;
 }
 
+async function postPortalWithRefresh(
+  target: PortalTarget,
+  endpoint: string,
+  body: unknown,
+): Promise<Response> {
+  const response = await postPortalOnce(target, endpoint, body);
+
+  if (
+    (response.status === 401 || response.status === 403) &&
+    (await refreshPortalToken(target))
+  ) {
+    return postPortalOnce(target, endpoint, body);
+  }
+
+  return response;
+}
+
+async function throwPortalFailure(response: Response): Promise<never> {
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(
+      `har-portal rejected the ingest token (HTTP ${response.status}) — run \`har control login\` (or check HAR_PORTAL_TOKEN).`,
+    );
+  }
+  const text = await response.text().catch(() => '');
+  throw new Error(`har-portal sync failed: HTTP ${response.status}${text ? ` — ${text}` : ''}`);
+}
+
 async function postPortal(
   target: PortalTarget,
   endpoint: string,
@@ -241,26 +277,25 @@ async function postPortal(
 ): Promise<Record<string, unknown> | null> {
   if (dryRun) return null;
 
-  let response = await postPortalOnce(target, endpoint, body);
-
-  if (
-    (response.status === 401 || response.status === 403) &&
-    (await refreshPortalToken(target))
-  ) {
-    response = await postPortalOnce(target, endpoint, body);
-  }
-
-  if (!response.ok) {
-    if (response.status === 401 || response.status === 403) {
-      throw new Error(
-        `har-portal rejected the ingest token (HTTP ${response.status}) — run \`har control login\` (or check HAR_PORTAL_TOKEN).`,
-      );
-    }
-    const text = await response.text().catch(() => '');
-    throw new Error(`har-portal sync failed: HTTP ${response.status}${text ? ` — ${text}` : ''}`);
-  }
+  const response = await postPortalWithRefresh(target, endpoint, body);
+  if (!response.ok) await throwPortalFailure(response);
 
   return (await response.json().catch(() => null)) as Record<string, unknown> | null;
+}
+
+async function postPortalIfSupported(
+  target: PortalTarget,
+  endpoint: string,
+  body: unknown,
+  dryRun?: boolean,
+): Promise<boolean> {
+  if (dryRun) return true;
+
+  const response = await postPortalWithRefresh(target, endpoint, body);
+  if (response.status === 404) return false;
+  if (!response.ok) await throwPortalFailure(response);
+
+  return true;
 }
 
 function resolvePortalUserEmail(): string | undefined {
@@ -658,10 +693,64 @@ async function syncRepoWithPortal(
   }
 
   for (const batch of chunkBySerializedSize(events, maxSyncBatchBytes())) {
-    await postPortal(portal, '/api/otel', { path: repoPath, events: batch, spans: [] }, dryRun);
+    await postPortal(portal, '/api/otel', { path: repoPath, events: batch }, dryRun);
   }
   if (!dryRun && maxSyncedAt) {
     writePortalWatermark(repoPath, portal.url, maxSyncedAt);
+  }
+
+  await syncTrajectoryWithPortal(portal, repoPath, controlApiUrl, dryRun, full);
+}
+
+async function syncTrajectoryWithPortal(
+  portal: PortalTarget,
+  repoPath: string,
+  controlApiUrl: string,
+  dryRun: boolean | undefined,
+  full: boolean | undefined,
+): Promise<void> {
+  const wantRecords = isPortalTrajectoryEnabled();
+  const wantSpans = isTelemetryEnabled();
+  if (!wantRecords && !wantSpans) return;
+
+  const recordsTarget = trajectoryWatermarkTarget(portal.url);
+  const spansTarget = spansWatermarkTarget(portal.url);
+  const { records, spans, recordsMaxSyncedAt, spansMaxSyncedAt } =
+    await fetchPersistedTrajectory(repoPath, controlApiUrl, {
+      records: wantRecords
+        ? { since: full ? null : readPortalWatermark(repoPath, recordsTarget) }
+        : false,
+      spans: wantSpans
+        ? { since: full ? null : readPortalWatermark(repoPath, spansTarget) }
+        : false,
+    });
+
+  for (const batch of chunkBySerializedSize(spans, maxSyncBatchBytes())) {
+    await postPortal(portal, '/api/otel', { path: repoPath, spans: batch }, dryRun);
+  }
+  if (!dryRun && spansMaxSyncedAt) {
+    writePortalWatermark(repoPath, spansTarget, spansMaxSyncedAt);
+  }
+
+  let recordsLanded = true;
+  for (const batch of chunkBySerializedSize(records, maxSyncBatchBytes())) {
+    const supported = await postPortalIfSupported(
+      portal,
+      '/api/trajectory',
+      { path: repoPath, records: batch },
+      dryRun,
+    );
+    if (!supported) {
+      recordsLanded = false;
+      warn(
+        `${path.basename(repoPath)}: this har-portal has no /api/trajectory endpoint — ` +
+          'trajectory forwarding skipped (upgrade the portal; records are kept for the next sync).',
+      );
+      break;
+    }
+  }
+  if (!dryRun && recordsLanded && recordsMaxSyncedAt) {
+    writePortalWatermark(repoPath, recordsTarget, recordsMaxSyncedAt);
   }
 }
 

--- a/src/core/telemetry-config.ts
+++ b/src/core/telemetry-config.ts
@@ -12,6 +12,7 @@ export interface TelemetrySignals {
 export interface TelemetryPreference {
   enabled: boolean;
   signals: TelemetrySignals;
+  portalTrajectory?: boolean;
   updatedAt?: string;
 }
 
@@ -71,6 +72,7 @@ export function readTelemetryPreference(): TelemetryPreference {
     return {
       enabled,
       signals: normalizeSignals(enabled, parsed.signals),
+      portalTrajectory: parsed.portalTrajectory === true,
       updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : undefined,
     };
   } catch {
@@ -90,6 +92,7 @@ export function writeTelemetryPreference(
   const preference: TelemetryPreference = {
     enabled,
     signals: enabled ? nextSignals : { ...DEFAULT_SIGNALS_OFF },
+    ...(current.portalTrajectory ? { portalTrajectory: true } : {}),
     updatedAt: new Date().toISOString(),
   };
   const preferencePath = getPreferencePath();
@@ -129,6 +132,27 @@ export function getTelemetrySignals(): TelemetrySignals {
 
 export function getTelemetryPreferencePath(): string {
   return getPreferencePath();
+}
+
+export function isPortalTrajectoryEnabled(): boolean {
+  if (!isTelemetryEnabled()) return false;
+  const envOverride = parseEnvOverride(process.env.HAR_PORTAL_TRAJECTORY);
+  if (envOverride !== undefined) return envOverride;
+  return readTelemetryPreference().portalTrajectory === true;
+}
+
+export function writePortalTrajectoryPreference(enabled: boolean): TelemetryPreference {
+  const current = readTelemetryPreference();
+  const preference: TelemetryPreference = {
+    enabled: current.enabled,
+    signals: current.signals,
+    ...(enabled ? { portalTrajectory: true } : {}),
+    updatedAt: new Date().toISOString(),
+  };
+  const preferencePath = getPreferencePath();
+  fs.mkdirSync(path.dirname(preferencePath), { recursive: true });
+  fs.writeFileSync(preferencePath, JSON.stringify(preference, null, 2) + '\n');
+  return preference;
 }
 
 export const TELEMETRY_SIGNALS = [

--- a/tests/control-persisted-trajectory.test.ts
+++ b/tests/control-persisted-trajectory.test.ts
@@ -1,0 +1,211 @@
+import { fetchPersistedTrajectory } from '../src/core/control-persisted-trajectory';
+
+const API = 'http://localhost:3847';
+
+function ledgerRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'row-1',
+    repositoryId: 'local-repo-1',
+    version: 1,
+    source: 'otel',
+    sourceEventId: 'evt-1',
+    contentKey: 'prompt',
+    sessionKey: 'feat/x',
+    agentId: 1,
+    agentTool: 'claude_code',
+    eventType: 'claude_code.user_prompt',
+    sequence: 3,
+    eventTimestamp: '2026-01-01T00:00:00.000Z',
+    payload: { promptText: 'hi', attributes: {} },
+    contentKind: 'prompt',
+    contentDisclosure: 'withheld',
+    contentLabel: null,
+    toolCallId: 'call-1',
+    traceId: null,
+    createdAt: '2026-01-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function spanRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'span-row-1',
+    sessionKey: 'feat/x',
+    agentId: 1,
+    agentTool: 'claude_code',
+    traceId: 'trace-1',
+    spanId: 'span-1',
+    parentSpanId: null,
+    name: 'tool.Read',
+    startTime: '2026-01-01T00:00:00.000Z',
+    endTime: null,
+    attributes: { 'gen_ai.tool.name': 'Read' },
+    createdAt: '2026-01-04T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function mockControl(options: {
+  repos?: { id: string; path: string }[];
+  records?: Record<string, unknown>[];
+  spans?: Record<string, unknown>[];
+  trajectoryStatus?: number;
+}): jest.Mock {
+  const fn = jest.fn(async (url: string) => {
+    const target = String(url);
+    if (target.endsWith('/api/repos')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => options.repos ?? [{ id: 'local-repo-1', path: '/repo/x' }],
+      };
+    }
+    if (target.includes('/trajectory')) {
+      const status = options.trajectoryStatus ?? 200;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => ({ records: options.records ?? [] }),
+      };
+    }
+    if (target.includes('/spans')) {
+      return { ok: true, status: 200, json: async () => ({ spans: options.spans ?? [] }) };
+    }
+    return { ok: false, status: 404, json: async () => ({}) };
+  });
+  (global as unknown as { fetch: unknown }).fetch = fn;
+  return fn;
+}
+
+const BOTH = { records: { since: null }, spans: { since: null } } as const;
+
+describe('fetchPersistedTrajectory', () => {
+  it('maps a stored ledger row to the canonical record shape', async () => {
+    mockControl({ records: [ledgerRow()] });
+
+    const { records } = await fetchPersistedTrajectory('/repo/x', API, BOTH);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      version: 1,
+      source: 'otel',
+      sourceEventId: 'evt-1',
+      contentKey: 'prompt',
+      sequence: 3,
+      // The DB column is eventTimestamp; the wire field is timestamp.
+      timestamp: '2026-01-01T00:00:00.000Z',
+      contentDisclosure: 'withheld',
+      toolCallId: 'call-1',
+    });
+  });
+
+  it('does not forward Mission Control storage identity', async () => {
+    mockControl({ records: [ledgerRow()] });
+
+    const { records } = await fetchPersistedTrajectory('/repo/x', API, BOTH);
+
+    expect(records[0]).not.toHaveProperty('id');
+    expect(records[0]).not.toHaveProperty('repositoryId');
+    expect(records[0]).not.toHaveProperty('createdAt');
+  });
+
+  it('omits absent optional fields rather than sending null', async () => {
+    mockControl({ records: [ledgerRow({ contentLabel: null, traceId: null })] });
+
+    const { records } = await fetchPersistedTrajectory('/repo/x', API, BOTH);
+
+    expect(records[0]).not.toHaveProperty('contentLabel');
+    expect(records[0]).not.toHaveProperty('traceId');
+  });
+
+  it('watermarks records and spans on storage order, independently', async () => {
+    mockControl({
+      records: [
+        ledgerRow({ sourceEventId: 'old', createdAt: '2026-01-01T00:00:00.000Z' }),
+        ledgerRow({ sourceEventId: 'new', createdAt: '2026-01-05T00:00:00.000Z' }),
+      ],
+      spans: [spanRow()],
+    });
+
+    const result = await fetchPersistedTrajectory('/repo/x', API, {
+      records: { since: '2026-01-02T00:00:00.000Z' },
+      spans: { since: null },
+    });
+
+    expect(result.records.map((r) => r.sourceEventId)).toEqual(['new']);
+    expect(result.recordsMaxSyncedAt).toBe('2026-01-05T00:00:00.000Z');
+    expect(result.spansMaxSyncedAt).toBe('2026-01-04T00:00:00.000Z');
+  });
+
+  it('skips a malformed row without discarding the batch', async () => {
+    mockControl({
+      records: [ledgerRow({ agentTool: 'not_an_agent' }), ledgerRow({ sourceEventId: 'evt-2' })],
+    });
+
+    const { records } = await fetchPersistedTrajectory('/repo/x', API, BOTH);
+
+    expect(records.map((r) => r.sourceEventId)).toEqual(['evt-2']);
+  });
+
+  it('requests only what the caller asked for', async () => {
+    const fetchMock = mockControl({ spans: [spanRow()] });
+
+    const result = await fetchPersistedTrajectory('/repo/x', API, {
+      records: false,
+      spans: { since: null },
+    });
+
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/trajectory'))).toBe(false);
+    expect(result.records).toEqual([]);
+    expect(result.spans).toHaveLength(1);
+  });
+
+  it('returns empty without calling control when nothing is requested', async () => {
+    const fetchMock = mockControl({});
+
+    const result = await fetchPersistedTrajectory('/repo/x', API, {
+      records: false,
+      spans: false,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      records: [],
+      spans: [],
+      recordsMaxSyncedAt: null,
+      spansMaxSyncedAt: null,
+    });
+  });
+
+  it('returns empty when the repo is not registered with control', async () => {
+    mockControl({ repos: [], records: [ledgerRow()] });
+
+    const result = await fetchPersistedTrajectory('/repo/x', API, BOTH);
+
+    expect(result.records).toEqual([]);
+    expect(result.recordsMaxSyncedAt).toBeNull();
+  });
+
+  it('returns empty instead of throwing when control is unreachable', async () => {
+    (global as unknown as { fetch: unknown }).fetch = jest.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+
+    await expect(fetchPersistedTrajectory('/repo/x', API, BOTH)).resolves.toEqual({
+      records: [],
+      spans: [],
+      recordsMaxSyncedAt: null,
+      spansMaxSyncedAt: null,
+    });
+  });
+
+  it('drops null span fields rather than forwarding them', async () => {
+    mockControl({ spans: [spanRow({ parentSpanId: null, endTime: null })] });
+
+    const { spans } = await fetchPersistedTrajectory('/repo/x', API, BOTH);
+
+    expect(spans[0]).not.toHaveProperty('parentSpanId');
+    expect(spans[0]).not.toHaveProperty('endTime');
+    expect(spans[0].attributes).toEqual({ 'gen_ai.tool.name': 'Read' });
+  });
+});

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -43,7 +43,18 @@ jest.mock('../src/core/portal-watermark', () => ({
   readRunsWatermarkEntry: jest.fn(() => null),
   writeRunsWatermark: jest.fn(),
 }));
-jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => true }));
+jest.mock('../src/core/telemetry-config', () => ({
+  isTelemetryEnabled: () => true,
+  isPortalTrajectoryEnabled: jest.fn(() => false),
+}));
+jest.mock('../src/core/control-persisted-trajectory', () => ({
+  fetchPersistedTrajectory: jest.fn(async () => ({
+    records: [],
+    spans: [],
+    recordsMaxSyncedAt: null,
+    spansMaxSyncedAt: null,
+  })),
+}));
 jest.mock('../src/harness/manifest', () => ({
   readManifest: () => null,
   resolveHarnessRoot: (p: string) => p,
@@ -446,7 +457,9 @@ describe('syncRepoWithControl — portal full payload', () => {
     expect(otelBody.events[0].promptText).toBe('hi');
     expect('responseText' in otelBody.events[0]).toBe(false);
     expect('rawTruncated' in otelBody.events[0]).toBe(false);
-    expect(Array.isArray(otelBody.spans)).toBe(true);
+    // Spans travel in their own call now, so an events batch carries no spans
+    // key at all — it used to always send an empty array.
+    expect('spans' in otelBody).toBe(false);
   });
 
   it('does not call /api/otel when there are no events', async () => {

--- a/tests/control-portal-trajectory.test.ts
+++ b/tests/control-portal-trajectory.test.ts
@@ -1,0 +1,291 @@
+import { syncRepoWithControl } from '../src/core/control-sync';
+
+// Same isolation as control-portal-sync: the collectors have their own suites,
+// so here only the trajectory/span forwarding decisions are under test.
+jest.mock('../src/core/portal-credentials', () => ({
+  readPortalCredentials: jest.fn(() => null),
+  writePortalCredentials: jest.fn(),
+}));
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+jest.mock('../src/core/runs', () => ({ listRuns: jest.fn(() => []) }));
+jest.mock('../src/core/slot-status', () => ({
+  collectEnvironmentStatus: jest.fn(() => ({
+    slots: [],
+    generatedAt: '2026-01-01T00:00:00.000Z',
+  })),
+}));
+jest.mock('../src/core/validations', () => ({ listValidations: jest.fn(() => []) }));
+jest.mock('../src/core/work-units', () => ({
+  listWorkUnits: jest.fn(() => []),
+  listWorkAttempts: jest.fn(() => []),
+  listValidationBindings: jest.fn(() => []),
+}));
+jest.mock('../src/core/usage-harvest', () => {
+  const actual = jest.requireActual('../src/core/usage-harvest') as typeof import('../src/core/usage-harvest');
+  return {
+    ...actual,
+    harvestUsageForSlot: jest.fn(() => []),
+    harvestEventsForSlot: jest.fn(() => []),
+  };
+});
+jest.mock('../src/core/control-persisted-usage', () => ({
+  fetchPersistedPortalTelemetry: jest.fn(async () => ({ usage: [], events: [], maxSyncedAt: null })),
+}));
+jest.mock('../src/core/control-persisted-trajectory', () => ({
+  fetchPersistedTrajectory: jest.fn(),
+}));
+jest.mock('../src/core/portal-watermark', () => ({
+  ...jest.requireActual('../src/core/portal-watermark'),
+  readPortalWatermark: jest.fn(() => null),
+  writePortalWatermark: jest.fn(),
+  readRunsWatermarkEntry: jest.fn(() => null),
+  writeRunsWatermark: jest.fn(),
+}));
+jest.mock('../src/core/telemetry-config', () => ({
+  isTelemetryEnabled: jest.fn(() => true),
+  isPortalTrajectoryEnabled: jest.fn(() => true),
+}));
+jest.mock('../src/harness/manifest', () => ({
+  readManifest: () => null,
+  resolveHarnessRoot: (p: string) => p,
+}));
+jest.mock('../src/harness/stages', () => ({ readStageRegistry: () => null }));
+
+import { fetchPersistedTrajectory } from '../src/core/control-persisted-trajectory';
+import { isPortalTrajectoryEnabled, isTelemetryEnabled } from '../src/core/telemetry-config';
+import { readPortalWatermark, writePortalWatermark } from '../src/core/portal-watermark';
+
+const fetchPersistedTrajectoryMock = fetchPersistedTrajectory as jest.Mock;
+const isPortalTrajectoryEnabledMock = isPortalTrajectoryEnabled as jest.Mock;
+const isTelemetryEnabledMock = isTelemetryEnabled as jest.Mock;
+const readPortalWatermarkMock = readPortalWatermark as jest.Mock;
+const writePortalWatermarkMock = writePortalWatermark as jest.Mock;
+
+const RECORD = {
+  version: 1 as const,
+  source: 'otel' as const,
+  sourceEventId: 'evt-1',
+  contentKey: 'prompt',
+  sessionKey: 'feat/x',
+  agentId: 1,
+  agentTool: 'claude_code' as const,
+  eventType: 'claude_code.user_prompt',
+  sequence: 7,
+  timestamp: '2026-01-01T00:00:00.000Z',
+  payload: { promptText: 'hi' },
+  contentKind: 'prompt',
+  contentDisclosure: 'truncated' as const,
+  toolCallId: 'call-1',
+};
+
+const SPAN = {
+  sessionKey: 'feat/x',
+  agentId: 1,
+  agentTool: 'claude_code',
+  traceId: 'trace-1',
+  spanId: 'span-1',
+  name: 'tool.Read',
+  startTime: '2026-01-01T00:00:00.000Z',
+};
+
+type EndpointStatus = Record<string, number>;
+
+function mockFetch(statuses: EndpointStatus = {}): jest.Mock {
+  const fn = jest.fn(async (url: string, init?: RequestInit) => {
+    const target = String(url);
+    const method = init?.method ?? 'GET';
+    if (target.includes('portal.example.com')) {
+      const path = new URL(target).pathname;
+      const status = statuses[path] ?? 200;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => '',
+        json: async () => ({}),
+      };
+    }
+    if (target.endsWith('/api/repos') && method === 'POST') {
+      return { ok: true, status: 200, text: async () => '', json: async () => ({ id: 'local-1' }) };
+    }
+    return { ok: true, status: 200, text: async () => '', json: async () => [] };
+  });
+  (global as unknown as { fetch: unknown }).fetch = fn;
+  return fn;
+}
+
+function portalCall(fetchMock: jest.Mock, endpoint: string): [string, RequestInit] | undefined {
+  return fetchMock.mock.calls.find(([url]) => String(url).endsWith(endpoint)) as
+    | [string, RequestInit]
+    | undefined;
+}
+
+function bodyOf(call: [string, RequestInit]): Record<string, unknown> {
+  return JSON.parse(call[1].body as string);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+  process.env.HAR_PORTAL_TOKEN = 'har_ingest_secret';
+  isTelemetryEnabledMock.mockReturnValue(true);
+  isPortalTrajectoryEnabledMock.mockReturnValue(true);
+  readPortalWatermarkMock.mockReturnValue(null);
+  fetchPersistedTrajectoryMock.mockResolvedValue({
+    records: [RECORD],
+    spans: [SPAN],
+    recordsMaxSyncedAt: '2026-01-02T00:00:00.000Z',
+    spansMaxSyncedAt: '2026-01-03T00:00:00.000Z',
+  });
+});
+
+afterEach(() => {
+  delete process.env.HAR_PORTAL_URL;
+  delete process.env.HAR_PORTAL_TOKEN;
+});
+
+describe('trajectory forwarding', () => {
+  it('posts ledger records to /api/trajectory with the ingest token', async () => {
+    const fetchMock = mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const call = portalCall(fetchMock, '/api/trajectory');
+    expect(call).toBeDefined();
+    expect((call![1].headers as Record<string, string>).Authorization).toBe(
+      'Bearer har_ingest_secret',
+    );
+    const body = bodyOf(call!);
+    expect(body.path).toBe('/repo/x');
+    expect(body.records).toHaveLength(1);
+  });
+
+  it('forwards contentDisclosure and the pairing id verbatim', async () => {
+    const fetchMock = mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const [record] = bodyOf(portalCall(fetchMock, '/api/trajectory')!).records as Record<
+      string,
+      unknown
+    >[];
+    expect(record.contentDisclosure).toBe('truncated');
+    expect(record.toolCallId).toBe('call-1');
+    expect(record.sequence).toBe(7);
+  });
+
+  it('sends spans on /api/otel instead of an empty array', async () => {
+    const fetchMock = mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const body = bodyOf(portalCall(fetchMock, '/api/otel')!);
+    expect(body.spans).toHaveLength(1);
+    expect((body.spans as Record<string, unknown>[])[0].spanId).toBe('span-1');
+  });
+
+  it('skips records but still sends spans when the opt-in is off', async () => {
+    isPortalTrajectoryEnabledMock.mockReturnValue(false);
+    fetchPersistedTrajectoryMock.mockResolvedValue({
+      records: [],
+      spans: [SPAN],
+      recordsMaxSyncedAt: null,
+      spansMaxSyncedAt: '2026-01-03T00:00:00.000Z',
+    });
+    const fetchMock = mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(portalCall(fetchMock, '/api/trajectory')).toBeUndefined();
+    expect(portalCall(fetchMock, '/api/otel')).toBeDefined();
+    expect(fetchPersistedTrajectoryMock).toHaveBeenCalledWith(
+      '/repo/x',
+      expect.any(String),
+      expect.objectContaining({ records: false }),
+    );
+  });
+
+  it('sends nothing when telemetry is off and the opt-in is off', async () => {
+    isTelemetryEnabledMock.mockReturnValue(false);
+    isPortalTrajectoryEnabledMock.mockReturnValue(false);
+    const fetchMock = mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(fetchPersistedTrajectoryMock).not.toHaveBeenCalled();
+    expect(portalCall(fetchMock, '/api/trajectory')).toBeUndefined();
+  });
+
+  it('advances each watermark independently', async () => {
+    mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(writePortalWatermarkMock).toHaveBeenCalledWith(
+      '/repo/x',
+      'trajectory:https://portal.example.com',
+      '2026-01-02T00:00:00.000Z',
+    );
+    expect(writePortalWatermarkMock).toHaveBeenCalledWith(
+      '/repo/x',
+      'spans:https://portal.example.com',
+      '2026-01-03T00:00:00.000Z',
+    );
+  });
+
+  it('keeps the records watermark when the portal has no trajectory endpoint', async () => {
+    const fetchMock = mockFetch({ '/api/trajectory': 404 });
+
+    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).resolves.toBeUndefined();
+
+    expect(portalCall(fetchMock, '/api/trajectory')).toBeDefined();
+    expect(writePortalWatermarkMock).not.toHaveBeenCalledWith(
+      '/repo/x',
+      'trajectory:https://portal.example.com',
+      expect.anything(),
+    );
+    // Spans ride the pre-existing endpoint, so they are unaffected by the skew.
+    expect(writePortalWatermarkMock).toHaveBeenCalledWith(
+      '/repo/x',
+      'spans:https://portal.example.com',
+      '2026-01-03T00:00:00.000Z',
+    );
+  });
+
+  it('still fails the sync on a real portal error', async () => {
+    mockFetch({ '/api/trajectory': 500 });
+
+    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('reads from the stored watermark unless --full', async () => {
+    readPortalWatermarkMock.mockImplementation((_repo: string, target: string) =>
+      target.startsWith('trajectory:') ? '2026-01-01T00:00:00.000Z' : null,
+    );
+    mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+    expect(fetchPersistedTrajectoryMock).toHaveBeenCalledWith(
+      '/repo/x',
+      expect.any(String),
+      expect.objectContaining({ records: { since: '2026-01-01T00:00:00.000Z' } }),
+    );
+
+    fetchPersistedTrajectoryMock.mockClear();
+    await syncRepoWithControl({ repoPath: '/repo/x', full: true });
+    expect(fetchPersistedTrajectoryMock).toHaveBeenCalledWith(
+      '/repo/x',
+      expect.any(String),
+      expect.objectContaining({ records: { since: null } }),
+    );
+  });
+
+  it('does not write watermarks on dry-run', async () => {
+    mockFetch();
+
+    await syncRepoWithControl({ repoPath: '/repo/x', dryRun: true });
+
+    expect(writePortalWatermarkMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/control-sync-batching.test.ts
+++ b/tests/control-sync-batching.test.ts
@@ -21,7 +21,10 @@ jest.mock('../src/core/usage-harvest', () => ({
   harvestUsageForSlot: () => [],
   harvestEventsForSlot: () => [],
 }));
-jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => false }));
+jest.mock('../src/core/telemetry-config', () => ({
+  isTelemetryEnabled: () => false,
+  isPortalTrajectoryEnabled: () => false,
+}));
 jest.mock('../src/harness/manifest', () => ({
   readManifest: () => null,
   resolveHarnessRoot: (p: string) => p,

--- a/tests/control-sync-repos.test.ts
+++ b/tests/control-sync-repos.test.ts
@@ -23,7 +23,10 @@ jest.mock('../src/core/usage-harvest', () => {
     harvestEventsForSlot: () => [],
   };
 });
-jest.mock('../src/core/telemetry-config', () => ({ isTelemetryEnabled: () => false }));
+jest.mock('../src/core/telemetry-config', () => ({
+  isTelemetryEnabled: () => false,
+  isPortalTrajectoryEnabled: () => false,
+}));
 jest.mock('../src/harness/manifest', () => ({
   readManifest: () => null,
   resolveHarnessRoot: (p: string) => p,

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -5,8 +5,10 @@ import * as path from 'path';
 import {
   ensureDefaultTelemetryPreference,
   getTelemetryPreferencePath,
+  isPortalTrajectoryEnabled,
   isTelemetryEnabled,
   readTelemetryPreference,
+  writePortalTrajectoryPreference,
   writeTelemetryPreference,
 } from '../src/core/telemetry-config';
 import {
@@ -92,6 +94,69 @@ describe('telemetry preference', () => {
     expect(isTelemetryEnabled()).toBe(false);
     process.env.HAR_TELEMETRY = '1';
     expect(isTelemetryEnabled()).toBe(true);
+  });
+});
+
+describe('portal trajectory opt-in', () => {
+  const originalTelemetry = process.env.HAR_TELEMETRY;
+  const originalTrajectory = process.env.HAR_PORTAL_TRAJECTORY;
+  const originalPath = process.env.HAR_TELEMETRY_CONFIG_PATH;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-trajectory-'));
+    process.env.HAR_TELEMETRY_CONFIG_PATH = path.join(tmpDir, 'telemetry.json');
+    delete process.env.HAR_TELEMETRY;
+    delete process.env.HAR_PORTAL_TRAJECTORY;
+  });
+
+  afterEach(() => {
+    if (originalTelemetry === undefined) delete process.env.HAR_TELEMETRY;
+    else process.env.HAR_TELEMETRY = originalTelemetry;
+    if (originalTrajectory === undefined) delete process.env.HAR_PORTAL_TRAJECTORY;
+    else process.env.HAR_PORTAL_TRAJECTORY = originalTrajectory;
+    if (originalPath === undefined) delete process.env.HAR_TELEMETRY_CONFIG_PATH;
+    else process.env.HAR_TELEMETRY_CONFIG_PATH = originalPath;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('is off by default even with telemetry fully on', () => {
+    expect(isTelemetryEnabled()).toBe(true);
+    expect(isPortalTrajectoryEnabled()).toBe(false);
+  });
+
+  it('persists the opt-in', () => {
+    writePortalTrajectoryPreference(true);
+    expect(isPortalTrajectoryEnabled()).toBe(true);
+    writePortalTrajectoryPreference(false);
+    expect(isPortalTrajectoryEnabled()).toBe(false);
+  });
+
+  it('stays off while telemetry is off', () => {
+    writePortalTrajectoryPreference(true);
+    writeTelemetryPreference(false);
+    expect(isPortalTrajectoryEnabled()).toBe(false);
+  });
+
+  it('survives a telemetry off/on cycle', () => {
+    writePortalTrajectoryPreference(true);
+    writeTelemetryPreference(false);
+    writeTelemetryPreference(true);
+    expect(isPortalTrajectoryEnabled()).toBe(true);
+  });
+
+  it('keeps the telemetry signals when toggled', () => {
+    writeTelemetryPreference(true, { prompts: false });
+    writePortalTrajectoryPreference(true);
+    expect(readTelemetryPreference().signals.prompts).toBe(false);
+  });
+
+  it('lets HAR_PORTAL_TRAJECTORY override the file', () => {
+    process.env.HAR_PORTAL_TRAJECTORY = 'on';
+    expect(isPortalTrajectoryEnabled()).toBe(true);
+    writePortalTrajectoryPreference(true);
+    process.env.HAR_PORTAL_TRAJECTORY = 'off';
+    expect(isPortalTrajectoryEnabled()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

`har control sync` posted only projected events, with a hardcoded `spans: []`. The ledger facts Mission Control's split-pane viewer is built on — which tool call a result belongs to, and whether a body is complete — were discarded at the sync boundary, so a hosted portal could only guess at pairing by inferring from `attributes`.

## What

- **New egress routes on Mission Control**: repo-scoped `GET /api/repos/[id]/trajectory` and `GET /api/repos/[id]/spans`, ordered by storage time so a forwarder can watermark. The existing slot-scoped trajectory route still serves the viewer.
- **Sync forwards both**: ledger records go to the portal's `/api/trajectory` as their own batch, chunked and watermarked like the event batches; spans now travel on the existing ingest call instead of an empty array.
- **A dedicated endpoint, not a new field**: the receiving payload is validated strictly, so an added key would make an older deployment reject the *whole* batch. A portal without the endpoint answers 404, which is tolerated — the rest of the sync lands, the watermark stays put, and a warning names the fix.
- **Opt-in for content**: forwarding prompts, tool arguments and tool results off the local machine needs `har control trajectory on` (or `HAR_PORTAL_TRAJECTORY`), default **off**. Spans ride with telemetry instead — call structure and timing whose attributes were already redacted at projection.
- **Independent watermarks** for records and spans, so enabling the opt-in later forwards the backlog rather than starting from that moment.

## Notes for review

**Watermarks key on storage time (`createdAt`), never `sequence`/`eventTimestamp`.** Those are the producer's replay position: a fact appended late carries an old one, so selecting on it would strand the record permanently.

**Egress re-applies the payload policy.** A record was bounded by whatever policy was in force when it was appended, so tightening `HAR_TRAJECTORY_MAX_PAYLOAD_BYTES` — or recognising a new secret attribute key — also bounds already-stored content on its way out. `contentDisclosure` travels with each record, so a truncated or withheld body is labelled as such remotely instead of arriving as apparently-complete text.

**Egress carries the ledger fact, not the storage row.** Mission Control's own `id`/`repositoryId` identify a row in the local database and mean nothing to a remote reader, so they are projected away; absent optional fields are omitted rather than sent as `null`.

Idempotency is unchanged from the local ledger: `(source, sourceEventId, contentKey)`, so a resent batch converges instead of appending.

## Tests

`tests/control-portal-trajectory.test.ts` (gating both ways, per-collection watermarks, 404 tolerance vs a real error, `--full`, dry-run), `tests/control-persisted-trajectory.test.ts` (canonical mapping, storage-order watermarking, malformed-row tolerance, unreachable control), `control/src/server/trajectory-egress.test.ts` (read ordering, limit cap, policy re-bound on egress, hidden disclosures not weakened), plus opt-in cases in `tests/telemetry.test.ts`.

Three existing suites mock `src/core/telemetry-config` partially and needed the new export added, or the import resolves `undefined`.

Verified end-to-end against a local Mission Control and a portal: forwarding off → no records; on → records arrive with secrets redacted and disclosure intact; re-syncing → no duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)