### PR TITLE
fix: stop har env verify from dumping duplicate JSON

### DIFF
--- a/.har/agent-slot.sh
+++ b/.har/agent-slot.sh
@@ -738,6 +738,29 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
+# Append one verify.sh step to RESULTS_JSON (caller global).
+# Passing steps omit output — it already appeared as ✓ on stderr.
+record_step_result() {
+  local name="$1"
+  local pass_bool="$2"
+  local elapsed="$3"
+  local output="${4:-}"
+  local step_json
+  if [ "$pass_bool" = "true" ]; then
+    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
+  else
+    local escaped
+    escaped=$(escape_step_output "$output")
+    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
+  fi
+  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
+const fs = require('fs');
+const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+arr.push($step_json);
+process.stdout.write(JSON.stringify(arr));
+" 2>/dev/null || echo "$RESULTS_JSON")
+}
+
 # Emit "<id>\t<command>" for each registered stage listed in stages.json
 # verificationStages (used by verify --full). Ids without a matching registered
 # stage are inline verify.sh steps and skipped here; lifecycle stages

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Verification pipeline for @osfactory/har.
-# Outputs JSON to stdout, human-readable progress to stderr.
+# Outputs JSON to stdout (machine contract), human-readable progress to stderr.
+# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
@@ -68,7 +69,7 @@ run_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -79,14 +80,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1

--- a/control/.har/agent-slot.sh
+++ b/control/.har/agent-slot.sh
@@ -756,6 +756,29 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
+# Append one verify.sh step to RESULTS_JSON (caller global).
+# Passing steps omit output — it already appeared as ✓ on stderr.
+record_step_result() {
+  local name="$1"
+  local pass_bool="$2"
+  local elapsed="$3"
+  local output="${4:-}"
+  local step_json
+  if [ "$pass_bool" = "true" ]; then
+    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
+  else
+    local escaped
+    escaped=$(escape_step_output "$output")
+    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
+  fi
+  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
+const fs = require('fs');
+const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+arr.push($step_json);
+process.stdout.write(JSON.stringify(arr));
+" 2>/dev/null || echo "$RESULTS_JSON")
+}
+
 # Emit "<id>\t<command>" for each registered stage listed in stages.json
 # verificationStages (used by verify --full). Ids without a matching registered
 # stage are inline verify.sh steps and skipped here; lifecycle stages

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Progressive verification pipeline for an agent environment.
-# Outputs JSON to stdout, human-readable progress to stderr.
+# Outputs JSON to stdout (machine contract), human-readable progress to stderr.
+# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 set -euo pipefail
@@ -68,7 +69,7 @@ run_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -79,14 +80,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1
@@ -109,7 +103,7 @@ run_http_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -119,14 +113,7 @@ run_http_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1

--- a/docs/.har/agent-slot.sh
+++ b/docs/.har/agent-slot.sh
@@ -756,6 +756,29 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
+# Append one verify.sh step to RESULTS_JSON (caller global).
+# Passing steps omit output — it already appeared as ✓ on stderr.
+record_step_result() {
+  local name="$1"
+  local pass_bool="$2"
+  local elapsed="$3"
+  local output="${4:-}"
+  local step_json
+  if [ "$pass_bool" = "true" ]; then
+    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
+  else
+    local escaped
+    escaped=$(escape_step_output "$output")
+    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
+  fi
+  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
+const fs = require('fs');
+const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+arr.push($step_json);
+process.stdout.write(JSON.stringify(arr));
+" 2>/dev/null || echo "$RESULTS_JSON")
+}
+
 # Emit "<id>\t<command>" for each registered stage listed in stages.json
 # verificationStages (used by verify --full). Ids without a matching registered
 # stage are inline verify.sh steps and skipped here; lifecycle stages

--- a/docs/.har/verify.sh
+++ b/docs/.har/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Progressive verification for the Astro docs / marketing site.
-# Outputs JSON to stdout, human-readable progress to stderr.
+# Outputs JSON to stdout (machine contract), human-readable progress to stderr.
+# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
@@ -70,7 +71,7 @@ run_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -81,14 +82,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1
@@ -111,7 +105,7 @@ run_http_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -121,14 +115,7 @@ run_http_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1

--- a/docs/src/content/docs/docs/guides/verification.md
+++ b/docs/src/content/docs/docs/guides/verification.md
@@ -8,12 +8,18 @@ description: Bind successful checks to exact code and enforce the result at comm
 ```bash
 har env verify 1
 har env verify 1 --full
+har env verify 1 --full --json   # structured result only
 ```
 
 Quick verification should be fast enough for iteration. Full verification is the
 repository's completion contract. The exact commands are adapted in
 `.har/verify.sh`; typical full checks include unit tests, lint, readiness, browser
 E2E, and project-specific stages.
+
+`har env verify` streams progress to stderr. It does not dump the per-step JSON
+contract afterward — that duplicated CI logs and agent context. Scripts that
+need the object can pass `--json`. Passing steps omit `output`; failed steps
+include a truncated excerpt.
 
 HAR records CLI and MCP verification as run JSON and records the exact Git tree state
 for full verification. A later source edit invalidates that validation.

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -145,10 +145,16 @@ launch. The same warning appears in `har env status --json`, MCP launch
 ### Verify and finish
 
 ```bash
-har env verify 1 [--full]
+har env verify 1 [--full] [--json]
 har env complete 1 [--skip-verify]
 har env teardown 1 [--delete-branch]
 ```
+
+Default verify output is the live progress lines on stderr (and a one-line
+summary). It does **not** reprint the machine JSON contract — that blob
+duplicates step logs already shown. Use `--json` when a script needs the
+structured result. Passing steps omit `output`; failed steps keep a truncated
+excerpt. MCP `har_run_verification` returns the same slim shape.
 
 ### Status and runs
 

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -44,7 +44,7 @@ active session.
 | Tool | Inputs | Result |
 | --- | --- | --- |
 | `har_run_stage` | `stageId` or `kind`, optional `agentId`, `args` | Normalized generic stage result |
-| `har_run_verification` | `agentId`, `full` | Verification steps, output, timing, and status |
+| `har_run_verification` | `agentId`, `full` | Status, timing, and failed-step output (passing steps omit logs) |
 
 Stage kinds are `setup`, `launch`, `verify`, `test`, `inspect`, `reset`,
 `teardown`, and `custom`.

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -46,6 +46,7 @@ import { handleCommitGateOnboarding } from '../../core/commit-gate-onboarding';
 import { readOnboardingPreferences } from '../../core/onboarding-preferences';
 import { EnvironmentStatusSchema, SlotReadinessSchema } from '../../harness/schema';
 import { validateAgentId } from '../../utils/validation';
+import { slimVerificationResult } from '../../core/results';
 import { info, success, error, header, divider, warn } from '../../utils/logging';
 import {
   HAR_ENV_EPILOG,
@@ -336,7 +337,12 @@ export const envCommand = {
           y
             .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
             .option('repo', { type: 'string', default: '.' })
-            .option('full', { type: 'boolean', default: false }),
+            .option('full', { type: 'boolean', default: false })
+            .option('json', {
+              type: 'boolean',
+              default: false,
+              describe: 'Structured JSON (passing steps omit output; default is progress only)',
+            }),
         handleVerify,
       )
       .command(
@@ -1025,16 +1031,42 @@ export async function handleRecover(argv: { id?: number; repo: string }): Promis
   });
 }
 
-export async function handleVerify(argv: { id?: number; repo: string; full: boolean }): Promise<void> {
+export async function handleVerify(argv: {
+  id?: number;
+  repo: string;
+  full: boolean;
+  json?: boolean;
+}): Promise<void> {
   const repo = path.resolve(argv.repo);
   const agentId = validateAgentId(argv.id, repo);
   const result = await runVerification({
     repoPath: repo,
     agentId,
     full: argv.full,
-    capture: false,
+    capture: Boolean(argv.json),
   });
-  if (result.stdout) process.stdout.write(result.stdout);
+
+  if (argv.json) {
+    const payload = slimVerificationResult(result.verification) ?? {
+      status: result.code === 0 ? 'pass' : 'fail',
+      agent_id: agentId,
+      stages: [],
+    };
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    return finishCommand(result.code);
+  }
+
+  if (result.verification) {
+    const failed = result.verification.stages.filter((stage) => !stage.pass).map((stage) => stage.name);
+    const elapsed =
+      result.verification.total_ms != null ? ` (${result.verification.total_ms}ms)` : '';
+    if (failed.length > 0) {
+      error(`Verification failed: ${failed.join(', ')}${elapsed}`);
+    } else {
+      success(`Verification ${result.verification.status}${elapsed}`);
+    }
+  }
+
   return finishCommand(result.code);
 }
 

--- a/src/core/local-executor.ts
+++ b/src/core/local-executor.ts
@@ -11,7 +11,6 @@ import { HarnessStage, StageResult } from '../harness/schema';
 import { validateAgentId } from '../utils/validation';
 import {
   quoteShellArg,
-  runScript,
   runScriptCapture,
   runShellCommand,
   ShellResult,
@@ -178,18 +177,23 @@ function buildExecutionPlan(
   };
 }
 
-async function executePlan(plan: StageExecutionPlan, capture: boolean): Promise<ShellResult> {
-  const spawnOptions = { cwd: plan.cwd, env: plan.env };
+async function executePlan(
+  plan: StageExecutionPlan,
+  options: { capture: boolean; streamStdout?: boolean },
+): Promise<ShellResult> {
+  const spawnOptions = {
+    cwd: plan.cwd,
+    env: plan.env,
+    stream: !options.capture,
+    streamStdout: options.streamStdout,
+  };
 
   if (plan.mode === 'shell' && plan.shellCommand) {
-    return runShellCommand(plan.shellCommand, { ...spawnOptions, stream: !capture });
+    return runShellCommand(plan.shellCommand, spawnOptions);
   }
 
   if (plan.scriptPath) {
-    if (capture) {
-      return runScriptCapture(plan.scriptPath, plan.args, spawnOptions);
-    }
-    return runScript(plan.scriptPath, plan.args, spawnOptions);
+    return runScriptCapture(plan.scriptPath, plan.args, spawnOptions);
   }
 
   throw new Error('Invalid stage execution plan');
@@ -215,7 +219,12 @@ export class LocalScriptExecutor implements StageExecutor {
     const plan = buildExecutionPlan(repoPath, stage, options);
     const capture = options.capture ?? ctx.capture ?? true;
     const started = Date.now();
-    const result = await executePlan(plan, capture);
+    // verify.sh writes a JSON contract to stdout and progress to stderr.
+    // Stream progress only — echoing stdout duplicates the blob in CI/agent logs.
+    const result = await executePlan(plan, {
+      capture,
+      streamStdout: stage.kind !== 'verify',
+    });
     const durationMs = Date.now() - started;
 
     const verification =

--- a/src/core/results.ts
+++ b/src/core/results.ts
@@ -48,6 +48,22 @@ export function parseVerificationResult(stdout: string): VerificationResult | nu
   return parsed.success ? parsed.data : null;
 }
 
+/** Drop passing-step logs — they duplicate stderr progress and bloat CI/MCP context. */
+export function slimVerificationResult(
+  verification: VerificationResult | null | undefined,
+): VerificationResult | null {
+  if (!verification) return null;
+  return {
+    ...verification,
+    stages: verification.stages.map((stage) => {
+      if (!stage.pass || stage.output === undefined) return stage;
+      const rest = { ...stage };
+      delete rest.output;
+      return rest;
+    }),
+  };
+}
+
 export function buildStageResult(input: {
   stageId: string;
   kind?: StageKind;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -30,6 +30,7 @@ import {
   repoJsonProperty,
   stageKindJsonProperty,
 } from './schema-tools';
+import { slimVerificationResult } from '../core/results';
 import { validateAgentId } from '../utils/validation';
 import {
   AddWorkUnitLinkInputSchema,
@@ -180,7 +181,8 @@ export const HAR_MCP_TOOLS: Tool[] = [
   },
   {
     name: 'har_run_verification',
-    description: 'Run the project verification pipeline for an agent slot.',
+    description:
+      'Run the project verification pipeline for an agent slot. Returns status, timing, and failed-step output (passing steps omit logs; stdout is not the raw JSON dump).',
     inputSchema: objectJsonSchema(
       {
         repo: repoJsonProperty,
@@ -423,7 +425,14 @@ export async function handleMcpToolCall(
         capture: true,
         trigger: 'mcp',
       });
-      return jsonContent(RunVerificationOutputSchema.parse(result));
+      return jsonContent(
+        RunVerificationOutputSchema.parse({
+          code: result.code,
+          stdout: '',
+          stderr: result.stderr,
+          verification: slimVerificationResult(result.verification),
+        }),
+      );
     }
 
     case 'har_get_status': {
@@ -473,7 +482,12 @@ export async function handleMcpToolCall(
         capture: true,
         trigger: 'mcp',
       });
-      return jsonContent(CompleteEnvironmentOutputSchema.parse(result));
+      return jsonContent(
+        CompleteEnvironmentOutputSchema.parse({
+          ...result,
+          verification: slimVerificationResult(result.verification),
+        }),
+      );
     }
 
     case 'har_list_artifacts': {

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -738,6 +738,29 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
+# Append one verify.sh step to RESULTS_JSON (caller global).
+# Passing steps omit output — it already appeared as ✓ on stderr.
+record_step_result() {
+  local name="$1"
+  local pass_bool="$2"
+  local elapsed="$3"
+  local output="${4:-}"
+  local step_json
+  if [ "$pass_bool" = "true" ]; then
+    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
+  else
+    local escaped
+    escaped=$(escape_step_output "$output")
+    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
+  fi
+  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
+const fs = require('fs');
+const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+arr.push($step_json);
+process.stdout.write(JSON.stringify(arr));
+" 2>/dev/null || echo "$RESULTS_JSON")
+}
+
 # Emit "<id>\t<command>" for each registered stage listed in stages.json
 # verificationStages (used by verify --full). Ids without a matching registered
 # stage are inline verify.sh steps and skipped here; lifecycle stages

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Verification pipeline for CLI/library repos.
-# Outputs JSON to stdout, human-readable progress to stderr.
+# Outputs JSON to stdout (machine contract), human-readable progress to stderr.
+# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
@@ -70,7 +71,7 @@ run_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -81,14 +82,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -405,6 +405,29 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
+# Append one verify.sh step to RESULTS_JSON (caller global).
+# Passing steps omit output — it already appeared as ✓ on stderr.
+record_step_result() {
+  local name="$1"
+  local pass_bool="$2"
+  local elapsed="$3"
+  local output="${4:-}"
+  local step_json
+  if [ "$pass_bool" = "true" ]; then
+    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
+  else
+    local escaped
+    escaped=$(escape_step_output "$output")
+    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
+  fi
+  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
+const fs = require('fs');
+const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+arr.push($step_json);
+process.stdout.write(JSON.stringify(arr));
+" 2>/dev/null || echo "$RESULTS_JSON")
+}
+
 # Emit "<id>\t<command>" for each registered stage listed in stages.json
 # verificationStages (used by verify --full). Ids without a matching registered
 # stage are inline verify.sh steps and skipped here; lifecycle stages

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Verification pipeline for iOS mobile app repos — build and test with xcodebuild.
-# Outputs JSON to stdout, human-readable progress to stderr.
+# Outputs JSON to stdout (machine contract), human-readable progress to stderr.
+# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
@@ -92,7 +93,7 @@ run_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -103,14 +104,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -756,6 +756,29 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
+# Append one verify.sh step to RESULTS_JSON (caller global).
+# Passing steps omit output — it already appeared as ✓ on stderr.
+record_step_result() {
+  local name="$1"
+  local pass_bool="$2"
+  local elapsed="$3"
+  local output="${4:-}"
+  local step_json
+  if [ "$pass_bool" = "true" ]; then
+    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
+  else
+    local escaped
+    escaped=$(escape_step_output "$output")
+    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
+  fi
+  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
+const fs = require('fs');
+const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
+arr.push($step_json);
+process.stdout.write(JSON.stringify(arr));
+" 2>/dev/null || echo "$RESULTS_JSON")
+}
+
 # Emit "<id>\t<command>" for each registered stage listed in stages.json
 # verificationStages (used by verify --full). Ids without a matching registered
 # stage are inline verify.sh steps and skipped here; lifecycle stages

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Progressive verification pipeline for an agent environment.
-# Outputs JSON to stdout, human-readable progress to stderr.
+# Outputs JSON to stdout (machine contract), human-readable progress to stderr.
+# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
@@ -73,7 +74,7 @@ run_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -84,14 +85,7 @@ run_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1
@@ -114,7 +108,7 @@ run_http_step() {
   end=$(now_ms)
   elapsed=$(( end - start ))
 
-  local pass_bool step_output_escaped
+  local pass_bool
   if [ "$exit_code" = "0" ]; then
     echo "✓ (${elapsed}ms)" >&2
     pass_bool="true"
@@ -124,14 +118,7 @@ run_http_step() {
     OVERALL_PASS=false
   fi
 
-  step_output_escaped=$(escape_step_output "$output")
-
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-let arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push({name:'$name',pass:$pass_bool,ms:$elapsed,output:$step_output_escaped});
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
+  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
 
   if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
     return 1

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -14,6 +14,8 @@ export function quoteShellArg(arg: string): string {
 
 export interface RunScriptOptions extends SpawnOptions {
   stream?: boolean;
+  /** When streaming, also echo child stdout. Default true. Set false for JSON-on-stdout contracts (verify). */
+  streamStdout?: boolean;
 }
 
 export function run(command: string, options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}): ShellResult {
@@ -49,8 +51,10 @@ export function runScriptCapture(
   options: RunScriptOptions = {},
 ): Promise<ShellResult> {
   const stream = options.stream ?? false;
-  const { stream: _stream, ...spawnOptions } = options;
+  const echoStdout = stream && (options.streamStdout ?? true);
+  const { stream: _stream, streamStdout: _streamStdout, ...spawnOptions } = options;
   void _stream;
+  void _streamStdout;
   return new Promise((resolve) => {
     const proc = spawn('bash', [scriptPath, ...args], {
       ...spawnOptions,
@@ -60,7 +64,7 @@ export function runScriptCapture(
     let stderr = '';
     proc.stdout?.on('data', (d: Buffer) => {
       stdout += d;
-      if (stream) process.stdout.write(d);
+      if (echoStdout) process.stdout.write(d);
     });
     proc.stderr?.on('data', (d: Buffer) => {
       stderr += d;
@@ -75,8 +79,10 @@ export function runShellCommand(
   options: RunScriptOptions = {},
 ): Promise<ShellResult> {
   const stream = options.stream ?? false;
-  const { stream: _stream, ...spawnOptions } = options;
+  const echoStdout = stream && (options.streamStdout ?? true);
+  const { stream: _stream, streamStdout: _streamStdout, ...spawnOptions } = options;
   void _stream;
+  void _streamStdout;
   return new Promise((resolve) => {
     const proc = spawn('bash', ['-lc', command], {
       ...spawnOptions,
@@ -86,7 +92,7 @@ export function runShellCommand(
     let stderr = '';
     proc.stdout?.on('data', (d: Buffer) => {
       stdout += d;
-      if (stream) process.stdout.write(d);
+      if (echoStdout) process.stdout.write(d);
     });
     proc.stderr?.on('data', (d: Buffer) => {
       stderr += d;

--- a/tests/core-results.test.ts
+++ b/tests/core-results.test.ts
@@ -1,6 +1,7 @@
 import {
   extractJsonFromOutput,
   parseVerificationResult,
+  slimVerificationResult,
   buildStageResult,
 } from '../src/core/results';
 
@@ -35,6 +36,35 @@ describe('parseVerificationResult', () => {
 
   it('returns null for invalid output', () => {
     expect(parseVerificationResult('not json')).toBeNull();
+  });
+});
+
+describe('slimVerificationResult', () => {
+  it('drops output from passing stages and keeps failed-step output', () => {
+    expect(
+      slimVerificationResult({
+        status: 'fail',
+        agent_id: 1,
+        total_ms: 20,
+        stages: [
+          { name: 'typecheck', pass: true, ms: 5, output: 'ok' },
+          { name: 'unit-tests', pass: false, ms: 15, output: 'FAIL' },
+        ],
+      }),
+    ).toEqual({
+      status: 'fail',
+      agent_id: 1,
+      total_ms: 20,
+      stages: [
+        { name: 'typecheck', pass: true, ms: 5 },
+        { name: 'unit-tests', pass: false, ms: 15, output: 'FAIL' },
+      ],
+    });
+  });
+
+  it('returns null when verification is missing', () => {
+    expect(slimVerificationResult(null)).toBeNull();
+    expect(slimVerificationResult(undefined)).toBeNull();
   });
 });
 

--- a/tests/env-cli.test.ts
+++ b/tests/env-cli.test.ts
@@ -21,6 +21,12 @@ describe('env CLI delegation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (runVerification as jest.Mock).mockResolvedValue({
+      code: 1,
+      stdout: '',
+      stderr: '',
+      verification: null,
+    });
     exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
       throw new Error(`exit:${code}`);
     });
@@ -62,6 +68,74 @@ describe('env CLI delegation', () => {
       full: true,
       capture: false,
     });
+  });
+
+  it('does not reprint the verify JSON contract on stdout', async () => {
+    (runVerification as jest.Mock).mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify({
+        status: 'pass',
+        agent_id: 3,
+        stages: [{ name: 'typecheck', pass: true, ms: 10, output: 'huge log' }],
+      }),
+      stderr: '  → typecheck... ✓',
+      verification: {
+        status: 'pass',
+        agent_id: 3,
+        total_ms: 10,
+        stages: [{ name: 'typecheck', pass: true, ms: 10, output: 'huge log' }],
+      },
+    });
+    const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await expect(handleVerify({ repo: FIXTURE, id: 3, full: true })).rejects.toThrow('exit:0');
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    writeSpy.mockRestore();
+  });
+
+  it('prints slim verification JSON with --json', async () => {
+    (runVerification as jest.Mock).mockResolvedValue({
+      code: 1,
+      stdout: '{"status":"fail","agent_id":3,"stages":[]}',
+      stderr: '',
+      verification: {
+        status: 'fail',
+        agent_id: 3,
+        total_ms: 50,
+        stages: [
+          { name: 'typecheck', pass: true, ms: 10, output: 'ok' },
+          { name: 'unit-tests', pass: false, ms: 40, output: 'FAIL spec.ts' },
+        ],
+      },
+    });
+    const chunks: string[] = [];
+    const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      chunks.push(String(chunk));
+      return true;
+    });
+
+    await expect(handleVerify({ repo: FIXTURE, id: 3, full: true, json: true })).rejects.toThrow(
+      'exit:1',
+    );
+
+    expect(runVerification).toHaveBeenCalledWith({
+      repoPath: path.resolve(FIXTURE),
+      agentId: 3,
+      full: true,
+      capture: true,
+    });
+    const payload = JSON.parse(chunks.join(''));
+    expect(payload).toEqual({
+      status: 'fail',
+      agent_id: 3,
+      total_ms: 50,
+      stages: [
+        { name: 'typecheck', pass: true, ms: 10 },
+        { name: 'unit-tests', pass: false, ms: 40, output: 'FAIL spec.ts' },
+      ],
+    });
+    writeSpy.mockRestore();
   });
 
   it('delegates status to the core status runner without forcing process exit', async () => {

--- a/tests/verify-shell-output.test.ts
+++ b/tests/verify-shell-output.test.ts
@@ -40,14 +40,50 @@ node -e "const r=$RESULTS_JSON;process.stdout.write(String(r.length)+':'+r.every
   const verifyPaths = [
     '.har/verify.sh',
     'control/.har/verify.sh',
+    'docs/.har/verify.sh',
     'src/templates/har-boilerplate/verify.sh',
     'src/templates/har-boilerplate-cli/verify.sh',
     'src/templates/har-boilerplate-ios/verify.sh',
   ];
 
-  it.each(verifyPaths)('%s escapes output without head -50 pipefail trap', (relPath) => {
+  it.each(verifyPaths)('%s records steps without embedding passing-step output', (relPath) => {
     const verifyScript = fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8');
-    expect(verifyScript).toContain('escape_step_output "$output"');
+    expect(verifyScript).toContain('record_step_result "$name" "$pass_bool" "$elapsed" "$output"');
+    expect(verifyScript).not.toMatch(/arr\.push\(\{name:'\$name',pass:\$pass_bool,ms:\$elapsed,output:\$step_output_escaped\}\)/);
     expect(verifyScript).not.toMatch(/step_output_escaped=\$\(echo "\$output" \| head -50/);
+  });
+});
+
+describe('record_step_result', () => {
+  it('omits output on pass and keeps a truncated excerpt on fail', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-record-step-'));
+    const script = path.join(dir, 'repro.sh');
+    fs.writeFileSync(
+      script,
+      `#!/usr/bin/env bash
+set -euo pipefail
+source "${AGENT_SLOT}"
+RESULTS_JSON='[]'
+record_step_result "typecheck" "true" "5" "$(seq 1 80)"
+record_step_result "unit-tests" "false" "9" "$(seq 1 80)"
+node -e "const r=$RESULTS_JSON;process.stdout.write(JSON.stringify(r))"
+`,
+    );
+    fs.chmodSync(script, 0o755);
+    const parsed = JSON.parse(sh(`bash "${script}"`, dir)) as Array<{
+      name: string;
+      pass: boolean;
+      output?: string;
+    }>;
+    expect(parsed).toEqual([
+      { name: 'typecheck', pass: true, ms: 5 },
+      expect.objectContaining({
+        name: 'unit-tests',
+        pass: false,
+        ms: 9,
+      }),
+    ]);
+    expect(parsed[0]).not.toHaveProperty('output');
+    expect(parsed[1]?.output?.split('\n')).toHaveLength(50);
   });
 });


### PR DESCRIPTION
## Summary
- `har env verify` now streams progress only and no longer reprints the machine JSON contract (CI was dumping the same blob twice).
- `--json` and MCP `har_run_verification` keep a slim structured result: passing steps omit `output`; failed steps keep a truncated excerpt.
- Templates and dogfood `verify.sh` write that same slim JSON so `./.har/verify.sh` is smaller too.

## Test plan
- [x] `har env verify 4 --full` passed in the session worktree
- [ ] Confirm CI `node dist/index.js env verify 1 --full` shows progress + a one-line summary, not a duplicated JSON dump
- [ ] Optional: `har env verify 1 --full --json` returns slim JSON (failed steps only include `output`)


Made with [Cursor](https://cursor.com)