### PR TITLE
fix(control): point login at app.harhq.com

### DIFF
--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -221,7 +221,7 @@ har control trajectory [on|off]
 ```
 
 `login` resolves the portal from `--portal`, then `HAR_PORTAL_URL`, then the
-portal of your last login, and finally `https://har.kerno.io`; it prints which
+portal of your last login, and finally `https://app.harhq.com`; it prints which
 one it picked. With `--api-key` it stores that ingest token; without it, HAR
 opens browser SSO and saves the resulting token.
 `sync --select` interactively chooses repositories; `--full` ignores the portal

--- a/src/core/control-config.ts
+++ b/src/core/control-config.ts
@@ -3,7 +3,7 @@ import { readPortalCredentials } from './portal-credentials';
 /** Default Mission Control API base URL (local Docker Compose). */
 export const DEFAULT_CONTROL_API_URL = 'http://localhost:3847';
 
-export const DEFAULT_PORTAL_URL = 'https://har.kerno.io';
+export const DEFAULT_PORTAL_URL = 'https://app.harhq.com';
 
 export function getControlApiUrl(): string {
   return process.env.HAR_CONTROL_API_URL ?? DEFAULT_CONTROL_API_URL;

--- a/tests/portal-credentials.test.ts
+++ b/tests/portal-credentials.test.ts
@@ -120,6 +120,7 @@ describe('resolvePortalUrl', () => {
   }
 
   it('falls back to the default portal when nothing is set', () => {
+    expect(DEFAULT_PORTAL_URL).toBe('https://app.harhq.com');
     expect(resolvePortalUrl()).toEqual({
       url: DEFAULT_PORTAL_URL,
       source: 'default',


### PR DESCRIPTION
## Summary
- make `app.harhq.com` the default destination for `har control login`
- document the new hosted portal URL
- add regression coverage for the concrete default

## Test plan
- [x] `npm test -- --runInBand tests/portal-credentials.test.ts`
- [x] `har env verify 4 --full`

Made with [Cursor](https://cursor.com)