### PR TITLE
fix: parse agent env in ecosystem template without dotenv

### DIFF
--- a/control/.har/ecosystem.agent.template.cjs
+++ b/control/.har/ecosystem.agent.template.cjs
@@ -6,11 +6,17 @@
 // launch.sh writes this file (and .env.agent.N) into the work dir — the
 // control/ project dir (repo root checkout or inside the agent's worktree) —
 // so __dirname IS the Next.js app directory.
+const fs = require('fs');
 const path = require('path');
-const dotenv = require('dotenv');
 
 const agentEnvPath = path.resolve(__dirname, '.env.agent.${AGENT_ID}');
-const env = dotenv.config({ path: agentEnvPath }).parsed || {};
+const env = {};
+try {
+  for (const line of fs.readFileSync(agentEnvPath, 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+    if (m && !line.trimStart().startsWith('#')) env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+} catch {}
 const port = env.FE_PORT || env.PORT || '3847';
 
 module.exports = {

--- a/control/.har/manifest.json
+++ b/control/.har/manifest.json
@@ -15,7 +15,7 @@
     "agent-slot.sh": "b61a59f65467f7d1",
     "attach.sh": "4755c9cfaf9abb45",
     "docker-compose.agent.yml": "1e47f6ff3ed219d1",
-    "ecosystem.agent.template.cjs": "ad305dbfcf6724e1",
+    "ecosystem.agent.template.cjs": "2511163f68bcfce0",
     "env.template": "d8c2c518447d6f55",
     "harness.env": "85ba37b2a8f478b1",
     "justfile": "e7c1048680a7a28c",

--- a/src/templates/har-boilerplate/ecosystem.agent.template.cjs
+++ b/src/templates/har-boilerplate/ecosystem.agent.template.cjs
@@ -7,11 +7,17 @@
 
 // launch.sh writes this file (and .env.agent.N) to the work dir root,
 // so __dirname IS the work dir — repo root or the agent's git worktree.
+const fs = require('fs');
 const path = require('path');
-const dotenv = require('dotenv');
 
 const agentEnvPath = path.resolve(__dirname, '.env.agent.${AGENT_ID}');
-const env = dotenv.config({ path: agentEnvPath }).parsed || {};
+const env = {};
+try {
+  for (const line of fs.readFileSync(agentEnvPath, 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+    if (m && !line.trimStart().startsWith('#')) env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+} catch {}
 
 module.exports = {
   apps: [

--- a/src/templates/runtime-bundles/pm2-runtime/ecosystem.agent.template.cjs
+++ b/src/templates/runtime-bundles/pm2-runtime/ecosystem.agent.template.cjs
@@ -7,11 +7,17 @@
 
 // launch.sh writes this file (and .env.agent.N) to the work dir root,
 // so __dirname IS the work dir — repo root or the agent's git worktree.
+const fs = require('fs');
 const path = require('path');
-const dotenv = require('dotenv');
 
 const agentEnvPath = path.resolve(__dirname, '.env.agent.${AGENT_ID}');
-const env = dotenv.config({ path: agentEnvPath }).parsed || {};
+const env = {};
+try {
+  for (const line of fs.readFileSync(agentEnvPath, 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+    if (m && !line.trimStart().startsWith('#')) env[m[1]] = m[2].replace(/^["']|["']$/g, '');
+  }
+} catch {}
 
 module.exports = {
   apps: [

--- a/tests/ecosystem-agent-template.test.ts
+++ b/tests/ecosystem-agent-template.test.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveTemplateFile } from '../src/utils/paths';
+
+const tmpDirs: string[] = [];
+
+function scaffoldEcosystemConfig(agentId = 1): { dir: string; configPath: string } {
+  const templatePath = resolveTemplateFile('har-boilerplate/ecosystem.agent.template.cjs');
+  if (!templatePath) {
+    throw new Error('ecosystem.agent.template.cjs template not found');
+  }
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-ecosystem-'));
+  tmpDirs.push(dir);
+
+  const template = fs
+    .readFileSync(templatePath, 'utf8')
+    .replace(/\$\{AGENT_ID\}/g, String(agentId))
+    .replace(/\$\{HARNESS_PROJECT_NAME\}/g, 'test-project');
+
+  const configPath = path.join(dir, 'ecosystem.agent.' + agentId + '.config.cjs');
+  fs.writeFileSync(configPath, template);
+  fs.writeFileSync(
+    path.join(dir, '.env.agent.' + agentId),
+  'API_PORT=4100\nPORT=4200\n# comment\nQUOTED="hello"\n',
+  );
+
+  return { dir, configPath };
+}
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('ecosystem.agent.template.cjs', () => {
+  it('loads .env.agent.<id> without requiring dotenv from node_modules', () => {
+    const { configPath } = scaffoldEcosystemConfig();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const config = require(configPath);
+
+    expect(config.apps[0].env.API_PORT).toBe('4100');
+    expect(config.apps[0].env.PORT).toBe('4100');
+    expect(config.apps[0].env.QUOTED).toBe('hello');
+  });
+
+  it('tolerates a missing .env.agent.<id> file', () => {
+    const { dir, configPath } = scaffoldEcosystemConfig(2);
+    fs.unlinkSync(path.join(dir, '.env.agent.2'));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const config = require(configPath);
+
+    expect(config.apps[0].env.NODE_ENV).toBe('development');
+    expect(config.apps[0].env.PORT).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #198.

The default-profile `ecosystem.agent.template.cjs` used `require('dotenv')` to load `.env.agent.<id>`. For non-Node primary apps (Python, Rails, Go), there is no `node_modules/dotenv` at the repo root, so PM2 failed to load the ecosystem and slots never started.

This change parses the per-agent env file with Node built-ins (`fs.readFileSync` + simple line parsing) so PM2 can start regardless of the primary app's toolchain.

## Changes

- `src/templates/har-boilerplate/ecosystem.agent.template.cjs` — built-in env parsing
- `src/templates/runtime-bundles/pm2-runtime/ecosystem.agent.template.cjs` — same (bundle copied before har-boilerplate overwrites)
- `control/.har/ecosystem.agent.template.cjs` — same for Mission Control harness consistency
- `tests/ecosystem-agent-template.test.ts` — asserts config loads without `dotenv` in `node_modules`

## Test plan

- [x] `npm test -- tests/ecosystem-agent-template.test.ts`
- [x] `./.har/verify.sh 1 --full` (typecheck, build, unit tests, lint, docs)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3af2d16d-0976-4b1f-8450-414bef375a62?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3af2d16d-0976-4b1f-8450-414bef375a62&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

