### PR TITLE
feat(control): send the CLI version on portal sync

### DIFF
--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -37,6 +37,7 @@ import {
 } from './work-units';
 import { createRemoteExecutor } from './cloud-executor';
 import { isPortalTrajectoryEnabled, isTelemetryEnabled } from './telemetry-config';
+import { getHarPackageVersion } from './package-version';
 import { warn } from '../utils/logging';
 import { harvestEventsForSlot, harvestUsageForSlot, omitHarvestEventsWhenOtelPresent, omitHarvestWhenOtelPresent } from './usage-harvest';
 import { buildSessionKey } from './telemetry-env';
@@ -440,6 +441,7 @@ async function buildPortalPayload(
 
   const syncBody: Record<string, unknown> = {
     path: repoPath,
+    cliVersion: getHarPackageVersion(),
     ...(status.gitRemote ? { gitRemote: status.gitRemote } : {}),
     ...(manifest ? { manifest } : {}),
     ...(stagesRegistry ? { stagesRegistry } : {}),

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -258,6 +258,32 @@ describe('syncRepoWithControl — portal push', () => {
     expect(body.generatedAt).toBe('2026-01-01T00:00:00.000Z');
   });
 
+  it('identifies the sending CLI with cliVersion', async () => {
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_secret';
+    process.env.HAR_PACKAGE_VERSION = '9.9.9';
+    try {
+      const fetchMock = mockFetch({ status: 200 });
+      await syncRepoWithControl({ repoPath: '/repo/x' });
+      const [, init] = portalSyncCall(fetchMock);
+      expect(JSON.parse(init.body as string).cliVersion).toBe('9.9.9');
+    } finally {
+      delete process.env.HAR_PACKAGE_VERSION;
+    }
+  });
+
+  it('resolves cliVersion from the package when no override is set', async () => {
+    delete process.env.HAR_PACKAGE_VERSION;
+    process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+    process.env.HAR_PORTAL_TOKEN = 'har_ingest_secret';
+    const fetchMock = mockFetch({ status: 200 });
+
+    await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    const [, init] = portalSyncCall(fetchMock);
+    expect(JSON.parse(init.body as string).cliVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
   it('syncs to local Mission Control before pushing to the portal', async () => {
     process.env.HAR_PORTAL_URL = 'https://portal.example.com';
     process.env.HAR_PORTAL_TOKEN = 'har_ingest_secret';


### PR DESCRIPTION
## Why

`har control sync` sends nothing that identifies the CLI producing the payload, so version skew is invisible in the data. When a workspace's sync is missing fields — a schema or payload that changed on one side only — there is no way to tell from the ingested record whether the sender was an old CLI or whether the receiver dropped something.

`.har/manifest.json`'s `generatorVersion` is not a substitute: that is the scaffold generator's version, not the CLI that ran the sync, and on a repo scaffolded long ago the two differ by many releases.

## What

- `src/core/control-sync.ts` — add `cliVersion` to the omnibus `syncBody`, resolved via the existing `getHarPackageVersion()` (which already honours the `HAR_PACKAGE_VERSION` override).

That is the whole change; `src/core/package-version.ts` needed no new plumbing.

A `User-Agent: har/<version>` header on `postPortalOnce` would cover every portal endpoint rather than just sync, but it needs a matching read on the receiving side. The body field is preferred because the sync schema already accepts it.

## Compatibility

Backward-compatible in both directions. The receiving schema takes the field as optional and strips unknown keys, so a newer CLI talking to an older receiver is fine, and an older CLI that sends no version stays a normal payload — never a rejection.

## Tests

Two cases in `tests/control-portal-sync.test.ts`: the posted body carries a pinned version under the `HAR_PACKAGE_VERSION` override, and it resolves a real semver from the package when no override is set. Both fail without the source change.

`tsc --noEmit` and `npm run lint` are clean. The full jest run has 13 pre-existing failures across 5 suites (macOS `/private` symlink and nested-worktree assertions) — identical suite-for-suite before and after this change.