### PR TITLE
fix: honor requires-python and uv when provisioning Python venv

### DIFF
--- a/src/templates/har-boilerplate-cli/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-cli/provision-toolchain.sh
@@ -228,52 +228,291 @@ provision_node() {
   append_path_prefix "$dir/node_modules/.bin"
 }
 
+# ── Python interpreter helpers ────────────────────────────────────────────────
+# Resolve the project Python (requires-python, .python-version, uv) instead of
+# blindly using PATH python3.
+
+har_python_version_from_bin() {
+  local bin="$1"
+  "$bin" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null \
+    | tr -d '[:space:]'
+}
+
+har_python_version_to_sortable() {
+  local v="${1#python}"
+  v="${v#v}"
+  local major=0 minor=0 patch=0
+  IFS='.' read -r major minor patch _ <<< "$v"
+  major=${major:-0}
+  minor=${minor:-0}
+  patch=${patch:-0}
+  printf '%03d%03d%03d' "$major" "$minor" "$patch"
+}
+
+har_python_version_ge() {
+  local a b
+  a="$(har_python_version_to_sortable "$1")"
+  b="$(har_python_version_to_sortable "$2")"
+  [ "$a" -ge "$b" ]
+}
+
+har_python_requires_minimum() {
+  local spec="$1"
+  local ver=""
+
+  [ -n "$spec" ] || return 1
+
+  ver="$(printf '%s' "$spec" | sed -n \
+    -e 's/.*>=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*~=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*==\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    | head -1)"
+
+  if [ -z "$ver" ]; then
+    ver="$(printf '%s' "$spec" | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
+  fi
+
+  [ -n "$ver" ] && echo "$ver"
+}
+
+har_python_read_dot_version() {
+  local dir="$1"
+  [ -f "$dir/.python-version" ] || return 1
+  head -1 "$dir/.python-version" | tr -d '[:space:]'
+}
+
+har_python_read_requires_spec() {
+  local dir="$1"
+  local spec=""
+
+  if [ -f "$dir/pyproject.toml" ]; then
+    spec="$(sed -n 's/^[[:space:]]*requires-python[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$dir/pyproject.toml" | head -1)"
+  fi
+  if [ -z "$spec" ] && [ -f "$dir/setup.cfg" ]; then
+    spec="$(sed -n '/^\[options\]/,/^\[/ s/^python_requires[[:space:]]*=[[:space:]]*\(.*\)/\1/p' \
+      "$dir/setup.cfg" | head -1 | tr -d ' "')"
+  fi
+  [ -n "$spec" ] && echo "$spec"
+}
+
+har_python_project_minimum() {
+  local dir="$1"
+  local req_min="" dot_ver="" higher=""
+
+  req_min="$(har_python_requires_minimum "$(har_python_read_requires_spec "$dir" || true)" || true)"
+  dot_ver="$(har_python_read_dot_version "$dir" || true)"
+  if [ -n "$dot_ver" ]; then
+    dot_ver="$(printf '%s' "$dot_ver" | sed 's/^v//; s/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/')"
+  fi
+
+  if [ -n "$req_min" ] && [ -n "$dot_ver" ]; then
+    if har_python_version_ge "$dot_ver" "$req_min"; then
+      higher="$dot_ver"
+    else
+      higher="$req_min"
+    fi
+  elif [ -n "$req_min" ]; then
+    higher="$req_min"
+  elif [ -n "$dot_ver" ]; then
+    higher="$dot_ver"
+  fi
+
+  [ -n "$higher" ] && echo "$higher"
+}
+
+har_python_is_uv_project() {
+  local dir="$1"
+  [ -f "$dir/uv.lock" ] && return 0
+  [ -f "$dir/pyproject.toml" ] && grep -q '^\[tool\.uv\]' "$dir/pyproject.toml" 2>/dev/null
+}
+
+har_python_uv_find() {
+  local dir="$1"
+  local request="${2:-}"
+
+  command -v uv >/dev/null 2>&1 || return 1
+  if [ -n "$request" ]; then
+    (cd "$dir" && uv python find "$request" 2>/dev/null)
+  else
+    (cd "$dir" && uv python find 2>/dev/null)
+  fi
+}
+
+har_python_resolve_interpreter() {
+  local dir="$1"
+  local minimum="${2:-}"
+  local found=""
+
+  if har_python_is_uv_project "$dir"; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if [ -f "$dir/.python-version" ]; then
+    found="$(har_python_uv_find "$dir" "$(har_python_read_dot_version "$dir")" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+    if command -v pyenv >/dev/null 2>&1; then
+      found="$(cd "$dir" && pyenv which python 2>/dev/null || true)"
+      if [ -n "$found" ] && [ -x "$found" ]; then
+        echo "$found"
+        return 0
+      fi
+    fi
+  fi
+
+  if [ -n "$minimum" ]; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    local sys_py sys_ver=""
+    sys_py="$(command -v python3)"
+    if [ -z "$minimum" ]; then
+      echo "$sys_py"
+      return 0
+    fi
+    sys_ver="$(har_python_version_from_bin "$sys_py")"
+    if [ -n "$sys_ver" ] && har_python_version_ge "$sys_ver" "$minimum"; then
+      echo "$sys_py"
+      return 0
+    fi
+    echo "$sys_py"
+    return 0
+  fi
+
+  return 1
+}
+
+har_python_warn_if_below_minimum() {
+  local bin="$1"
+  local minimum="$2"
+  local actual=""
+
+  [ -n "$minimum" ] || return 0
+  actual="$(har_python_version_from_bin "$bin")"
+  [ -n "$actual" ] || return 0
+  if ! har_python_version_ge "$actual" "$minimum"; then
+    pt_log "WARNING: resolved Python ${actual} is older than required ${minimum} (requires-python / .python-version)"
+  fi
+}
+
+har_python_create_venv() {
+  local dir="$1"
+  local venv_dir="$2"
+  local interpreter="$3"
+  local venv_rel="${venv_dir#"$dir"/}"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Creating Python venv with uv at ${venv_rel}..."
+    if (cd "$dir" && uv venv --python "$interpreter" "$venv_dir" 2>/dev/null) \
+      || (cd "$dir" && uv venv "$venv_dir" 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv venv failed — falling back to ${interpreter} -m venv"
+  fi
+
+  pt_log "Creating Python venv at ${venv_rel}..."
+  "$interpreter" -m venv "$venv_dir"
+}
+
+har_python_install_deps() {
+  local dir="$1"
+  local venv_dir="$2"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Syncing Python dependencies with uv..."
+    if (cd "$dir" && UV_PROJECT_ENVIRONMENT="$venv_dir" uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    if (cd "$dir" && uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv sync failed — falling back to pip"
+    return 1
+  fi
+  return 1
+}
+
 provision_python() {
   local dir="$1"
   local venv_rel="${HARNESS_PYTHON_VENV_DIR:-.har/venv}"
   local venv_dir="$dir/$venv_rel"
-  local python_bin="python3"
+  local python_bin=""
+  local interpreter=""
+  local project_min=""
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    pt_log "python3 not found on PATH — skipping venv provisioning"
+  project_min="$(har_python_project_minimum "$dir" || true)"
+  interpreter="$(har_python_resolve_interpreter "$dir" "$project_min" || true)"
+
+  if [ -z "$interpreter" ] || ! command -v "$interpreter" >/dev/null 2>&1; then
+    pt_log "No suitable Python interpreter found — skipping venv provisioning"
     append_env "HARNESS_ECOSYSTEM" "python"
     append_env "PYTHON_BIN" "${PYTHON_BIN:-python3}"
     return
   fi
 
-  if [ ! -d "$venv_dir" ]; then
-    pt_log "Creating Python venv at $venv_rel..."
-    if ! python3 -m venv "$venv_dir"; then
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$interpreter" "$project_min"
+  fi
+
+  if [ -d "$venv_dir" ] && [ -x "$venv_dir/bin/python" ] && [ -n "$project_min" ]; then
+    local venv_ver=""
+    venv_ver="$(har_python_version_from_bin "$venv_dir/bin/python")"
+    if [ -n "$venv_ver" ] && ! har_python_version_ge "$venv_ver" "$project_min"; then
+      pt_log "Existing venv Python ${venv_ver} is older than required ${project_min} — recreating..."
       rm -rf "$venv_dir"
-      pt_log "python3 -m venv failed (on Debian/Ubuntu install python3-venv) — using system python3"
+    fi
+  fi
+
+  if [ ! -d "$venv_dir" ]; then
+    if ! har_python_create_venv "$dir" "$venv_dir" "$interpreter"; then
+      rm -rf "$venv_dir"
+      pt_log "venv creation failed (on Debian/Ubuntu install python3-venv) — using resolved interpreter"
       append_env "HARNESS_ECOSYSTEM" "python"
-      append_env "PYTHON_BIN" "$(command -v python3)"
+      append_env "PYTHON_BIN" "$interpreter"
       return
     fi
   fi
 
   if [ ! -x "$venv_dir/bin/python" ]; then
-    pt_log "Python venv at $venv_rel is missing or broken — using system python3"
+    pt_log "Python venv at $venv_rel is missing or broken — using resolved interpreter"
     append_env "HARNESS_ECOSYSTEM" "python"
-    append_env "PYTHON_BIN" "$(command -v python3)"
+    append_env "PYTHON_BIN" "$interpreter"
     return
   fi
 
   python_bin="$venv_dir/bin/python"
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$python_bin" "$project_min"
+  fi
+
   # shellcheck disable=SC1091
   source "$venv_dir/bin/activate"
 
   if ! run_install_cmd "$dir"; then
-    pt_log "Installing Python dependencies..."
-    if [ -f "$dir/pyproject.toml" ]; then
-      (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/requirements.txt" ]; then
-      (cd "$dir" && pip install -q -r requirements.txt)
-    elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
-      (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
-      (cd "$dir" && pipenv install --dev)
-      python_bin="$(cd "$dir" && pipenv --py)"
+    if ! har_python_install_deps "$dir" "$venv_dir"; then
+      pt_log "Installing Python dependencies..."
+      if [ -f "$dir/pyproject.toml" ]; then
+        (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/requirements.txt" ]; then
+        (cd "$dir" && pip install -q -r requirements.txt)
+      elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+        (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
+        (cd "$dir" && pipenv install --dev)
+        python_bin="$(cd "$dir" && pipenv --py)"
+      fi
     fi
   fi
 

--- a/src/templates/har-boilerplate-ios/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-ios/provision-toolchain.sh
@@ -228,52 +228,291 @@ provision_node() {
   append_path_prefix "$dir/node_modules/.bin"
 }
 
+# ── Python interpreter helpers ────────────────────────────────────────────────
+# Resolve the project Python (requires-python, .python-version, uv) instead of
+# blindly using PATH python3.
+
+har_python_version_from_bin() {
+  local bin="$1"
+  "$bin" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null \
+    | tr -d '[:space:]'
+}
+
+har_python_version_to_sortable() {
+  local v="${1#python}"
+  v="${v#v}"
+  local major=0 minor=0 patch=0
+  IFS='.' read -r major minor patch _ <<< "$v"
+  major=${major:-0}
+  minor=${minor:-0}
+  patch=${patch:-0}
+  printf '%03d%03d%03d' "$major" "$minor" "$patch"
+}
+
+har_python_version_ge() {
+  local a b
+  a="$(har_python_version_to_sortable "$1")"
+  b="$(har_python_version_to_sortable "$2")"
+  [ "$a" -ge "$b" ]
+}
+
+har_python_requires_minimum() {
+  local spec="$1"
+  local ver=""
+
+  [ -n "$spec" ] || return 1
+
+  ver="$(printf '%s' "$spec" | sed -n \
+    -e 's/.*>=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*~=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*==\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    | head -1)"
+
+  if [ -z "$ver" ]; then
+    ver="$(printf '%s' "$spec" | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
+  fi
+
+  [ -n "$ver" ] && echo "$ver"
+}
+
+har_python_read_dot_version() {
+  local dir="$1"
+  [ -f "$dir/.python-version" ] || return 1
+  head -1 "$dir/.python-version" | tr -d '[:space:]'
+}
+
+har_python_read_requires_spec() {
+  local dir="$1"
+  local spec=""
+
+  if [ -f "$dir/pyproject.toml" ]; then
+    spec="$(sed -n 's/^[[:space:]]*requires-python[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$dir/pyproject.toml" | head -1)"
+  fi
+  if [ -z "$spec" ] && [ -f "$dir/setup.cfg" ]; then
+    spec="$(sed -n '/^\[options\]/,/^\[/ s/^python_requires[[:space:]]*=[[:space:]]*\(.*\)/\1/p' \
+      "$dir/setup.cfg" | head -1 | tr -d ' "')"
+  fi
+  [ -n "$spec" ] && echo "$spec"
+}
+
+har_python_project_minimum() {
+  local dir="$1"
+  local req_min="" dot_ver="" higher=""
+
+  req_min="$(har_python_requires_minimum "$(har_python_read_requires_spec "$dir" || true)" || true)"
+  dot_ver="$(har_python_read_dot_version "$dir" || true)"
+  if [ -n "$dot_ver" ]; then
+    dot_ver="$(printf '%s' "$dot_ver" | sed 's/^v//; s/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/')"
+  fi
+
+  if [ -n "$req_min" ] && [ -n "$dot_ver" ]; then
+    if har_python_version_ge "$dot_ver" "$req_min"; then
+      higher="$dot_ver"
+    else
+      higher="$req_min"
+    fi
+  elif [ -n "$req_min" ]; then
+    higher="$req_min"
+  elif [ -n "$dot_ver" ]; then
+    higher="$dot_ver"
+  fi
+
+  [ -n "$higher" ] && echo "$higher"
+}
+
+har_python_is_uv_project() {
+  local dir="$1"
+  [ -f "$dir/uv.lock" ] && return 0
+  [ -f "$dir/pyproject.toml" ] && grep -q '^\[tool\.uv\]' "$dir/pyproject.toml" 2>/dev/null
+}
+
+har_python_uv_find() {
+  local dir="$1"
+  local request="${2:-}"
+
+  command -v uv >/dev/null 2>&1 || return 1
+  if [ -n "$request" ]; then
+    (cd "$dir" && uv python find "$request" 2>/dev/null)
+  else
+    (cd "$dir" && uv python find 2>/dev/null)
+  fi
+}
+
+har_python_resolve_interpreter() {
+  local dir="$1"
+  local minimum="${2:-}"
+  local found=""
+
+  if har_python_is_uv_project "$dir"; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if [ -f "$dir/.python-version" ]; then
+    found="$(har_python_uv_find "$dir" "$(har_python_read_dot_version "$dir")" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+    if command -v pyenv >/dev/null 2>&1; then
+      found="$(cd "$dir" && pyenv which python 2>/dev/null || true)"
+      if [ -n "$found" ] && [ -x "$found" ]; then
+        echo "$found"
+        return 0
+      fi
+    fi
+  fi
+
+  if [ -n "$minimum" ]; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    local sys_py sys_ver=""
+    sys_py="$(command -v python3)"
+    if [ -z "$minimum" ]; then
+      echo "$sys_py"
+      return 0
+    fi
+    sys_ver="$(har_python_version_from_bin "$sys_py")"
+    if [ -n "$sys_ver" ] && har_python_version_ge "$sys_ver" "$minimum"; then
+      echo "$sys_py"
+      return 0
+    fi
+    echo "$sys_py"
+    return 0
+  fi
+
+  return 1
+}
+
+har_python_warn_if_below_minimum() {
+  local bin="$1"
+  local minimum="$2"
+  local actual=""
+
+  [ -n "$minimum" ] || return 0
+  actual="$(har_python_version_from_bin "$bin")"
+  [ -n "$actual" ] || return 0
+  if ! har_python_version_ge "$actual" "$minimum"; then
+    pt_log "WARNING: resolved Python ${actual} is older than required ${minimum} (requires-python / .python-version)"
+  fi
+}
+
+har_python_create_venv() {
+  local dir="$1"
+  local venv_dir="$2"
+  local interpreter="$3"
+  local venv_rel="${venv_dir#"$dir"/}"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Creating Python venv with uv at ${venv_rel}..."
+    if (cd "$dir" && uv venv --python "$interpreter" "$venv_dir" 2>/dev/null) \
+      || (cd "$dir" && uv venv "$venv_dir" 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv venv failed — falling back to ${interpreter} -m venv"
+  fi
+
+  pt_log "Creating Python venv at ${venv_rel}..."
+  "$interpreter" -m venv "$venv_dir"
+}
+
+har_python_install_deps() {
+  local dir="$1"
+  local venv_dir="$2"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Syncing Python dependencies with uv..."
+    if (cd "$dir" && UV_PROJECT_ENVIRONMENT="$venv_dir" uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    if (cd "$dir" && uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv sync failed — falling back to pip"
+    return 1
+  fi
+  return 1
+}
+
 provision_python() {
   local dir="$1"
   local venv_rel="${HARNESS_PYTHON_VENV_DIR:-.har/venv}"
   local venv_dir="$dir/$venv_rel"
-  local python_bin="python3"
+  local python_bin=""
+  local interpreter=""
+  local project_min=""
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    pt_log "python3 not found on PATH — skipping venv provisioning"
+  project_min="$(har_python_project_minimum "$dir" || true)"
+  interpreter="$(har_python_resolve_interpreter "$dir" "$project_min" || true)"
+
+  if [ -z "$interpreter" ] || ! command -v "$interpreter" >/dev/null 2>&1; then
+    pt_log "No suitable Python interpreter found — skipping venv provisioning"
     append_env "HARNESS_ECOSYSTEM" "python"
     append_env "PYTHON_BIN" "${PYTHON_BIN:-python3}"
     return
   fi
 
-  if [ ! -d "$venv_dir" ]; then
-    pt_log "Creating Python venv at $venv_rel..."
-    if ! python3 -m venv "$venv_dir"; then
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$interpreter" "$project_min"
+  fi
+
+  if [ -d "$venv_dir" ] && [ -x "$venv_dir/bin/python" ] && [ -n "$project_min" ]; then
+    local venv_ver=""
+    venv_ver="$(har_python_version_from_bin "$venv_dir/bin/python")"
+    if [ -n "$venv_ver" ] && ! har_python_version_ge "$venv_ver" "$project_min"; then
+      pt_log "Existing venv Python ${venv_ver} is older than required ${project_min} — recreating..."
       rm -rf "$venv_dir"
-      pt_log "python3 -m venv failed (on Debian/Ubuntu install python3-venv) — using system python3"
+    fi
+  fi
+
+  if [ ! -d "$venv_dir" ]; then
+    if ! har_python_create_venv "$dir" "$venv_dir" "$interpreter"; then
+      rm -rf "$venv_dir"
+      pt_log "venv creation failed (on Debian/Ubuntu install python3-venv) — using resolved interpreter"
       append_env "HARNESS_ECOSYSTEM" "python"
-      append_env "PYTHON_BIN" "$(command -v python3)"
+      append_env "PYTHON_BIN" "$interpreter"
       return
     fi
   fi
 
   if [ ! -x "$venv_dir/bin/python" ]; then
-    pt_log "Python venv at $venv_rel is missing or broken — using system python3"
+    pt_log "Python venv at $venv_rel is missing or broken — using resolved interpreter"
     append_env "HARNESS_ECOSYSTEM" "python"
-    append_env "PYTHON_BIN" "$(command -v python3)"
+    append_env "PYTHON_BIN" "$interpreter"
     return
   fi
 
   python_bin="$venv_dir/bin/python"
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$python_bin" "$project_min"
+  fi
+
   # shellcheck disable=SC1091
   source "$venv_dir/bin/activate"
 
   if ! run_install_cmd "$dir"; then
-    pt_log "Installing Python dependencies..."
-    if [ -f "$dir/pyproject.toml" ]; then
-      (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/requirements.txt" ]; then
-      (cd "$dir" && pip install -q -r requirements.txt)
-    elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
-      (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
-      (cd "$dir" && pipenv install --dev)
-      python_bin="$(cd "$dir" && pipenv --py)"
+    if ! har_python_install_deps "$dir" "$venv_dir"; then
+      pt_log "Installing Python dependencies..."
+      if [ -f "$dir/pyproject.toml" ]; then
+        (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/requirements.txt" ]; then
+        (cd "$dir" && pip install -q -r requirements.txt)
+      elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+        (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
+        (cd "$dir" && pipenv install --dev)
+        python_bin="$(cd "$dir" && pipenv --py)"
+      fi
     fi
   fi
 

--- a/src/templates/har-boilerplate/provision-toolchain.sh
+++ b/src/templates/har-boilerplate/provision-toolchain.sh
@@ -228,52 +228,291 @@ provision_node() {
   append_path_prefix "$dir/node_modules/.bin"
 }
 
+# ── Python interpreter helpers ────────────────────────────────────────────────
+# Resolve the project Python (requires-python, .python-version, uv) instead of
+# blindly using PATH python3.
+
+har_python_version_from_bin() {
+  local bin="$1"
+  "$bin" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null \
+    | tr -d '[:space:]'
+}
+
+har_python_version_to_sortable() {
+  local v="${1#python}"
+  v="${v#v}"
+  local major=0 minor=0 patch=0
+  IFS='.' read -r major minor patch _ <<< "$v"
+  major=${major:-0}
+  minor=${minor:-0}
+  patch=${patch:-0}
+  printf '%03d%03d%03d' "$major" "$minor" "$patch"
+}
+
+har_python_version_ge() {
+  local a b
+  a="$(har_python_version_to_sortable "$1")"
+  b="$(har_python_version_to_sortable "$2")"
+  [ "$a" -ge "$b" ]
+}
+
+har_python_requires_minimum() {
+  local spec="$1"
+  local ver=""
+
+  [ -n "$spec" ] || return 1
+
+  ver="$(printf '%s' "$spec" | sed -n \
+    -e 's/.*>=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*~=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*==\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    | head -1)"
+
+  if [ -z "$ver" ]; then
+    ver="$(printf '%s' "$spec" | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
+  fi
+
+  [ -n "$ver" ] && echo "$ver"
+}
+
+har_python_read_dot_version() {
+  local dir="$1"
+  [ -f "$dir/.python-version" ] || return 1
+  head -1 "$dir/.python-version" | tr -d '[:space:]'
+}
+
+har_python_read_requires_spec() {
+  local dir="$1"
+  local spec=""
+
+  if [ -f "$dir/pyproject.toml" ]; then
+    spec="$(sed -n 's/^[[:space:]]*requires-python[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$dir/pyproject.toml" | head -1)"
+  fi
+  if [ -z "$spec" ] && [ -f "$dir/setup.cfg" ]; then
+    spec="$(sed -n '/^\[options\]/,/^\[/ s/^python_requires[[:space:]]*=[[:space:]]*\(.*\)/\1/p' \
+      "$dir/setup.cfg" | head -1 | tr -d ' "')"
+  fi
+  [ -n "$spec" ] && echo "$spec"
+}
+
+har_python_project_minimum() {
+  local dir="$1"
+  local req_min="" dot_ver="" higher=""
+
+  req_min="$(har_python_requires_minimum "$(har_python_read_requires_spec "$dir" || true)" || true)"
+  dot_ver="$(har_python_read_dot_version "$dir" || true)"
+  if [ -n "$dot_ver" ]; then
+    dot_ver="$(printf '%s' "$dot_ver" | sed 's/^v//; s/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/')"
+  fi
+
+  if [ -n "$req_min" ] && [ -n "$dot_ver" ]; then
+    if har_python_version_ge "$dot_ver" "$req_min"; then
+      higher="$dot_ver"
+    else
+      higher="$req_min"
+    fi
+  elif [ -n "$req_min" ]; then
+    higher="$req_min"
+  elif [ -n "$dot_ver" ]; then
+    higher="$dot_ver"
+  fi
+
+  [ -n "$higher" ] && echo "$higher"
+}
+
+har_python_is_uv_project() {
+  local dir="$1"
+  [ -f "$dir/uv.lock" ] && return 0
+  [ -f "$dir/pyproject.toml" ] && grep -q '^\[tool\.uv\]' "$dir/pyproject.toml" 2>/dev/null
+}
+
+har_python_uv_find() {
+  local dir="$1"
+  local request="${2:-}"
+
+  command -v uv >/dev/null 2>&1 || return 1
+  if [ -n "$request" ]; then
+    (cd "$dir" && uv python find "$request" 2>/dev/null)
+  else
+    (cd "$dir" && uv python find 2>/dev/null)
+  fi
+}
+
+har_python_resolve_interpreter() {
+  local dir="$1"
+  local minimum="${2:-}"
+  local found=""
+
+  if har_python_is_uv_project "$dir"; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if [ -f "$dir/.python-version" ]; then
+    found="$(har_python_uv_find "$dir" "$(har_python_read_dot_version "$dir")" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+    if command -v pyenv >/dev/null 2>&1; then
+      found="$(cd "$dir" && pyenv which python 2>/dev/null || true)"
+      if [ -n "$found" ] && [ -x "$found" ]; then
+        echo "$found"
+        return 0
+      fi
+    fi
+  fi
+
+  if [ -n "$minimum" ]; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    local sys_py sys_ver=""
+    sys_py="$(command -v python3)"
+    if [ -z "$minimum" ]; then
+      echo "$sys_py"
+      return 0
+    fi
+    sys_ver="$(har_python_version_from_bin "$sys_py")"
+    if [ -n "$sys_ver" ] && har_python_version_ge "$sys_ver" "$minimum"; then
+      echo "$sys_py"
+      return 0
+    fi
+    echo "$sys_py"
+    return 0
+  fi
+
+  return 1
+}
+
+har_python_warn_if_below_minimum() {
+  local bin="$1"
+  local minimum="$2"
+  local actual=""
+
+  [ -n "$minimum" ] || return 0
+  actual="$(har_python_version_from_bin "$bin")"
+  [ -n "$actual" ] || return 0
+  if ! har_python_version_ge "$actual" "$minimum"; then
+    pt_log "WARNING: resolved Python ${actual} is older than required ${minimum} (requires-python / .python-version)"
+  fi
+}
+
+har_python_create_venv() {
+  local dir="$1"
+  local venv_dir="$2"
+  local interpreter="$3"
+  local venv_rel="${venv_dir#"$dir"/}"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Creating Python venv with uv at ${venv_rel}..."
+    if (cd "$dir" && uv venv --python "$interpreter" "$venv_dir" 2>/dev/null) \
+      || (cd "$dir" && uv venv "$venv_dir" 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv venv failed — falling back to ${interpreter} -m venv"
+  fi
+
+  pt_log "Creating Python venv at ${venv_rel}..."
+  "$interpreter" -m venv "$venv_dir"
+}
+
+har_python_install_deps() {
+  local dir="$1"
+  local venv_dir="$2"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Syncing Python dependencies with uv..."
+    if (cd "$dir" && UV_PROJECT_ENVIRONMENT="$venv_dir" uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    if (cd "$dir" && uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv sync failed — falling back to pip"
+    return 1
+  fi
+  return 1
+}
+
 provision_python() {
   local dir="$1"
   local venv_rel="${HARNESS_PYTHON_VENV_DIR:-.har/venv}"
   local venv_dir="$dir/$venv_rel"
-  local python_bin="python3"
+  local python_bin=""
+  local interpreter=""
+  local project_min=""
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    pt_log "python3 not found on PATH — skipping venv provisioning"
+  project_min="$(har_python_project_minimum "$dir" || true)"
+  interpreter="$(har_python_resolve_interpreter "$dir" "$project_min" || true)"
+
+  if [ -z "$interpreter" ] || ! command -v "$interpreter" >/dev/null 2>&1; then
+    pt_log "No suitable Python interpreter found — skipping venv provisioning"
     append_env "HARNESS_ECOSYSTEM" "python"
     append_env "PYTHON_BIN" "${PYTHON_BIN:-python3}"
     return
   fi
 
-  if [ ! -d "$venv_dir" ]; then
-    pt_log "Creating Python venv at $venv_rel..."
-    if ! python3 -m venv "$venv_dir"; then
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$interpreter" "$project_min"
+  fi
+
+  if [ -d "$venv_dir" ] && [ -x "$venv_dir/bin/python" ] && [ -n "$project_min" ]; then
+    local venv_ver=""
+    venv_ver="$(har_python_version_from_bin "$venv_dir/bin/python")"
+    if [ -n "$venv_ver" ] && ! har_python_version_ge "$venv_ver" "$project_min"; then
+      pt_log "Existing venv Python ${venv_ver} is older than required ${project_min} — recreating..."
       rm -rf "$venv_dir"
-      pt_log "python3 -m venv failed (on Debian/Ubuntu install python3-venv) — using system python3"
+    fi
+  fi
+
+  if [ ! -d "$venv_dir" ]; then
+    if ! har_python_create_venv "$dir" "$venv_dir" "$interpreter"; then
+      rm -rf "$venv_dir"
+      pt_log "venv creation failed (on Debian/Ubuntu install python3-venv) — using resolved interpreter"
       append_env "HARNESS_ECOSYSTEM" "python"
-      append_env "PYTHON_BIN" "$(command -v python3)"
+      append_env "PYTHON_BIN" "$interpreter"
       return
     fi
   fi
 
   if [ ! -x "$venv_dir/bin/python" ]; then
-    pt_log "Python venv at $venv_rel is missing or broken — using system python3"
+    pt_log "Python venv at $venv_rel is missing or broken — using resolved interpreter"
     append_env "HARNESS_ECOSYSTEM" "python"
-    append_env "PYTHON_BIN" "$(command -v python3)"
+    append_env "PYTHON_BIN" "$interpreter"
     return
   fi
 
   python_bin="$venv_dir/bin/python"
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$python_bin" "$project_min"
+  fi
+
   # shellcheck disable=SC1091
   source "$venv_dir/bin/activate"
 
   if ! run_install_cmd "$dir"; then
-    pt_log "Installing Python dependencies..."
-    if [ -f "$dir/pyproject.toml" ]; then
-      (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/requirements.txt" ]; then
-      (cd "$dir" && pip install -q -r requirements.txt)
-    elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
-      (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
-      (cd "$dir" && pipenv install --dev)
-      python_bin="$(cd "$dir" && pipenv --py)"
+    if ! har_python_install_deps "$dir" "$venv_dir"; then
+      pt_log "Installing Python dependencies..."
+      if [ -f "$dir/pyproject.toml" ]; then
+        (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/requirements.txt" ]; then
+        (cd "$dir" && pip install -q -r requirements.txt)
+      elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+        (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
+        (cd "$dir" && pipenv install --dev)
+        python_bin="$(cd "$dir" && pipenv --py)"
+      fi
     fi
   fi
 

--- a/src/templates/runtime-bundles/shared-kernel/provision-toolchain.sh
+++ b/src/templates/runtime-bundles/shared-kernel/provision-toolchain.sh
@@ -228,52 +228,291 @@ provision_node() {
   append_path_prefix "$dir/node_modules/.bin"
 }
 
+# ── Python interpreter helpers ────────────────────────────────────────────────
+# Resolve the project Python (requires-python, .python-version, uv) instead of
+# blindly using PATH python3.
+
+har_python_version_from_bin() {
+  local bin="$1"
+  "$bin" -c 'import sys; print(".".join(map(str, sys.version_info[:3])))' 2>/dev/null \
+    | tr -d '[:space:]'
+}
+
+har_python_version_to_sortable() {
+  local v="${1#python}"
+  v="${v#v}"
+  local major=0 minor=0 patch=0
+  IFS='.' read -r major minor patch _ <<< "$v"
+  major=${major:-0}
+  minor=${minor:-0}
+  patch=${patch:-0}
+  printf '%03d%03d%03d' "$major" "$minor" "$patch"
+}
+
+har_python_version_ge() {
+  local a b
+  a="$(har_python_version_to_sortable "$1")"
+  b="$(har_python_version_to_sortable "$2")"
+  [ "$a" -ge "$b" ]
+}
+
+har_python_requires_minimum() {
+  local spec="$1"
+  local ver=""
+
+  [ -n "$spec" ] || return 1
+
+  ver="$(printf '%s' "$spec" | sed -n \
+    -e 's/.*>=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*~=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    -e 's/.*==\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
+    | head -1)"
+
+  if [ -z "$ver" ]; then
+    ver="$(printf '%s' "$spec" | sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')"
+  fi
+
+  [ -n "$ver" ] && echo "$ver"
+}
+
+har_python_read_dot_version() {
+  local dir="$1"
+  [ -f "$dir/.python-version" ] || return 1
+  head -1 "$dir/.python-version" | tr -d '[:space:]'
+}
+
+har_python_read_requires_spec() {
+  local dir="$1"
+  local spec=""
+
+  if [ -f "$dir/pyproject.toml" ]; then
+    spec="$(sed -n 's/^[[:space:]]*requires-python[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
+      "$dir/pyproject.toml" | head -1)"
+  fi
+  if [ -z "$spec" ] && [ -f "$dir/setup.cfg" ]; then
+    spec="$(sed -n '/^\[options\]/,/^\[/ s/^python_requires[[:space:]]*=[[:space:]]*\(.*\)/\1/p' \
+      "$dir/setup.cfg" | head -1 | tr -d ' "')"
+  fi
+  [ -n "$spec" ] && echo "$spec"
+}
+
+har_python_project_minimum() {
+  local dir="$1"
+  local req_min="" dot_ver="" higher=""
+
+  req_min="$(har_python_requires_minimum "$(har_python_read_requires_spec "$dir" || true)" || true)"
+  dot_ver="$(har_python_read_dot_version "$dir" || true)"
+  if [ -n "$dot_ver" ]; then
+    dot_ver="$(printf '%s' "$dot_ver" | sed 's/^v//; s/^\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/')"
+  fi
+
+  if [ -n "$req_min" ] && [ -n "$dot_ver" ]; then
+    if har_python_version_ge "$dot_ver" "$req_min"; then
+      higher="$dot_ver"
+    else
+      higher="$req_min"
+    fi
+  elif [ -n "$req_min" ]; then
+    higher="$req_min"
+  elif [ -n "$dot_ver" ]; then
+    higher="$dot_ver"
+  fi
+
+  [ -n "$higher" ] && echo "$higher"
+}
+
+har_python_is_uv_project() {
+  local dir="$1"
+  [ -f "$dir/uv.lock" ] && return 0
+  [ -f "$dir/pyproject.toml" ] && grep -q '^\[tool\.uv\]' "$dir/pyproject.toml" 2>/dev/null
+}
+
+har_python_uv_find() {
+  local dir="$1"
+  local request="${2:-}"
+
+  command -v uv >/dev/null 2>&1 || return 1
+  if [ -n "$request" ]; then
+    (cd "$dir" && uv python find "$request" 2>/dev/null)
+  else
+    (cd "$dir" && uv python find 2>/dev/null)
+  fi
+}
+
+har_python_resolve_interpreter() {
+  local dir="$1"
+  local minimum="${2:-}"
+  local found=""
+
+  if har_python_is_uv_project "$dir"; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if [ -f "$dir/.python-version" ]; then
+    found="$(har_python_uv_find "$dir" "$(har_python_read_dot_version "$dir")" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+    if command -v pyenv >/dev/null 2>&1; then
+      found="$(cd "$dir" && pyenv which python 2>/dev/null || true)"
+      if [ -n "$found" ] && [ -x "$found" ]; then
+        echo "$found"
+        return 0
+      fi
+    fi
+  fi
+
+  if [ -n "$minimum" ]; then
+    found="$(har_python_uv_find "$dir" "$minimum" || true)"
+    if [ -n "$found" ] && [ -x "$found" ]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    local sys_py sys_ver=""
+    sys_py="$(command -v python3)"
+    if [ -z "$minimum" ]; then
+      echo "$sys_py"
+      return 0
+    fi
+    sys_ver="$(har_python_version_from_bin "$sys_py")"
+    if [ -n "$sys_ver" ] && har_python_version_ge "$sys_ver" "$minimum"; then
+      echo "$sys_py"
+      return 0
+    fi
+    echo "$sys_py"
+    return 0
+  fi
+
+  return 1
+}
+
+har_python_warn_if_below_minimum() {
+  local bin="$1"
+  local minimum="$2"
+  local actual=""
+
+  [ -n "$minimum" ] || return 0
+  actual="$(har_python_version_from_bin "$bin")"
+  [ -n "$actual" ] || return 0
+  if ! har_python_version_ge "$actual" "$minimum"; then
+    pt_log "WARNING: resolved Python ${actual} is older than required ${minimum} (requires-python / .python-version)"
+  fi
+}
+
+har_python_create_venv() {
+  local dir="$1"
+  local venv_dir="$2"
+  local interpreter="$3"
+  local venv_rel="${venv_dir#"$dir"/}"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Creating Python venv with uv at ${venv_rel}..."
+    if (cd "$dir" && uv venv --python "$interpreter" "$venv_dir" 2>/dev/null) \
+      || (cd "$dir" && uv venv "$venv_dir" 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv venv failed — falling back to ${interpreter} -m venv"
+  fi
+
+  pt_log "Creating Python venv at ${venv_rel}..."
+  "$interpreter" -m venv "$venv_dir"
+}
+
+har_python_install_deps() {
+  local dir="$1"
+  local venv_dir="$2"
+
+  if har_python_is_uv_project "$dir" && command -v uv >/dev/null 2>&1; then
+    pt_log "Syncing Python dependencies with uv..."
+    if (cd "$dir" && UV_PROJECT_ENVIRONMENT="$venv_dir" uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    if (cd "$dir" && uv sync --quiet 2>/dev/null); then
+      return 0
+    fi
+    pt_log "uv sync failed — falling back to pip"
+    return 1
+  fi
+  return 1
+}
+
 provision_python() {
   local dir="$1"
   local venv_rel="${HARNESS_PYTHON_VENV_DIR:-.har/venv}"
   local venv_dir="$dir/$venv_rel"
-  local python_bin="python3"
+  local python_bin=""
+  local interpreter=""
+  local project_min=""
 
-  if ! command -v python3 >/dev/null 2>&1; then
-    pt_log "python3 not found on PATH — skipping venv provisioning"
+  project_min="$(har_python_project_minimum "$dir" || true)"
+  interpreter="$(har_python_resolve_interpreter "$dir" "$project_min" || true)"
+
+  if [ -z "$interpreter" ] || ! command -v "$interpreter" >/dev/null 2>&1; then
+    pt_log "No suitable Python interpreter found — skipping venv provisioning"
     append_env "HARNESS_ECOSYSTEM" "python"
     append_env "PYTHON_BIN" "${PYTHON_BIN:-python3}"
     return
   fi
 
-  if [ ! -d "$venv_dir" ]; then
-    pt_log "Creating Python venv at $venv_rel..."
-    if ! python3 -m venv "$venv_dir"; then
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$interpreter" "$project_min"
+  fi
+
+  if [ -d "$venv_dir" ] && [ -x "$venv_dir/bin/python" ] && [ -n "$project_min" ]; then
+    local venv_ver=""
+    venv_ver="$(har_python_version_from_bin "$venv_dir/bin/python")"
+    if [ -n "$venv_ver" ] && ! har_python_version_ge "$venv_ver" "$project_min"; then
+      pt_log "Existing venv Python ${venv_ver} is older than required ${project_min} — recreating..."
       rm -rf "$venv_dir"
-      pt_log "python3 -m venv failed (on Debian/Ubuntu install python3-venv) — using system python3"
+    fi
+  fi
+
+  if [ ! -d "$venv_dir" ]; then
+    if ! har_python_create_venv "$dir" "$venv_dir" "$interpreter"; then
+      rm -rf "$venv_dir"
+      pt_log "venv creation failed (on Debian/Ubuntu install python3-venv) — using resolved interpreter"
       append_env "HARNESS_ECOSYSTEM" "python"
-      append_env "PYTHON_BIN" "$(command -v python3)"
+      append_env "PYTHON_BIN" "$interpreter"
       return
     fi
   fi
 
   if [ ! -x "$venv_dir/bin/python" ]; then
-    pt_log "Python venv at $venv_rel is missing or broken — using system python3"
+    pt_log "Python venv at $venv_rel is missing or broken — using resolved interpreter"
     append_env "HARNESS_ECOSYSTEM" "python"
-    append_env "PYTHON_BIN" "$(command -v python3)"
+    append_env "PYTHON_BIN" "$interpreter"
     return
   fi
 
   python_bin="$venv_dir/bin/python"
+  if [ -n "$project_min" ]; then
+    har_python_warn_if_below_minimum "$python_bin" "$project_min"
+  fi
+
   # shellcheck disable=SC1091
   source "$venv_dir/bin/activate"
 
   if ! run_install_cmd "$dir"; then
-    pt_log "Installing Python dependencies..."
-    if [ -f "$dir/pyproject.toml" ]; then
-      (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/requirements.txt" ]; then
-      (cd "$dir" && pip install -q -r requirements.txt)
-    elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
-      (cd "$dir" && pip install -q -e .)
-    elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
-      (cd "$dir" && pipenv install --dev)
-      python_bin="$(cd "$dir" && pipenv --py)"
+    if ! har_python_install_deps "$dir" "$venv_dir"; then
+      pt_log "Installing Python dependencies..."
+      if [ -f "$dir/pyproject.toml" ]; then
+        (cd "$dir" && pip install -q -e ".[dev]" 2>/dev/null) || (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/requirements.txt" ]; then
+        (cd "$dir" && pip install -q -r requirements.txt)
+      elif [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+        (cd "$dir" && pip install -q -e .)
+      elif [ -f "$dir/Pipfile" ] && command -v pipenv >/dev/null 2>&1; then
+        (cd "$dir" && pipenv install --dev)
+        python_bin="$(cd "$dir" && pipenv --py)"
+      fi
     fi
   fi
 

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -343,11 +343,11 @@ describe('provision-toolchain.sh template contract', () => {
       const result = run(
         `set -a && . "${harnessEnv}" && set +a && ` +
           `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
-          `bash "${script}"`,
+          `bash "${script}" 2>&1`,
       );
 
       expect(result.code).toBe(0);
-      expect(result.stderr).toContain('Creating Python venv with uv');
+      expect(result.stdout).toContain('Creating Python venv with uv');
       const envContent = fs.readFileSync(envFile, 'utf8');
       expect(envContent).toContain('PYTHON_BIN=');
     });

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -320,15 +320,73 @@ describe('provision-toolchain.sh template contract', () => {
       expect(check.stdout.trim()).toBe('recreate');
     });
 
-    it('detects uv-managed projects and prefers uv for venv creation when available', () => {
-      const uvCheck = run('command -v uv');
-      if (uvCheck.code !== 0) {
-        return;
-      }
+    it('detects uv-managed projects from uv.lock and [tool.uv]', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-uv-detect-'));
+      const lockOnly = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-uv-lock-'));
+      const toolOnly = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-uv-tool-'));
 
+      fs.writeFileSync(path.join(lockOnly, 'uv.lock'), '# lock\n');
+      fs.writeFileSync(
+        path.join(toolOnly, 'pyproject.toml'),
+        '[project]\nname = "fixture"\nversion = "0.0.0"\n\n[tool.uv]\n',
+      );
+
+      const result = sourcePythonHelpers(
+        `har_python_is_uv_project "${lockOnly}" && echo lock && ` +
+          `har_python_is_uv_project "${toolOnly}" && echo tool && ` +
+          `har_python_is_uv_project "${tmpDir}" || echo plain`,
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.stdout.trim().split('\n')).toEqual(['lock', 'tool', 'plain']);
+    });
+
+    it('routes uv-managed projects through uv venv/sync when uv is on PATH', () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-uv-'));
       const script = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'provision-toolchain.sh');
       const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+      const fakeBin = path.join(tmpDir, 'bin');
+      const fakeUv = path.join(fakeBin, 'uv');
+      const uvLog = path.join(tmpDir, 'uv.log');
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(
+        fakeUv,
+        [
+          '#!/usr/bin/env bash',
+          'set -euo pipefail',
+          `log=${JSON.stringify(uvLog)}`,
+          'printf \'%s\\n\' "$*" >> "$log"',
+          'case "$1" in',
+          '  python)',
+          '    [ "$2" = find ] || exit 1',
+          '    shift 2',
+          '    [ -n "${1:-}" ] && printf \'%s\\n\' "$1" >> "$log"',
+          '    command -v python3',
+          '    ;;',
+          '  venv)',
+          '    venv_dir=""',
+          '    for arg in "$@"; do',
+          '      case "$arg" in',
+          '        /*|./*) venv_dir="$arg" ;;',
+          '      esac',
+          '    done',
+          '    [ -n "$venv_dir" ] || exit 1',
+          '    mkdir -p "$venv_dir/bin"',
+          '    ln -sf "$(command -v python3)" "$venv_dir/bin/python"',
+          '    printf \'%s\\n\' \'# stub activate for harness tests\' > "$venv_dir/bin/activate"',
+          '    ;;',
+          '  sync)',
+          '    exit 0',
+          '    ;;',
+          '  *)',
+          '    exit 1',
+          '    ;;',
+          'esac',
+          '',
+        ].join('\n'),
+        { mode: 0o755 },
+      );
 
       fs.writeFileSync(
         path.join(tmpDir, 'pyproject.toml'),
@@ -342,14 +400,19 @@ describe('provision-toolchain.sh template contract', () => {
 
       const result = run(
         `set -a && . "${harnessEnv}" && set +a && ` +
+          `PATH="${fakeBin}:$PATH" ` +
           `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
           `bash "${script}" 2>&1`,
       );
 
       expect(result.code).toBe(0);
       expect(result.stdout).toContain('Creating Python venv with uv');
+      expect(result.stdout).toContain('Syncing Python dependencies with uv');
       const envContent = fs.readFileSync(envFile, 'utf8');
       expect(envContent).toContain('PYTHON_BIN=');
+      const uvLogContent = fs.readFileSync(uvLog, 'utf8');
+      expect(uvLogContent).toContain('venv');
+      expect(uvLogContent).toContain('sync');
     });
   });
 });

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -279,6 +279,10 @@ describe('provision-toolchain.sh template contract', () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-warn-'));
       const script = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'provision-toolchain.sh');
       const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+      const fakeBin = path.join(tmpDir, 'bin');
+
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(fakeBin, 'uv'), '#!/usr/bin/env bash\nexit 1\n', { mode: 0o755 });
 
       fs.writeFileSync(
         path.join(tmpDir, 'pyproject.toml'),
@@ -291,6 +295,7 @@ describe('provision-toolchain.sh template contract', () => {
 
       const result = run(
         `set -a && . "${harnessEnv}" && set +a && ` +
+          `PATH="${fakeBin}:$PATH" HARNESS_INSTALL_CMD=true ` +
           `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
           `bash "${script}" 2>&1`,
       );

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -233,4 +233,123 @@ describe('provision-toolchain.sh template contract', () => {
       expect(content).not.toMatch(/run_step "[^"]+" "npm /);
     }
   });
+
+  describe('Python interpreter resolution', () => {
+    const scriptPath = path.join(
+      resolveTemplatesDir(),
+      'har-boilerplate-cli',
+      'provision-toolchain.sh',
+    );
+
+    const sourcePythonHelpers = (body: string): ReturnType<typeof run> =>
+      run(
+        `HAR_WORK_DIR="." HAR_ENV_FILE=/dev/null HAR_AGENT_ID= HAR_WORKTREE_DIR= HAR_REL_PREFIX= ` +
+          `bash -c 'source <(sed "/^append_env \\"HARNESS_TOOLCHAIN_PROVISIONED\\"/,\\$d" "${scriptPath}") && ${body}'`,
+      );
+
+    it('compares Python versions and parses requires-python minimums', () => {
+      const ge = sourcePythonHelpers(
+        'har_python_version_ge 3.12.1 3.11 && har_python_version_ge 3.11 3.11 && ! har_python_version_ge 3.10 3.11',
+      );
+      expect(ge.code).toBe(0);
+
+      const specs = sourcePythonHelpers(
+        'echo "$(har_python_requires_minimum ">=3.11, <3.14")" && ' +
+          'echo "$(har_python_requires_minimum "~=3.12.0")" && ' +
+          'echo "$(har_python_requires_minimum "==3.10.*")"',
+      );
+      expect(specs.code).toBe(0);
+      expect(specs.stdout.trim().split('\n')).toEqual(['3.11', '3.12', '3.10']);
+    });
+
+    it('derives the project minimum from requires-python and .python-version', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-min-'));
+      fs.writeFileSync(
+        path.join(tmpDir, 'pyproject.toml'),
+        '[project]\nrequires-python = ">=3.11, <3.14"\n',
+      );
+      fs.writeFileSync(path.join(tmpDir, '.python-version'), '3.13\n');
+
+      const result = sourcePythonHelpers(`echo "$(har_python_project_minimum "${tmpDir}")"`);
+      expect(result.code).toBe(0);
+      expect(result.stdout.trim()).toBe('3.13');
+    });
+
+    it('warns when the resolved interpreter is older than requires-python', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-warn-'));
+      const script = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'provision-toolchain.sh');
+      const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+
+      fs.writeFileSync(
+        path.join(tmpDir, 'pyproject.toml'),
+        '[project]\nname = "fixture"\nversion = "0.0.0"\nrequires-python = ">=99.0"\n',
+      );
+      fs.writeFileSync(path.join(tmpDir, 'requirements.txt'), '# empty fixture\n');
+
+      const envFile = path.join(tmpDir, '.env.agent.1');
+      fs.writeFileSync(envFile, `AGENT_ID=1\nREPO_ROOT=${tmpDir}\n`);
+
+      const result = run(
+        `set -a && . "${harnessEnv}" && set +a && ` +
+          `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
+          `bash "${script}" 2>&1`,
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('WARNING: resolved Python');
+      expect(result.stdout).toContain('older than required 99.0');
+    });
+
+    it('flags an existing venv for recreation when its Python is below requires-python', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-recreate-'));
+      const venvPython = path.join(tmpDir, '.har', 'venv', 'bin', 'python');
+
+      fs.mkdirSync(path.dirname(venvPython), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, 'pyproject.toml'),
+        '[project]\nname = "fixture"\nversion = "0.0.0"\nrequires-python = ">=3.11"\n',
+      );
+
+      const check = sourcePythonHelpers(
+        `project_min="$(har_python_project_minimum "${tmpDir}")" && ` +
+          `venv_ver="3.9.6" && ` +
+          `if ! har_python_version_ge "$venv_ver" "$project_min"; then echo recreate; fi`,
+      );
+
+      expect(check.code).toBe(0);
+      expect(check.stdout.trim()).toBe('recreate');
+    });
+
+    it('detects uv-managed projects and prefers uv for venv creation when available', () => {
+      const uvCheck = run('command -v uv');
+      if (uvCheck.code !== 0) {
+        return;
+      }
+
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-pt-py-uv-'));
+      const script = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'provision-toolchain.sh');
+      const harnessEnv = path.join(resolveTemplatesDir(), 'har-boilerplate-cli', 'harness.env');
+
+      fs.writeFileSync(
+        path.join(tmpDir, 'pyproject.toml'),
+        '[project]\nname = "fixture"\nversion = "0.0.0"\nrequires-python = ">=3.11"\n\n[tool.uv]\n',
+      );
+      fs.writeFileSync(path.join(tmpDir, 'uv.lock'), '# uv lock fixture\n');
+      fs.writeFileSync(path.join(tmpDir, 'requirements.txt'), '# empty fixture\n');
+
+      const envFile = path.join(tmpDir, '.env.agent.1');
+      fs.writeFileSync(envFile, `AGENT_ID=1\nREPO_ROOT=${tmpDir}\n`);
+
+      const result = run(
+        `set -a && . "${harnessEnv}" && set +a && ` +
+          `HAR_WORK_DIR="${tmpDir}" HAR_ENV_FILE="${envFile}" HAR_AGENT_ID=1 ` +
+          `bash "${script}"`,
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toContain('Creating Python venv with uv');
+      const envContent = fs.readFileSync(envFile, 'utf8');
+      expect(envContent).toContain('PYTHON_BIN=');
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #197 — `provision-toolchain.sh` no longer blindly uses system `python3` when provisioning Python projects.

- Resolves the project interpreter from `requires-python`, `.python-version`, and uv (`uv python find`)
- Creates venvs with the resolved interpreter (`uv venv` for uv-managed projects, otherwise `python -m venv`)
- Installs dependencies via `uv sync` when the project is uv-managed
- Warns when the resolved `PYTHON_BIN` is older than the project minimum
- Recreates an existing `.har/venv` when its Python is below the required version

## CI fix (root cause)

The first CI failures were **not** a bad assertion on stderr vs stdout alone. The uv integration test:

1. Only ran when `uv` was on PATH (GitHub runners have it; most dev laptops do not)
2. Invoked **real** `uv venv` / `uv sync` (~5–6s, possible Python downloads)
3. Ran inside Jest's parallel worker pool, starving other suites (notably `verify-validation.test.ts`, 5s default timeout)
4. Failedures were **hidden** because `har env verify` truncates stage output to 50 lines

**Fix:** replace the real-uv integration test with a **fake `uv` shim** on `PATH` that logs invocations and returns instantly (~200ms). Adds helper tests for `har_python_is_uv_project`.

## Production behavior (unchanged intent)

- Non-uv projects: unchanged fallback to resolved `python3 -m venv`, with warnings when too old
- uv projects with `uv` installed: uses `uv python find` / `uv venv` / `uv sync`, pip fallback on sync failure
- uv projects **without** `uv` installed: same as before, but now warns on version mismatch

## Testing

- `tests/provision-toolchain.test.ts` — version parsing, warnings, uv detection, fake-uv routing
- Full HAR verify passed locally (`har env verify 1 --full`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dcd63e0-13ed-4fb4-9454-90eadd485102?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dcd63e0-13ed-4fb4-9454-90eadd485102&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

