### PR TITLE
feat(plugins): default add-plugin to skip CI workflows, add --with-ci opt-in

### DIFF
--- a/docs/src/content/docs/docs/guides/plugins.md
+++ b/docs/src/content/docs/docs/guides/plugins.md
@@ -64,7 +64,7 @@ This adds:
 - a `browser-e2e` test stage;
 - Playwright configuration;
 - frontend, API health, and accessibility smoke specs;
-- CI workflow and artifact directories unless `--skip-ci` is used.
+- artifact directories, plus a CI workflow when `--with-ci` is passed (CI files are skipped by default).
 
 Adapt selectors and URLs after installation. Full verification runs the stage when
 it is listed in `verificationStages` (the plugin updates that list for you).
@@ -129,8 +129,8 @@ This adds:
   against the agent work dir (uncommitted changes included) and fails on findings;
 - a root `.gitleaks.toml` extending the default ruleset with harness allowlists
   (skipped if the repo already has one);
-- a CI workflow using the official `gitleaks/gitleaks-action` unless `--skip-ci`
-  is used.
+- a CI workflow using the official `gitleaks/gitleaks-action` when `--with-ci`
+  is passed (skipped by default).
 
 The `gitleaks` binary is an external requirement (`brew install gitleaks` or a
 [release binary](https://github.com/gitleaks/gitleaks/releases)) — the stage
@@ -156,8 +156,8 @@ This adds:
   Terraform, Dockerfiles, Kubernetes manifests, and other IaC (Trivy absorbed
   tfsec, so Terraform checks are included);
 - a `.trivyignore` scaffold for documented suppressions;
-- a CI workflow that uploads SARIF to GitHub code scanning unless `--skip-ci`
-  is used.
+- a CI workflow that uploads SARIF to GitHub code scanning when `--with-ci`
+  is passed (skipped by default).
 
 The `trivy` binary is an external requirement (`brew install trivy`); the stage
 fails fast with an install hint when missing. The fail threshold defaults to
@@ -179,7 +179,7 @@ This adds:
 
 - a `sast` test stage that scans the session worktree with Semgrep;
 - an adaptation guide (`.har/stages/SEMGREP.md`) covering rulesets and noise tuning;
-- a CI workflow running the official `semgrep ci` recipe unless `--skip-ci` is used.
+- a CI workflow running the official `semgrep ci` recipe when `--with-ci` is passed (skipped by default).
 
 The `semgrep` CLI itself is an external requirement (`pipx install semgrep`).
 Reports (JSON + SARIF) land under `.har/artifacts/sast/`. Pin rulesets with
@@ -214,7 +214,7 @@ HAR is open source. Anyone can ship a verification plugin without changing HAR c
 - Repository: [os-factory/har-plugin](https://github.com/os-factory/har-plugin) (*Use this template*)
 - Agent guide (fit + examples): [AGENTS.md](https://github.com/os-factory/har-plugin/blob/main/AGENTS.md)
 - Authoring guide: [docs/AUTHORING.md](https://github.com/os-factory/har-plugin/blob/main/docs/AUTHORING.md)
-- Try the example: `har env add-plugin github:os-factory/har-plugin --skip-ci`
+- Try the example: `har env add-plugin github:os-factory/har-plugin`
 
 **1. Author a bundle** — a directory with:
 

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -86,12 +86,12 @@ har env maintain [--yes] [--finalize]
 
 ```bash
 har env add-plugin --list
-har env add-plugin playwright [--force] [--skip-ci]
+har env add-plugin playwright [--force] [--with-ci]
 har env add-plugin rocketsim [--force]
-har env add-plugin kerno [--force] [--skip-ci]
-har env add-plugin gitleaks [--force] [--skip-ci]
-har env add-plugin trivy [--force] [--skip-ci]
-har env add-plugin semgrep [--force] [--skip-ci]
+har env add-plugin kerno [--force] [--with-ci]
+har env add-plugin gitleaks [--force] [--with-ci]
+har env add-plugin trivy [--force] [--with-ci]
+har env add-plugin semgrep [--force] [--with-ci]
 har env add-plugin ./my-plugin [--force]
 har env add-plugin @org/har-cypress [--force]
 har env add-plugin github:org/har-plugin [--force]

--- a/docs/src/data/plugins.ts
+++ b/docs/src/data/plugins.ts
@@ -51,7 +51,7 @@ export const plugins: PluginEntry[] = [
       'Playwright configuration wired to the slot’s computed BASE_URL and ports.',
       'Frontend, API health, and accessibility smoke specs as a starting point.',
       'Pinned `devDependencies` and npm scripts merged into `package.json`.',
-      'A GitHub Actions workflow from the official Playwright recipe (skip with `--skip-ci`).',
+      'A GitHub Actions workflow from the official Playwright recipe (opt in with `--with-ci`).',
     ],
     requirements: ['Node.js project (the plugin merges `package.json`)', 'Browsers via `npx playwright install`'],
     artifacts:
@@ -153,7 +153,7 @@ export const plugins: PluginEntry[] = [
     installs: [
       'A `secrets-scan` test stage registered in `.har/stages.json` and added to `verificationStages`.',
       'A root `.gitleaks.toml` extending the default ruleset with harness allowlists (skipped if your repo already has one).',
-      'A GitHub Actions workflow using the official `gitleaks/gitleaks-action` (skip with `--skip-ci`).',
+      'A GitHub Actions workflow using the official `gitleaks/gitleaks-action` (opt in with `--with-ci`).',
     ],
     requirements: [
       'The `gitleaks` binary (`brew install gitleaks` or a release binary) — the stage fails fast with an install hint when missing',
@@ -190,7 +190,7 @@ export const plugins: PluginEntry[] = [
     installs: [
       'A `vuln-scan` test stage registered in `.har/stages.json` and added to `verificationStages`.',
       'A `.trivyignore` scaffold for documented suppressions that travel with the change batch.',
-      'A GitHub Actions workflow that uploads SARIF to GitHub code scanning (skip with `--skip-ci`).',
+      'A GitHub Actions workflow that uploads SARIF to GitHub code scanning (opt in with `--with-ci`).',
     ],
     requirements: [
       'The `trivy` binary (`brew install trivy`) — the stage fails fast with an install hint when missing',
@@ -227,7 +227,7 @@ export const plugins: PluginEntry[] = [
     installs: [
       'A `sast` test stage registered in `.har/stages.json` and added to `verificationStages`.',
       'An adaptation guide at `.har/stages/SEMGREP.md` covering rulesets and noise tuning.',
-      'A GitHub Actions workflow running the official `semgrep ci` recipe (skip with `--skip-ci`).',
+      'A GitHub Actions workflow running the official `semgrep ci` recipe (opt in with `--with-ci`).',
     ],
     requirements: [
       'The `semgrep` CLI (`pipx install semgrep`) — the stage fails fast with an install hint when missing',

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -194,8 +194,14 @@ export const envCommand = {
             })
             .option('skip-ci', {
               type: 'boolean',
+              default: true,
+              describe:
+                'Do not copy optional CI workflow files (default; pass --with-ci to include them)',
+            })
+            .option('with-ci', {
+              type: 'boolean',
               default: false,
-              describe: 'Do not copy optional CI workflow files (e.g. .github/workflows/playwright.yml)',
+              describe: 'Copy optional CI workflow files (e.g. .github/workflows/playwright.yml)',
             }),
         handleAddPlugin,
       )
@@ -249,8 +255,14 @@ export const envCommand = {
             })
             .option('skip-ci', {
               type: 'boolean',
+              default: true,
+              describe:
+                'Do not copy optional CI workflow files (default; pass --with-ci to include them)',
+            })
+            .option('with-ci', {
+              type: 'boolean',
               default: false,
-              describe: 'Do not copy optional CI workflow files (e.g. .github/workflows/playwright.yml)',
+              describe: 'Copy optional CI workflow files (e.g. .github/workflows/playwright.yml)',
             }),
         handleAddStage,
       )
@@ -772,6 +784,7 @@ export async function handleAddPlugin(argv: {
   repo: string;
   force: boolean;
   skipCi: boolean;
+  withCi?: boolean;
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
   const available = listPluginIds();
@@ -798,7 +811,8 @@ export async function handleAddPlugin(argv: {
   try {
     const result = addPlugin(repoPath, argv.plugin, {
       force: argv.force,
-      skipCi: argv.skipCi,
+      // --with-ci wins over the skip-ci default: CI workflows are opt-in.
+      skipCi: argv.withCi ? false : argv.skipCi,
       spec: argv.plugin,
     });
 
@@ -834,6 +848,7 @@ export async function handleAddStage(argv: {
   repo: string;
   force: boolean;
   skipCi: boolean;
+  withCi?: boolean;
 }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
   const available = listPluginIds();
@@ -905,6 +920,7 @@ export async function handleAddStage(argv: {
     repo: argv.repo,
     force: argv.force,
     skipCi: argv.skipCi,
+    withCi: argv.withCi,
   });
 }
 

--- a/src/templates/plugins/gitleaks/.github/workflows/gitleaks.yml
+++ b/src/templates/plugins/gitleaks/.github/workflows/gitleaks.yml
@@ -1,5 +1,5 @@
 # Secrets scanning with the official Gitleaks action.
-# Installed by `har env add-plugin gitleaks` (skip with --skip-ci).
+# Installed by `har env add-plugin gitleaks --with-ci` (CI files are skipped by default).
 #
 # This CI run is what produces org-level scanning evidence that compliance
 # platforms (Vanta, Drata, …) can ingest via your GitHub organization.

--- a/src/templates/plugins/gitleaks/.har/stages/GITLEAKS.md
+++ b/src/templates/plugins/gitleaks/.har/stages/GITLEAKS.md
@@ -63,7 +63,7 @@ same config governs local stage runs and CI.
 
 ## CI and compliance platforms (Vanta, Drata, …)
 
-The optional workflow `.github/workflows/gitleaks.yml` (skipped with `--skip-ci`)
+The optional workflow `.github/workflows/gitleaks.yml` (installed only with `--with-ci`)
 runs the official [`gitleaks/gitleaks-action`](https://github.com/gitleaks/gitleaks-action)
 on pushes and pull requests.
 

--- a/src/templates/plugins/gitleaks/README.md
+++ b/src/templates/plugins/gitleaks/README.md
@@ -16,7 +16,7 @@ What it adds:
 - `.gitleaks.toml` — default config extending the built-in ruleset with harness
   allowlists (skipped if the repo already has one)
 - `.github/workflows/gitleaks.yml` — official `gitleaks/gitleaks-action` CI
-  workflow (skip with `--skip-ci`)
+  workflow (opt in with `--with-ci`)
 
 Requirements: the `gitleaks` binary on PATH (`brew install gitleaks` or a
 [release binary](https://github.com/gitleaks/gitleaks/releases)). No package.json

--- a/src/templates/plugins/kerno/README.md
+++ b/src/templates/plugins/kerno/README.md
@@ -15,7 +15,7 @@ har env add-plugin kerno
 | `.har/stages/backend-validation.sh` | Stage runner. Re-runs the Kerno suite against the running slot over REST |
 | `.har/stages/KERNO.md` | Setup and adaptation guide: prerequisites, the one-agent rule, artifacts |
 | `tests/kerno/README.md` | This file |
-| `.github/workflows/kerno.yml` | Optional CI workflow (skip with `--skip-ci`) |
+| `.github/workflows/kerno.yml` | Optional CI workflow (opt in with `--with-ci`) |
 
 ## Workflow
 

--- a/src/templates/plugins/semgrep/README.md
+++ b/src/templates/plugins/semgrep/README.md
@@ -13,7 +13,7 @@ har env add-plugin semgrep
 |------|---------|
 | `.har/stages/sast.sh` | Stage runner — scans the session worktree with Semgrep |
 | `.har/stages/SEMGREP.md` | Adaptation guide: rulesets, noise tuning, CI/Vanta story |
-| `.github/workflows/semgrep.yml` | Optional CI workflow (`--skip-ci` to omit) — official `semgrep ci` recipe |
+| `.github/workflows/semgrep.yml` | Optional CI workflow (opt in with `--with-ci`) — official `semgrep ci` recipe |
 
 ## Workflow
 

--- a/src/templates/plugins/trivy/README.md
+++ b/src/templates/plugins/trivy/README.md
@@ -9,7 +9,7 @@ agent's worktree:
   CloudFormation (Trivy absorbed tfsec, so this covers the Terraform use case)
 
 ```bash
-har env add-plugin trivy            # --skip-ci to omit the GitHub workflow
+har env add-plugin trivy            # --with-ci to include the GitHub workflow
 ```
 
 What it adds:

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -407,6 +407,51 @@ describe('plugins', () => {
     expect(registry.stages.some((s) => s.id === 'browser-e2e')).toBe(true);
   });
 
+  it('CLI add-plugin skips CI workflow by default and copies it with --with-ci', () => {
+    const workflowPath = ['.github', 'workflows', 'playwright.yml'];
+
+    const defaultRepo = makeTempRepo('har-playwright-cli-noci');
+    fs.writeFileSync(
+      path.join(defaultRepo, 'package.json'),
+      JSON.stringify({ name: 'test-app', version: '1.0.0' }, null, 2) + '\n',
+    );
+    scaffoldHarnessBoilerplate(defaultRepo, { force: true, profile: 'cli' });
+    execFileSync(
+      process.execPath,
+      [
+        path.join(__dirname, '..', 'dist', 'index.js'),
+        'env',
+        'add-plugin',
+        'playwright',
+        '--repo',
+        defaultRepo,
+      ],
+      { encoding: 'utf8', stdio: 'pipe' },
+    );
+    expect(fs.existsSync(path.join(defaultRepo, ...workflowPath))).toBe(false);
+
+    const ciRepo = makeTempRepo('har-playwright-cli-withci');
+    fs.writeFileSync(
+      path.join(ciRepo, 'package.json'),
+      JSON.stringify({ name: 'test-app', version: '1.0.0' }, null, 2) + '\n',
+    );
+    scaffoldHarnessBoilerplate(ciRepo, { force: true, profile: 'cli' });
+    execFileSync(
+      process.execPath,
+      [
+        path.join(__dirname, '..', 'dist', 'index.js'),
+        'env',
+        'add-plugin',
+        'playwright',
+        '--repo',
+        ciRepo,
+        '--with-ci',
+      ],
+      { encoding: 'utf8', stdio: 'pipe' },
+    );
+    expect(fs.existsSync(path.join(ciRepo, ...workflowPath))).toBe(true);
+  });
+
   it('CLI add-stage <plugin> still works as deprecated alias', () => {
     const repoPath = makeTempRepo('har-playwright-cli-alias');
     fs.writeFileSync(


### PR DESCRIPTION
Refs #195 — implements the skip-ci half only (part B); the adaptation-prompt half stays open, so this does **not** close the issue. Supersedes #267 (auto-closed when its stacked base branch was deleted on merge).

**Stack 2/5** — rebased onto `v1` after #266 merged.

- `--skip-ci` now defaults to `true` on `add-plugin` and the deprecated `add-stage` alias; new `--with-ci` flag opts back in and wins over the default
- Docs, plugin READMEs, and CLI reference updated; test asserts the workflow is not copied by default and is copied with `--with-ci`

**Gate:** M0 milestone gate green — `har env verify --full` run `573b295e-6b80-4f8d-b05c-8da334c3bf91`, 678/678 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)