### PR TITLE
fix: load persisted infra ports after setup-infra.sh

### DIFF
--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -120,6 +120,24 @@ har_allocate_port() {
   har_pick_free_port "$scan_start" "$scan_end"
 }
 
+# Load persisted infra host ports from .har/state/infra.env (written by setup-infra.sh).
+# Optional repo_root: when launching from a worktree, infra may live in the main checkout.
+har_load_infra_state() {
+  local repo_root="${1:-${REPO_ROOT:-}}"
+  local infra_state="$SCRIPT_DIR/state/infra.env"
+  if [ ! -f "$infra_state" ] && [ -n "$repo_root" ]; then
+    local common_git_dir
+    common_git_dir="$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null || true)"
+    if [ -n "$common_git_dir" ]; then
+      infra_state="$(cd "$(dirname "$common_git_dir")" && pwd)/.har/state/infra.env"
+    fi
+  fi
+  if [ -f "$infra_state" ]; then
+    # shellcheck source=/dev/null
+    source "$infra_state"
+  fi
+}
+
 # Allocate FE/API/DEBUG ports for a slot. Sets FE_PORT, API_PORT, DEBUG_PORT.
 har_allocate_slot_app_ports() {
   local agent_id="$1"
@@ -278,6 +296,7 @@ har_regenerate_agent_env_file() {
   local env_file="$3"
   local worktree_dir="${4:-}"
   local template="${SCRIPT_DIR}/env.template"
+  har_load_infra_state "${work_dir:-${REPO_ROOT:-}}"
   if [ -f "$template" ]; then
     AGENT_ID="$agent_id" \
     API_PORT="${API_PORT:-}" \
@@ -426,6 +445,7 @@ try {
     fi
   fi
   har_allocate_slot_app_ports "$agent_id"
+  har_load_infra_state "$repo_root"
   DB_PORT="${AGENT_DB_PORT:-${HARNESS_DB_PORT_DEFAULT:-15432}}"
   export FE_PORT API_PORT DEBUG_PORT DB_PORT
 }

--- a/src/templates/har-boilerplate-cli/launch.sh
+++ b/src/templates/har-boilerplate-cli/launch.sh
@@ -89,6 +89,7 @@ else
 fi
 
 "$SCRIPT_DIR/setup-infra.sh"
+har_load_infra_state
 
 if [ "$RESUME" != true ]; then
   WORK_DIR="$REPO_ROOT"

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -120,6 +120,24 @@ har_allocate_port() {
   har_pick_free_port "$scan_start" "$scan_end"
 }
 
+# Load persisted infra host ports from .har/state/infra.env (written by setup-infra.sh).
+# Optional repo_root: when launching from a worktree, infra may live in the main checkout.
+har_load_infra_state() {
+  local repo_root="${1:-${REPO_ROOT:-}}"
+  local infra_state="$SCRIPT_DIR/state/infra.env"
+  if [ ! -f "$infra_state" ] && [ -n "$repo_root" ]; then
+    local common_git_dir
+    common_git_dir="$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null || true)"
+    if [ -n "$common_git_dir" ]; then
+      infra_state="$(cd "$(dirname "$common_git_dir")" && pwd)/.har/state/infra.env"
+    fi
+  fi
+  if [ -f "$infra_state" ]; then
+    # shellcheck source=/dev/null
+    source "$infra_state"
+  fi
+}
+
 # Allocate FE/API/DEBUG ports for a slot. Sets FE_PORT, API_PORT, DEBUG_PORT.
 har_allocate_slot_app_ports() {
   local agent_id="$1"
@@ -304,6 +322,7 @@ har_regenerate_agent_env_file() {
   if [ ! -f "$template" ]; then
     return 0
   fi
+  har_load_infra_state "${work_dir:-${REPO_ROOT:-}}"
   AGENT_ID="$agent_id" \
   API_PORT="$API_PORT" \
   FE_PORT="$FE_PORT" \
@@ -444,6 +463,7 @@ try {
     fi
   fi
   har_allocate_slot_app_ports "$agent_id"
+  har_load_infra_state "$repo_root"
   DB_PORT="${AGENT_DB_PORT:-${HARNESS_DB_PORT_DEFAULT:-15432}}"
   export FE_PORT API_PORT DEBUG_PORT DB_PORT
 }

--- a/src/templates/har-boilerplate/launch.sh
+++ b/src/templates/har-boilerplate/launch.sh
@@ -99,6 +99,7 @@ fi
 
 # Ensure shared infra is running (persists host ports in .har/state/infra.env).
 "$SCRIPT_DIR/setup-infra.sh"
+har_load_infra_state
 DB_PORT="${AGENT_DB_PORT:-${HARNESS_DB_PORT_DEFAULT:-15432}}"
 MINIO_PORT="${AGENT_MINIO_PORT:-${HARNESS_MINIO_PORT_DEFAULT:-19000}}"
 BROWSER_PORT="${AGENT_BROWSER_PORT:-${HARNESS_BROWSER_PORT_DEFAULT:-13001}}"

--- a/tests/agent-slots-bash.test.ts
+++ b/tests/agent-slots-bash.test.ts
@@ -85,6 +85,44 @@ describe('bash agent slot limits', () => {
     expect(fs.existsSync(witness)).toBe(false); // still running, deliberately not awaited
   });
 
+  it('har_load_infra_state reads persisted ports from infra.env', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-infra-state-'));
+    const harDir = path.join(dir, '.har');
+    fs.mkdirSync(path.join(harDir, 'state'), { recursive: true });
+    fs.writeFileSync(
+      path.join(harDir, 'state', 'infra.env'),
+      'export AGENT_DB_PORT=15433\nexport AGENT_MINIO_PORT=19001\n',
+    );
+
+    const out = execSync(
+      `bash -c 'SCRIPT_DIR="${harDir}"; source "${AGENT_SLOT}"; har_load_infra_state; echo "db=$AGENT_DB_PORT minio=$AGENT_MINIO_PORT"'`,
+      { encoding: 'utf8' },
+    ).trim();
+    expect(out).toBe('db=15433 minio=19001');
+  });
+
+  it('har_load_infra_state falls back to the main checkout when worktree has no infra.env', () => {
+    const main = fs.mkdtempSync(path.join(os.tmpdir(), 'har-infra-main-'));
+    execSync('git init -q', { cwd: main });
+    execSync('git -c user.email=har@example.com -c user.name=har -c commit.gpgsign=false commit --allow-empty -qm init', {
+      cwd: main,
+    });
+    const mainHar = path.join(main, '.har');
+    fs.mkdirSync(path.join(mainHar, 'state'), { recursive: true });
+    fs.writeFileSync(path.join(mainHar, 'state', 'infra.env'), 'export AGENT_DB_PORT=15444\n');
+
+    const worktree = path.join(main, 'wt');
+    execSync(`git worktree add -q "${worktree}" -b har-agent-1`, { cwd: main });
+    const worktreeHar = path.join(worktree, '.har');
+    fs.mkdirSync(worktreeHar, { recursive: true });
+
+    const out = execSync(
+      `bash -c 'SCRIPT_DIR="${worktreeHar}"; REPO_ROOT="${worktree}"; source "${AGENT_SLOT}"; har_load_infra_state "${worktree}"; echo "db=$AGENT_DB_PORT"'`,
+      { encoding: 'utf8' },
+    ).trim();
+    expect(out).toBe('db=15444');
+  });
+
   it('har_warn_untracked_worktree names untracked paths and stays quiet when ignored', () => {
     const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-untracked-warn-'));
     execSync('git init -q', { cwd: repo });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #196.

When the default Postgres host port (`HARNESS_DB_PORT_DEFAULT`, 15432) is already in use, `setup-infra.sh` scans for a free port and persists it to `.har/state/infra.env`. `launch.sh` and `agent-slot.sh` were not reading that file, so generated `.env.agent.<id>` files pointed `DATABASE_URL` at the default port instead of the shared Docker Postgres instance.

## Changes

- Add `har_load_infra_state()` to `agent-slot.sh` (default and CLI templates) to source `.har/state/infra.env`, with a fallback to the main checkout when running from a worktree.
- Call `har_load_infra_state` in `launch.sh` immediately after `setup-infra.sh`.
- Call `har_load_infra_state` from `har_regenerate_agent_env_file` and `load_agent_ports` so env regeneration and CLI status commands also pick up scanned ports.
- Add unit tests for direct and worktree fallback loading.

## Testing

- `npm test -- tests/agent-slots-bash.test.ts`
- `./.har/verify.sh 1 --full` (all stages pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37e2dfcc-4056-42f6-acbd-59106a4e5944?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37e2dfcc-4056-42f6-acbd-59106a4e5944&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

