### PR TITLE
feat: close CLI/MCP parity gaps and deduplicate the launch guard (#233)

### DIFF
--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -146,6 +146,24 @@ milestone_asserts() {
         || fail "M1: fresh scaffold harness.env missing HARNESS_INFRA_PORT_LANES"
       [ -f "$FRESH/.har/lib/infra.sh" ] || fail "M1: fresh scaffold missing lib/infra.sh"
       echo "    harness.env is pure config with port lanes; lib/infra.sh present ✓"
+
+      echo "──> M1 asserts: CLI/MCP parity surfaces (#233)"
+      # One status implementation: --json must be the structured source with slots.
+      har "$CLONE" env status --json | node -e '
+        let raw = "";
+        process.stdin.on("data", (c) => (raw += c));
+        process.stdin.on("end", () => {
+          const status = JSON.parse(raw);
+          if (!Array.isArray(status.slots) || status.slots.length === 0) {
+            console.error("M1: status --json returned no slots");
+            process.exit(1);
+          }
+        });
+      ' || fail "M1: har env status --json is not structured"
+      echo "    status --json structured ✓"
+      har "$CLONE" env artifacts --json >/dev/null || fail "M1: har env artifacts failed"
+      echo "    artifacts listing ✓"
+
       echo "──> M1 asserts: doctor contract checks"
       if har "$CLONE" env doctor >/dev/null 2>&1; then
         echo "    doctor green on adapted harness ✓"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,35 @@ naming plugins ≠ shipping a marketplace.
 - **Plugins** — optional bundles applied with `har env add-plugin <id|path|npm|git>` (e.g. `playwright` → `browser-e2e` stage + test scaffold). Discovered from `src/templates/plugins/*/template.manifest.json` (no closed enum). Installs are recorded in `.har/plugins.json`. They compile down to generic stage kinds (`setup`, `launch`, `verify`, `test`, `custom`, etc.). Do not add stack-specific MCP tools like `run_playwright`. Philosophy: *plugins install stages; agents only talk to the stage registry.*
 - **Profiles** — ordered runtime bundles (`src/templates/profiles/<id>/profile.manifest.json`), not forked logic in core. Stack capabilities (PM2, Simulator, ports) are detected via `src/harness/capabilities.ts` marker files.
 
+## Operation × surface matrix (CLI ↔ MCP)
+
+Every environment operation is available on both surfaces unless listed here as an
+intentional hole. Both surfaces delegate to the same `core/run-service.ts` /
+`core/harness.ts` code paths; status is one structured implementation
+(`collectEnvironmentStatus`) with text rendered on top, the launch guard runs
+exactly once inside `run-service`, and status is a pure read (no run records) on
+every surface.
+
+| Operation | CLI | MCP |
+|---|---|---|
+| describe / init / maintain / add-plugin | `har env init`, `maintain`, `add-plugin` | `har_describe_project`, `har_init_harness`, `har_maintain`, `har_add_plugin` |
+| launch / recover / preflight | `har env launch`, `recover`, `preflight` | `har_launch_environment`, `har_recover_environment`, `har_preflight_environment` |
+| verify / run-stage / logs / status / artifacts | `har env verify`, `run-stage`, `logs`, `status`, `artifacts` | `har_run_verification`, `har_run_stage`, `har_get_logs`, `har_get_status`, `har_list_artifacts` |
+| complete / teardown | `har env complete`, `teardown` | `har_complete_environment`, `har_teardown_environment` |
+| runs / work links | `har env runs list\|get`, `work-link` | `har_list_runs`, `har_get_run`, `har_add_work_unit_link` |
+| Mission Control | `har control up` | `har_control_up` |
+
+Intentional holes (human-only, no MCP tool):
+
+- `har env cleanup` — cross-repo destructive teardown with interactive confirmation; an
+  agent must free its own slot with complete/teardown instead.
+- `har env add-stage --custom` — authoring a project stage is an adaptation task done in
+  the checkout, not a tool call; agents edit `.har/stages.json` + `stages/` directly.
+- Hooks / commit-gate onboarding (`har hooks …`, init/maintain onboarding prompts) —
+  installs git hooks and records user policy preferences; a policy decision for humans.
+- Onboarding/preferences, telemetry toggles, and portal login (`har onboard`,
+  `har preferences`, `har telemetry`, `har hq`) — account- and machine-level state.
+
 ## Anti-patterns
 
 - Orchestration logic in `mcp/server.ts` or `cli/commands/` — adapters delegate to `core/`

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -55,6 +55,9 @@ With `--yes` and no `--agent-slots`, the profile template default is kept.
 | `complete <id>` | Full verify, record validation, teardown, keep branch |
 | `teardown <id>` | Free a slot without a completion validation; keep branch |
 | `status` | Inspect all slots |
+| `logs <id> [service]` | Show recent logs for a slot (optionally one service) |
+| `run-stage <id> <stage> [args..]` | Run one registered harness stage by id |
+| `artifacts` | List result files under `.har/artifacts/` |
 | `cleanup` | Discover stale sessions and orphan worktrees across registered repos |
 | `runs list` | List persisted run records |
 | `runs get <runId>` | Return one run record |
@@ -166,12 +169,22 @@ excerpt. MCP `har_run_verification` returns the same slim shape.
 
 ```bash
 har env status [--json]
+har env logs 1 [service]
+har env run-stage 1 <stage> [args..] [--json]
+har env artifacts [--stage <id>] [--json]
 har env cleanup [--dry-run] [--yes] [--repo <path>]
                 [--keep repo:agentId,/path/to/worktree]
                 [--stale 7] [--orphans] [--include-review] [--json]
 har env runs list [--stage <id>] [--limit 50] [--json]
 har env runs get <uuid> [--json]
 ```
+
+`status` has one implementation on every surface: the structured collector
+behind `--json` is the source, the text view is rendered on top, and MCP
+`har_get_status` returns the same object. Status is a pure read — it writes no
+run records. `run-stage` executes any stage registered in `.har/stages.json`
+(the CLI twin of MCP `har_run_stage`); `artifacts` is the twin of
+`har_list_artifacts`.
 
 `cleanup` scans every repo in `~/.har/repos.json` (plus `--repo` when set),
 classifies active slots and orphan directories under `~/worktrees`, and runs

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -12,6 +12,8 @@ Start the server with `har mcp --repo <path>`. Every tool accepts an optional
 | --- | --- | --- |
 | `har_describe_project` | `repo` | Manifest, stack hints, scripts, stages, and slot limits |
 | `har_init_harness` | `repo`, `force`, `smoke`, `profile` (`default` \| `cli` \| `ios`) | Scaffold and validation result, plus a `docker` block (`cliInstalled`, `daemonRunning`, `version`, `warning`) — Docker is required for Mission Control and harness infra |
+| `har_maintain` | `repo`, optional `finalize`, `summary` | Validation issues, template drift, and the maintenance bundle report; `finalize: true` records a completed manual adaptation in `.har/manifest.json` |
+| `har_add_plugin` | `plugin` (bundled id, path, npm package, or git URL), optional `force`, `withCi` | Registered stage ids, files written, warnings, and next steps |
 
 ## Session lifecycle
 
@@ -26,7 +28,7 @@ Use `relatedLinks` or `har_add_work_unit_link` for secondary URLs (GitHub PR, mi
 issue, Bitbucket). Omit work metadata for ad-hoc work with no tracker identity.
 | `har_add_work_unit_link` | `workUnitId`, `source`, `url`, optional `label` | Append a related external link to an existing work unit |
 | `har_recover_environment` | `agentId` | Resumed failed or partial launch |
-| `har_get_status` | optional `agentId` | Slot, process, worktree, branch, and dirty state |
+| `har_get_status` | optional `agentId` | Structured slot status (same source as `har env status --json`): worktree, branch, dirty state, readiness, last run/verify. A pure read — writes no run records |
 | `har_get_logs` | `agentId`, optional `service` | Recent service output |
 | `har_complete_environment` | `agentId`, `skipVerify` | Validation, teardown, and retained branch |
 | `har_teardown_environment` | `agentId`, `deleteBranch` | Teardown result |

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -23,17 +23,18 @@ import {
 } from '../../harness/instruction-files';
 import {
   completeEnvironment,
+  getEnvironmentLogs,
   getEnvironmentStatus,
   launchEnvironment,
+  listArtifacts,
   preflightEnvironment,
+  runStage,
   runVerification,
   teardownEnvironment,
 } from '../../core/run-service';
-import { checkLaunchGuard } from '../../core/slot-launch-guard';
 import { listRuns, getRun } from '../../core/runs';
 import { addWorkUnitLinks, parseWorkLinkSpec } from '../../core/work-units';
 import { resolveHarnessRoot } from '../../harness/manifest';
-import { collectEnvironmentStatus } from '../../core/slot-status';
 import {
   confirmCleanupSelection,
   discoverCleanupCandidates,
@@ -56,6 +57,8 @@ import {
   LAUNCH_RESUME_DESCRIBE,
 } from '../help-text';
 
+// Operation × surface matrix (CLI ↔ MCP) is documented in AGENTS.md — keep it
+// current when adding or removing a subcommand here or a tool in mcp/server.ts.
 const workLinkOptions = (y: Argv) =>
   y
     .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
@@ -396,6 +399,38 @@ export const envCommand = {
         handleStatus,
       )
       .command(
+        'logs <id> [service]',
+        'Show recent logs for an agent slot (optionally one service)',
+        (y: Argv) =>
+          y
+            .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
+            .positional('service', { type: 'string', describe: 'Limit logs to one service' })
+            .option('repo', { type: 'string', default: '.' }),
+        handleLogs,
+      )
+      .command(
+        'run-stage <id> <stage> [args..]',
+        'Run one registered harness stage by id for an agent slot',
+        (y: Argv) =>
+          y
+            .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
+            .positional('stage', { type: 'string', describe: 'Stage id from .har/stages.json' })
+            .positional('args', { type: 'string', array: true, describe: 'Extra arguments passed to the stage' })
+            .option('repo', { type: 'string', default: '.' })
+            .option('json', { type: 'boolean', default: false, describe: 'Structured JSON output' }),
+        handleRunStage,
+      )
+      .command(
+        'artifacts',
+        'List result JSON, screenshots, traces, and reports under .har/artifacts/',
+        (y: Argv) =>
+          y
+            .option('repo', { type: 'string', default: '.' })
+            .option('stage', { type: 'string', describe: 'Filter by stage id' })
+            .option('json', { type: 'boolean', default: false, describe: 'Structured JSON output' }),
+        handleArtifacts,
+      )
+      .command(
         'cleanup',
         'Discover stale session worktrees across registered repos and tear them down',
         (y: Argv) =>
@@ -474,7 +509,7 @@ export const envCommand = {
       )
       .demandCommand(
         1,
-        'Please specify a subcommand: init, maintain, add-stage, launch, recover, verify, complete, teardown, status, cleanup, runs',
+        'Please specify a subcommand: init, maintain, add-plugin, add-stage, launch, recover, verify, complete, teardown, status, logs, run-stage, artifacts, cleanup, runs',
       )
       .epilog(HAR_ENV_EPILOG),
   handler: () => {},
@@ -963,17 +998,8 @@ export async function handleLaunch(argv: {
   const repo = path.resolve(argv.repo);
   const agentId = validateAgentId(argv.id, repo);
 
-  if (!argv.resume) {
-    const guard = checkLaunchGuard(repo, agentId, { worktree: argv.worktree });
-    if (!guard.allowed && guard.blocked) {
-      error(guard.reason ?? `Slot ${agentId} is occupied.`);
-      return finishCommand(2);
-    }
-    for (const warning of guard.readiness?.warnings ?? []) {
-      warn(warning);
-    }
-  }
-
+  // The launch guard runs exactly once, inside run-service (also on --resume);
+  // this layer only renders the outcome.
   const result = await launchEnvironment({
     repoPath: repo,
     agentId,
@@ -991,6 +1017,9 @@ export async function handleLaunch(argv: {
   if (result.blocked) {
     error(result.stderr || 'Launch blocked: slot is occupied.');
     return finishCommand(result.code || 2);
+  }
+  for (const warning of result.warnings ?? []) {
+    warn(warning);
   }
   if (result.code === 0 && result.workDir) {
     if (result.stderr) {
@@ -1134,17 +1163,95 @@ export async function handleComplete(argv: {
 export async function handleStatus(argv: { repo: string; json?: boolean }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
 
+  // One status implementation for text, --json, and MCP: the structured
+  // collector inside getEnvironmentStatus. Status is a pure read (no run records).
+  const result = await getEnvironmentStatus({
+    repoPath,
+    capture: false,
+  });
+
   if (argv.json) {
-    const status = collectEnvironmentStatus(repoPath);
-    const output = EnvironmentStatusSchema.parse(status);
+    const output = EnvironmentStatusSchema.parse(result.status);
     process.stdout.write(JSON.stringify(output, null, 2) + '\n');
     return;
   }
 
-  await getEnvironmentStatus({
-    repoPath,
-    capture: false,
+  if (result.stdout) process.stdout.write(result.stdout);
+}
+
+export async function handleLogs(argv: {
+  id?: number;
+  repo: string;
+  service?: string;
+}): Promise<void> {
+  const repo = path.resolve(argv.repo);
+  const agentId = validateAgentId(argv.id, repo);
+  const result = await getEnvironmentLogs({
+    repoPath: repo,
+    agentId,
+    service: argv.service,
   });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  return finishCommand(result.code);
+}
+
+export async function handleRunStage(argv: {
+  id?: number;
+  stage?: string;
+  repo: string;
+  args?: string[];
+  json?: boolean;
+}): Promise<void> {
+  const repo = path.resolve(argv.repo);
+  const agentId = validateAgentId(argv.id, repo);
+  if (!argv.stage) {
+    error('Missing stage id. Usage: har env run-stage <id> <stage> [args..]');
+    return finishCommand(1);
+  }
+
+  try {
+    const result = await runStage({
+      repoPath: repo,
+      stageId: argv.stage,
+      agentId,
+      args: argv.args,
+      capture: Boolean(argv.json),
+    });
+    if (argv.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    }
+    const code = result.code ?? (result.status === 'pass' ? 0 : 1);
+    return finishCommand(code);
+  } catch (err: unknown) {
+    error(err instanceof Error ? err.message : String(err));
+    return finishCommand(1);
+  }
+}
+
+export async function handleArtifacts(argv: {
+  repo: string;
+  stage?: string;
+  json?: boolean;
+}): Promise<void> {
+  const artifacts = listArtifacts({
+    repoPath: path.resolve(argv.repo),
+    stageId: argv.stage,
+  });
+
+  if (argv.json) {
+    process.stdout.write(JSON.stringify({ artifacts }, null, 2) + '\n');
+    return;
+  }
+
+  header('har env artifacts');
+  if (artifacts.length === 0) {
+    info('No artifacts found under .har/artifacts/');
+    return;
+  }
+  for (const artifact of artifacts) {
+    info(`${artifact.relativePath}  (${artifact.sizeBytes} bytes, ${artifact.modifiedAt})`);
+  }
 }
 
 export async function handleCleanup(argv: {

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -14,7 +14,8 @@ import {
   upsertWorkUnit,
 } from './work-units';
 import { resolveHarnessRoot } from '../harness/manifest';
-import { getAgentSlotIds, resolveStage } from '../harness/stages';
+import { resolveStage } from '../harness/stages';
+import { collectEnvironmentStatus, renderEnvironmentStatusText } from './slot-status';
 import { HarnessStage } from '../harness/schema';
 import { validateAgentId } from '../utils/validation';
 import { ensureTelemetryInfrastructure } from './telemetry-ensure';
@@ -27,6 +28,7 @@ import * as path from 'path';
 import {
   ArtifactEntry,
   EnvironmentRunResult,
+  EnvironmentStatusRunResult,
   ExecutionContext,
   LaunchOptions,
   LogsOptions,
@@ -317,6 +319,11 @@ export class RunService {
       if (launchBanner) {
         envResult.stderr = `${launchBanner}${envResult.stderr ?? ''}`;
       }
+      // Structured copy of the readiness warnings so surfaces can render them
+      // without scraping WARN: lines out of stderr.
+      if (guard.readiness?.warnings?.length) {
+        envResult.warnings = guard.readiness.warnings;
+      }
     }
     return envResult;
   }
@@ -531,45 +538,33 @@ export class RunService {
     };
   }
 
+  /**
+   * Status is a pure read with one implementation: the structured collector is
+   * the source, text is rendered on top. No run records are written on any
+   * surface (CLI text, CLI --json, MCP) — the policy is identical by design.
+   */
   async getEnvironmentStatus(options: {
     repoPath: string;
     agentId?: number;
     capture?: boolean;
     trigger?: ExecutionContext['trigger'];
-  }): Promise<EnvironmentRunResult> {
-    const capture = options.capture ?? true;
-
+  }): Promise<EnvironmentStatusRunResult> {
     if (options.agentId !== undefined) {
       validateAgentId(options.agentId, options.repoPath);
-      const result = await this.runStage({
-        repoPath: options.repoPath,
-        stageId: 'status',
-        agentId: options.agentId,
-        capture,
-        trigger: options.trigger ?? 'cli',
-      });
-      return toEnvironmentRunResult(result);
     }
 
-    let combinedStdout = '';
-    let combinedStderr = '';
-    let exitCode = 0;
+    const full = collectEnvironmentStatus(options.repoPath);
+    const status =
+      options.agentId !== undefined
+        ? { ...full, slots: full.slots.filter((slot) => slot.agentId === options.agentId) }
+        : full;
 
-    for (const id of getAgentSlotIds(options.repoPath)) {
-      const result = await this.runStage({
-        repoPath: options.repoPath,
-        stageId: 'status',
-        agentId: id,
-        capture,
-        trigger: options.trigger ?? 'cli',
-      });
-      const shell = extractShellOutput(result);
-      combinedStdout += shell.stdout;
-      combinedStderr += shell.stderr;
-      if (shell.code !== 0) exitCode = shell.code;
-    }
-
-    return { code: exitCode, stdout: combinedStdout, stderr: combinedStderr };
+    return {
+      code: 0,
+      stdout: renderEnvironmentStatusText(status),
+      stderr: '',
+      status,
+    };
   }
 
   async getEnvironmentLogs(options: LogsOptions & { trigger?: ExecutionContext['trigger'] }): Promise<EnvironmentRunResult> {
@@ -608,6 +603,7 @@ export { computePreviewUrls, readHarnessEnv } from './local-executor';
 export type {
   ArtifactEntry,
   EnvironmentRunResult,
+  EnvironmentStatusRunResult,
   LaunchOptions,
   LogsOptions,
   PreflightOptions,

--- a/src/core/slot-status.ts
+++ b/src/core/slot-status.ts
@@ -294,6 +294,57 @@ function collectSlotStatus(
   };
 }
 
+/**
+ * Text rendering over the structured status — the single status source for the
+ * CLI text view, `--json`, and MCP. Deliberately omits gitRemote: remote URLs
+ * can embed credentials and must never reach logs.
+ */
+export function renderEnvironmentStatusText(status: EnvironmentStatus): string {
+  const lines: string[] = [];
+  lines.push(`Harness: ${status.harnessRoot}${status.profile ? ` (profile: ${status.profile})` : ''}`);
+
+  for (const slot of status.slots) {
+    const state = slot.active ? (slot.sessionStatus ?? 'active') : 'free';
+    lines.push(`Agent ${slot.agentId}: ${state}`);
+    if (slot.branch) {
+      const drift = [
+        slot.dirty ? 'dirty' : undefined,
+        slot.ahead ? `ahead ${slot.ahead}` : undefined,
+        slot.stale ? `stale (base behind main by ${slot.behind})` : undefined,
+        slot.detachedHead ? 'detached HEAD' : undefined,
+      ].filter(Boolean);
+      lines.push(`  branch:      ${slot.branch}${drift.length ? ` [${drift.join(', ')}]` : ''}`);
+    }
+    if (slot.workDir) lines.push(`  work dir:    ${slot.workDir}`);
+    if (slot.previewUrls && Object.keys(slot.previewUrls).length > 0) {
+      lines.push(
+        `  preview:     ${Object.entries(slot.previewUrls)
+          .map(([label, url]) => `${label}=${url}`)
+          .join(' ')}`,
+      );
+    }
+    if (slot.workUnitId) {
+      lines.push(`  work unit:   ${slot.workUnitId}${slot.attemptId ? ` (attempt ${slot.attemptId})` : ''}`);
+    }
+    if (slot.lastRunAt) {
+      lines.push(`  last run:    ${slot.lastRunAt} (${slot.harnessUsage})`);
+    }
+    if (slot.lastVerifyStatus) {
+      lines.push(`  last verify: ${slot.lastVerifyStatus}`);
+    }
+    if (slot.pm2Issue) lines.push(`  pm2:         ${slot.pm2Issue}`);
+    if (slot.lastError) lines.push(`  last error:  ${slot.lastError}`);
+    if (slot.resumeHint) lines.push(`  resume:      ${slot.resumeHint}`);
+    if (slot.readiness && !slot.readiness.canLaunch && !slot.active) {
+      for (const blocker of slot.readiness.blockers) {
+        lines.push(`  blocker:     ${blocker}`);
+      }
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
 export function collectEnvironmentStatus(repoPath: string): EnvironmentStatus {
   const harnessRoot = resolveHarnessRoot(repoPath);
   const runs = listRuns(harnessRoot, { limit: 200 });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,6 @@
 import type { ShellResult } from '../utils/shell';
 import type {
+  EnvironmentStatus,
   RunRecordTriggerSchema,
   SlotReadiness,
   StageKind,
@@ -87,6 +88,8 @@ export interface EnvironmentRunResult {
   attemptId?: string;
   /** Launch refused because the slot is occupied — teardown/complete it first, then launch. */
   blocked?: boolean;
+  /** Advisory readiness warnings — surfaces render them; they never block. */
+  warnings?: string[];
   occupiedSlot?: {
     agentId: number;
     workDir?: string;
@@ -95,6 +98,11 @@ export interface EnvironmentRunResult {
     dirty?: boolean;
     sessionCreatedAt?: string;
   };
+}
+
+/** Status is a pure read: one structured source, text rendered on top, no run records. */
+export interface EnvironmentStatusRunResult extends EnvironmentRunResult {
+  status: EnvironmentStatus;
 }
 
 export interface VerificationRunResult extends EnvironmentRunResult {

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  EnvironmentStatusSchema,
   HAR_AGENT_SLOT_MIN,
   HarnessManifestSchema,
   HarnessStageSchema,
@@ -93,6 +94,10 @@ export const AddWorkUnitLinkInputSchema = z.object({
 });
 
 export const LaunchEnvironmentOutputSchema = ShellRunOutputSchema.extend({
+  warnings: z
+    .array(z.string())
+    .optional()
+    .describe('Advisory readiness warnings — never block the launch'),
   previewUrls: z.record(z.string()).optional(),
   workDir: z
     .string()
@@ -186,6 +191,36 @@ export const ListArtifactsOutputSchema = z.object({
 });
 
 export const EnvironmentRunOutputSchema = ShellRunOutputSchema;
+
+/** Structured status is the source; text views render on top of it. */
+export const GetStatusOutputSchema = EnvironmentStatusSchema;
+
+export const MaintainHarnessInputSchema = z.object({
+  repo: z.string().default('.'),
+  finalize: z
+    .boolean()
+    .default(false)
+    .describe('Record the completed manual adaptation in .har/manifest.json'),
+  summary: z
+    .string()
+    .min(1)
+    .max(512)
+    .optional()
+    .describe('Adaptation summary stored in the manifest (finalize only)'),
+});
+
+export const AddPluginInputSchema = z.object({
+  repo: z.string().default('.'),
+  plugin: z
+    .string()
+    .min(1)
+    .describe('Bundled plugin id, local path (./plugin), npm package (@org/pkg), or git URL'),
+  force: z.boolean().default(false).describe('Overwrite existing plugin files and stage entry'),
+  withCi: z
+    .boolean()
+    .default(false)
+    .describe('Also copy optional CI workflow files (skipped by default)'),
+});
 
 export const ListRunsInputSchema = z.object({
   repo: z.string().default('.'),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,7 +6,7 @@ import {
   ListToolsRequestSchema,
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
-import { describeProject, initHarness } from '../core/harness';
+import { addPlugin, describeProject, initHarness, maintainHarness } from '../core/harness';
 import { startControlAndSync } from '../core/control-lifecycle';
 import { getHarPackageVersion } from '../core/package-version';
 import { detectDockerStatus, formatDockerRequirementWarning } from '../core/docker-status';
@@ -54,6 +54,9 @@ import {
   GetRunOutputSchema,
   ControlUpInputSchema,
   ControlUpOutputSchema,
+  GetStatusOutputSchema,
+  MaintainHarnessInputSchema,
+  AddPluginInputSchema,
   RunStageInputSchema,
   RunVerificationInputSchema,
   RunVerificationOutputSchema,
@@ -76,6 +79,42 @@ export const HAR_MCP_TOOLS: Tool[] = [
       smoke: { type: 'boolean' },
       profile: { type: 'string', enum: ['default', 'cli', 'ios'] },
     }),
+  },
+  {
+    name: 'har_maintain',
+    description:
+      'Validate .har/ against the bundled templates: returns validation issues, drift, and a maintenance bundle report. Pass finalize=true (optionally with summary) to record a completed manual adaptation in .har/manifest.json.',
+    inputSchema: objectJsonSchema({
+      repo: repoJsonProperty,
+      finalize: {
+        type: 'boolean',
+        description: 'Record the completed manual adaptation in .har/manifest.json',
+      },
+      summary: {
+        type: 'string',
+        description: 'Adaptation summary stored in the manifest (finalize only)',
+      },
+    }),
+  },
+  {
+    name: 'har_add_plugin',
+    description:
+      'Install a verification plugin (bundled id, local path, npm package, or git URL) that registers stages in .har/stages.json.',
+    inputSchema: objectJsonSchema(
+      {
+        repo: repoJsonProperty,
+        plugin: {
+          type: 'string',
+          description: 'Bundled plugin id, local path (./plugin), npm package (@org/pkg), or git URL',
+        },
+        force: { type: 'boolean', description: 'Overwrite existing plugin files and stage entry' },
+        withCi: {
+          type: 'boolean',
+          description: 'Also copy optional CI workflow files (skipped by default)',
+        },
+      },
+      ['plugin'],
+    ),
   },
   {
     name: 'har_launch_environment',
@@ -197,7 +236,7 @@ export const HAR_MCP_TOOLS: Tool[] = [
   {
     name: 'har_get_status',
     description:
-      'Return slot/process status for one agent or all slots. Call BEFORE har_launch_environment when a slot may already be in use — shows worktree path, dirty state, and branch.',
+      'Return structured slot status for one agent or all slots (same source as har env status/--json). Call BEFORE har_launch_environment when a slot may already be in use — shows worktree path, dirty state, branch, and readiness.',
     inputSchema: objectJsonSchema({
       repo: repoJsonProperty,
       agentId: agentIdJsonProperty,
@@ -319,6 +358,39 @@ export async function handleMcpToolCall(
           ...docker,
           warning: formatDockerRequirementWarning(docker),
         },
+      });
+    }
+
+    case 'har_maintain': {
+      const input = MaintainHarnessInputSchema.parse({ ...args, repo });
+      const result = await maintainHarness({
+        repoPath: repo,
+        finalize: input.finalize,
+        summary: input.summary,
+      });
+      return jsonContent({
+        validation: result.validation,
+        drift: result.drift,
+        bundleReport: result.bundle?.report,
+        finalized: input.finalize,
+      });
+    }
+
+    case 'har_add_plugin': {
+      const input = AddPluginInputSchema.parse({ ...args, repo });
+      const result = addPlugin(repo, input.plugin, {
+        force: input.force,
+        skipCi: !input.withCi,
+        spec: input.plugin,
+      });
+      return jsonContent({
+        pluginId: result.pluginId,
+        stageIds: result.stageIds,
+        filesWritten: result.filesWritten,
+        warnings: result.warnings,
+        nextSteps: result.nextSteps,
+        docsPath: result.docsPath,
+        source: result.source,
       });
     }
 
@@ -453,7 +525,7 @@ export async function handleMcpToolCall(
         capture: true,
         trigger: 'mcp',
       });
-      return jsonContent(EnvironmentRunOutputSchema.parse(result));
+      return jsonContent(GetStatusOutputSchema.parse(result.status));
     }
 
     case 'har_get_logs': {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -8,6 +8,8 @@ describe('HAR MCP tool schemas', () => {
     expect(names).toEqual([
       'har_describe_project',
       'har_init_harness',
+      'har_maintain',
+      'har_add_plugin',
       'har_launch_environment',
       'har_add_work_unit_link',
       'har_recover_environment',

--- a/tests/run-service-parity.test.ts
+++ b/tests/run-service-parity.test.ts
@@ -1,10 +1,58 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { launchEnvironment, runStage } from '../src/core/run-service';
+import { getEnvironmentStatus, launchEnvironment, runStage } from '../src/core/run-service';
+import { collectEnvironmentStatus, renderEnvironmentStatusText } from '../src/core/slot-status';
+import { getSlotRegistryPath } from '../src/core/slot-registry';
 import { synthesizeStageRegistry } from '../src/harness/stages';
 
 const FIXTURE = path.join(__dirname, 'fixtures/minimal-harness');
+
+function makeTempRepo(prefix: string): string {
+  const tempRepo = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.cpSync(path.join(FIXTURE, '.har'), path.join(tempRepo, '.har'), { recursive: true });
+  for (const dir of ['runs', 'slots', 'work-units', 'work-attempts']) {
+    fs.rmSync(path.join(tempRepo, '.har', dir), { recursive: true, force: true });
+  }
+  return tempRepo;
+}
+
+function readRunRecords(repoPath: string): Array<Record<string, unknown>> {
+  const runsDir = path.join(repoPath, '.har', 'runs');
+  const records: Array<Record<string, unknown>> = [];
+  const walk = (dir: string) => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.json')) records.push(JSON.parse(fs.readFileSync(full, 'utf8')));
+    }
+  };
+  walk(runsDir);
+  return records;
+}
+
+function writeSlotRegistryEntry(
+  repoPath: string,
+  agentId: number,
+  status: 'starting' | 'active' | 'failed' | 'completed',
+): void {
+  const file = getSlotRegistryPath(repoPath, agentId);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      agentId,
+      projectName: 'minimal',
+      mode: 'root',
+      workDir: repoPath,
+      branch: 'session-branch',
+      createdAt: new Date().toISOString(),
+      status,
+    }),
+  );
+}
 
 describe('run service parity', () => {
   it(
@@ -76,6 +124,89 @@ describe('run service parity', () => {
     expect(allFiles.length).toBeGreaterThan(0);
     expect(allFiles.some((f) => f.includes('launch_agent-1.json'))).toBe(true);
   });
+});
+
+describe('trigger tagging parity (#233)', () => {
+  it('tags run records with the surface trigger for generic stages', async () => {
+    const tempRepo = makeTempRepo('har-trigger-parity-');
+
+    await runStage({ repoPath: tempRepo, stageId: 'logs', agentId: 1, capture: true, trigger: 'mcp' });
+    await runStage({ repoPath: tempRepo, stageId: 'logs', agentId: 2, capture: true, trigger: 'cli' });
+
+    const records = readRunRecords(tempRepo).filter((r) => r.stageId === 'logs');
+    expect(records.find((r) => r.agentId === 1)?.trigger).toBe('mcp');
+    expect(records.find((r) => r.agentId === 2)?.trigger).toBe('cli');
+  }, 20_000);
+});
+
+describe('status parity (#233)', () => {
+  it('renders text from the same structured source on every surface and writes no run records', async () => {
+    const tempRepo = makeTempRepo('har-status-parity-');
+    writeSlotRegistryEntry(tempRepo, 1, 'active');
+
+    const result = await getEnvironmentStatus({ repoPath: tempRepo, capture: true });
+    const structured = collectEnvironmentStatus(tempRepo);
+
+    // Same structured source: identical slot set and identical text rendering.
+    expect(result.status.slots.map((s) => s.agentId)).toEqual(
+      structured.slots.map((s) => s.agentId),
+    );
+    expect(result.stdout).toBe(
+      renderEnvironmentStatusText({ ...structured, generatedAt: result.status.generatedAt }),
+    );
+    expect(result.status.slots.find((s) => s.agentId === 1)?.active).toBe(true);
+    expect(result.stdout).toContain('Agent 1');
+    // Remote URLs can embed credentials — the text view must never include them.
+    if (structured.gitRemote) expect(result.stdout).not.toContain(structured.gitRemote);
+
+    // Run-record policy is identical across CLI text, CLI --json, and MCP: none.
+    expect(readRunRecords(tempRepo)).toHaveLength(0);
+  }, 30_000);
+
+  it('filters to one slot when agentId is given', async () => {
+    const tempRepo = makeTempRepo('har-status-one-slot-');
+    const result = await getEnvironmentStatus({ repoPath: tempRepo, agentId: 3, capture: true });
+    expect(result.status.slots.map((s) => s.agentId)).toEqual([3]);
+  }, 30_000);
+});
+
+describe('launch guard parity (#233)', () => {
+  it('blocks an occupied slot inside run-service (no CLI-layer guard needed)', async () => {
+    const tempRepo = makeTempRepo('har-guard-occupied-');
+    writeSlotRegistryEntry(tempRepo, 1, 'active');
+
+    const result = await launchEnvironment({ repoPath: tempRepo, agentId: 1, capture: true });
+    expect(result.blocked).toBe(true);
+    expect(result.code).toBe(2);
+    expect(readRunRecords(tempRepo).filter((r) => r.kind === 'launch')).toHaveLength(0);
+  }, 20_000);
+
+  it('applies the guard on resume too: an active slot cannot be resumed', async () => {
+    const tempRepo = makeTempRepo('har-guard-resume-active-');
+    writeSlotRegistryEntry(tempRepo, 1, 'active');
+
+    const result = await launchEnvironment({
+      repoPath: tempRepo,
+      agentId: 1,
+      resume: true,
+      capture: true,
+    });
+    expect(result.blocked).toBe(true);
+  }, 20_000);
+
+  it('allows resuming a failed session', async () => {
+    const tempRepo = makeTempRepo('har-guard-resume-failed-');
+    writeSlotRegistryEntry(tempRepo, 1, 'failed');
+
+    const result = await launchEnvironment({
+      repoPath: tempRepo,
+      agentId: 1,
+      resume: true,
+      capture: true,
+    });
+    expect(result.blocked).toBeUndefined();
+    expect(result.code).toBe(0);
+  }, 20_000);
 });
 
 describe('synthesizeStageRegistry fallback', () => {

--- a/tests/run-service-surface-bugs.test.ts
+++ b/tests/run-service-surface-bugs.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import {
   getEnvironmentStatus,
   launchEnvironment,
+  runStage,
   teardownEnvironment,
 } from '../src/core/run-service';
 import { createWorkAttempt, findWorkUnit, upsertWorkUnit, decideWorkUnitOutcome } from '../src/core/work-units';
@@ -86,15 +87,26 @@ describe('MCP launch trigger parity (#228)', () => {
   }, 20_000);
 });
 
-describe('status execution (#228)', () => {
-  // The fixture agent-cli.sh rejects extra args, so the old duplicated
-  // `status status` invocation fails this test.
-  it('runs the status stage without a duplicated subcommand arg', async () => {
+describe('status execution (#228, #233)', () => {
+  // The fixture agent-cli.sh rejects extra args, so a duplicated
+  // `status status` invocation fails this test (guards {agentId} substitution).
+  it('runs the registered status stage via run-stage without a duplicated subcommand arg', async () => {
+    const tempRepo = makeTempRepo();
+    const result = await runStage({ repoPath: tempRepo, stageId: 'status', agentId: 1, capture: true });
+    const stdout = result.logs?.find((log) => log.stream === 'stdout')?.content ?? '';
+    expect(stdout).toContain('Agent 1 running');
+    expect(stdout).not.toContain('unexpected extra args');
+    expect(result.status).toBe('pass');
+  }, 20_000);
+
+  it('status is a structured pure read: text rendered from the collector, no run records', async () => {
     const tempRepo = makeTempRepo();
     const result = await getEnvironmentStatus({ repoPath: tempRepo, agentId: 1, capture: true });
-    expect(result.stderr).not.toContain('unexpected extra args');
     expect(result.code).toBe(0);
-    expect(result.stdout).toContain('Agent 1 running');
+    expect(result.status.slots).toHaveLength(1);
+    expect(result.status.slots[0].agentId).toBe(1);
+    expect(result.stdout).toContain('Agent 1');
+    expect(readRunRecords(tempRepo)).toHaveLength(0);
   }, 20_000);
 });
 


### PR DESCRIPTION
Closes #233

**Stack 2/4** — based on #272. M1 (Contract) stack: #230 → #233 → #231 → #232.

- New CLI: `har env logs <id> [service]`, `har env run-stage <id> <stage>`, `har env artifacts [--stage] [--json]`
- New MCP tools: `har_maintain`, `har_add_plugin`; remaining intentional human-only holes documented in a new AGENTS.md operation×surface matrix
- One status implementation: `collectEnvironmentStatus` (TS) is the single source, text rendering on top; MCP `har_get_status` now structured; status is a pure read on every surface (no per-slot run records)
- Launch guard runs exactly once, in `run-service` (including on `--resume`); CLI only renders warnings
- Parity tests extended: trigger tagging, status parity + record policy, guard behavior
- fixture-e2e M1 asserts: structured `status --json`, artifacts listing

Gate: full verify green in-slot; M1 milestone gate run from the stack tip (see #225 handoff comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)