### PR TITLE
feat: assign leftover repos to workspaces after hq connect

### DIFF
--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -259,10 +259,12 @@ conflict and can select another port in the slot lane.
 ## HAR HQ
 
 `har hq connect` opens browser SSO (or stores `--api-key`) and attaches the current
-repository to the workspace you pick in the portal. Saved connections live in
-`~/.har/portal-targets.json`; `har hq list` / `har hq disconnect` manage them.
-Workspace choices are never committed into `.har/`. `har control login` still
-works as a deprecated alias.
+repository to the workspace you pick in the portal. Other locally registered
+repositories are listed with a count so you can send all of them to one workspace,
+or assign leftover paths per workspace. Unattached checkouts are not ingested into
+the only leftover connection. Saved connections live in `~/.har/portal-targets.json`;
+`har hq list` / `har hq disconnect` manage them. Workspace choices are never
+committed into `.har/`. `har control login` still works as a deprecated alias.
 
 `har control sync --cloud` targets HAR Cloud. Hosted coordination is separate from
 the local open-source dashboard and portable `.har/` contract.

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -229,9 +229,17 @@ har hq disconnect [name] [--yes] [--json]
 Connect this checkout to a HAR HQ workspace. On a TTY, `connect` asks Production
 (`https://app.harhq.com`), Development (`https://app.dev.harhq.com`), or a custom
 URL, then opens browser SSO. The workspace chosen on the consent screen is the
-destination; HAR attaches **this repository** to that workspace. A second
-`har hq connect` from another checkout (or against another workspace) adds another
-attachment — it does not replace the first connection.
+destination; HAR attaches **this repository** to that workspace. When other
+repositories are already registered locally, the consent page (or a TTY fallback)
+shows their count and paths. You can send all of them to one workspace, or pick
+a workspace and then the repositories for it — already-assigned paths are hidden
+on the next workspace. `--yes` / `--json` skip that prompt and attach only the
+current checkout. A second `har hq connect` from another checkout (or against
+another workspace) adds another attachment — it does not replace the first
+connection.
+
+Automatic sync sends only to workspaces a repository is **attached** to. A
+single leftover connection is not inherited by unattached checkouts.
 
 `list` shows saved connections (workspace + portal host, never tokens).
 `disconnect` removes one connection and its credentials. Credentials stay in

--- a/src/cli/commands/hq.ts
+++ b/src/cli/commands/hq.ts
@@ -8,6 +8,12 @@ import {
 } from '../../core/control-config';
 import { runPortalConnect } from '../../core/portal-connect';
 import {
+  applyRepoWorkspaceMap,
+  planRepoWorkspaceMap,
+  remainingConnections,
+  remainingUnassignedRepos,
+} from '../../core/portal-repo-map';
+import {
   displayPortalTargetLabel,
   findPortalTargetRecord,
   listPortalTargetRecords,
@@ -53,7 +59,7 @@ export const hqCommand = {
               alias: 'y',
               type: 'boolean',
               default: false,
-              describe: 'Skip the destination prompt and use the resolved portal URL',
+              describe: 'Skip interactive prompts (portal URL and extra-repo mapping)',
             }),
         (argv) =>
           handleHqConnect(
@@ -136,6 +142,102 @@ async function resolveConnectPortalUrl(
   return resolvePortalUrl(url);
 }
 
+async function promptExtraRepoAttachments(opts: {
+  currentRepo: string | null;
+  currentAlias: string;
+}): Promise<string[]> {
+  const plan = planRepoWorkspaceMap(opts);
+  if (plan.kind === 'none') return [];
+
+  const noun = plan.repos.length === 1 ? 'repository' : 'repositories';
+  info(`${plan.repos.length} other registered ${noun}:`);
+  for (const repoPath of plan.repos) info(`  ${repoPath}`);
+
+  if (plan.kind === 'attach-more') {
+    const { selected } = await inquirer.prompt<{ selected: string[] }>([
+      {
+        type: 'checkbox',
+        name: 'selected',
+        message: `Attach which of these ${plan.repos.length} ${noun} to ${plan.workspaceLabel}?`,
+        choices: plan.repos.map((repoPath) => ({
+          name: repoPath,
+          value: repoPath,
+          checked: true,
+        })),
+      },
+    ]);
+    return applyRepoWorkspaceMap(
+      selected.map((repoPath) => ({ repoPath, alias: plan.workspaceAlias })),
+    );
+  }
+
+  const { sendAll } = await inquirer.prompt<{ sendAll: boolean }>([
+    {
+      type: 'confirm',
+      name: 'sendAll',
+      message: `Send all ${plan.repos.length} ${noun} to the same workspace?`,
+      default: true,
+    },
+  ]);
+
+  if (sendAll) {
+    const { alias } = await inquirer.prompt<{ alias: string }>([
+      {
+        type: 'list',
+        name: 'alias',
+        message: 'Which workspace?',
+        default: plan.currentAlias,
+        choices: plan.connections.map((entry) => ({
+          name: entry.label,
+          value: entry.alias,
+        })),
+      },
+    ]);
+    return applyRepoWorkspaceMap(plan.repos.map((repoPath) => ({ repoPath, alias })));
+  }
+
+  const attached: string[] = [];
+  let remainingRepos = [...plan.repos];
+  let remainingOrgs = [...plan.connections];
+  while (remainingRepos.length > 0 && remainingOrgs.length > 0) {
+    const left = remainingRepos.length === 1 ? 'repository' : 'repositories';
+    info(`${remainingRepos.length} ${left} left to assign.`);
+    const { alias } = await inquirer.prompt<{ alias: string }>([
+      {
+        type: 'list',
+        name: 'alias',
+        message: 'Workspace to assign repositories to',
+        default:
+          remainingOrgs.some((entry) => entry.alias === plan.currentAlias)
+            ? plan.currentAlias
+            : remainingOrgs[0]?.alias,
+        choices: [
+          ...remainingOrgs.map((entry) => ({
+            name: entry.label,
+            value: entry.alias,
+          })),
+          { name: 'Done — leave the rest unattached', value: '' },
+        ],
+      },
+    ]);
+    if (!alias) break;
+    const { selected } = await inquirer.prompt<{ selected: string[] }>([
+      {
+        type: 'checkbox',
+        name: 'selected',
+        message: `Repositories for ${remainingOrgs.find((entry) => entry.alias === alias)?.label ?? alias}`,
+        choices: remainingRepos.map((repoPath) => ({ name: repoPath, value: repoPath })),
+      },
+    ]);
+    if (selected.length > 0) {
+      attached.push(...applyRepoWorkspaceMap(selected.map((repoPath) => ({ repoPath, alias }))));
+    }
+    remainingRepos = remainingUnassignedRepos(remainingRepos, selected);
+    remainingOrgs = remainingConnections(remainingOrgs, [alias]);
+  }
+  return attached;
+}
+
 export async function handleHqConnect(argv: {
   portal?: string;
   apiKey?: string;
@@ -156,7 +258,7 @@ export async function handleHqConnect(argv: {
   }
 
   try {
-    const { record, attachedRepo } = await runPortalConnect({
+    const { record, attachedRepo, extraAttached, mappedInBrowser } = await runPortalConnect({
       portalUrl,
       apiKey: argv.apiKey,
       repoPath: argv.repo ?? '.',
@@ -184,6 +286,20 @@ export async function handleHqConnect(argv: {
     } else {
       info('No local repository attached (run this from a repo, or pass --repo).');
     }
+    for (const repoPath of extraAttached) {
+      success(`Attached ${repoPath}`);
+    }
+
+    if (!argv.json && !argv.yes && !mappedInBrowser && isInteractive()) {
+      const extra = await promptExtraRepoAttachments({
+        currentRepo: attachedRepo,
+        currentAlias: record.alias,
+      });
+      for (const repoPath of extra) {
+        success(`Attached ${repoPath}`);
+      }
+    }
+
     info('Sync: har control sync');
   } catch (err) {
     error(`Connect failed: ${(err as Error).message}`);

--- a/src/core/portal-connect.ts
+++ b/src/core/portal-connect.ts
@@ -2,8 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
 import { canonicalizeControlRepoPath } from './control-repo-path';
-import { recordRepoForControlSync } from './control-registry';
+import { listRegisteredRepos, recordRepoForControlSync } from './control-registry';
 import { loginViaBrowser } from './portal-login';
+import { applyRepoWorkspaceMap } from './portal-repo-map';
 import {
   attachRepoPortalTarget,
   upsertPortalTarget,
@@ -21,6 +22,8 @@ export interface PortalConnectInput {
 export interface PortalConnectResult {
   record: PortalTargetRecord;
   attachedRepo: string | null;
+  extraAttached: string[];
+  mappedInBrowser: boolean;
 }
 
 function attachRepoIfPresent(alias: string, repoPath?: string): string | null {
@@ -45,10 +48,17 @@ export async function runPortalConnect(input: PortalConnectInput): Promise<Porta
       token: input.apiKey,
       setAsDefault: true,
     });
-    return { record, attachedRepo: attachRepoIfPresent(record.alias, input.repoPath) };
+    return {
+      record,
+      attachedRepo: attachRepoIfPresent(record.alias, input.repoPath),
+      extraAttached: [],
+      mappedInBrowser: false,
+    };
   }
 
-  const creds = await loginViaBrowser(input.portalUrl);
+  const creds = await loginViaBrowser(input.portalUrl, {
+    repos: listRegisteredReposForConnect(input.repoPath),
+  });
   const record = upsertPortalTarget({
     alias: input.alias,
     portalUrl: input.portalUrl,
@@ -62,5 +72,35 @@ export async function runPortalConnect(input: PortalConnectInput): Promise<Porta
     email: creds.email,
     setAsDefault: true,
   });
-  return { record, attachedRepo: attachRepoIfPresent(record.alias, input.repoPath) };
+  const attachedRepo = attachRepoIfPresent(record.alias, input.repoPath);
+  if (!creds.targets || creds.targets.length === 0) {
+    return { record, attachedRepo, extraAttached: [], mappedInBrowser: false };
+  }
+
+  const extraAttached: string[] = [];
+  for (const target of creds.targets) {
+    const next = upsertPortalTarget({
+      portalUrl: input.portalUrl,
+      workspaceId: target.workspaceId,
+      workspace: target.workspace,
+      workspaceSlug: target.workspace,
+      workspaceName: target.workspaceName,
+      token: target.token,
+      refreshToken: target.refreshToken,
+      expiresAt: target.expiresAt,
+      email: creds.email,
+      setAsDefault: false,
+    });
+    const attached = applyRepoWorkspaceMap(
+      target.repos.map((repoPath) => ({ repoPath, alias: next.alias })),
+    );
+    extraAttached.push(...attached.filter((repoPath) => repoPath !== attachedRepo));
+  }
+  return { record, attachedRepo, extraAttached, mappedInBrowser: true };
+}
+
+function listRegisteredReposForConnect(repoPath?: string): string[] {
+  const resolved = repoPath ? path.resolve(repoPath) : null;
+  const current = resolved && fs.existsSync(resolved) ? canonicalizeControlRepoPath(resolved) : null;
+  return [...new Set([...(current ? [current] : []), ...listRegisteredRepos()])];
 }

--- a/src/core/portal-login.ts
+++ b/src/core/portal-login.ts
@@ -24,13 +24,65 @@ function openBrowser(url: string): void {
   }
 }
 
+export type BrowserConnectTarget = {
+  workspaceId: string;
+  workspace?: string;
+  workspaceName?: string;
+  token: string;
+  refreshToken?: string;
+  expiresAt?: string;
+  repos: string[];
+};
+
+export type PortalLoginResult = PortalCredentials & {
+  /** Present when the portal assigned repositories in the browser. */
+  targets?: BrowserConnectTarget[];
+};
+
+export type LoginViaBrowserOptions = {
+  openUrl?: (url: string) => void;
+  repos?: string[];
+};
+
+const REPOS_QUERY_BUDGET = 1800;
+
+export function encodeCliReposQuery(repos: string[]): string | null {
+  const unique = [...new Set(repos.filter((repo) => repo.trim().length > 0))];
+  if (unique.length === 0) return null;
+  const encoded = encodeURIComponent(JSON.stringify(unique));
+  if (encoded.length > REPOS_QUERY_BUDGET) return null;
+  return encoded;
+}
+
+export function parseCliTargetsParam(raw: string | null): BrowserConnectTarget[] | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as {
+      targets?: BrowserConnectTarget[];
+    };
+    if (!Array.isArray(parsed.targets)) return null;
+    const targets = parsed.targets.filter(
+      (entry) =>
+        typeof entry?.workspaceId === 'string' &&
+        typeof entry?.token === 'string' &&
+        Array.isArray(entry.repos),
+    );
+    return targets.length > 0 ? targets : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function loginViaBrowser(
   portalUrl: string,
-  openUrl: (url: string) => void = openBrowser,
-): Promise<PortalCredentials> {
+  openUrlOrOptions: ((url: string) => void) | LoginViaBrowserOptions = openBrowser,
+): Promise<PortalLoginResult> {
+  const options: LoginViaBrowserOptions =
+    typeof openUrlOrOptions === 'function' ? { openUrl: openUrlOrOptions } : openUrlOrOptions;
+  const openUrl = options.openUrl ?? openBrowser;
   const state = randomUUID();
 
-  return new Promise<PortalCredentials>((resolve, reject) => {
+  return new Promise<PortalLoginResult>((resolve, reject) => {
     let timer: NodeJS.Timeout;
     const server = http.createServer((req, res) => {
       const requestUrl = new URL(req.url ?? '', 'http://127.0.0.1');
@@ -61,6 +113,7 @@ export async function loginViaBrowser(
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end('<h1>Logged in</h1><p>You can close this tab and return to the terminal.</p>');
       cleanup();
+      const targets = parseCliTargetsParam(requestUrl.searchParams.get('targets'));
       resolve({
         portalUrl,
         token,
@@ -76,6 +129,7 @@ export async function loginViaBrowser(
         refreshToken,
         expiresAt,
         createdAt: new Date().toISOString(),
+        ...(targets ? { targets } : {}),
       });
     });
 
@@ -92,7 +146,10 @@ export async function loginViaBrowser(
     server.listen(0, '127.0.0.1', () => {
       const { port } = server.address() as AddressInfo;
       const callback = `http://127.0.0.1:${port}${CALLBACK_PATH}`;
-      const loginUrl = `${portalUrl}/cli/login?callback=${encodeURIComponent(callback)}&state=${state}`;
+      const reposQuery = encodeCliReposQuery(options.repos ?? []);
+      const loginUrl = `${portalUrl}/cli/login?callback=${encodeURIComponent(callback)}&state=${state}${
+        reposQuery ? `&repos=${reposQuery}` : ''
+      }`;
       openUrl(loginUrl);
       process.stderr.write(`Opening ${loginUrl}\nIf your browser did not open, paste that URL.\n`);
       timer = setTimeout(() => {

--- a/src/core/portal-repo-map.ts
+++ b/src/core/portal-repo-map.ts
@@ -1,0 +1,98 @@
+import { canonicalizeControlRepoPath } from './control-repo-path';
+import { listRegisteredRepos, recordRepoForControlSync } from './control-registry';
+import {
+  attachRepoPortalTarget,
+  displayPortalTargetLabel,
+  listPortalTargetRecords,
+  type PortalTargetRecord,
+} from './portal-targets';
+
+export type RepoMapConnection = { alias: string; label: string };
+
+export type RepoMapPlan =
+  | { kind: 'none' }
+  | {
+      kind: 'attach-more';
+      workspaceAlias: string;
+      workspaceLabel: string;
+      repos: string[];
+    }
+  | {
+      kind: 'map-orgs';
+      currentAlias: string;
+      repos: string[];
+      connections: RepoMapConnection[];
+    };
+
+/**
+ * After `har hq connect` attaches the current checkout, decide whether to ask
+ * about other registered repositories. One saved workspace → checkbox to attach
+ * more to that workspace. Several workspaces → pick a destination per repo.
+ */
+export function planRepoWorkspaceMap(opts: {
+  currentRepo: string | null;
+  currentAlias: string;
+  registeredRepos?: string[];
+  connections?: PortalTargetRecord[];
+}): RepoMapPlan {
+  const registered = (opts.registeredRepos ?? listRegisteredRepos()).map((repoPath) =>
+    canonicalizeControlRepoPath(repoPath),
+  );
+  const current = opts.currentRepo ? canonicalizeControlRepoPath(opts.currentRepo) : null;
+  const others = registered.filter((repoPath) => repoPath !== current);
+  const connections = opts.connections ?? listPortalTargetRecords();
+  if (others.length === 0 || connections.length === 0) return { kind: 'none' };
+
+  if (connections.length === 1) {
+    const only = connections[0];
+    return {
+      kind: 'attach-more',
+      workspaceAlias: only.alias,
+      workspaceLabel: displayPortalTargetLabel(only),
+      repos: others,
+    };
+  }
+
+  return {
+    kind: 'map-orgs',
+    currentAlias: opts.currentAlias,
+    repos: others,
+    connections: connections.map((entry) => ({
+      alias: entry.alias,
+      label: displayPortalTargetLabel(entry),
+    })),
+  };
+}
+
+export function applyRepoWorkspaceMap(
+  assignments: { repoPath: string; alias: string | null }[],
+): string[] {
+  const attached: string[] = [];
+  for (const row of assignments) {
+    if (!row.alias) continue;
+    const canonical = canonicalizeControlRepoPath(row.repoPath);
+    attachRepoPortalTarget(canonical, row.alias);
+    recordRepoForControlSync(canonical);
+    attached.push(canonical);
+  }
+  return attached;
+}
+
+/** Repos still unassigned after a mapping round — already-picked paths are hidden. */
+export function remainingUnassignedRepos(
+  repos: string[],
+  assigned: Iterable<string>,
+): string[] {
+  const taken = new Set(
+    [...assigned].map((repoPath) => canonicalizeControlRepoPath(repoPath)),
+  );
+  return repos.filter((repoPath) => !taken.has(canonicalizeControlRepoPath(repoPath)));
+}
+
+export function remainingConnections(
+  connections: RepoMapConnection[],
+  usedAliases: Iterable<string>,
+): RepoMapConnection[] {
+  const used = new Set([...usedAliases]);
+  return connections.filter((entry) => !used.has(entry.alias));
+}

--- a/src/core/portal-targets.ts
+++ b/src/core/portal-targets.ts
@@ -481,11 +481,9 @@ export function resolvePortalTargetsForRepo(options?: {
       .map(recordToPortalTarget);
     if (attached.length > 0) return { source: 'repo', targets: attached };
 
-    // One saved connection and no explicit mapping yet: existing single-login users
-    // keep syncing without a second connect.
-    if (store.targets.length === 1) {
-      return { source: 'single', targets: [recordToPortalTarget(store.targets[0])] };
-    }
+    // Unattached repos do not inherit the only saved connection — that would
+    // ingest every registered checkout into whichever workspace you last
+    // connected. Attach explicitly at `har hq connect` (or via --target).
     return null;
   }
 

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -911,6 +911,7 @@ describe('syncRepoWithControl — token refresh on 401', () => {
       setAsDefault: true,
       ...overrides,
     });
+    attachRepoPortalTarget('/repo/x', 'test');
   }
 
   function refreshFetch(opts: {

--- a/tests/portal-connect.test.ts
+++ b/tests/portal-connect.test.ts
@@ -47,6 +47,7 @@ describe('runPortalConnect', () => {
     expect(result.record.portalUrl).toBe('https://app.harhq.com');
     expect(result.record.token).toBe('har_ingest_test');
     expect(result.attachedRepo).toBe(repoPath);
+    expect(result.mappedInBrowser).toBe(false);
     expect(getRepoPortalTargetAliases(repoPath)).toEqual([result.record.alias]);
     expect(readPortalTargetsStore().targets).toHaveLength(1);
   });

--- a/tests/portal-login.test.ts
+++ b/tests/portal-login.test.ts
@@ -1,6 +1,10 @@
 import * as http from 'http';
 
-import { loginViaBrowser } from '../src/core/portal-login';
+import {
+  encodeCliReposQuery,
+  loginViaBrowser,
+  parseCliTargetsParam,
+} from '../src/core/portal-login';
 
 function hitCallback(
   loginUrl: string,
@@ -13,6 +17,7 @@ function hitCallback(
     email?: string;
     refreshToken?: string;
     expiresAt?: string;
+    targets?: string;
   },
 ): void {
   const url = new URL(loginUrl);
@@ -26,6 +31,7 @@ function hitCallback(
   if (opts.email) params.set('email', opts.email);
   if (opts.refreshToken) params.set('refreshToken', opts.refreshToken);
   if (opts.expiresAt) params.set('expiresAt', opts.expiresAt);
+  if (opts.targets) params.set('targets', opts.targets);
   http.get(`${callback}?${params.toString()}`, (res) => res.resume());
 }
 
@@ -74,11 +80,69 @@ describe('loginViaBrowser', () => {
     expect(creds.expiresAt).toBe('2026-02-01T00:00:00.000Z');
   });
 
+  it('forwards registered repos on the consent URL', async () => {
+    const pending = loginViaBrowser('https://portal.example.com', {
+      repos: ['/repo/a', '/repo/b'],
+      openUrl: (url) => {
+        const parsed = new URL(url);
+        expect(JSON.parse(parsed.searchParams.get('repos') ?? '[]')).toEqual([
+          '/repo/a',
+          '/repo/b',
+        ]);
+        hitCallback(url, { token: 'har_ingest_abc' });
+      },
+    });
+    await expect(pending).resolves.toMatchObject({ token: 'har_ingest_abc' });
+  });
+
+  it('captures browser assignment targets from the callback', async () => {
+    const targets = Buffer.from(
+      JSON.stringify({
+        targets: [
+          {
+            workspaceId: 'org-a',
+            workspace: 'acme',
+            token: 'har_ingest_a',
+            repos: ['/repo/a'],
+          },
+        ],
+      }),
+      'utf8',
+    ).toString('base64url');
+    const creds = await loginViaBrowser('https://portal.example.com', (url) =>
+      hitCallback(url, { token: 'har_ingest_a', workspaceId: 'org-a', targets }),
+    );
+    expect(creds.targets).toEqual([
+      {
+        workspaceId: 'org-a',
+        workspace: 'acme',
+        token: 'har_ingest_a',
+        repos: ['/repo/a'],
+      },
+    ]);
+  });
+
   it('rejects on state mismatch', async () => {
     await expect(
       loginViaBrowser('https://portal.example.com', (url) =>
         hitCallback(url, { token: 'har_ingest_abc', state: 'wrong-state' }),
       ),
     ).rejects.toThrow(/state mismatch/);
+  });
+});
+
+describe('cli repos / targets encoding', () => {
+  it('encodes a short repo list and round-trips targets', () => {
+    expect(JSON.parse(decodeURIComponent(encodeCliReposQuery(['/a', '/b'])!))).toEqual([
+      '/a',
+      '/b',
+    ]);
+    const raw = Buffer.from(
+      JSON.stringify({
+        targets: [{ workspaceId: 'o', token: 't', repos: ['/a'] }],
+      }),
+      'utf8',
+    ).toString('base64url');
+    expect(parseCliTargetsParam(raw)?.[0]).toMatchObject({ workspaceId: 'o', repos: ['/a'] });
   });
 });

--- a/tests/portal-repo-map.test.ts
+++ b/tests/portal-repo-map.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  applyRepoWorkspaceMap,
+  planRepoWorkspaceMap,
+  remainingConnections,
+  remainingUnassignedRepos,
+} from '../src/core/portal-repo-map';
+import { getRepoPortalTargetAliases, upsertPortalTarget } from '../src/core/portal-targets';
+
+const ENV_KEYS = ['HAR_PORTAL_TARGETS_PATH', 'HAR_CONTROL_REGISTRY_PATH', 'HAR_CREDENTIALS_PATH'] as const;
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-repo-map-'));
+  process.env.HAR_PORTAL_TARGETS_PATH = path.join(tmpDir, 'portal-targets.json');
+  process.env.HAR_CONTROL_REGISTRY_PATH = path.join(tmpDir, 'repos.json');
+  process.env.HAR_CREDENTIALS_PATH = path.join(tmpDir, 'credentials.json');
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+describe('planRepoWorkspaceMap', () => {
+  it('is a no-op when there are no other registered repos', () => {
+    const repo = path.join(tmpDir, 'only');
+    expect(
+      planRepoWorkspaceMap({
+        currentRepo: repo,
+        currentAlias: 'acme',
+        registeredRepos: [repo],
+        connections: [
+          {
+            alias: 'acme',
+            portalUrl: 'https://app.harhq.com',
+            workspaceId: 'org-1',
+            workspaceName: 'Acme',
+            token: 't',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    ).toEqual({ kind: 'none' });
+  });
+
+  it('offers extra attachments when only one workspace is saved', () => {
+    const current = path.join(tmpDir, 'current');
+    const other = path.join(tmpDir, 'other');
+    const plan = planRepoWorkspaceMap({
+      currentRepo: current,
+      currentAlias: 'acme',
+      registeredRepos: [current, other],
+      connections: [
+        {
+          alias: 'acme',
+          portalUrl: 'https://app.harhq.com',
+          workspaceId: 'org-1',
+          workspaceName: 'Acme',
+          token: 't',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    expect(plan.kind).toBe('attach-more');
+    if (plan.kind !== 'attach-more') return;
+    expect(plan.repos).toEqual([other]);
+    expect(plan.workspaceAlias).toBe('acme');
+  });
+
+  it('asks for a per-repo workspace when several connections exist', () => {
+    const current = path.join(tmpDir, 'current');
+    const other = path.join(tmpDir, 'other');
+    const plan = planRepoWorkspaceMap({
+      currentRepo: current,
+      currentAlias: 'kerno',
+      registeredRepos: [current, other],
+      connections: [
+        {
+          alias: 'haulieros',
+          portalUrl: 'http://localhost:3020',
+          workspaceId: 'org-h',
+          workspaceName: 'HaulierOS',
+          token: 't1',
+          createdAt: new Date().toISOString(),
+        },
+        {
+          alias: 'kerno',
+          portalUrl: 'http://localhost:3020',
+          workspaceId: 'org-k',
+          workspaceName: 'Kerno',
+          token: 't2',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    expect(plan.kind).toBe('map-orgs');
+    if (plan.kind !== 'map-orgs') return;
+    expect(plan.repos).toEqual([other]);
+    expect(plan.connections.map((c) => c.alias)).toEqual(['haulieros', 'kerno']);
+  });
+});
+
+describe('applyRepoWorkspaceMap', () => {
+  it('attaches selected repos and skips the rest', () => {
+    upsertPortalTarget({
+      alias: 'acme',
+      portalUrl: 'https://app.harhq.com',
+      workspaceId: 'org-1',
+      token: 't',
+    });
+    const keep = path.join(tmpDir, 'keep');
+    const skip = path.join(tmpDir, 'skip');
+    fs.mkdirSync(keep, { recursive: true });
+    fs.mkdirSync(skip, { recursive: true });
+
+    expect(
+      applyRepoWorkspaceMap([
+        { repoPath: keep, alias: 'acme' },
+        { repoPath: skip, alias: null },
+      ]),
+    ).toEqual([keep]);
+    expect(getRepoPortalTargetAliases(keep)).toEqual(['acme']);
+    expect(getRepoPortalTargetAliases(skip)).toEqual([]);
+  });
+});
+
+describe('remainingUnassignedRepos / remainingConnections', () => {
+  it('hides already-assigned repositories from the next workspace', () => {
+    const a = path.join(tmpDir, 'a');
+    const b = path.join(tmpDir, 'b');
+    const c = path.join(tmpDir, 'c');
+    expect(remainingUnassignedRepos([a, b, c], [b])).toEqual([a, c]);
+  });
+
+  it('drops a workspace once it has been used in a round', () => {
+    expect(
+      remainingConnections(
+        [
+          { alias: 'kerno', label: 'Kerno' },
+          { alias: 'haulieros', label: 'HaulierOS' },
+        ],
+        ['kerno'],
+      ),
+    ).toEqual([{ alias: 'haulieros', label: 'HaulierOS' }]);
+  });
+});

--- a/tests/portal-targets.test.ts
+++ b/tests/portal-targets.test.ts
@@ -263,6 +263,18 @@ describe('resolvePortalTargetsForRepo', () => {
       resolvePortalTargetsForRepo({ repoPath })?.targets.map((entry) => entry.alias).sort(),
     ).toEqual(['dev', 'prod']);
   });
+
+  it('does not fan an unattached repo out to the only saved connection', () => {
+    upsertPortalTarget({
+      alias: 'only',
+      portalUrl: 'https://app.harhq.com',
+      workspaceId: 'ws_only',
+      token: 't',
+    });
+    const repoPath = path.join(tmpDir, 'unattached');
+    fs.mkdirSync(repoPath, { recursive: true });
+    expect(resolvePortalTargetsForRepo({ repoPath })).toBeNull();
+  });
 });
 
 describe('target-specific trajectory preference', () => {


### PR DESCRIPTION
## Summary
- After `har hq connect`, leftover registered repositories are listed with a count. You can send all of them to one workspace, or pick a workspace and then the leftover paths for it — already-assigned repos are hidden on the next workspace.
- The consent URL carries that repo list so the same mapping can happen in the browser (`/cli/login`) instead of only in the TTY. `--yes` / `--json` still attach only the current checkout.
- Unattached checkouts still do not inherit the only leftover connection.

Pairs with the har-portal follow-up that renders the assign UI and mints one ingest token per destination workspace.

Related: https://github.com/os-factory/har/pull/262
Linear: https://linear.app/kerno/issue/FE-1647/har-core-support-named-portal-targets-per-workspace-and-repository

## Test plan
- [ ] `har hq connect` with one saved workspace and other registered repos — shows the count/list, checkbox defaults to all
- [ ] With several workspaces — confirm "send all to the same workspace?", pick one, all attach
- [ ] Say no — pick workspace, checkbox leftover repos, those paths disappear for the next workspace
- [ ] Browser consent with `repos` query assigns paths and returns `targets`; TTY extra prompt is skipped
- [ ] `--yes` attaches only the current checkout
- [ ] `har env verify --full` on this branch


Made with [Cursor](https://cursor.com)