### PR TITLE
fix: surface bugs — MCP launch trigger, status arg, cli setup-infra dead code, quick verify exit, teardown attempt outcome

### DIFF
--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -10,6 +10,7 @@ import {
   bindValidationToAttempt,
   createWorkAttempt,
   decideWorkUnitOutcome,
+  findWorkUnit,
   upsertWorkUnit,
 } from './work-units';
 import { resolveHarnessRoot } from '../harness/manifest';
@@ -263,7 +264,7 @@ export class RunService {
         workUnitId,
         attemptId,
       },
-      trigger: 'cli',
+      trigger: options.trigger ?? 'cli',
     });
     const envResult = toEnvironmentRunResult(result);
     if (envResult.code === 0) {
@@ -404,6 +405,11 @@ export class RunService {
     capture?: boolean;
     trigger?: ExecutionContext['trigger'];
   }): Promise<EnvironmentRunResult> {
+    // Captured before teardown clears the slot registry — the attempt binding
+    // is gone afterwards.
+    const harnessRoot = resolveHarnessRoot(options.repoPath);
+    const session = readSlotRegistry(harnessRoot, options.agentId);
+
     const result = await this.runStage({
       repoPath: options.repoPath,
       kind: 'teardown',
@@ -412,7 +418,27 @@ export class RunService {
       capture: options.capture ?? false,
       trigger: options.trigger ?? 'cli',
     });
-    return toEnvironmentRunResult(result);
+    const envResult = toEnvironmentRunResult(result);
+
+    // Teardown is the only exit besides `complete`; close the open attempt so
+    // work units don't linger as in-flight forever. `complete` records its
+    // 'completed' outcome before tearing down, so an existing outcome wins.
+    if (envResult.code === 0 && session?.workUnitId) {
+      try {
+        const workUnit = findWorkUnit(harnessRoot, session.workUnitId);
+        if (workUnit && !workUnit.outcome) {
+          decideWorkUnitOutcome(harnessRoot, session.workUnitId, {
+            decision: 'abandoned',
+            decidedAt: new Date().toISOString(),
+            attemptId: session.attemptId,
+            reason: 'Session torn down without completion.',
+          });
+        }
+      } catch {
+        // Outcome bookkeeping must not fail an otherwise successful teardown.
+      }
+    }
+    return envResult;
   }
 
   /**
@@ -519,7 +545,6 @@ export class RunService {
         repoPath: options.repoPath,
         stageId: 'status',
         agentId: options.agentId,
-        args: ['status'],
         capture,
         trigger: options.trigger ?? 'cli',
       });
@@ -535,7 +560,6 @@ export class RunService {
         repoPath: options.repoPath,
         stageId: 'status',
         agentId: id,
-        args: ['status'],
         capture,
         trigger: options.trigger ?? 'cli',
       });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -58,6 +58,7 @@ export interface LaunchOptions {
   title?: string;
   parentWorkUnitId?: string;
   relatedLinks?: WorkUnitRelatedLink[];
+  trigger?: ExecutionContext['trigger'];
 }
 
 export interface PreflightOptions {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -338,6 +338,7 @@ export async function handleMcpToolCall(
         parentWorkUnitId: input.parentWorkUnitId,
         relatedLinks: input.relatedLinks,
         capture: true,
+        trigger: 'mcp',
       });
       const parsed = LaunchEnvironmentOutputSchema.parse(result);
       return {
@@ -362,6 +363,7 @@ export async function handleMcpToolCall(
         parentWorkUnitId: input.parentWorkUnitId,
         relatedLinks: input.relatedLinks,
         capture: true,
+        trigger: 'mcp',
       });
       const parsed = LaunchEnvironmentOutputSchema.parse(result);
       return {

--- a/src/templates/har-boilerplate-cli/setup-infra.sh
+++ b/src/templates/har-boilerplate-cli/setup-infra.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Sets up shared infrastructure for all agents.
-# Starts the docker compose services listed in HARNESS_INFRA_SERVICES, creates
-# the template database (when "db" is enabled), and starts optional shared app
-# services (ecosystem.shared.config.cjs). One instance serves every agent slot.
+# Starts the docker compose services listed in HARNESS_INFRA_SERVICES and
+# optional shared app services (ecosystem.shared.config.cjs). One instance
+# serves every agent slot.
 # Idempotent — safe to run multiple times.
 #
 # Usage: ./.har/setup-infra.sh
@@ -111,7 +111,9 @@ else
   log "No shared infra services enabled in harness.env (HARNESS_INFRA_SERVICES)"
 fi
 
-# Wait for PostgreSQL and prepare the template database
+# Wait for PostgreSQL when the optional db service is enabled. The cli profile
+# has no template-database flow — per-slot databases are the pm2 profiles'
+# concern (see har-boilerplate/setup-infra.sh).
 if har_infra_enabled db; then
   log "Waiting for PostgreSQL on port $DB_PORT..."
   for i in $(seq 1 30); do
@@ -128,33 +130,6 @@ if har_infra_enabled db; then
 
   log "Enabling pg_stat_statements extension..."
   $PSQL -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements" 2>/dev/null || true
-
-  if [ -n "${HARNESS_TEMPLATE_DB:-}" ]; then
-    if $PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = '$HARNESS_TEMPLATE_DB'" | grep -q 1; then
-      log "Template database '$HARNESS_TEMPLATE_DB' already exists. Skipping creation."
-    else
-      log "Creating template database '$HARNESS_TEMPLATE_DB'..."
-      $PSQL -c "CREATE DATABASE $HARNESS_TEMPLATE_DB"
-
-      if [ -n "${HARNESS_DB_MIGRATE_CMD:-}" ] && [ "$HARNESS_DB_MIGRATE_CMD" != "echo 'TODO: set migrate command'" ]; then
-        log "Running migrations..."
-        PGPASSWORD=password PGHOST=localhost PGPORT="$DB_PORT" PGUSER=postgres \
-          PGDATABASE="$HARNESS_TEMPLATE_DB" \
-          bash -c "cd '$REPO_ROOT' && $HARNESS_DB_MIGRATE_CMD"
-      fi
-
-      if [ -n "${HARNESS_DB_SEED_CMD:-}" ] && [ "$HARNESS_DB_SEED_CMD" != "echo 'TODO: set seed command'" ]; then
-        log "Running seeds..."
-        PGPASSWORD=password PGHOST=localhost PGPORT="$DB_PORT" PGUSER=postgres \
-          PGDATABASE="$HARNESS_TEMPLATE_DB" \
-          bash -c "cd '$REPO_ROOT' && $HARNESS_DB_SEED_CMD"
-      fi
-
-      log "Marking '$HARNESS_TEMPLATE_DB' as a PostgreSQL template..."
-      $PSQL -c "UPDATE pg_database SET datistemplate = true WHERE datname = '$HARNESS_TEMPLATE_DB'"
-      log "Template database ready: $HARNESS_TEMPLATE_DB"
-    fi
-  fi
 fi
 
 # Shared app services — supporting services of a monolith/monorepo that agents

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -172,11 +172,35 @@ run_full_checks() {
   esac
 }
 
+# Emit the results JSON and exit non-zero when any step failed. Quick mode
+# calls this at the first failing step (stopping early); the full pipeline
+# runs every step and calls it once at the end.
+emit_results() {
+  END_TOTAL=$(now_ms)
+  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+
+  node -e "
+const results = $RESULTS_JSON;
+const overall = results.length > 0 && results.every(r => r.pass);
+const out = {
+  status: overall ? 'pass' : 'fail',
+  agent_id: $AGENT_ID,
+  total_ms: $TOTAL_MS,
+  stages: results,
+};
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
+
+  if [ "$OVERALL_PASS" = "false" ]; then
+    exit 1
+  fi
+}
+
 # ── Verification stages ─────────────────────────────────────────────────────
 # These stock steps are intentionally generic conventions. Adapt this section
 # to the repository's real commands from package.json, Makefile, CI, pyproject,
 # Cargo.toml, go.mod, pom.xml, etc.
-run_quick_smoke || { [ -z "$FULL" ] && true; }
+run_quick_smoke || emit_results
 
 if [ -n "$FULL" ]; then
   run_full_checks
@@ -190,21 +214,4 @@ if [ -n "$FULL" ]; then
   done < <(list_registered_verification_stage_commands "$SCRIPT_DIR" "$AGENT_ID")
 fi
 
-END_TOTAL=$(now_ms)
-TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
-
-node -e "
-const results = $RESULTS_JSON;
-const overall = results.length > 0 && results.every(r => r.pass);
-const out = {
-  status: overall ? 'pass' : 'fail',
-  agent_id: $AGENT_ID,
-  total_ms: $TOTAL_MS,
-  stages: results,
-};
-process.stdout.write(JSON.stringify(out, null, 2) + '\n');
-" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
-
-if [ "$OVERALL_PASS" = "false" ]; then
-  exit 1
-fi
+emit_results

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -120,6 +120,30 @@ run_step() {
 # Quick (default): compile-only — use XCODEBUILD_BIN from .env.agent.<id> (written by launch)
 # Nothing is installed or run, so CODE_SIGNING_ALLOWED=NO keeps the smoke build
 # from needing a signing identity.
+# Emit the results JSON and exit non-zero when any step failed. Quick mode
+# calls this at the first failing step (stopping early); the full pipeline
+# runs every step and calls it once at the end.
+emit_results() {
+  END_TOTAL=$(now_ms)
+  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+
+  node -e "
+const results = $RESULTS_JSON;
+const overall = results.length > 0 && results.every(r => r.pass);
+const out = {
+  status: overall ? 'pass' : 'fail',
+  agent_id: $AGENT_ID,
+  total_ms: $TOTAL_MS,
+  stages: results,
+};
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
+
+  if [ "$OVERALL_PASS" = "false" ]; then
+    exit 1
+  fi
+}
+
 run_step "build" '${XCODEBUILD_BIN:-xcodebuild} build \
   ${XC_FLAGS} \
   -scheme "${XC_SCHEME}" \
@@ -131,7 +155,7 @@ run_step "build" '${XCODEBUILD_BIN:-xcodebuild} build \
     -scheme "${XC_SCHEME}" \
     -destination "${XC_DESTINATION}" \
     -derivedDataPath "${XC_DERIVED}" \
-    CODE_SIGNING_ALLOWED=NO' || { [ -z "$FULL" ] && true; }
+    CODE_SIGNING_ALLOWED=NO' || emit_results
 
 if [ -n "$FULL" ]; then
   # Full: project-specific checks — add/remove/reorder steps for this repo.
@@ -165,21 +189,4 @@ if [ -n "$FULL" ]; then
   done < <(list_registered_verification_stage_commands "$SCRIPT_DIR" "$AGENT_ID")
 fi
 
-END_TOTAL=$(now_ms)
-TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
-
-node -e "
-const results = $RESULTS_JSON;
-const overall = results.length > 0 && results.every(r => r.pass);
-const out = {
-  status: overall ? 'pass' : 'fail',
-  agent_id: $AGENT_ID,
-  total_ms: $TOTAL_MS,
-  stages: results,
-};
-process.stdout.write(JSON.stringify(out, null, 2) + '\n');
-" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
-
-if [ "$OVERALL_PASS" = "false" ]; then
-  exit 1
-fi
+emit_results

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -208,12 +208,36 @@ run_full_checks() {
   esac
 }
 
+# Emit the results JSON and exit non-zero when any step failed. Quick mode
+# calls this at the first failing step (stopping early); the full pipeline
+# runs every step and calls it once at the end.
+emit_results() {
+  END_TOTAL=$(now_ms)
+  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
+
+  node -e "
+const results = $RESULTS_JSON;
+const overall = results.length > 0 && results.every(r => r.pass);
+const out = {
+  status: overall ? 'pass' : 'fail',
+  agent_id: $AGENT_ID,
+  total_ms: $TOTAL_MS,
+  stages: results,
+};
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
+
+  if [ "$OVERALL_PASS" = "false" ]; then
+    exit 1
+  fi
+}
+
 # ── Verification stages ─────────────────────────────────────────────────────
 # These stock steps are intentionally generic conventions. Adapt this section
 # to the repository's real commands from package.json, Makefile, CI, pyproject,
 # Cargo.toml, go.mod, pom.xml, etc.
-run_quick_smoke || { [ -z "$FULL" ] && true; }
-run_http_step "api-health" "http://localhost:${API_PORT}${HARNESS_HEALTH_CHECK_PATH}" || { [ -z "$FULL" ] && true; }
+run_quick_smoke || emit_results
+run_http_step "api-health" "http://localhost:${API_PORT}${HARNESS_HEALTH_CHECK_PATH}" || emit_results
 
 if [ -n "$FULL" ]; then
   run_full_checks
@@ -229,21 +253,4 @@ fi
 
 # ── Output results ────────────────────────────────────────────────────────────
 
-END_TOTAL=$(now_ms)
-TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
-
-node -e "
-const results = $RESULTS_JSON;
-const overall = results.length > 0 && results.every(r => r.pass);
-const out = {
-  status: overall ? 'pass' : 'fail',
-  agent_id: $AGENT_ID,
-  total_ms: $TOTAL_MS,
-  stages: results,
-};
-process.stdout.write(JSON.stringify(out, null, 2) + '\n');
-" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
-
-if [ "$OVERALL_PASS" = "false" ]; then
-  exit 1
-fi
+emit_results

--- a/tests/fixtures/minimal-harness/.har/agent-cli.sh
+++ b/tests/fixtures/minimal-harness/.har/agent-cli.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 AGENT_ID="${1:?agent id required}"
 CMD="${2:?command required}"
+if [ "$#" -gt 2 ]; then
+  echo "unexpected extra args: ${*:3}" >&2
+  exit 1
+fi
 case "$CMD" in
   status)
     echo "Agent ${AGENT_ID} running"

--- a/tests/fixtures/minimal-harness/.har/stages.json
+++ b/tests/fixtures/minimal-harness/.har/stages.json
@@ -4,7 +4,9 @@
     "min": 1,
     "max": 5
   },
-  "verificationStages": ["smoke"],
+  "verificationStages": [
+    "smoke"
+  ],
   "stages": [
     {
       "id": "launch",
@@ -31,8 +33,7 @@
       "id": "status",
       "kind": "inspect",
       "description": "Inspect agent slot",
-      "script": "agent-cli.sh",
-      "requiresAgentId": true
+      "command": "./.har/agent-cli.sh {agentId} status"
     },
     {
       "id": "logs",

--- a/tests/run-service-surface-bugs.test.ts
+++ b/tests/run-service-surface-bugs.test.ts
@@ -1,0 +1,137 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  getEnvironmentStatus,
+  launchEnvironment,
+  teardownEnvironment,
+} from '../src/core/run-service';
+import { createWorkAttempt, findWorkUnit, upsertWorkUnit, decideWorkUnitOutcome } from '../src/core/work-units';
+import { getSlotRegistryPath } from '../src/core/slot-registry';
+
+const FIXTURE = path.join(__dirname, 'fixtures/minimal-harness');
+
+function makeTempRepo(): string {
+  const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-surface-bugs-'));
+  fs.cpSync(path.join(FIXTURE, '.har'), path.join(tempRepo, '.har'), { recursive: true });
+  // Other suites run stages against the fixture directly and leave run/slot
+  // records behind — drop that transient state so assertions see only ours.
+  for (const dir of ['runs', 'slots', 'work-units', 'work-attempts', 'validation-bindings']) {
+    fs.rmSync(path.join(tempRepo, '.har', dir), { recursive: true, force: true });
+  }
+  return tempRepo;
+}
+
+function readRunRecords(repoPath: string): Array<Record<string, unknown>> {
+  const runsDir = path.join(repoPath, '.har', 'runs');
+  const records: Array<Record<string, unknown>> = [];
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.json')) {
+        records.push(JSON.parse(fs.readFileSync(full, 'utf8')));
+      }
+    }
+  };
+  walk(runsDir);
+  return records;
+}
+
+function writeSlotRegistryEntry(
+  repoPath: string,
+  agentId: number,
+  extra: Record<string, unknown> = {},
+): void {
+  const file = getSlotRegistryPath(repoPath, agentId);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      agentId,
+      projectName: 'minimal',
+      mode: 'root',
+      workDir: repoPath,
+      createdAt: new Date().toISOString(),
+      status: 'active',
+      ...extra,
+    }),
+  );
+}
+
+describe('MCP launch trigger parity (#228)', () => {
+  it('records trigger:"mcp" when launch is invoked from MCP', async () => {
+    const tempRepo = makeTempRepo();
+    const result = await launchEnvironment({
+      repoPath: tempRepo,
+      agentId: 1,
+      capture: true,
+      trigger: 'mcp',
+    });
+    expect(result.code).toBe(0);
+    const launches = readRunRecords(tempRepo).filter((r) => r.kind === 'launch');
+    expect(launches.length).toBeGreaterThan(0);
+    expect(launches.every((r) => r.trigger === 'mcp')).toBe(true);
+  }, 20_000);
+
+  it('defaults to trigger:"cli" when no trigger is given', async () => {
+    const tempRepo = makeTempRepo();
+    const result = await launchEnvironment({ repoPath: tempRepo, agentId: 1, capture: true });
+    expect(result.code).toBe(0);
+    const launches = readRunRecords(tempRepo).filter((r) => r.kind === 'launch');
+    expect(launches.length).toBeGreaterThan(0);
+    expect(launches.every((r) => r.trigger === 'cli')).toBe(true);
+  }, 20_000);
+});
+
+describe('status execution (#228)', () => {
+  // The fixture agent-cli.sh rejects extra args, so the old duplicated
+  // `status status` invocation fails this test.
+  it('runs the status stage without a duplicated subcommand arg', async () => {
+    const tempRepo = makeTempRepo();
+    const result = await getEnvironmentStatus({ repoPath: tempRepo, agentId: 1, capture: true });
+    expect(result.stderr).not.toContain('unexpected extra args');
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('Agent 1 running');
+  }, 20_000);
+});
+
+describe('teardown closes the open work attempt (#228)', () => {
+  const attemptId = '00000000-0000-4000-8000-000000000228';
+
+  it('marks an undecided work unit abandoned on teardown', async () => {
+    const tempRepo = makeTempRepo();
+    upsertWorkUnit(tempRepo, { workUnitId: 'gh-228', source: 'github' });
+    createWorkAttempt(tempRepo, { attemptId, workUnitId: 'gh-228', agentId: 1 });
+    writeSlotRegistryEntry(tempRepo, 1, { workUnitId: 'gh-228', attemptId });
+
+    const result = await teardownEnvironment({ repoPath: tempRepo, agentId: 1, capture: true });
+    expect(result.code).toBe(0);
+
+    const workUnit = findWorkUnit(tempRepo, 'gh-228');
+    expect(workUnit?.outcome?.decision).toBe('abandoned');
+    expect(workUnit?.outcome?.attemptId).toBe(attemptId);
+  }, 20_000);
+
+  it('does not overwrite an already-completed outcome', async () => {
+    const tempRepo = makeTempRepo();
+    upsertWorkUnit(tempRepo, { workUnitId: 'gh-228-done', source: 'github' });
+    createWorkAttempt(tempRepo, { attemptId, workUnitId: 'gh-228-done', agentId: 1 });
+    decideWorkUnitOutcome(tempRepo, 'gh-228-done', {
+      decision: 'completed',
+      decidedAt: new Date().toISOString(),
+      attemptId,
+      validationId: '00000000-0000-4000-8000-00000000dead',
+      treeHash: 'a'.repeat(40),
+    });
+    writeSlotRegistryEntry(tempRepo, 1, { workUnitId: 'gh-228-done', attemptId });
+
+    const result = await teardownEnvironment({ repoPath: tempRepo, agentId: 1, capture: true });
+    expect(result.code).toBe(0);
+
+    const workUnit = findWorkUnit(tempRepo, 'gh-228-done');
+    expect(workUnit?.outcome?.decision).toBe('completed');
+  }, 20_000);
+});


### PR DESCRIPTION
Closes #228

**Stack 1/5** — based on `v1`.

- MCP launches now record `trigger:"mcp"` (threaded through `LaunchOptions`); parity tests added
- Removed the duplicated `status` arg in both status execution paths
- Deleted the dead Postgres template-DB block from `har-boilerplate-cli/setup-infra.sh`
- Quick verify now emits results and exits 1 on step failure instead of swallowing it (all three profiles + ios)
- Teardown marks an undecided work unit `abandoned` (existing `completed` outcome wins), CLI + MCP

**Gate:** M0 milestone gate green — `har env verify --full` run `573b295e-6b80-4f8d-b05c-8da334c3bf91` (typecheck, build, docs, unit-tests, lint, readiness, docs-drift, fixture-e2e incl. M0 asserts), 678/678 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)