### PR TITLE
docs: improve GitHub, npm, and site discoverability

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,3 @@
-Copyright 2026 Antoine Frau
-
-SPDX-License-Identifier: Apache-2.0
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-------------------------------------------------------------------------
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+HAR
+Copyright 2026 Antoine Frau
+
+This product includes software developed at OS Factory
+(https://github.com/os-factory/har, https://harproject.dev/).

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 [![Release](https://img.shields.io/github/v/release/os-factory/har)](https://github.com/os-factory/har/releases)
 [![CI](https://github.com/os-factory/har/actions/workflows/test.yml/badge.svg)](https://github.com/os-factory/har/actions/workflows/test.yml)
 [![Documentation](https://img.shields.io/badge/docs-harproject.dev-38c976)](https://harproject.dev/)
+[![GitHub stars](https://img.shields.io/github/stars/os-factory/har?style=social)](https://github.com/os-factory/har)
 
-HAR is an open-source, agent-agnostic framework for building multi-agent coding workflows. Run a fleet of coding agents in parallel on any repository, with deterministic validation gates, verifiable proof, and full observability across every agent, all extensible and customizable to your own workflow and tooling.
+HAR is an open-source **agent harness** — a **CLI** and **MCP** server — for multi-agent coding workflows. Run a fleet of coding agents in isolated **worktrees**, with deterministic validation, verifiable proof, and full observability. Use it as a portable **software factory** for Claude Code, Cursor, Codex, or any MCP agent.
 
 <table align="center">
   <tr>

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,7 +48,7 @@ export default defineConfig({
 		starlight({
 			title: 'HAR',
 			description:
-				'An open-source, agent-agnostic standard for multi-agent coding workflows — parallel agents, deterministic validation, verifiable proof, and observability.',
+				'HAR is an open-source agent harness — CLI and MCP server — for multi-agent coding workflows. Isolated worktrees, deterministic verification, and software-factory observability.',
 			logo: {
 				src: './public/assets/har-logo.png',
 				alt: 'HAR',

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -21,13 +21,19 @@ const homePrefix = active === 'home' ? '' : '/';
         <a href="/teams/" class:list={{ active: active === 'teams' }} aria-current={active === 'teams' ? 'page' : undefined}>Teams</a>
       </nav>
       <div class="nav-actions">
-        <iframe
+        <a
           class="github-star"
-          src="https://ghbtns.com/github-btn.html?user=os-factory&repo=har&type=star&count=true&size=large"
-          title="Star HAR on GitHub"
-          width="170"
-          height="30"
-        ></iframe>
+          href="https://github.com/os-factory/har"
+          data-github-star
+          aria-label="Star HAR on GitHub"
+          rel="noopener noreferrer"
+        >
+          <svg viewBox="0 0 16 16" aria-hidden="true">
+            <path d="M8 .2a8 8 0 0 0-2.5 15.6c.4 0 .5-.2.5-.4v-1.5c-2.1.5-2.6-1-2.6-1-.3-.9-.8-1.1-.8-1.1-.7-.5.1-.5.1-.5.8.1 1.2.8 1.2.8.7 1.2 1.9.9 2.3.7.1-.5.3-.9.5-1.1-1.8-.2-3.6-.9-3.6-4 0-.9.3-1.6.8-2.1-.1-.2-.4-1 .1-2.1 0 0 .7-.2 2.2.8a7.6 7.6 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8.5 1.1.2 1.9.1 2.1.5.5.8 1.2.8 2.1 0 3.1-1.9 3.8-3.6 4 .3.3.6.8.6 1.6v2.4c0 .2.1.5.5.4A8 8 0 0 0 8 .2Z" />
+          </svg>
+          Star
+          <span class="github-star-count" data-github-star-count hidden></span>
+        </a>
         <ThemeToggle />
         <button class="menu-button" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-button>
           <span></span><span></span>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -21,7 +21,7 @@ const homePrefix = active === 'home' ? '' : '/';
         <a href="/teams/" class:list={{ active: active === 'teams' }} aria-current={active === 'teams' ? 'page' : undefined}>Teams</a>
       </nav>
       <div class="nav-actions">
-        <a class="nav-link" href="https://github.com/os-factory/har">GitHub <span aria-hidden="true">↗</span></a>
+        <a class="nav-link" href="https://github.com/os-factory/har">Star on GitHub <span aria-hidden="true">★</span></a>
         <ThemeToggle />
         <button class="menu-button" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-button>
           <span></span><span></span>
@@ -34,6 +34,6 @@ const homePrefix = active === 'home' ? '' : '/';
     <a href="/docs">Documentation</a>
     <a href="/plugins/">Plugins</a>
     <a href="/teams/">Teams</a>
-    <a href="https://github.com/os-factory/har">GitHub</a>
+    <a href="https://github.com/os-factory/har">Star on GitHub</a>
   </div>
 </header>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -21,7 +21,13 @@ const homePrefix = active === 'home' ? '' : '/';
         <a href="/teams/" class:list={{ active: active === 'teams' }} aria-current={active === 'teams' ? 'page' : undefined}>Teams</a>
       </nav>
       <div class="nav-actions">
-        <a class="nav-link" href="https://github.com/os-factory/har">Star on GitHub <span aria-hidden="true">★</span></a>
+        <iframe
+          class="github-star"
+          src="https://ghbtns.com/github-btn.html?user=os-factory&repo=har&type=star&count=true&size=large"
+          title="Star HAR on GitHub"
+          width="170"
+          height="30"
+        ></iframe>
         <ThemeToggle />
         <button class="menu-button" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-button>
           <span></span><span></span>

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -21,19 +21,13 @@ const homePrefix = active === 'home' ? '' : '/';
         <a href="/teams/" class:list={{ active: active === 'teams' }} aria-current={active === 'teams' ? 'page' : undefined}>Teams</a>
       </nav>
       <div class="nav-actions">
-        <a
+        <iframe
           class="github-star"
-          href="https://github.com/os-factory/har"
-          data-github-star
-          aria-label="Star HAR on GitHub"
-          rel="noopener noreferrer"
-        >
-          <svg viewBox="0 0 16 16" aria-hidden="true">
-            <path d="M8 .2a8 8 0 0 0-2.5 15.6c.4 0 .5-.2.5-.4v-1.5c-2.1.5-2.6-1-2.6-1-.3-.9-.8-1.1-.8-1.1-.7-.5.1-.5.1-.5.8.1 1.2.8 1.2.8.7 1.2 1.9.9 2.3.7.1-.5.3-.9.5-1.1-1.8-.2-3.6-.9-3.6-4 0-.9.3-1.6.8-2.1-.1-.2-.4-1 .1-2.1 0 0 .7-.2 2.2.8a7.6 7.6 0 0 1 4 0c1.5-1 2.2-.8 2.2-.8.5 1.1.2 1.9.1 2.1.5.5.8 1.2.8 2.1 0 3.1-1.9 3.8-3.6 4 .3.3.6.8.6 1.6v2.4c0 .2.1.5.5.4A8 8 0 0 0 8 .2Z" />
-          </svg>
-          Star
-          <span class="github-star-count" data-github-star-count hidden></span>
-        </a>
+          src="https://ghbtns.com/github-btn.html?user=os-factory&repo=har&type=star&count=true"
+          title="GitHub"
+          width="86"
+          height="20"
+        ></iframe>
         <ThemeToggle />
         <button class="menu-button" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-button>
           <span></span><span></span>

--- a/docs/src/content/docs/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/docs/getting-started/introduction.md
@@ -1,12 +1,12 @@
 ---
 title: Introduction
-description: What HAR solves and where it fits in an agent development workflow.
+description: HAR is an open-source agent harness (CLI + MCP) for multi-agent coding workflows, isolated worktrees, and deterministic verification.
 ---
 
-HAR is an open-source, agent-agnostic framework for building multi-agent coding
-workflows. Run a fleet of coding agents in parallel on any repository, with
-deterministic validation gates, verifiable proof, and full observability across
-every agent, all extensible and customizable to your own workflow and tooling.
+HAR is an open-source, agent-agnostic **harness** — a CLI and MCP server — for
+building multi-agent coding workflows. Run a fleet of coding agents in isolated
+worktrees, with deterministic validation gates, verifiable proof, and full
+observability. Use it as a portable software factory across any coding agent.
 
 <div class="intro-video">
 <div class="video-embed">

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -14,11 +14,24 @@ interface Props {
 
 const {
   title,
-  description = 'HAR is an open-source, agent-agnostic standard for multi-agent coding workflows — parallel agents, deterministic validation gates, verifiable proof, and full observability.',
+  description = 'HAR is an open-source agent harness — CLI and MCP server — for multi-agent coding workflows. Isolated worktrees, deterministic verification, and software-factory observability for Claude Code, Cursor, and Codex.',
   bodyClass = '',
   canonicalPath = Astro.url.pathname,
 } = Astro.props;
 const canonical = new URL(canonicalPath, Astro.site ?? Astro.url.origin);
+const ogImage = new URL('/assets/har-logo.png', Astro.site ?? Astro.url.origin);
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'HAR',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Linux, macOS, Windows',
+  url: 'https://harproject.dev/',
+  downloadUrl: 'https://www.npmjs.com/package/@osfactory/har',
+  license: 'https://www.apache.org/licenses/LICENSE-2.0',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  description,
+};
 ---
 <!doctype html>
 <html lang="en">
@@ -28,9 +41,20 @@ const canonical = new URL(canonicalPath, Astro.site ?? Astro.url.origin);
     <meta name="description" content={description} />
     <meta name="theme-color" content="#f6f4ee" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="HAR" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={ogImage} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
     <link rel="canonical" href={canonical} />
     <link rel="icon" type="image/png" href="/assets/har-logo.png" />
     <title>{title}</title>
+    <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
     <PostHog />
     <script is:inline>
       (() => {

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -8,7 +8,12 @@ import { plugins } from '../data/plugins';
 
 const heroRunTotal = formatHeroRunTotal();
 ---
-<BaseLayout title="HAR — Harnesses for coding agents" bodyClass="home-page" canonicalPath="/">
+<BaseLayout
+  title="HAR — Open agent harness (CLI + MCP) for coding agents"
+  description="HAR is an open-source agent harness — CLI and MCP server — for multi-agent coding workflows. Isolated worktrees, deterministic verification, and software-factory observability for Claude Code, Cursor, and Codex."
+  bodyClass="home-page"
+  canonicalPath="/"
+>
   <Header active="home" />
   <main>
 <section class="hero blueprint-surface">
@@ -16,7 +21,7 @@ const heroRunTotal = formatHeroRunTotal();
 <div class="hero-copy reveal">
 <div class="eyebrow"><span class="eyebrow-dot"></span> Open-source · Agent-agnostic</div>
 <h1>The open harness for multi-agent coding workflows.</h1>
-<p class="hero-lede">Run fleets of coding agents with deterministic validation gates, verifiable proof, and full observability. Extensible and customizable to your workflow and tooling.</p>
+<p class="hero-lede">An open agent harness — CLI and MCP — for coding agents. Isolated worktrees, deterministic validation, and verifiable proof. Extensible to your own software-factory workflow.</p>
 <div class="hero-install">
 <button aria-label="Copy install command" class="install-command" data-copy="npm install -g @osfactory/har@latest" type="button">
 <span class="terminal-prompt">$</span>

--- a/docs/src/pages/teams.astro
+++ b/docs/src/pages/teams.astro
@@ -5,7 +5,7 @@ import Footer from '../components/Footer.astro';
 ---
 <BaseLayout
   title="HAR for teams"
-  description="Run a fleet of coding agents across your whole organization, in one shared place. See what every agent costs down to the ticket, check what each run shipped, and help everyone work like your best engineers. Built on the open HAR core you already run."
+  description="Run a software-factory fleet of coding agents across your organization with the HAR harness. See what every agent costs, check what each run shipped, and keep verification evidence in one place."
   bodyClass="home-page"
   canonicalPath="/teams/"
 >

--- a/docs/src/scripts/site.ts
+++ b/docs/src/scripts/site.ts
@@ -24,59 +24,6 @@ function setTheme(theme: 'light' | 'dark', persist = true) {
 
 setTheme(html.dataset.theme === 'dark' ? 'dark' : 'light', false);
 
-const GITHUB_STAR_CACHE_KEY = 'har-github-stars';
-const GITHUB_STAR_CACHE_TTL_MS = 60 * 60 * 1000;
-
-function formatStarCount(count: number): string {
-  return new Intl.NumberFormat('en-US').format(count);
-}
-
-async function hydrateGithubStars() {
-  const counters = document.querySelectorAll<HTMLElement>('[data-github-star-count]');
-  if (counters.length === 0) return;
-
-  const apply = (count: number) => {
-    const label = formatStarCount(count);
-    counters.forEach((node) => {
-      node.textContent = label;
-      node.hidden = false;
-    });
-  };
-
-  try {
-    const cached = sessionStorage.getItem(GITHUB_STAR_CACHE_KEY);
-    if (cached) {
-      const parsed = JSON.parse(cached) as { count?: number; fetchedAt?: number };
-      if (
-        typeof parsed.count === 'number' &&
-        typeof parsed.fetchedAt === 'number' &&
-        Date.now() - parsed.fetchedAt < GITHUB_STAR_CACHE_TTL_MS
-      ) {
-        apply(parsed.count);
-        return;
-      }
-    }
-  } catch {
-    /* ignore stale cache */
-  }
-
-  try {
-    const response = await fetch('https://api.github.com/repos/os-factory/har');
-    if (!response.ok) return;
-    const body = (await response.json()) as { stargazers_count?: number };
-    if (typeof body.stargazers_count !== 'number') return;
-    apply(body.stargazers_count);
-    sessionStorage.setItem(
-      GITHUB_STAR_CACHE_KEY,
-      JSON.stringify({ count: body.stargazers_count, fetchedAt: Date.now() }),
-    );
-  } catch {
-    /* keep the compact Star label if GitHub is unreachable */
-  }
-}
-
-void hydrateGithubStars();
-
 document.querySelectorAll<HTMLButtonElement>('[data-theme-toggle]').forEach((button) => {
   button.addEventListener('click', () => {
     setTheme(html.dataset.theme === 'dark' ? 'light' : 'dark');

--- a/docs/src/scripts/site.ts
+++ b/docs/src/scripts/site.ts
@@ -24,6 +24,59 @@ function setTheme(theme: 'light' | 'dark', persist = true) {
 
 setTheme(html.dataset.theme === 'dark' ? 'dark' : 'light', false);
 
+const GITHUB_STAR_CACHE_KEY = 'har-github-stars';
+const GITHUB_STAR_CACHE_TTL_MS = 60 * 60 * 1000;
+
+function formatStarCount(count: number): string {
+  return new Intl.NumberFormat('en-US').format(count);
+}
+
+async function hydrateGithubStars() {
+  const counters = document.querySelectorAll<HTMLElement>('[data-github-star-count]');
+  if (counters.length === 0) return;
+
+  const apply = (count: number) => {
+    const label = formatStarCount(count);
+    counters.forEach((node) => {
+      node.textContent = label;
+      node.hidden = false;
+    });
+  };
+
+  try {
+    const cached = sessionStorage.getItem(GITHUB_STAR_CACHE_KEY);
+    if (cached) {
+      const parsed = JSON.parse(cached) as { count?: number; fetchedAt?: number };
+      if (
+        typeof parsed.count === 'number' &&
+        typeof parsed.fetchedAt === 'number' &&
+        Date.now() - parsed.fetchedAt < GITHUB_STAR_CACHE_TTL_MS
+      ) {
+        apply(parsed.count);
+        return;
+      }
+    }
+  } catch {
+    /* ignore stale cache */
+  }
+
+  try {
+    const response = await fetch('https://api.github.com/repos/os-factory/har');
+    if (!response.ok) return;
+    const body = (await response.json()) as { stargazers_count?: number };
+    if (typeof body.stargazers_count !== 'number') return;
+    apply(body.stargazers_count);
+    sessionStorage.setItem(
+      GITHUB_STAR_CACHE_KEY,
+      JSON.stringify({ count: body.stargazers_count, fetchedAt: Date.now() }),
+    );
+  } catch {
+    /* keep the compact Star label if GitHub is unreachable */
+  }
+}
+
+void hydrateGithubStars();
+
 document.querySelectorAll<HTMLButtonElement>('[data-theme-toggle]').forEach((button) => {
   button.addEventListener('click', () => {
     setTheme(html.dataset.theme === 'dark' ? 'light' : 'dark');

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -55,6 +55,7 @@ code, pre { font-family: var(--mono); }
 .desktop-nav a, .nav-link { font-size: 14px; color: #4e5661; transition: color .2s ease; }
 .desktop-nav a:hover, .desktop-nav a.active, .nav-link:hover { color: var(--ink); }
 .nav-actions { display: flex; align-items: center; gap: 18px; }
+.github-star { display: block; width: 170px; height: 30px; border: 0; overflow: hidden; flex: none; }
 .button { display: inline-flex; align-items: center; justify-content: center; gap: 9px; min-height: 48px; padding: 0 20px; border-radius: 5px; font-weight: 650; font-size: 14px; border: 1px solid transparent; cursor: pointer; transition: transform .2s ease, box-shadow .2s ease, background .2s ease; }
 .button:hover { transform: translateY(-2px); }
 
@@ -225,7 +226,7 @@ code, pre { font-family: var(--mono); }
 
 @media (max-width: 760px) {
   .container { width: min(calc(100% - 28px), var(--container)); }
-  .site-header { height: 68px; }.desktop-nav, .nav-link, .nav-actions > .button { display: none; }.menu-button { display: block; }
+  .site-header { height: 68px; }.desktop-nav, .nav-link, .github-star, .nav-actions > .button { display: none; }.menu-button { display: block; }
   .mobile-menu { position: fixed; z-index: 49; top: 68px; left: 14px; right: 14px; display: grid; gap: 2px; padding: 10px; border-radius: 5px; background: rgba(246,244,238,.98); border: 1px solid rgba(17,22,29,.1); box-shadow: 0 22px 50px rgba(15,23,42,.16); transform: translateY(-10px); opacity: 0; pointer-events: none; transition: .2s ease; }.mobile-menu.is-open { opacity: 1; transform: none; pointer-events: auto; }.mobile-menu a { padding: 13px; border-radius: 5px; font-size: 14px; }.mobile-menu a:hover { background: rgba(17,22,29,.05); }
   .hero { min-height: auto; padding: 120px 0 80px; }
   .hero .hero-grid { width: min(calc(100% - 28px), var(--container)); gap: 42px; }

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -55,38 +55,8 @@ code, pre { font-family: var(--mono); }
 .desktop-nav a, .nav-link { font-size: 14px; color: #4e5661; transition: color .2s ease; }
 .desktop-nav a:hover, .desktop-nav a.active, .nav-link:hover { color: var(--ink); }
 .nav-actions { display: flex; align-items: center; gap: 18px; }
-.github-star {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 28px;
-  padding: 0 8px 0 7px;
-  border-radius: 5px;
-  border: 1px solid var(--theme-border);
-  background: var(--theme-surface-raised);
-  color: var(--theme-nav);
-  font-size: 13px;
-  font-weight: 650;
-  line-height: 1;
-  flex: none;
-  width: max-content;
-  transition: color .2s ease, background .2s ease, border-color .2s ease;
-}
-.github-star:hover { color: var(--text); background: var(--theme-surface-solid); }
-.github-star svg { width: 14px; height: 14px; fill: currentColor; flex: none; }
-.github-star-count {
-  display: inline-flex;
-  align-items: center;
-  min-height: 18px;
-  padding: 0 6px;
-  border-radius: 4px;
-  border: 1px solid var(--theme-border);
-  background: var(--paper);
-  color: var(--text);
-  font-size: 12px;
-  font-variant-numeric: tabular-nums;
-}
-.github-star-count[hidden] { display: none; }
+.github-star { display: block; width: 86px; height: 20px; border: 0; overflow: hidden; flex: none; }
+:root[data-theme="dark"] .github-star { filter: invert(0.93) hue-rotate(100deg); }
 .button { display: inline-flex; align-items: center; justify-content: center; gap: 9px; min-height: 48px; padding: 0 20px; border-radius: 5px; font-weight: 650; font-size: 14px; border: 1px solid transparent; cursor: pointer; transition: transform .2s ease, box-shadow .2s ease, background .2s ease; }
 .button:hover { transform: translateY(-2px); }
 

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -55,7 +55,38 @@ code, pre { font-family: var(--mono); }
 .desktop-nav a, .nav-link { font-size: 14px; color: #4e5661; transition: color .2s ease; }
 .desktop-nav a:hover, .desktop-nav a.active, .nav-link:hover { color: var(--ink); }
 .nav-actions { display: flex; align-items: center; gap: 18px; }
-.github-star { display: block; width: 170px; height: 30px; border: 0; overflow: hidden; flex: none; }
+.github-star {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 8px 0 7px;
+  border-radius: 5px;
+  border: 1px solid var(--theme-border);
+  background: var(--theme-surface-raised);
+  color: var(--theme-nav);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1;
+  flex: none;
+  width: max-content;
+  transition: color .2s ease, background .2s ease, border-color .2s ease;
+}
+.github-star:hover { color: var(--text); background: var(--theme-surface-solid); }
+.github-star svg { width: 14px; height: 14px; fill: currentColor; flex: none; }
+.github-star-count {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 0 6px;
+  border-radius: 4px;
+  border: 1px solid var(--theme-border);
+  background: var(--paper);
+  color: var(--text);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.github-star-count[hidden] { display: none; }
 .button { display: inline-flex; align-items: center; justify-content: center; gap: 9px; min-height: 48px; padding: 0 20px; border-radius: 5px; font-weight: 650; font-size: 14px; border: 1px solid transparent; cursor: pointer; transition: transform .2s ease, box-shadow .2s ease, background .2s ease; }
 .button:hover { transform: translateY(-2px); }
 

--- a/docs/tests/frontend/smoke.spec.cjs
+++ b/docs/tests/frontend/smoke.spec.cjs
@@ -8,6 +8,15 @@ test.describe('Frontend smoke', () => {
       'The open harness for multi-agent coding workflows',
     );
     await expect(page.getByRole('link', { name: /Read the docs/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Star on GitHub/i }).first()).toBeVisible();
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+      'content',
+      /agent harness/i,
+    );
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+      'content',
+      /agent harness/i,
+    );
   });
 
   test('plugin marketplace lists every plugin with a working detail page', async ({ page }) => {

--- a/docs/tests/frontend/smoke.spec.cjs
+++ b/docs/tests/frontend/smoke.spec.cjs
@@ -8,7 +8,10 @@ test.describe('Frontend smoke', () => {
       'The open harness for multi-agent coding workflows',
     );
     await expect(page.getByRole('link', { name: /Read the docs/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /Star on GitHub/i }).first()).toBeVisible();
+    await expect(page.locator('iframe.github-star')).toHaveAttribute(
+      'src',
+      /ghbtns\.com\/github-btn\.html\?user=os-factory&repo=har/,
+    );
     await expect(page.locator('meta[name="description"]')).toHaveAttribute(
       'content',
       /agent harness/i,

--- a/docs/tests/frontend/smoke.spec.cjs
+++ b/docs/tests/frontend/smoke.spec.cjs
@@ -8,11 +8,10 @@ test.describe('Frontend smoke', () => {
       'The open harness for multi-agent coding workflows',
     );
     await expect(page.getByRole('link', { name: /Read the docs/i })).toBeVisible();
-    await expect(page.locator('a.github-star')).toHaveAttribute(
-      'href',
-      'https://github.com/os-factory/har',
+    await expect(page.locator('iframe.github-star')).toHaveAttribute(
+      'src',
+      /ghbtns\.com\/github-btn\.html\?user=os-factory&repo=har/,
     );
-    await expect(page.locator('a.github-star')).toContainText('Star');
     await expect(page.locator('meta[name="description"]')).toHaveAttribute(
       'content',
       /agent harness/i,

--- a/docs/tests/frontend/smoke.spec.cjs
+++ b/docs/tests/frontend/smoke.spec.cjs
@@ -8,10 +8,11 @@ test.describe('Frontend smoke', () => {
       'The open harness for multi-agent coding workflows',
     );
     await expect(page.getByRole('link', { name: /Read the docs/i })).toBeVisible();
-    await expect(page.locator('iframe.github-star')).toHaveAttribute(
-      'src',
-      /ghbtns\.com\/github-btn\.html\?user=os-factory&repo=har/,
+    await expect(page.locator('a.github-star')).toHaveAttribute(
+      'href',
+      'https://github.com/os-factory/har',
     );
+    await expect(page.locator('a.github-star')).toContainText('Star');
     await expect(page.locator('meta[name="description"]')).toHaveAttribute(
       'content',
       /agent harness/i,

--- a/package.json
+++ b/package.json
@@ -1,14 +1,23 @@
 {
   "name": "@osfactory/har",
   "version": "0.62.2",
-  "description": "Open harness for reproducible multi-agent coding workflows",
+  "description": "HAR: open agent harness CLI and MCP server for coding agents, isolated worktrees, and software-factory workflows",
   "keywords": [
     "har",
+    "harness",
+    "agent-harness",
     "cli",
     "mcp",
+    "mcp-server",
     "agent",
-    "harness",
-    "devops"
+    "coding-agent",
+    "coding-agents",
+    "software-factory",
+    "worktree",
+    "claude-code",
+    "cursor",
+    "devops",
+    "typescript"
   ],
   "bin": {
     "har": "dist/index.js"


### PR DESCRIPTION
## Summary
- Front-load searchable terms (`agent harness`, `CLI`, `MCP`, `worktrees`, `software factory`) in the README, npm description/keywords, docs titles, and meta tags.
- Restore GitHub Apache-2.0 license detection by using a stock `LICENSE` plus a `NOTICE` copyright file.
- Add Open Graph / Twitter cards, SoftwareApplication JSON-LD, and a **Star on GitHub** header CTA so visitors can actually star the repo.

GitHub About, topics, org bio, and watching were updated directly on the repository (not in this diff).

## Test plan
- [x] `har env verify 1 --full` on the docs harness (check, health, drift, build, links, browser-e2e)
- [ ] Confirm GitHub sidebar shows Apache-2.0 after merge (license classifier)
- [ ] Confirm npm keywords after the next publish
- [ ] Click **Star on GitHub** on http://localhost:4321 and on the production header after deploy


Made with [Cursor](https://cursor.com)