### PR TITLE
fix(ios): generate the Xcode project at launch and detect the real target

### DIFF
--- a/docs/src/content/docs/docs/reference/environment.md
+++ b/docs/src/content/docs/docs/reference/environment.md
@@ -49,6 +49,24 @@ repository: any lockfile it writes is removed after the install.
 verification steps) and `HARNESS_PKG_EXEC` holds the matching package runner
 (`npx --yes`, `bunx`, `pnpm dlx`, or `yarn dlx`).
 
+### iOS generated Xcode projects
+
+Tuist, XcodeGen, and CocoaPods treat the `.xcodeproj` / `.xcworkspace` as a build
+product, so a fresh session worktree has nothing for `xcodebuild` to open. When no
+project file is present, launch runs the generator the repository declares —
+`tuist generate` for `Project.swift`, `xcodegen generate` for `project.yml` — and
+`pod install` whenever a `Podfile` is present and `Pods/` is missing. A generator
+the repository needs but the machine lacks fails the launch by name instead of
+surfacing later as an opaque *scheme not found* from `xcodebuild`.
+
+`HARNESS_INSTALL_CMD` owns provisioning outright when set: the default generators
+do not run behind it, and a failing override fails the launch.
+
+`HARNESS_XCODE_WORKSPACE`, `HARNESS_XCODE_PROJECT`, `HARNESS_XCODE_SCHEME`, and
+`HARNESS_BUNDLE_ID` stay adapt-time values in `.har/harness.env`. With both project
+variables empty, verification auto-detects the project — ignoring the
+`project.xcworkspace` nested inside every `.xcodeproj` and anything under `Pods/`.
+
 ## iOS simulator allocation
 
 Each iOS slot creates `har-<project>-agent-<id>-<model>` at launch and deletes it at

--- a/src/templates/har-boilerplate-cli/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-cli/provision-toolchain.sh
@@ -586,9 +586,129 @@ provision_ruby() {
   append_path_prefix "$dir/vendor/bundle/bin"
 }
 
+# ── iOS Xcode project helpers ─────────────────────────────────────────────────
+# Tuist, XcodeGen and CocoaPods treat the .xcodeproj / .xcworkspace as a build
+# product rather than a tracked file, so a fresh worktree has nothing for
+# xcodebuild to open. Generate it here — and fail naming the missing generator,
+# instead of letting xcodebuild report an opaque "scheme not found" later.
+
+# First project file of a kind in the work dir. Runs from inside the dir so a dot
+# in the worktree path itself cannot trip the dotfile filter, and skips both the
+# project.xcworkspace every .xcodeproj carries inside it and whatever CocoaPods
+# generates under Pods/.
+har_ios_find_project_file() {
+  local dir="$1"
+  local pattern="$2"
+  local match=""
+  match="$(cd "$dir" 2>/dev/null && find . -maxdepth 2 -name "$pattern" \
+    ! -path "./.*" ! -path "*.xcodeproj/*" ! -path "*/Pods/*" 2>/dev/null | head -1)" || true
+  [ -n "$match" ] || return 1
+  echo "${match#./}"
+}
+
+# True when this worktree already has something xcodebuild can open. Adapt-time
+# HARNESS_XCODE_WORKSPACE / HARNESS_XCODE_PROJECT decide it when set: they name
+# the generated file, so a missing one means the generator still has to run.
+har_ios_has_project() {
+  local dir="$1"
+
+  if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] || [ -n "${HARNESS_XCODE_PROJECT:-}" ]; then
+    if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] && [ -e "$dir/$HARNESS_XCODE_WORKSPACE" ]; then
+      return 0
+    fi
+    if [ -n "${HARNESS_XCODE_PROJECT:-}" ] && [ -e "$dir/$HARNESS_XCODE_PROJECT" ]; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if har_ios_find_project_file "$dir" '*.xcworkspace' >/dev/null; then return 0; fi
+  if har_ios_find_project_file "$dir" '*.xcodeproj' >/dev/null; then return 0; fi
+  return 1
+}
+
+# Generator this repo declares, or empty. A Podfile counts: `pod install` is what
+# writes the .xcworkspace for a CocoaPods project.
+har_ios_project_generator() {
+  local dir="$1"
+  if [ -f "$dir/Project.swift" ] || [ -f "$dir/Workspace.swift" ]; then echo tuist; return; fi
+  if [ -f "$dir/project.yml" ] || [ -f "$dir/project.yaml" ]; then echo xcodegen; return; fi
+  if [ -f "$dir/Podfile" ]; then echo pod; return; fi
+  echo ""
+}
+
+har_ios_generate_project() {
+  local dir="$1"
+  local generator=""
+
+  if har_ios_has_project "$dir"; then
+    return 0
+  fi
+
+  generator="$(har_ios_project_generator "$dir")"
+  if [ -z "$generator" ]; then
+    pt_log "No .xcodeproj/.xcworkspace found and no generator manifest (Project.swift, project.yml, Podfile) — set HARNESS_XCODE_PROJECT/HARNESS_XCODE_WORKSPACE or HARNESS_INSTALL_CMD in harness.env"
+    return 0
+  fi
+
+  if ! command -v "$generator" >/dev/null 2>&1; then
+    local label="$generator"
+    [ "$generator" = "pod" ] && label="CocoaPods (pod)"
+    pt_log "ERROR: this repo generates its Xcode project with ${label}, which is not on PATH."
+    pt_log "       Install ${label}, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  case "$generator" in
+    tuist)
+      pt_log "Generating the Xcode project with tuist..."
+      if ! (cd "$dir" && tuist generate --no-open); then
+        pt_log "tuist generate --no-open failed — retrying without the flag"
+        (cd "$dir" && tuist generate)
+      fi
+      ;;
+    xcodegen)
+      pt_log "Generating the Xcode project with xcodegen..."
+      (cd "$dir" && xcodegen generate)
+      ;;
+    pod)
+      # har_ios_pod_install writes the workspace right after this.
+      :
+      ;;
+  esac
+}
+
+# CocoaPods dependencies. Independent of project generation: a tracked
+# .xcworkspace still cannot build when Pods/ is missing in a fresh worktree.
+har_ios_pod_install() {
+  local dir="$1"
+
+  [ -f "$dir/Podfile" ] || return 0
+  [ -d "$dir/Pods" ] && return 0
+
+  if ! command -v pod >/dev/null 2>&1; then
+    pt_log "ERROR: this repo uses CocoaPods (Podfile, no Pods/) and pod is not on PATH."
+    pt_log "       Install CocoaPods, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  pt_log "Installing CocoaPods dependencies..."
+  (cd "$dir" && pod install)
+}
+
 provision_ios() {
   local dir="$1"
-  run_install_cmd "$dir" || true
+
+  # An explicit HARNESS_INSTALL_CMD owns provisioning outright: the default
+  # generators stay out of the way, and a failing override fails the launch
+  # rather than being papered over.
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    run_install_cmd "$dir"
+  else
+    har_ios_generate_project "$dir"
+    har_ios_pod_install "$dir"
+  fi
+
   append_env "HARNESS_ECOSYSTEM" "ios"
   append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
   if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then

--- a/src/templates/har-boilerplate-ios/ADAPT-PROMPT.md
+++ b/src/templates/har-boilerplate-ios/ADAPT-PROMPT.md
@@ -21,6 +21,12 @@ structure, then make the changes listed below. Commit when done.
 | `HARNESS_SIMULATOR_NAME` | Display name exactly as shown in `xcrun simctl list devices` (e.g. `iPhone 16`). |
 | `HARNESS_BUNDLE_ID` | App bundle identifier from the Xcode target (e.g. `com.example.myapp`). |
 
+If the project is generated (`Project.swift`, `project.yml`, or a `Podfile` with no
+tracked `.xcworkspace`), still set the path the generator produces — launch runs
+`tuist generate` / `xcodegen generate` / `pod install` when the file is absent from
+a fresh worktree. Use `HARNESS_INSTALL_CMD` only when that default is wrong; it then
+owns provisioning outright.
+
 Run `./.har/setup-infra.sh` after editing to confirm the simulator boots.
 
 ## 3 — Verify `.har/verify.sh` builds and tests correctly

--- a/src/templates/har-boilerplate-ios/README.md
+++ b/src/templates/har-boilerplate-ios/README.md
@@ -21,7 +21,7 @@ Generated and maintained by [`har`](https://github.com/os-factory/har). Run `har
 | `setup-infra.sh` | Check the toolchain; start optional Docker services |
 | `simulator.sh` | Create, boot and delete one iOS Simulator per agent slot |
 | `launch.sh` | Launch one agent slot (git worktree, toolchain provisioning, simulator, env file) |
-| `provision-toolchain.sh` | Write Xcode/simulator paths (`XCODEBUILD_BIN`, …) to `.env.agent.<id>` |
+| `provision-toolchain.sh` | Generate the Xcode project when it is a build product (Tuist / XcodeGen / CocoaPods) and write Xcode paths (`XCODEBUILD_BIN`, …) to `.env.agent.<id>` |
 | `verify.sh` | Verification pipeline (build smoke by default; --full adds tests, lint, flows) |
 | `teardown.sh` | Tear down one agent slot (worktree + env file) |
 | `agent-cli.sh` | Inspect slot status, run xcodebuild commands, install/launch app |

--- a/src/templates/har-boilerplate-ios/harness.env
+++ b/src/templates/har-boilerplate-ios/harness.env
@@ -9,6 +9,12 @@ export HARNESS_AGENT_SLOT_MAX=3
 
 # Toolchain provisioning — launch writes Xcode/simulator paths into .env.agent.<id>
 export HARNESS_ECOSYSTEM="ios"
+# Generated projects: when the worktree has no .xcodeproj/.xcworkspace, launch runs
+# the generator this repo declares — tuist generate (Project.swift), xcodegen
+# generate (project.yml) — plus pod install when a Podfile is present and Pods/ is
+# missing. A missing generator fails the launch by name.
+# HARNESS_INSTALL_CMD owns provisioning outright: set it and no default generator
+# runs, and its failure fails the launch.
 # export HARNESS_INSTALL_CMD="xcodebuild -resolvePackageDependencies ..."
 # Node package manager: auto-detected from package.json "packageManager" and the
 # lockfile (bun.lock → bun, pnpm-lock.yaml → pnpm, yarn.lock → yarn, else npm),

--- a/src/templates/har-boilerplate-ios/provision-toolchain.sh
+++ b/src/templates/har-boilerplate-ios/provision-toolchain.sh
@@ -586,9 +586,129 @@ provision_ruby() {
   append_path_prefix "$dir/vendor/bundle/bin"
 }
 
+# ── iOS Xcode project helpers ─────────────────────────────────────────────────
+# Tuist, XcodeGen and CocoaPods treat the .xcodeproj / .xcworkspace as a build
+# product rather than a tracked file, so a fresh worktree has nothing for
+# xcodebuild to open. Generate it here — and fail naming the missing generator,
+# instead of letting xcodebuild report an opaque "scheme not found" later.
+
+# First project file of a kind in the work dir. Runs from inside the dir so a dot
+# in the worktree path itself cannot trip the dotfile filter, and skips both the
+# project.xcworkspace every .xcodeproj carries inside it and whatever CocoaPods
+# generates under Pods/.
+har_ios_find_project_file() {
+  local dir="$1"
+  local pattern="$2"
+  local match=""
+  match="$(cd "$dir" 2>/dev/null && find . -maxdepth 2 -name "$pattern" \
+    ! -path "./.*" ! -path "*.xcodeproj/*" ! -path "*/Pods/*" 2>/dev/null | head -1)" || true
+  [ -n "$match" ] || return 1
+  echo "${match#./}"
+}
+
+# True when this worktree already has something xcodebuild can open. Adapt-time
+# HARNESS_XCODE_WORKSPACE / HARNESS_XCODE_PROJECT decide it when set: they name
+# the generated file, so a missing one means the generator still has to run.
+har_ios_has_project() {
+  local dir="$1"
+
+  if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] || [ -n "${HARNESS_XCODE_PROJECT:-}" ]; then
+    if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] && [ -e "$dir/$HARNESS_XCODE_WORKSPACE" ]; then
+      return 0
+    fi
+    if [ -n "${HARNESS_XCODE_PROJECT:-}" ] && [ -e "$dir/$HARNESS_XCODE_PROJECT" ]; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if har_ios_find_project_file "$dir" '*.xcworkspace' >/dev/null; then return 0; fi
+  if har_ios_find_project_file "$dir" '*.xcodeproj' >/dev/null; then return 0; fi
+  return 1
+}
+
+# Generator this repo declares, or empty. A Podfile counts: `pod install` is what
+# writes the .xcworkspace for a CocoaPods project.
+har_ios_project_generator() {
+  local dir="$1"
+  if [ -f "$dir/Project.swift" ] || [ -f "$dir/Workspace.swift" ]; then echo tuist; return; fi
+  if [ -f "$dir/project.yml" ] || [ -f "$dir/project.yaml" ]; then echo xcodegen; return; fi
+  if [ -f "$dir/Podfile" ]; then echo pod; return; fi
+  echo ""
+}
+
+har_ios_generate_project() {
+  local dir="$1"
+  local generator=""
+
+  if har_ios_has_project "$dir"; then
+    return 0
+  fi
+
+  generator="$(har_ios_project_generator "$dir")"
+  if [ -z "$generator" ]; then
+    pt_log "No .xcodeproj/.xcworkspace found and no generator manifest (Project.swift, project.yml, Podfile) — set HARNESS_XCODE_PROJECT/HARNESS_XCODE_WORKSPACE or HARNESS_INSTALL_CMD in harness.env"
+    return 0
+  fi
+
+  if ! command -v "$generator" >/dev/null 2>&1; then
+    local label="$generator"
+    [ "$generator" = "pod" ] && label="CocoaPods (pod)"
+    pt_log "ERROR: this repo generates its Xcode project with ${label}, which is not on PATH."
+    pt_log "       Install ${label}, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  case "$generator" in
+    tuist)
+      pt_log "Generating the Xcode project with tuist..."
+      if ! (cd "$dir" && tuist generate --no-open); then
+        pt_log "tuist generate --no-open failed — retrying without the flag"
+        (cd "$dir" && tuist generate)
+      fi
+      ;;
+    xcodegen)
+      pt_log "Generating the Xcode project with xcodegen..."
+      (cd "$dir" && xcodegen generate)
+      ;;
+    pod)
+      # har_ios_pod_install writes the workspace right after this.
+      :
+      ;;
+  esac
+}
+
+# CocoaPods dependencies. Independent of project generation: a tracked
+# .xcworkspace still cannot build when Pods/ is missing in a fresh worktree.
+har_ios_pod_install() {
+  local dir="$1"
+
+  [ -f "$dir/Podfile" ] || return 0
+  [ -d "$dir/Pods" ] && return 0
+
+  if ! command -v pod >/dev/null 2>&1; then
+    pt_log "ERROR: this repo uses CocoaPods (Podfile, no Pods/) and pod is not on PATH."
+    pt_log "       Install CocoaPods, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  pt_log "Installing CocoaPods dependencies..."
+  (cd "$dir" && pod install)
+}
+
 provision_ios() {
   local dir="$1"
-  run_install_cmd "$dir" || true
+
+  # An explicit HARNESS_INSTALL_CMD owns provisioning outright: the default
+  # generators stay out of the way, and a failing override fails the launch
+  # rather than being papered over.
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    run_install_cmd "$dir"
+  else
+    har_ios_generate_project "$dir"
+    har_ios_pod_install "$dir"
+  fi
+
   append_env "HARNESS_ECOSYSTEM" "ios"
   append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
   if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -58,12 +58,18 @@ xc_target_flags() {
   elif [ -n "${HARNESS_XCODE_PROJECT:-}" ] && [ -e "$WORK_DIR/${HARNESS_XCODE_PROJECT}" ]; then
     echo "-project $WORK_DIR/${HARNESS_XCODE_PROJECT}"
   else
-    # Auto-detect: prefer workspace (CocoaPods), then project
+    # Auto-detect: prefer workspace (CocoaPods), then project. Runs from inside
+    # WORK_DIR so a dot in the worktree path itself cannot trip the dotfile
+    # filter, and skips both the project.xcworkspace every .xcodeproj carries
+    # inside it and the CocoaPods project under Pods/ — either would point
+    # xcodebuild at the wrong target.
     local ws prj
-    ws="$(find "$WORK_DIR" -maxdepth 2 -name "*.xcworkspace" ! -path "*/\.*" 2>/dev/null | head -1 || true)"
-    prj="$(find "$WORK_DIR" -maxdepth 2 -name "*.xcodeproj" ! -path "*/\.*" 2>/dev/null | head -1 || true)"
-    if [ -n "$ws" ]; then echo "-workspace $ws"
-    elif [ -n "$prj" ]; then echo "-project $prj"
+    ws="$(cd "$WORK_DIR" && find . -maxdepth 2 -name "*.xcworkspace" \
+      ! -path "./.*" ! -path "*.xcodeproj/*" ! -path "*/Pods/*" 2>/dev/null | head -1 || true)"
+    prj="$(cd "$WORK_DIR" && find . -maxdepth 2 -name "*.xcodeproj" \
+      ! -path "./.*" ! -path "*/Pods/*" 2>/dev/null | head -1 || true)"
+    if [ -n "$ws" ]; then echo "-workspace $WORK_DIR/${ws#./}"
+    elif [ -n "$prj" ]; then echo "-project $WORK_DIR/${prj#./}"
     fi
   fi
 }

--- a/src/templates/har-boilerplate/provision-toolchain.sh
+++ b/src/templates/har-boilerplate/provision-toolchain.sh
@@ -586,9 +586,129 @@ provision_ruby() {
   append_path_prefix "$dir/vendor/bundle/bin"
 }
 
+# ── iOS Xcode project helpers ─────────────────────────────────────────────────
+# Tuist, XcodeGen and CocoaPods treat the .xcodeproj / .xcworkspace as a build
+# product rather than a tracked file, so a fresh worktree has nothing for
+# xcodebuild to open. Generate it here — and fail naming the missing generator,
+# instead of letting xcodebuild report an opaque "scheme not found" later.
+
+# First project file of a kind in the work dir. Runs from inside the dir so a dot
+# in the worktree path itself cannot trip the dotfile filter, and skips both the
+# project.xcworkspace every .xcodeproj carries inside it and whatever CocoaPods
+# generates under Pods/.
+har_ios_find_project_file() {
+  local dir="$1"
+  local pattern="$2"
+  local match=""
+  match="$(cd "$dir" 2>/dev/null && find . -maxdepth 2 -name "$pattern" \
+    ! -path "./.*" ! -path "*.xcodeproj/*" ! -path "*/Pods/*" 2>/dev/null | head -1)" || true
+  [ -n "$match" ] || return 1
+  echo "${match#./}"
+}
+
+# True when this worktree already has something xcodebuild can open. Adapt-time
+# HARNESS_XCODE_WORKSPACE / HARNESS_XCODE_PROJECT decide it when set: they name
+# the generated file, so a missing one means the generator still has to run.
+har_ios_has_project() {
+  local dir="$1"
+
+  if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] || [ -n "${HARNESS_XCODE_PROJECT:-}" ]; then
+    if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] && [ -e "$dir/$HARNESS_XCODE_WORKSPACE" ]; then
+      return 0
+    fi
+    if [ -n "${HARNESS_XCODE_PROJECT:-}" ] && [ -e "$dir/$HARNESS_XCODE_PROJECT" ]; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if har_ios_find_project_file "$dir" '*.xcworkspace' >/dev/null; then return 0; fi
+  if har_ios_find_project_file "$dir" '*.xcodeproj' >/dev/null; then return 0; fi
+  return 1
+}
+
+# Generator this repo declares, or empty. A Podfile counts: `pod install` is what
+# writes the .xcworkspace for a CocoaPods project.
+har_ios_project_generator() {
+  local dir="$1"
+  if [ -f "$dir/Project.swift" ] || [ -f "$dir/Workspace.swift" ]; then echo tuist; return; fi
+  if [ -f "$dir/project.yml" ] || [ -f "$dir/project.yaml" ]; then echo xcodegen; return; fi
+  if [ -f "$dir/Podfile" ]; then echo pod; return; fi
+  echo ""
+}
+
+har_ios_generate_project() {
+  local dir="$1"
+  local generator=""
+
+  if har_ios_has_project "$dir"; then
+    return 0
+  fi
+
+  generator="$(har_ios_project_generator "$dir")"
+  if [ -z "$generator" ]; then
+    pt_log "No .xcodeproj/.xcworkspace found and no generator manifest (Project.swift, project.yml, Podfile) — set HARNESS_XCODE_PROJECT/HARNESS_XCODE_WORKSPACE or HARNESS_INSTALL_CMD in harness.env"
+    return 0
+  fi
+
+  if ! command -v "$generator" >/dev/null 2>&1; then
+    local label="$generator"
+    [ "$generator" = "pod" ] && label="CocoaPods (pod)"
+    pt_log "ERROR: this repo generates its Xcode project with ${label}, which is not on PATH."
+    pt_log "       Install ${label}, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  case "$generator" in
+    tuist)
+      pt_log "Generating the Xcode project with tuist..."
+      if ! (cd "$dir" && tuist generate --no-open); then
+        pt_log "tuist generate --no-open failed — retrying without the flag"
+        (cd "$dir" && tuist generate)
+      fi
+      ;;
+    xcodegen)
+      pt_log "Generating the Xcode project with xcodegen..."
+      (cd "$dir" && xcodegen generate)
+      ;;
+    pod)
+      # har_ios_pod_install writes the workspace right after this.
+      :
+      ;;
+  esac
+}
+
+# CocoaPods dependencies. Independent of project generation: a tracked
+# .xcworkspace still cannot build when Pods/ is missing in a fresh worktree.
+har_ios_pod_install() {
+  local dir="$1"
+
+  [ -f "$dir/Podfile" ] || return 0
+  [ -d "$dir/Pods" ] && return 0
+
+  if ! command -v pod >/dev/null 2>&1; then
+    pt_log "ERROR: this repo uses CocoaPods (Podfile, no Pods/) and pod is not on PATH."
+    pt_log "       Install CocoaPods, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  pt_log "Installing CocoaPods dependencies..."
+  (cd "$dir" && pod install)
+}
+
 provision_ios() {
   local dir="$1"
-  run_install_cmd "$dir" || true
+
+  # An explicit HARNESS_INSTALL_CMD owns provisioning outright: the default
+  # generators stay out of the way, and a failing override fails the launch
+  # rather than being papered over.
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    run_install_cmd "$dir"
+  else
+    har_ios_generate_project "$dir"
+    har_ios_pod_install "$dir"
+  fi
+
   append_env "HARNESS_ECOSYSTEM" "ios"
   append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
   if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then

--- a/src/templates/runtime-bundles/shared-kernel/provision-toolchain.sh
+++ b/src/templates/runtime-bundles/shared-kernel/provision-toolchain.sh
@@ -586,9 +586,129 @@ provision_ruby() {
   append_path_prefix "$dir/vendor/bundle/bin"
 }
 
+# ── iOS Xcode project helpers ─────────────────────────────────────────────────
+# Tuist, XcodeGen and CocoaPods treat the .xcodeproj / .xcworkspace as a build
+# product rather than a tracked file, so a fresh worktree has nothing for
+# xcodebuild to open. Generate it here — and fail naming the missing generator,
+# instead of letting xcodebuild report an opaque "scheme not found" later.
+
+# First project file of a kind in the work dir. Runs from inside the dir so a dot
+# in the worktree path itself cannot trip the dotfile filter, and skips both the
+# project.xcworkspace every .xcodeproj carries inside it and whatever CocoaPods
+# generates under Pods/.
+har_ios_find_project_file() {
+  local dir="$1"
+  local pattern="$2"
+  local match=""
+  match="$(cd "$dir" 2>/dev/null && find . -maxdepth 2 -name "$pattern" \
+    ! -path "./.*" ! -path "*.xcodeproj/*" ! -path "*/Pods/*" 2>/dev/null | head -1)" || true
+  [ -n "$match" ] || return 1
+  echo "${match#./}"
+}
+
+# True when this worktree already has something xcodebuild can open. Adapt-time
+# HARNESS_XCODE_WORKSPACE / HARNESS_XCODE_PROJECT decide it when set: they name
+# the generated file, so a missing one means the generator still has to run.
+har_ios_has_project() {
+  local dir="$1"
+
+  if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] || [ -n "${HARNESS_XCODE_PROJECT:-}" ]; then
+    if [ -n "${HARNESS_XCODE_WORKSPACE:-}" ] && [ -e "$dir/$HARNESS_XCODE_WORKSPACE" ]; then
+      return 0
+    fi
+    if [ -n "${HARNESS_XCODE_PROJECT:-}" ] && [ -e "$dir/$HARNESS_XCODE_PROJECT" ]; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if har_ios_find_project_file "$dir" '*.xcworkspace' >/dev/null; then return 0; fi
+  if har_ios_find_project_file "$dir" '*.xcodeproj' >/dev/null; then return 0; fi
+  return 1
+}
+
+# Generator this repo declares, or empty. A Podfile counts: `pod install` is what
+# writes the .xcworkspace for a CocoaPods project.
+har_ios_project_generator() {
+  local dir="$1"
+  if [ -f "$dir/Project.swift" ] || [ -f "$dir/Workspace.swift" ]; then echo tuist; return; fi
+  if [ -f "$dir/project.yml" ] || [ -f "$dir/project.yaml" ]; then echo xcodegen; return; fi
+  if [ -f "$dir/Podfile" ]; then echo pod; return; fi
+  echo ""
+}
+
+har_ios_generate_project() {
+  local dir="$1"
+  local generator=""
+
+  if har_ios_has_project "$dir"; then
+    return 0
+  fi
+
+  generator="$(har_ios_project_generator "$dir")"
+  if [ -z "$generator" ]; then
+    pt_log "No .xcodeproj/.xcworkspace found and no generator manifest (Project.swift, project.yml, Podfile) — set HARNESS_XCODE_PROJECT/HARNESS_XCODE_WORKSPACE or HARNESS_INSTALL_CMD in harness.env"
+    return 0
+  fi
+
+  if ! command -v "$generator" >/dev/null 2>&1; then
+    local label="$generator"
+    [ "$generator" = "pod" ] && label="CocoaPods (pod)"
+    pt_log "ERROR: this repo generates its Xcode project with ${label}, which is not on PATH."
+    pt_log "       Install ${label}, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  case "$generator" in
+    tuist)
+      pt_log "Generating the Xcode project with tuist..."
+      if ! (cd "$dir" && tuist generate --no-open); then
+        pt_log "tuist generate --no-open failed — retrying without the flag"
+        (cd "$dir" && tuist generate)
+      fi
+      ;;
+    xcodegen)
+      pt_log "Generating the Xcode project with xcodegen..."
+      (cd "$dir" && xcodegen generate)
+      ;;
+    pod)
+      # har_ios_pod_install writes the workspace right after this.
+      :
+      ;;
+  esac
+}
+
+# CocoaPods dependencies. Independent of project generation: a tracked
+# .xcworkspace still cannot build when Pods/ is missing in a fresh worktree.
+har_ios_pod_install() {
+  local dir="$1"
+
+  [ -f "$dir/Podfile" ] || return 0
+  [ -d "$dir/Pods" ] && return 0
+
+  if ! command -v pod >/dev/null 2>&1; then
+    pt_log "ERROR: this repo uses CocoaPods (Podfile, no Pods/) and pod is not on PATH."
+    pt_log "       Install CocoaPods, or set HARNESS_INSTALL_CMD in harness.env to provision the project another way."
+    return 1
+  fi
+
+  pt_log "Installing CocoaPods dependencies..."
+  (cd "$dir" && pod install)
+}
+
 provision_ios() {
   local dir="$1"
-  run_install_cmd "$dir" || true
+
+  # An explicit HARNESS_INSTALL_CMD owns provisioning outright: the default
+  # generators stay out of the way, and a failing override fails the launch
+  # rather than being papered over.
+  if [ -n "${HARNESS_INSTALL_CMD:-}" ]; then
+    run_install_cmd "$dir"
+  else
+    har_ios_generate_project "$dir"
+    har_ios_pod_install "$dir"
+  fi
+
   append_env "HARNESS_ECOSYSTEM" "ios"
   append_env "XCODEBUILD_BIN" "$(command -v xcodebuild 2>/dev/null || echo xcodebuild)"
   if [ -n "${HARNESS_XCODE_SCHEME:-}" ]; then

--- a/tests/ios-verify-target-flags.test.ts
+++ b/tests/ios-verify-target-flags.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { run } from '../src/utils/shell';
+import { resolveTemplatesDir } from '../src/utils/paths';
+
+const VERIFY = path.join(resolveTemplatesDir(), 'har-boilerplate-ios', 'verify.sh');
+
+/**
+ * Run verify.sh's xc_target_flags against a fixture work dir. The function is
+ * lifted out of the script so the test exercises the real detection logic
+ * without booting a simulator.
+ */
+function xcTargetFlags(workDir: string, env: Record<string, string> = {}): string {
+  const script = fs.readFileSync(VERIFY, 'utf8');
+  const start = script.indexOf('xc_target_flags() {');
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = script.indexOf('\n}\n', start);
+  expect(end).toBeGreaterThan(start);
+  const fn = script.slice(start, end + 3);
+
+  const runner = path.join(workDir, 'run-xc-target-flags.sh');
+  fs.writeFileSync(
+    runner,
+    ['set -euo pipefail', `WORK_DIR="${workDir}"`, fn, 'xc_target_flags', ''].join('\n'),
+  );
+
+  const assignments = Object.entries(env)
+    .map(([key, value]) => `${key}="${value}" `)
+    .join('');
+  const result = run(`${assignments}bash "${runner}"`);
+  expect(result.code).toBe(0);
+  return result.stdout.trim();
+}
+
+/** Work dir whose path contains a dot component, like a real session worktree. */
+function fixture(name: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `har-xc-${name}-`));
+  const dir = path.join(root, '.har', 'work');
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('iOS verify.sh xc_target_flags auto-detection', () => {
+  it('picks the real project, not the .xcworkspace nested inside it', () => {
+    const dir = fixture('nested');
+    fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj', 'project.xcworkspace'), { recursive: true });
+
+    expect(xcTargetFlags(dir)).toBe(`-project ${dir}/MyApp.xcodeproj`);
+  });
+
+  it('prefers a real workspace over the project', () => {
+    const dir = fixture('workspace');
+    fs.mkdirSync(path.join(dir, 'MyApp.xcworkspace'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj', 'project.xcworkspace'), { recursive: true });
+
+    expect(xcTargetFlags(dir)).toBe(`-workspace ${dir}/MyApp.xcworkspace`);
+  });
+
+  it('never selects the CocoaPods project under Pods/', () => {
+    const dir = fixture('pods');
+    fs.mkdirSync(path.join(dir, 'Pods', 'Pods.xcodeproj'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'MyApp.xcodeproj'), { recursive: true });
+
+    expect(xcTargetFlags(dir)).toBe(`-project ${dir}/MyApp.xcodeproj`);
+  });
+
+  it('honors the adapt-time workspace and project values', () => {
+    const dir = fixture('explicit');
+    fs.mkdirSync(path.join(dir, 'App', 'Other.xcodeproj'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'App', 'Real.xcworkspace'), { recursive: true });
+
+    expect(xcTargetFlags(dir, { HARNESS_XCODE_WORKSPACE: 'App/Real.xcworkspace' })).toBe(
+      `-workspace ${dir}/App/Real.xcworkspace`,
+    );
+    expect(xcTargetFlags(dir, { HARNESS_XCODE_PROJECT: 'App/Other.xcodeproj' })).toBe(
+      `-project ${dir}/App/Other.xcodeproj`,
+    );
+  });
+
+  it('emits nothing when the worktree has no project yet', () => {
+    expect(xcTargetFlags(fixture('empty'))).toBe('');
+  });
+});

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -420,4 +420,166 @@ describe('provision-toolchain.sh template contract', () => {
       expect(uvLogContent).toContain('sync');
     });
   });
+
+  describe('iOS project generation', () => {
+    const scriptPath = path.join(
+      resolveTemplatesDir(),
+      'har-boilerplate-ios',
+      'provision-toolchain.sh',
+    );
+
+    /** Fixture work dir with a fake bin dir on PATH and an agent env file. */
+    const iosFixture = (name: string): { dir: string; bin: string; envFile: string; log: string } => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), `har-pt-ios-${name}-`));
+      const bin = path.join(dir, 'fakebin');
+      const envFile = path.join(dir, '.env.agent.1');
+      fs.mkdirSync(bin, { recursive: true });
+      fs.writeFileSync(envFile, `AGENT_ID=1\nREPO_ROOT=${dir}\n`);
+      return { dir, bin, envFile, log: path.join(dir, 'generator.log') };
+    };
+
+    /** Stub generator that records its argv and creates the project it would generate. */
+    const stubGenerator = (bin: string, tool: string, log: string, project = ''): void => {
+      const create = project ? `mkdir -p "${project}"\n` : '';
+      fs.writeFileSync(
+        path.join(bin, tool),
+        `#!/usr/bin/env bash\nprintf '%s %s\\n' "${tool}" "$*" >> "${log}"\n${create}exit 0\n`,
+        { mode: 0o755 },
+      );
+    };
+
+    const provision = (
+      fixture: { dir: string; bin: string; envFile: string },
+      opts: { pathPrefix?: string; installCmd?: string } = {},
+    ): ReturnType<typeof run> => {
+      // A bare system PATH for the "generator missing" cases: the machine
+      // running the tests may well have tuist or xcodegen installed elsewhere.
+      const pathValue =
+        opts.pathPrefix === undefined ? `${fixture.bin}:/usr/bin:/bin` : opts.pathPrefix;
+      const install = opts.installCmd === undefined ? '' : `HARNESS_INSTALL_CMD=${opts.installCmd} `;
+      return run(
+        `PATH="${pathValue}" HARNESS_ECOSYSTEM=ios ${install}` +
+          `HAR_WORK_DIR="${fixture.dir}" HAR_ENV_FILE="${fixture.envFile}" HAR_AGENT_ID=1 ` +
+          `bash "${scriptPath}" 2>&1`,
+      );
+    };
+
+    it('runs xcodegen when project.yml has no generated .xcodeproj', () => {
+      const fixture = iosFixture('xcodegen');
+      fs.writeFileSync(path.join(fixture.dir, 'project.yml'), 'name: Fixture\n');
+      stubGenerator(fixture.bin, 'xcodegen', fixture.log, path.join(fixture.dir, 'Fixture.xcodeproj'));
+
+      const result = provision(fixture);
+
+      expect(result.code).toBe(0);
+      expect(fs.readFileSync(fixture.log, 'utf8')).toContain('xcodegen generate');
+    });
+
+    it('runs tuist generate for a Project.swift repo', () => {
+      const fixture = iosFixture('tuist');
+      fs.writeFileSync(path.join(fixture.dir, 'Project.swift'), '// tuist fixture\n');
+      stubGenerator(fixture.bin, 'tuist', fixture.log, path.join(fixture.dir, 'Fixture.xcodeproj'));
+
+      const result = provision(fixture);
+
+      expect(result.code).toBe(0);
+      expect(fs.readFileSync(fixture.log, 'utf8')).toContain('tuist generate --no-open');
+    });
+
+    it('fails naming the generator when it is not on PATH', () => {
+      const fixture = iosFixture('no-tuist');
+      fs.writeFileSync(path.join(fixture.dir, 'Project.swift'), '// tuist fixture\n');
+
+      const result = provision(fixture, { pathPrefix: '/usr/bin:/bin' });
+
+      expect(result.code).not.toBe(0);
+      expect(result.stdout).toContain('tuist');
+      expect(result.stdout).toContain('HARNESS_INSTALL_CMD');
+    });
+
+    it('installs CocoaPods dependencies when Pods/ is missing', () => {
+      const fixture = iosFixture('pods');
+      fs.writeFileSync(path.join(fixture.dir, 'Podfile'), "platform :ios, '17.0'\n");
+      stubGenerator(fixture.bin, 'pod', fixture.log, path.join(fixture.dir, 'Fixture.xcworkspace'));
+
+      const result = provision(fixture);
+
+      expect(result.code).toBe(0);
+      expect(fs.readFileSync(fixture.log, 'utf8')).toContain('pod install');
+    });
+
+    it('fails naming CocoaPods when pod is not on PATH', () => {
+      const fixture = iosFixture('no-pod');
+      fs.writeFileSync(path.join(fixture.dir, 'Podfile'), "platform :ios, '17.0'\n");
+
+      const result = provision(fixture, { pathPrefix: '/usr/bin:/bin' });
+
+      expect(result.code).not.toBe(0);
+      expect(result.stdout).toContain('CocoaPods');
+    });
+
+    it('skips generation when the worktree already has a project', () => {
+      const fixture = iosFixture('tracked');
+      fs.writeFileSync(path.join(fixture.dir, 'project.yml'), 'name: Fixture\n');
+      // A real .xcodeproj carries an inner project.xcworkspace — that must not
+      // change the answer either way.
+      fs.mkdirSync(path.join(fixture.dir, 'Fixture.xcodeproj', 'project.xcworkspace'), {
+        recursive: true,
+      });
+      stubGenerator(fixture.bin, 'xcodegen', fixture.log);
+
+      const result = provision(fixture);
+
+      expect(result.code).toBe(0);
+      expect(fs.existsSync(fixture.log)).toBe(false);
+    });
+
+    it('regenerates when HARNESS_XCODE_PROJECT names a file this worktree lacks', () => {
+      const fixture = iosFixture('adapt-time');
+      fs.writeFileSync(path.join(fixture.dir, 'project.yml'), 'name: Fixture\n');
+      stubGenerator(fixture.bin, 'xcodegen', fixture.log, path.join(fixture.dir, 'Fixture.xcodeproj'));
+
+      const result = run(
+        `PATH="${fixture.bin}:/usr/bin:/bin" HARNESS_ECOSYSTEM=ios ` +
+          `HARNESS_XCODE_PROJECT=Fixture.xcodeproj ` +
+          `HAR_WORK_DIR="${fixture.dir}" HAR_ENV_FILE="${fixture.envFile}" HAR_AGENT_ID=1 ` +
+          `bash "${scriptPath}" 2>&1`,
+      );
+
+      expect(result.code).toBe(0);
+      expect(fs.readFileSync(fixture.log, 'utf8')).toContain('xcodegen generate');
+    });
+
+    it('lets an explicit HARNESS_INSTALL_CMD own provisioning', () => {
+      const fixture = iosFixture('install-cmd');
+      fs.writeFileSync(path.join(fixture.dir, 'project.yml'), 'name: Fixture\n');
+      stubGenerator(fixture.bin, 'xcodegen', fixture.log);
+
+      const result = provision(fixture, { installCmd: 'true' });
+
+      expect(result.code).toBe(0);
+      expect(fs.existsSync(fixture.log)).toBe(false);
+    });
+
+    it('fails the launch when HARNESS_INSTALL_CMD fails', () => {
+      const fixture = iosFixture('install-cmd-fail');
+      fs.writeFileSync(path.join(fixture.dir, 'project.yml'), 'name: Fixture\n');
+      stubGenerator(fixture.bin, 'xcodegen', fixture.log);
+
+      const result = provision(fixture, { installCmd: 'false' });
+
+      expect(result.code).not.toBe(0);
+      expect(fs.existsSync(fixture.log)).toBe(false);
+    });
+
+    it('records XCODEBUILD_BIN with no generator manifest present', () => {
+      const fixture = iosFixture('bare');
+
+      const result = provision(fixture);
+
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('no generator manifest');
+      expect(fs.readFileSync(fixture.envFile, 'utf8')).toContain('XCODEBUILD_BIN=');
+    });
+  });
 });


### PR DESCRIPTION
Closes #202

## Problem

Two independent mechanics in the iOS boilerplate broke launch/verify on common real Xcode layouts, even with the right scheme and bundle id adapted in.

1. **Generated projects have nothing to build in a fresh worktree.** Tuist, XcodeGen and CocoaPods treat the `.xcodeproj` / `.xcworkspace` as a build product, so a new session worktree had no project for `xcodebuild` to open — launch failed with an opaque *scheme not found* instead of naming the missing generator.
2. **Fallback target detection matched the nested `project.xcworkspace`.** Every `.xcodeproj` carries one at depth 2, so it (or `Pods/Pods.xcodeproj`) won the auto-detect and pointed `xcodebuild` at the wrong target.

## Changes

`provision-toolchain.sh` (all four mirrored copies: default, cli, ios, `runtime-bundles/shared-kernel`):

- New `har_ios_*` helpers and a rewritten `provision_ios`. With no project file in the worktree, launch runs the generator the repo declares — `tuist generate --no-open` for `Project.swift`/`Workspace.swift`, `xcodegen generate` for `project.yml`/`.yaml` — and `pod install` whenever a `Podfile` is present and `Pods/` is missing (independent of generation: a tracked `.xcworkspace` still cannot build without `Pods/`).
- A generator the repo needs but the machine lacks **fails the launch naming that tool** (`CocoaPods (pod)` for pod) and points at `HARNESS_INSTALL_CMD`. No fall-through to `xcodebuild`.
- `HARNESS_INSTALL_CMD` owns provisioning outright: no default generator runs behind it, and its failure fails the launch (the old `run_install_cmd "$dir" || true` is gone).
- Adapt-time `HARNESS_XCODE_PROJECT` / `HARNESS_XCODE_WORKSPACE` decide whether a project exists when set — naming a file the fresh worktree lacks means the generator still has to run. Nothing is introspected at `har env init`; scheme, bundle id and workspace/project stay adapt-time values in `harness.env`.
- No project and no generator manifest → one clear log line, launch continues.

`har-boilerplate-ios/verify.sh` — the `xc_target_flags` auto-detect branch now excludes `*.xcodeproj/*` and `*/Pods/*`, and runs `find` from inside the work dir. That also fixes a latent bug: the old `! -path "*/\.*"` filter matched the absolute worktree path itself, so any dot component upstream excluded every candidate.

## Tests

- 10 new cases in `tests/provision-toolchain.test.ts` — stubbed `tuist`/`xcodegen`/`pod` generators, missing-tool failures, install-cmd ownership and failure, already-present project, adapt-time path that the worktree lacks.
- New `tests/ios-verify-target-flags.test.ts` lifts `xc_target_flags` out of the real script and runs it against fixtures (nested workspace, Pods, explicit values, empty worktree, dotted worktree path).

## Verification

`har env verify 4 --full` → pass (typecheck, build, docs-check, docs-build, unit-tests, lint, readiness, docs-drift).

## Docs

iOS generated-projects section in `docs/.../reference/environment.md`, plus notes in the iOS `harness.env`, `ADAPT-PROMPT.md`, and `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)