### PR TITLE
feat!: verification as data — one stage namespace with quick/full tiers (#231)

### DIFF
--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -164,6 +164,26 @@ milestone_asserts() {
       har "$CLONE" env artifacts --json >/dev/null || fail "M1: har env artifacts failed"
       echo "    artifacts listing ✓"
 
+      echo "──> M1 asserts: verification as data (#231)"
+      node -e '
+        const fs = require("fs");
+        const reg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        const ids = reg.verificationStages ?? [];
+        if (ids.length === 0) { console.error("M1: fresh scaffold has no verificationStages"); process.exit(1); }
+        const runnable = new Set(["test", "custom"]);
+        for (const id of ids) {
+          const st = (reg.stages ?? []).find((s) => s.id === id);
+          if (!st || !runnable.has(st.kind)) { console.error(`M1: verificationStages id ${id} does not resolve`); process.exit(1); }
+        }
+        if (!(reg.stages ?? []).some((s) => s.tier === "quick")) { console.error("M1: no quick-tier stage registered"); process.exit(1); }
+      ' "$FRESH/.har/stages.json" || fail "M1: fresh scaffold verificationStages namespace not fully resolvable/tiered"
+      grep -q 'lib/verify-runner.mjs' "$FRESH/.har/verify.sh" \
+        || fail "M1: fresh scaffold verify.sh does not delegate to the stage-registry runner"
+      if grep -q 'run_quick_smoke' "$FRESH/.har/verify.sh"; then
+        fail "M1: fresh scaffold verify.sh still carries inline ecosystem case tables"
+      fi
+      echo "    verificationStages fully resolvable, tiered, runner-delegated ✓"
+
       echo "──> M1 asserts: doctor contract checks"
       if har "$CLONE" env doctor >/dev/null 2>&1; then
         echo "    doctor green on adapted harness ✓"

--- a/docs/src/content/docs/docs/guides/stages.md
+++ b/docs/src/content/docs/docs/guides/stages.md
@@ -28,8 +28,9 @@ Stages are registered in `.har/stages.json`:
 
 A stage has an `id`, `kind`, and either `script` (relative to `.har/`) or `command`.
 Other fields are `description`, `cwd`, `env`, `resultPath`, `requiresAgentId`,
-`group`, `acceptsArgs`, and `artifacts`. `{agentId}` is expanded in commands at
-execution.
+`group`, `acceptsArgs`, `tier`, and `artifacts`. `{agentId}` is expanded in
+commands at execution. `tier` (`"quick"` or `"full"`, default `"full"`) controls
+whether a verification stage runs on every `har env verify` or only on `--full`.
 
 Kinds are `setup`, `launch`, `verify`, `test`, `inspect`, `reset`, `teardown`, and
 `custom`. Artifact kinds are `file`, `directory`, `log`, `report`, `screenshot`,
@@ -82,10 +83,15 @@ Repositories may declare the stage ids that constitute verification:
 }
 ```
 
-Full verification runs registered `test` and `custom` stages listed in
-`verificationStages`. Lifecycle and `verify` stages are never nested into
-verification. IDs without a registered stage remain inline steps owned by
-`.har/verify.sh`. Mission Control uses the same list to render the expected pipeline.
+`verificationStages` is the pipeline: every id must resolve to a registered
+`test` or `custom` stage, and the list order is the execution order. Quick
+verification (`har env verify <id>`) runs the stages marked `tier: "quick"`;
+`--full` runs the whole list. The ecosystem defaults (`typecheck`, `unit-tests`,
+`lint`, `readiness`, and `api-health` on web profiles) are ordinary registered
+stages written at init from `HARNESS_ECOSYSTEM` — there are no inline steps.
+Unresolvable ids are reported by validation and skipped with a warning at run
+time. Lifecycle and `verify` stages are never nested into verification. Mission
+Control uses the same list to render the expected pipeline.
 
 ## Install plugins
 

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -99,6 +99,12 @@ export const HarnessStageSchema = z
     requiresAgentId: z.boolean().optional(),
     group: z.string().optional(),
     acceptsArgs: z.array(z.string()).optional(),
+    /**
+     * Verification tier: 'quick' stages run on every verify; 'full' stages
+     * only on --full. Absent means 'full'. Only meaningful for stages listed
+     * in verificationStages.
+     */
+    tier: z.enum(['quick', 'full']).optional(),
   })
   .passthrough();
 

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -11,6 +11,7 @@ import {
 } from '../harness/maintain-bundle';
 import { readManifest, getHarnessDir } from '../harness/manifest';
 import { getVerificationStageIds, getAgentSlotRange, listStages, syncAgentSlotsToHarnessEnv } from '../harness/stages';
+import { ensureEcosystemVerificationStages } from '../harness/verification';
 import {
   applyPlugin,
   ApplyPluginOptions,
@@ -105,6 +106,7 @@ export async function initHarness(options: InitHarnessOptions): Promise<InitHarn
     profile: options.profile,
   });
   syncAgentSlotsToHarnessEnv(repoPath);
+  ensureEcosystemVerificationStages(repoPath);
 
   const validation = validateHarness(repoPath);
   let smoke: ValidationResult | undefined;
@@ -127,6 +129,7 @@ export async function maintainHarness(options: MaintainHarnessOptions): Promise<
     throw new Error('No .har/ found. Run "har env init" first.');
   }
 
+  ensureEcosystemVerificationStages(repoPath);
   const drift = compareHarnessToTemplate(repoPath);
   const validation = validateHarness(repoPath);
 

--- a/src/harness/plugins.ts
+++ b/src/harness/plugins.ts
@@ -267,15 +267,6 @@ function patchStageRegistry(
     }
   }
 
-  const verifyIdx = nextStages.findIndex((s) => s.id === 'verify');
-  if (verifyIdx >= 0) {
-    nextStages[verifyIdx] = {
-      ...nextStages[verifyIdx],
-      description: `Verification pipeline (quick smoke by default; --full runs the registry's verificationStages: ${verificationStages.join(', ')})`,
-      acceptsArgs: ['--full'],
-    };
-  }
-
   const updated: HarnessStageRegistry = {
     ...registry,
     stages: nextStages,

--- a/src/harness/validator.ts
+++ b/src/harness/validator.ts
@@ -4,6 +4,7 @@ import { run } from '../utils/shell';
 import { readValidatedHarnessEnv } from './env';
 import { getHarnessDir, readManifest } from './manifest';
 import { readStageRegistry } from './stages';
+import { findPhantomVerificationStageIds } from './verification';
 
 export interface ValidationIssue {
   file: string;
@@ -158,6 +159,15 @@ export function validateHarness(repoPath: string): ValidationResult {
       const registry = readStageRegistry(repoPath);
       if (registry.stages.length === 0) {
         issues.push({ file: 'stages.json', message: 'No harness stages declared', severity: 'warning' });
+      }
+      for (const id of findPhantomVerificationStageIds(registry)) {
+        // Warning until har env doctor (#232) enforces the resolvable-namespace
+        // contract as an error.
+        issues.push({
+          file: 'stages.json',
+          message: `verificationStages id "${id}" does not resolve to a registered runnable stage`,
+          severity: 'warning',
+        });
       }
     } catch (err) {
       issues.push({

--- a/src/harness/verification.ts
+++ b/src/harness/verification.ts
@@ -1,0 +1,273 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { HarnessStage, HarnessStageRegistry } from './schema';
+import { readHarnessEnv, readValidatedHarnessEnv } from './env';
+import { getHarnessDir } from './manifest';
+import { readStageRegistry, writeStageRegistry } from './stages';
+
+/** Stage kinds that may appear in verificationStages. */
+export const RUNNABLE_VERIFICATION_KINDS = new Set(['test', 'custom']);
+
+export interface VerificationPlan {
+  /** Stages to execute, in verificationStages order. */
+  steps: HarnessStage[];
+  /** Ids listed in verificationStages that resolve to no runnable stage. */
+  phantomIds: string[];
+}
+
+/**
+ * Resolve the verification plan from the registry. verificationStages is the
+ * single namespace and its order is execution order: every id must map to a
+ * registered stage of a runnable kind. Quick mode keeps tier 'quick' stages
+ * only; full mode runs the whole list.
+ */
+export function resolveVerificationPlan(
+  registry: HarnessStageRegistry,
+  options: { full?: boolean } = {},
+): VerificationPlan {
+  const ids = registry.verificationStages ?? [];
+  const steps: HarnessStage[] = [];
+  const phantomIds: string[] = [];
+
+  for (const id of ids) {
+    const stage = registry.stages.find((s) => s.id === id);
+    if (!stage || !RUNNABLE_VERIFICATION_KINDS.has(stage.kind)) {
+      phantomIds.push(id);
+      continue;
+    }
+    if (!options.full && stage.tier !== 'quick') continue;
+    steps.push(stage);
+  }
+
+  return { steps, phantomIds };
+}
+
+/**
+ * Ids in verificationStages that do not resolve to a registered runnable
+ * stage. Consumed by validateHarness (warning) and `har env doctor` (#232,
+ * error).
+ */
+export function findPhantomVerificationStageIds(registry: HarnessStageRegistry): string[] {
+  return resolveVerificationPlan(registry, { full: true }).phantomIds;
+}
+
+interface EcosystemStageDefaults {
+  order: string[];
+  stages: HarnessStage[];
+}
+
+function nodeSmokeCommand(repoPath: string): { id: string; command: string; description: string } {
+  const pkgPath = path.join(repoPath, 'package.json');
+  let scripts: Record<string, unknown> = {};
+  try {
+    scripts = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).scripts ?? {};
+  } catch {
+    scripts = {};
+  }
+  if (scripts.typecheck) {
+    return {
+      id: 'typecheck',
+      command: '${NPM_BIN:-npm} run typecheck',
+      description: 'Type check (ecosystem quick smoke)',
+    };
+  }
+  if (scripts.build) {
+    return {
+      id: 'typecheck',
+      command: '${NPM_BIN:-npm} run build',
+      description: 'Build smoke (no typecheck script; ecosystem quick smoke)',
+    };
+  }
+  return {
+    id: 'typecheck',
+    command: '${NODE_BIN:-node} -e "require(\'./package.json\')"',
+    description: 'Package-load smoke (no typecheck/build scripts)',
+  };
+}
+
+function nodeScriptOrSkip(repoPath: string, script: string): string {
+  const pkgPath = path.join(repoPath, 'package.json');
+  try {
+    const scripts = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).scripts ?? {};
+    if (scripts[script]) {
+      return script === 'test' ? '${NPM_BIN:-npm} test' : `\${NPM_BIN:-npm} run ${script}`;
+    }
+  } catch {
+    /* fall through to skip */
+  }
+  return `echo 'No ${script} script configured; skipping.'`;
+}
+
+/**
+ * Ecosystem-default verification stages, as data. These replace the
+ * run_quick_smoke/run_full_checks case tables that lived in verify.sh.
+ */
+export function deriveEcosystemDefaultStages(
+  ecosystem: string,
+  repoPath: string,
+): EcosystemStageDefaults {
+  const quick = (stage: Partial<HarnessStage> & { id: string }): HarnessStage =>
+    ({ kind: 'test', tier: 'quick', requiresAgentId: true, artifacts: [], ...stage }) as HarnessStage;
+  const full = (stage: Partial<HarnessStage> & { id: string }): HarnessStage =>
+    ({ kind: 'test', tier: 'full', requiresAgentId: true, artifacts: [], ...stage }) as HarnessStage;
+
+  const readiness = full({
+    id: 'readiness',
+    script: 'stages/readiness.sh',
+    description: 'Project readiness smoke (HARNESS_READINESS_CMD)',
+  });
+
+  switch (ecosystem) {
+    case 'node': {
+      const smoke = nodeSmokeCommand(repoPath);
+      return {
+        order: ['typecheck', 'unit-tests', 'lint', 'readiness'],
+        stages: [
+          quick({ id: smoke.id, command: smoke.command, description: smoke.description }),
+          full({ id: 'unit-tests', command: nodeScriptOrSkip(repoPath, 'test'), description: 'Unit tests' }),
+          full({ id: 'lint', command: nodeScriptOrSkip(repoPath, 'lint'), description: 'Lint' }),
+          readiness,
+        ],
+      };
+    }
+    case 'python':
+      return {
+        order: ['typecheck', 'unit-tests', 'readiness'],
+        stages: [
+          quick({
+            id: 'typecheck',
+            command: '${PYTHON_BIN:-python3} -m compileall -q .',
+            description: 'Python compile smoke',
+          }),
+          full({
+            id: 'unit-tests',
+            command:
+              'if ${PYTHON_BIN:-python3} -c "import pytest" >/dev/null 2>&1; then ${PYTHON_BIN:-python3} -m pytest -q; else echo "pytest not installed; adapt stages.json for this Python repo."; fi',
+            description: 'Unit tests (pytest)',
+          }),
+          readiness,
+        ],
+      };
+    case 'go':
+      return {
+        order: ['typecheck', 'unit-tests', 'readiness'],
+        stages: [
+          quick({ id: 'typecheck', command: '${GO_BIN:-go} build ./...', description: 'Go build smoke' }),
+          full({ id: 'unit-tests', command: '${GO_BIN:-go} test ./...', description: 'Unit tests' }),
+          readiness,
+        ],
+      };
+    case 'rust':
+      return {
+        order: ['typecheck', 'unit-tests', 'readiness'],
+        stages: [
+          quick({ id: 'typecheck', command: '${CARGO_BIN:-cargo} check', description: 'Cargo check smoke' }),
+          full({ id: 'unit-tests', command: '${CARGO_BIN:-cargo} test', description: 'Unit tests' }),
+          readiness,
+        ],
+      };
+    case 'java':
+      return {
+        order: ['typecheck', 'unit-tests', 'readiness'],
+        stages: [
+          quick({
+            id: 'typecheck',
+            command:
+              'if [ -x ./mvnw ]; then ./mvnw -q -DskipTests compile; elif command -v mvn >/dev/null 2>&1; then mvn -q -DskipTests compile; elif [ -x ./gradlew ]; then ./gradlew classes; elif command -v gradle >/dev/null 2>&1; then gradle classes; else echo "No Maven/Gradle command found; adapt stages.json for this Java repo."; fi',
+            description: 'Java compile smoke',
+          }),
+          full({
+            id: 'unit-tests',
+            command:
+              'if [ -x ./mvnw ]; then ./mvnw -q test; elif command -v mvn >/dev/null 2>&1; then mvn -q test; elif [ -x ./gradlew ]; then ./gradlew test; elif command -v gradle >/dev/null 2>&1; then gradle test; else echo "No Maven/Gradle command found; adapt stages.json for this Java repo."; fi',
+            description: 'Unit tests',
+          }),
+          readiness,
+        ],
+      };
+    case 'ruby':
+      return {
+        order: ['typecheck', 'unit-tests', 'readiness'],
+        stages: [
+          quick({
+            id: 'typecheck',
+            command: '${RUBY_BIN:-ruby} -e "puts RUBY_VERSION"',
+            description: 'Ruby smoke',
+          }),
+          full({
+            id: 'unit-tests',
+            command:
+              'if command -v "${BUNDLE_BIN:-bundle}" >/dev/null 2>&1 && [ -f Gemfile ]; then "${BUNDLE_BIN:-bundle}" exec rake test 2>/dev/null || "${BUNDLE_BIN:-bundle}" exec rspec; else echo "No Ruby test command detected; adapt stages.json for this Ruby repo."; fi',
+            description: 'Unit tests',
+          }),
+          readiness,
+        ],
+      };
+    default:
+      return {
+        order: ['typecheck', 'readiness'],
+        stages: [
+          quick({
+            id: 'typecheck',
+            command: `echo 'No stock smoke for HARNESS_ECOSYSTEM=${ecosystem}; adapt .har/stages.json for this repo.'`,
+            description: 'Placeholder smoke — adapt stages.json',
+          }),
+          readiness,
+        ],
+      };
+  }
+}
+
+/**
+ * Register the ecosystem-default verification stages (derived from
+ * HARNESS_ECOSYSTEM) in stages.json. Fills in missing stages and
+ * verificationStages entries only — never overwrites stages a user or
+ * adaptation already customized. Called at init and maintain.
+ */
+export function ensureEcosystemVerificationStages(repoPath: string): boolean {
+  // Only 1.0-contract harnesses get synced: a pre-1.0 harness.env (functions,
+  // port triplets) means verify.sh still owns inline steps, and registering
+  // defaults there would double-run or break them. Migration is #241.
+  const validation = readValidatedHarnessEnv(repoPath);
+  if (!validation || !validation.ok) return false;
+
+  const env = readHarnessEnv(repoPath);
+  const ecosystem = env.HARNESS_ECOSYSTEM || 'none';
+  const defaults = deriveEcosystemDefaultStages(ecosystem, repoPath);
+  const harnessDir = getHarnessDir(repoPath);
+
+  const registry = readStageRegistry(repoPath);
+  const stages = [...registry.stages];
+  let changed = false;
+  const skipped = new Set<string>();
+
+  for (const stage of defaults.stages) {
+    if (stages.some((s) => s.id === stage.id)) continue;
+    if (stage.script && !fs.existsSync(path.join(harnessDir, stage.script))) {
+      skipped.add(stage.id);
+      continue;
+    }
+    stages.push(stage);
+    changed = true;
+  }
+
+  const verificationStages = [...(registry.verificationStages ?? [])];
+  // Insert missing defaults ahead of existing extras (plugins append at the
+  // end), preserving the relative order users already chose.
+  let insertAt = 0;
+  for (const id of defaults.order) {
+    if (skipped.has(id) && !stages.some((s) => s.id === id)) continue;
+    const existing = verificationStages.indexOf(id);
+    if (existing >= 0) {
+      insertAt = existing + 1;
+      continue;
+    }
+    verificationStages.splice(insertAt, 0, id);
+    insertAt += 1;
+    changed = true;
+  }
+
+  if (!changed) return false;
+  writeStageRegistry(repoPath, { ...registry, stages, verificationStages });
+  return true;
+}

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -61,13 +61,18 @@ Primary app, ports, `HARNESS_INFRA_SERVICES`, migrate/seed commands, health chec
 ### `.har/ecosystem.agent.template.cjs` (default profile only)
 PM2 processes for the primary application only, matching how it runs in dev. Skip entirely for the CLI profile.
 
-### `.har/verify.sh`
-Adapt verification for this repository's toolchain. Step lists in the template are
-**examples, not exhaustive** — add, remove, or reorder `run_step` calls to match
-how this project is built and tested. Use toolchain variables from `.env.agent.<id>`
-(e.g. `${NPM_BIN:-npm}`, `${PYTHON_BIN:-python3}`, `${XCODEBUILD_BIN:-xcodebuild}`).
-The stock verify section is keyed by `HARNESS_ECOSYSTEM`; it is a starting point,
-not the repo's final contract. Replace conventions that do not match this project.
+### Verification stages (`.har/stages.json`)
+Verification is data: `.har/stages.json` lists the pipeline in
+`verificationStages` (execution order), and every id resolves to a registered
+stage with `"tier": "quick" | "full"`. Adapt verification by editing the stage
+entries — commands, tiers, order — or adding stage scripts (see
+`.har/STAGES.md`). **Never edit `.har/verify.sh`**; it is a thin iterator that
+runs the registry. The scaffolded defaults (`typecheck`, `unit-tests`, `lint`,
+`readiness`, plus `api-health` on web profiles) are derived from
+`HARNESS_ECOSYSTEM` — a starting point, not the repo's final contract. Replace
+conventions that do not match this project. Use toolchain variables from
+`.env.agent.<id>` (e.g. `${NPM_BIN:-npm}`, `${PYTHON_BIN:-python3}`,
+`${XCODEBUILD_BIN:-xcodebuild}`).
 
 `${NPM_BIN}` may resolve to bun, pnpm, or yarn as well as npm, so keep Node steps
 package-manager agnostic: always `${NPM_BIN:-npm} run <script>` (never bare
@@ -84,7 +89,7 @@ such as `--prefix` — use a subshell like `(cd docs && ${NPM_BIN:-npm} run buil
 - **Quick** must stay fast and minimal (syntax, compile, import smoke) — not the full test suite.
 - **Full** holds unit tests, lint, and heavier checks; optional Playwright runs on `--full` when installed.
 - Reuse real commands from `package.json`, `Makefile`, CI, `pyproject.toml`, etc.
-- Remove stock npm/pytest/go/cargo/maven/gradle examples that do not apply.
+- Remove stock stage commands that do not apply; keep every listed id resolvable.
 - Replace all TODO placeholders in both tiers.
 
 ### Readiness vs liveness (required)

--- a/src/templates/har-boilerplate-cli/agent-slot.sh
+++ b/src/templates/har-boilerplate-cli/agent-slot.sh
@@ -773,67 +773,7 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
-# Append one verify.sh step to RESULTS_JSON (caller global).
-# Passing steps omit output — it already appeared as ✓ on stderr.
-record_step_result() {
-  local name="$1"
-  local pass_bool="$2"
-  local elapsed="$3"
-  local output="${4:-}"
-  local step_json
-  if [ "$pass_bool" = "true" ]; then
-    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
-  else
-    local escaped
-    escaped=$(escape_step_output "$output")
-    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
-  fi
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push($step_json);
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
-}
 
-# Emit "<id>\t<command>" for each registered stage listed in stages.json
-# verificationStages (used by verify --full). Ids without a matching registered
-# stage are inline verify.sh steps and skipped here; lifecycle stages
-# (setup/launch/reset/teardown/inspect) and the verify stage itself never run.
-# Authoring contract: .har/STAGES.md
-list_registered_verification_stage_commands() {
-  local script_dir="$1"
-  local agent_id="$2"
-  local registry="$script_dir/stages.json"
-  [ -f "$registry" ] || return 0
-  HAR_STAGE_REGISTRY="$registry" HAR_SCRIPT_DIR="$script_dir" HAR_AGENT_ID="$agent_id" node <<'NODE' 2>/dev/null || true
-const fs = require('fs');
-const { HAR_STAGE_REGISTRY, HAR_SCRIPT_DIR, HAR_AGENT_ID } = process.env;
-const shq = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'";
-let reg;
-try { reg = JSON.parse(fs.readFileSync(HAR_STAGE_REGISTRY, 'utf8')); } catch { process.exit(0); }
-const ids = Array.isArray(reg.verificationStages) ? reg.verificationStages : [];
-const stages = Array.isArray(reg.stages) ? reg.stages : [];
-const runnable = new Set(['test', 'custom']);
-for (const id of ids) {
-  const stage = stages.find((s) => s && s.id === id);
-  if (!stage || stage.id === 'verify' || !runnable.has(stage.kind)) continue;
-  const needsAgent = stage.requiresAgentId !== false;
-  let cmd;
-  if (stage.script) {
-    cmd = shq(HAR_SCRIPT_DIR + '/' + stage.script) + (needsAgent ? ' ' + shq(HAR_AGENT_ID) : '');
-  } else if (stage.command) {
-    cmd = stage.command.split('{agentId}').join(HAR_AGENT_ID);
-  } else {
-    continue;
-  }
-  if (stage.cwd) cmd = 'cd ' + shq(stage.cwd) + ' && ' + cmd;
-  const env = stage.env && typeof stage.env === 'object' ? stage.env : {};
-  const prefix = Object.entries(env).map(([k, v]) => k + '=' + shq(v)).join(' ');
-  process.stdout.write(id + '\t' + (prefix ? prefix + ' ' : '') + cmd + '\n');
-}
-NODE
-}
 
 # Optional project-owned "agent usable" smoke beyond health.
 run_readiness_if_configured() {

--- a/src/templates/har-boilerplate-cli/stages.json
+++ b/src/templates/har-boilerplate-cli/stages.json
@@ -32,9 +32,11 @@
     {
       "id": "verify",
       "kind": "verify",
-      "description": "Verification pipeline (quick smoke by default; --full runs the registry's verificationStages)",
+      "description": "Verification pipeline: runs stages.json verificationStages in order (tier \"quick\" by default; --full runs the whole list)",
       "command": "./.har/verify.sh {agentId}",
-      "acceptsArgs": ["--full"],
+      "acceptsArgs": [
+        "--full"
+      ],
       "artifacts": [
         {
           "path": ".har/artifacts",
@@ -61,6 +63,44 @@
       "kind": "teardown",
       "description": "Remove worktree and env file for the slot",
       "command": "./.har/teardown.sh {agentId}"
+    },
+    {
+      "id": "typecheck",
+      "kind": "test",
+      "tier": "quick",
+      "description": "Ecosystem quick smoke (registered from HARNESS_ECOSYSTEM at init; adapt to this repo)",
+      "command": "${NPM_BIN:-npm} run typecheck",
+      "requiresAgentId": true
+    },
+    {
+      "id": "unit-tests",
+      "kind": "test",
+      "tier": "full",
+      "description": "Unit tests",
+      "command": "${NPM_BIN:-npm} test",
+      "requiresAgentId": true
+    },
+    {
+      "id": "lint",
+      "kind": "test",
+      "tier": "full",
+      "description": "Lint",
+      "command": "${NPM_BIN:-npm} run lint",
+      "requiresAgentId": true
+    },
+    {
+      "id": "readiness",
+      "kind": "test",
+      "tier": "full",
+      "description": "Project readiness smoke (HARNESS_READINESS_CMD)",
+      "script": "stages/readiness.sh",
+      "requiresAgentId": true
     }
+  ],
+  "verificationStages": [
+    "typecheck",
+    "unit-tests",
+    "lint",
+    "readiness"
   ]
 }

--- a/src/templates/har-boilerplate-cli/verify.sh
+++ b/src/templates/har-boilerplate-cli/verify.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 # Verification pipeline for CLI/library repos.
 # Outputs JSON to stdout (machine contract), human-readable progress to stderr.
-# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
-# Quick (default): ecosystem smoke — compile/import/build only
-# Full (--full):   + conventional tests, lint, readiness, and every registered
-#                  stage in stages.json verificationStages (see .har/STAGES.md)
-# Stock steps are examples. Replace them during adaptation to match this repo.
+# The pipeline is data: .har/stages.json's verificationStages list, in order.
+# Quick (default) runs the stages marked tier "quick"; --full runs the whole
+# list. Customize verification by editing stages.json or adding a stage script
+# (see .har/STAGES.md) — never by editing this file.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -51,167 +50,6 @@ else
   echo "    Registry: missing (${REG_FILE})" >&2
 fi
 
-OVERALL_PASS=true
-START_TOTAL=$(now_ms)
-RESULTS_JSON="[]"
-
-run_step() {
-  local name="$1"
-  local cmd="$2"
-  local start end elapsed exit_code output
-
-  printf "  → %-40s" "$name..." >&2
-  start=$(now_ms)
-
-  set +e
-  output=$(cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$cmd" 2>&1)
-  exit_code=$?
-  set -e
-
-  end=$(now_ms)
-  elapsed=$(( end - start ))
-
-  local pass_bool
-  if [ "$exit_code" = "0" ]; then
-    echo "✓ (${elapsed}ms)" >&2
-    pass_bool="true"
-  else
-    echo "✗ (${elapsed}ms)" >&2
-    echo "$output" | head -30 | sed 's/^/    /' >&2
-    pass_bool="false"
-    OVERALL_PASS=false
-  fi
-
-  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
-
-  if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
-    return 1
-  fi
-}
-
-node_package_script_exists() {
-  local script="$1"
-  "${NODE_BIN:-node}" -e "
-const fs = require('fs');
-const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-const script = process.argv[1];
-process.exit(pkg.scripts && pkg.scripts[script] ? 0 : 1);
-" "$script"
-}
-
-run_node_script_or_skip() {
-  local name="$1"
-  local script="$2"
-  if node_package_script_exists "$script"; then
-    run_step "$name" "${NPM_BIN:-npm} run ${script}"
-  else
-    run_step "$name" "echo 'No ${script} script configured; skipping.'"
-  fi
-}
-
-run_node_quick_smoke() {
-  if node_package_script_exists typecheck; then
-    run_step "node-typecheck" '${NPM_BIN:-npm} run typecheck'
-  elif node_package_script_exists build; then
-    run_step "node-build" '${NPM_BIN:-npm} run build'
-  else
-    run_step "node-package-load" '${NODE_BIN:-node} -e "require(\"./package.json\")"'
-  fi
-}
-
-run_quick_smoke() {
-  case "${HARNESS_ECOSYSTEM:-none}" in
-    node)
-      run_node_quick_smoke
-      ;;
-    python)
-      run_step "python-compile" '${PYTHON_BIN:-python3} -m compileall -q .'
-      ;;
-    go)
-      run_step "go-build" '${GO_BIN:-go} build ./...'
-      ;;
-    rust)
-      run_step "rust-check" '${CARGO_BIN:-cargo} check'
-      ;;
-    java)
-      run_step "java-compile" 'if [ -x ./mvnw ]; then ./mvnw -q -DskipTests compile; elif command -v mvn >/dev/null 2>&1; then mvn -q -DskipTests compile; elif [ -x ./gradlew ]; then ./gradlew classes; elif command -v gradle >/dev/null 2>&1; then gradle classes; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi'
-      ;;
-    ruby)
-      run_step "ruby-smoke" '${RUBY_BIN:-ruby} -e "puts RUBY_VERSION"'
-      ;;
-    custom|none|*)
-      run_step "smoke-not-configured" 'echo "No stock smoke for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."'
-      ;;
-  esac
-}
-
-run_full_checks() {
-  case "${HARNESS_ECOSYSTEM:-none}" in
-    node)
-      run_node_script_or_skip "unit-tests" test || true
-      run_node_script_or_skip "lint" lint || true
-      ;;
-    python)
-      run_step "unit-tests" 'if ${PYTHON_BIN:-python3} -c "import pytest" >/dev/null 2>&1; then ${PYTHON_BIN:-python3} -m pytest -q; else echo "pytest not installed; adapt verify.sh for this Python repo."; fi' || true
-      ;;
-    go)
-      run_step "unit-tests" '${GO_BIN:-go} test ./...' || true
-      ;;
-    rust)
-      run_step "unit-tests" '${CARGO_BIN:-cargo} test' || true
-      ;;
-    java)
-      run_step "unit-tests" 'if [ -x ./mvnw ]; then ./mvnw -q test; elif command -v mvn >/dev/null 2>&1; then mvn -q test; elif [ -x ./gradlew ]; then ./gradlew test; elif command -v gradle >/dev/null 2>&1; then gradle test; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi' || true
-      ;;
-    ruby)
-      run_step "unit-tests" 'if command -v "${BUNDLE_BIN:-bundle}" >/dev/null 2>&1 && [ -f Gemfile ]; then "${BUNDLE_BIN:-bundle}" exec rake test 2>/dev/null || "${BUNDLE_BIN:-bundle}" exec rspec; else echo "No Ruby test command detected; adapt verify.sh for this Ruby repo."; fi' || true
-      ;;
-    custom|none|*)
-      run_step "unit-tests" 'echo "No stock full checks for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."' || true
-      ;;
-  esac
-}
-
-# Emit the results JSON and exit non-zero when any step failed. Quick mode
-# calls this at the first failing step (stopping early); the full pipeline
-# runs every step and calls it once at the end.
-emit_results() {
-  END_TOTAL=$(now_ms)
-  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
-
-  node -e "
-const results = $RESULTS_JSON;
-const overall = results.length > 0 && results.every(r => r.pass);
-const out = {
-  status: overall ? 'pass' : 'fail',
-  agent_id: $AGENT_ID,
-  total_ms: $TOTAL_MS,
-  stages: results,
-};
-process.stdout.write(JSON.stringify(out, null, 2) + '\n');
-" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
-
-  if [ "$OVERALL_PASS" = "false" ]; then
-    exit 1
-  fi
-}
-
-# ── Verification stages ─────────────────────────────────────────────────────
-# These stock steps are intentionally generic conventions. Adapt this section
-# to the repository's real commands from package.json, Makefile, CI, pyproject,
-# Cargo.toml, go.mod, pom.xml, etc.
-run_quick_smoke || emit_results
-
-if [ -n "$FULL" ]; then
-  run_full_checks
-  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
-  # Registered verification stages from .har/stages.json (see .har/STAGES.md).
-  # Every stage listed in verificationStages with a registered script/command
-  # runs here -- plugins and custom stages alike.
-  while IFS=$'\t' read -r STAGE_ID STAGE_CMD; do
-    [ -n "$STAGE_ID" ] || continue
-    run_step "$STAGE_ID" "$STAGE_CMD" || true
-  done < <(list_registered_verification_stage_commands "$SCRIPT_DIR" "$AGENT_ID")
-fi
-
-emit_results
+export HAR_HARNESS_DIR="$SCRIPT_DIR"
+export WORK_DIR
+exec node "$SCRIPT_DIR/lib/verify-runner.mjs" --agent "$AGENT_ID" ${FULL:+--full}

--- a/src/templates/har-boilerplate-ios/agent-slot.sh
+++ b/src/templates/har-boilerplate-ios/agent-slot.sh
@@ -420,67 +420,7 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
-# Append one verify.sh step to RESULTS_JSON (caller global).
-# Passing steps omit output — it already appeared as ✓ on stderr.
-record_step_result() {
-  local name="$1"
-  local pass_bool="$2"
-  local elapsed="$3"
-  local output="${4:-}"
-  local step_json
-  if [ "$pass_bool" = "true" ]; then
-    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
-  else
-    local escaped
-    escaped=$(escape_step_output "$output")
-    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
-  fi
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push($step_json);
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
-}
 
-# Emit "<id>\t<command>" for each registered stage listed in stages.json
-# verificationStages (used by verify --full). Ids without a matching registered
-# stage are inline verify.sh steps and skipped here; lifecycle stages
-# (setup/launch/reset/teardown/inspect) and the verify stage itself never run.
-# Authoring contract: .har/STAGES.md
-list_registered_verification_stage_commands() {
-  local script_dir="$1"
-  local agent_id="$2"
-  local registry="$script_dir/stages.json"
-  [ -f "$registry" ] || return 0
-  HAR_STAGE_REGISTRY="$registry" HAR_SCRIPT_DIR="$script_dir" HAR_AGENT_ID="$agent_id" node <<'NODE' 2>/dev/null || true
-const fs = require('fs');
-const { HAR_STAGE_REGISTRY, HAR_SCRIPT_DIR, HAR_AGENT_ID } = process.env;
-const shq = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'";
-let reg;
-try { reg = JSON.parse(fs.readFileSync(HAR_STAGE_REGISTRY, 'utf8')); } catch { process.exit(0); }
-const ids = Array.isArray(reg.verificationStages) ? reg.verificationStages : [];
-const stages = Array.isArray(reg.stages) ? reg.stages : [];
-const runnable = new Set(['test', 'custom']);
-for (const id of ids) {
-  const stage = stages.find((s) => s && s.id === id);
-  if (!stage || stage.id === 'verify' || !runnable.has(stage.kind)) continue;
-  const needsAgent = stage.requiresAgentId !== false;
-  let cmd;
-  if (stage.script) {
-    cmd = shq(HAR_SCRIPT_DIR + '/' + stage.script) + (needsAgent ? ' ' + shq(HAR_AGENT_ID) : '');
-  } else if (stage.command) {
-    cmd = stage.command.split('{agentId}').join(HAR_AGENT_ID);
-  } else {
-    continue;
-  }
-  if (stage.cwd) cmd = 'cd ' + shq(stage.cwd) + ' && ' + cmd;
-  const env = stage.env && typeof stage.env === 'object' ? stage.env : {};
-  const prefix = Object.entries(env).map(([k, v]) => k + '=' + shq(v)).join(' ');
-  process.stdout.write(id + '\t' + (prefix ? prefix + ' ' : '') + cmd + '\n');
-}
-NODE
-}
 
 # Optional project-owned "agent usable" smoke beyond health.
 run_readiness_if_configured() {

--- a/src/templates/har-boilerplate-ios/stages.json
+++ b/src/templates/har-boilerplate-ios/stages.json
@@ -32,9 +32,11 @@
     {
       "id": "verify",
       "kind": "verify",
-      "description": "Verification pipeline (quick smoke by default; --full runs the registry's verificationStages)",
+      "description": "Verification pipeline: runs stages.json verificationStages in order (tier \"quick\" by default; --full runs the whole list)",
       "command": "./.har/verify.sh {agentId}",
-      "acceptsArgs": ["--full"],
+      "acceptsArgs": [
+        "--full"
+      ],
       "artifacts": [
         {
           "path": ".har/artifacts",
@@ -61,6 +63,44 @@
       "kind": "teardown",
       "description": "Remove worktree and env file for the slot",
       "command": "./.har/teardown.sh {agentId}"
+    },
+    {
+      "id": "build",
+      "kind": "test",
+      "tier": "quick",
+      "description": "Xcode build smoke (compile-only, unsigned)",
+      "command": "${XCODEBUILD_BIN:-xcodebuild} build ${XC_FLAGS} -scheme \"${XC_SCHEME}\" -destination \"${XC_DESTINATION}\" -derivedDataPath \"${XC_DERIVED}\" CODE_SIGNING_ALLOWED=NO | xcbeautify 2>/dev/null || ${XCODEBUILD_BIN:-xcodebuild} build ${XC_FLAGS} -scheme \"${XC_SCHEME}\" -destination \"${XC_DESTINATION}\" -derivedDataPath \"${XC_DERIVED}\" CODE_SIGNING_ALLOWED=NO",
+      "requiresAgentId": true
+    },
+    {
+      "id": "unit-tests",
+      "kind": "test",
+      "tier": "full",
+      "description": "Xcode unit tests (signed: simulator installs the host app)",
+      "command": "${XCODEBUILD_BIN:-xcodebuild} test ${XC_FLAGS} -scheme \"${XC_SCHEME}\" -destination \"${XC_DESTINATION}\" -derivedDataPath \"${XC_DERIVED}\" | xcbeautify 2>/dev/null || ${XCODEBUILD_BIN:-xcodebuild} test ${XC_FLAGS} -scheme \"${XC_SCHEME}\" -destination \"${XC_DESTINATION}\" -derivedDataPath \"${XC_DERIVED}\"",
+      "requiresAgentId": true
+    },
+    {
+      "id": "lint",
+      "kind": "test",
+      "tier": "full",
+      "description": "SwiftLint (skips when not installed)",
+      "command": "command -v \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" >/dev/null 2>&1 && \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" --quiet || echo \"swiftlint not installed — skipping\"",
+      "requiresAgentId": true
+    },
+    {
+      "id": "readiness",
+      "kind": "test",
+      "tier": "full",
+      "description": "Project readiness smoke (HARNESS_READINESS_CMD)",
+      "script": "stages/readiness.sh",
+      "requiresAgentId": true
     }
+  ],
+  "verificationStages": [
+    "build",
+    "unit-tests",
+    "lint",
+    "readiness"
   ]
 }

--- a/src/templates/har-boilerplate-ios/verify.sh
+++ b/src/templates/har-boilerplate-ios/verify.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Verification pipeline for iOS mobile app repos — build and test with xcodebuild.
 # Outputs JSON to stdout (machine contract), human-readable progress to stderr.
-# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
-# Quick (default): build smoke (compile-only)
-# Full (--full):   + unit tests, lint (SwiftLint), and every registered stage
-#                  in stages.json verificationStages (see .har/STAGES.md)
-# Step lists are examples — not exhaustive. Adapt commands to this repo's stack.
+# The pipeline is data: .har/stages.json's verificationStages list, in order.
+# Quick (default) runs the stages marked tier "quick"; --full runs the whole
+# list. Stage commands use the XC_* variables exported below. Customize
+# verification by editing stages.json or adding a stage script (see
+# .har/STAGES.md) — never by editing this file.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -75,118 +75,11 @@ xc_target_flags() {
 }
 
 XC_FLAGS="$(xc_target_flags)"
-XC_SCHEME="${HARNESS_XCODE_SCHEME:-MyApp}"
-XC_DESTINATION="${HARNESS_IOS_DESTINATION:-platform=iOS Simulator,name=${HARNESS_SIMULATOR_NAME:-iPhone 16}}"
-XC_DERIVED="${WORK_DIR}/build/DerivedData"
+export XC_FLAGS
+export XC_SCHEME="${HARNESS_XCODE_SCHEME:-MyApp}"
+export XC_DESTINATION="${HARNESS_IOS_DESTINATION:-platform=iOS Simulator,name=${HARNESS_SIMULATOR_NAME:-iPhone 16}}"
+export XC_DERIVED="${WORK_DIR}/build/DerivedData"
 
-OVERALL_PASS=true
-START_TOTAL=$(now_ms)
-RESULTS_JSON="[]"
-
-run_step() {
-  local name="$1"
-  local cmd="$2"
-  local start end elapsed exit_code output
-
-  printf "  → %-40s" "$name..." >&2
-  start=$(now_ms)
-
-  set +e
-  output=$(cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$cmd" 2>&1)
-  exit_code=$?
-  set -e
-
-  end=$(now_ms)
-  elapsed=$(( end - start ))
-
-  local pass_bool
-  if [ "$exit_code" = "0" ]; then
-    echo "✓ (${elapsed}ms)" >&2
-    pass_bool="true"
-  else
-    echo "✗ (${elapsed}ms)" >&2
-    echo "$output" | head -40 | sed 's/^/    /' >&2
-    pass_bool="false"
-    OVERALL_PASS=false
-  fi
-
-  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
-
-  if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
-    return 1
-  fi
-}
-
-# Quick (default): compile-only — use XCODEBUILD_BIN from .env.agent.<id> (written by launch)
-# Nothing is installed or run, so CODE_SIGNING_ALLOWED=NO keeps the smoke build
-# from needing a signing identity.
-# Emit the results JSON and exit non-zero when any step failed. Quick mode
-# calls this at the first failing step (stopping early); the full pipeline
-# runs every step and calls it once at the end.
-emit_results() {
-  END_TOTAL=$(now_ms)
-  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
-
-  node -e "
-const results = $RESULTS_JSON;
-const overall = results.length > 0 && results.every(r => r.pass);
-const out = {
-  status: overall ? 'pass' : 'fail',
-  agent_id: $AGENT_ID,
-  total_ms: $TOTAL_MS,
-  stages: results,
-};
-process.stdout.write(JSON.stringify(out, null, 2) + '\n');
-" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
-
-  if [ "$OVERALL_PASS" = "false" ]; then
-    exit 1
-  fi
-}
-
-run_step "build" '${XCODEBUILD_BIN:-xcodebuild} build \
-  ${XC_FLAGS} \
-  -scheme "${XC_SCHEME}" \
-  -destination "${XC_DESTINATION}" \
-  -derivedDataPath "${XC_DERIVED}" \
-  CODE_SIGNING_ALLOWED=NO \
-  | xcbeautify 2>/dev/null || ${XCODEBUILD_BIN:-xcodebuild} build \
-    ${XC_FLAGS} \
-    -scheme "${XC_SCHEME}" \
-    -destination "${XC_DESTINATION}" \
-    -derivedDataPath "${XC_DERIVED}" \
-    CODE_SIGNING_ALLOWED=NO' || emit_results
-
-if [ -n "$FULL" ]; then
-  # Full: project-specific checks — add/remove/reorder steps for this repo.
-  # No CODE_SIGNING_ALLOWED=NO here, unlike the build step: tests install and run
-  # the host app on the simulator, and an unsigned app gets no entitlements. Apps
-  # using CloudKit, NSUbiquitousKeyValueStore, or push then trap at launch, before
-  # the test harness connects — the whole bundle is lost, not one test.
-  run_step "unit-tests" '${XCODEBUILD_BIN:-xcodebuild} test \
-    ${XC_FLAGS} \
-    -scheme "${XC_SCHEME}" \
-    -destination "${XC_DESTINATION}" \
-    -derivedDataPath "${XC_DERIVED}" \
-    | xcbeautify 2>/dev/null || ${XCODEBUILD_BIN:-xcodebuild} test \
-      ${XC_FLAGS} \
-      -scheme "${XC_SCHEME}" \
-      -destination "${XC_DESTINATION}" \
-      -derivedDataPath "${XC_DERIVED}"' || true
-
-  # SwiftLint — optional, skip gracefully when not installed
-  run_step "lint" "command -v \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" >/dev/null 2>&1 && \
-    \"${HARNESS_SWIFTLINT_CMD:-swiftlint}\" --quiet 2>&1 || echo 'swiftlint not installed — skipping'" || true
-
-  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
-
-  # Registered verification stages from .har/stages.json (see .har/STAGES.md).
-  # Every stage listed in verificationStages with a registered script/command
-  # runs here -- plugins and custom stages alike.
-  while IFS=$'\t' read -r STAGE_ID STAGE_CMD; do
-    [ -n "$STAGE_ID" ] || continue
-    run_step "$STAGE_ID" "$STAGE_CMD" || true
-  done < <(list_registered_verification_stage_commands "$SCRIPT_DIR" "$AGENT_ID")
-fi
-
-emit_results
+export HAR_HARNESS_DIR="$SCRIPT_DIR"
+export WORK_DIR
+exec node "$SCRIPT_DIR/lib/verify-runner.mjs" --agent "$AGENT_ID" ${FULL:+--full}

--- a/src/templates/har-boilerplate/agent-slot.sh
+++ b/src/templates/har-boilerplate/agent-slot.sh
@@ -791,67 +791,7 @@ escape_step_output() {
   printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
 
-# Append one verify.sh step to RESULTS_JSON (caller global).
-# Passing steps omit output — it already appeared as ✓ on stderr.
-record_step_result() {
-  local name="$1"
-  local pass_bool="$2"
-  local elapsed="$3"
-  local output="${4:-}"
-  local step_json
-  if [ "$pass_bool" = "true" ]; then
-    step_json=$(NAME="$name" MS="$elapsed" node -e 'process.stdout.write(JSON.stringify({name:process.env.NAME,pass:true,ms:Number(process.env.MS)}))' 2>/dev/null) || return 0
-  else
-    local escaped
-    escaped=$(escape_step_output "$output")
-    step_json=$(NAME="$name" MS="$elapsed" node -e "process.stdout.write(JSON.stringify({name:process.env.NAME,pass:false,ms:Number(process.env.MS),output:$escaped}))" 2>/dev/null) || return 0
-  fi
-  RESULTS_JSON=$(echo "$RESULTS_JSON" | node -e "
-const fs = require('fs');
-const arr = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-arr.push($step_json);
-process.stdout.write(JSON.stringify(arr));
-" 2>/dev/null || echo "$RESULTS_JSON")
-}
 
-# Emit "<id>\t<command>" for each registered stage listed in stages.json
-# verificationStages (used by verify --full). Ids without a matching registered
-# stage are inline verify.sh steps and skipped here; lifecycle stages
-# (setup/launch/reset/teardown/inspect) and the verify stage itself never run.
-# Authoring contract: .har/STAGES.md
-list_registered_verification_stage_commands() {
-  local script_dir="$1"
-  local agent_id="$2"
-  local registry="$script_dir/stages.json"
-  [ -f "$registry" ] || return 0
-  HAR_STAGE_REGISTRY="$registry" HAR_SCRIPT_DIR="$script_dir" HAR_AGENT_ID="$agent_id" node <<'NODE' 2>/dev/null || true
-const fs = require('fs');
-const { HAR_STAGE_REGISTRY, HAR_SCRIPT_DIR, HAR_AGENT_ID } = process.env;
-const shq = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'";
-let reg;
-try { reg = JSON.parse(fs.readFileSync(HAR_STAGE_REGISTRY, 'utf8')); } catch { process.exit(0); }
-const ids = Array.isArray(reg.verificationStages) ? reg.verificationStages : [];
-const stages = Array.isArray(reg.stages) ? reg.stages : [];
-const runnable = new Set(['test', 'custom']);
-for (const id of ids) {
-  const stage = stages.find((s) => s && s.id === id);
-  if (!stage || stage.id === 'verify' || !runnable.has(stage.kind)) continue;
-  const needsAgent = stage.requiresAgentId !== false;
-  let cmd;
-  if (stage.script) {
-    cmd = shq(HAR_SCRIPT_DIR + '/' + stage.script) + (needsAgent ? ' ' + shq(HAR_AGENT_ID) : '');
-  } else if (stage.command) {
-    cmd = stage.command.split('{agentId}').join(HAR_AGENT_ID);
-  } else {
-    continue;
-  }
-  if (stage.cwd) cmd = 'cd ' + shq(stage.cwd) + ' && ' + cmd;
-  const env = stage.env && typeof stage.env === 'object' ? stage.env : {};
-  const prefix = Object.entries(env).map(([k, v]) => k + '=' + shq(v)).join(' ');
-  process.stdout.write(id + '\t' + (prefix ? prefix + ' ' : '') + cmd + '\n');
-}
-NODE
-}
 
 # Optional project-owned "agent usable" smoke beyond health.
 run_readiness_if_configured() {

--- a/src/templates/har-boilerplate/stages.json
+++ b/src/templates/har-boilerplate/stages.json
@@ -32,9 +32,11 @@
     {
       "id": "verify",
       "kind": "verify",
-      "description": "Verification pipeline (quick smoke by default; --full runs the registry's verificationStages)",
+      "description": "Verification pipeline: runs stages.json verificationStages in order (tier \"quick\" by default; --full runs the whole list)",
       "command": "./.har/verify.sh {agentId}",
-      "acceptsArgs": ["--full"],
+      "acceptsArgs": [
+        "--full"
+      ],
       "artifacts": [
         {
           "path": ".har/artifacts",
@@ -67,6 +69,53 @@
       "kind": "teardown",
       "description": "Stop processes and release agent slot resources",
       "command": "./.har/teardown.sh {agentId}"
+    },
+    {
+      "id": "typecheck",
+      "kind": "test",
+      "tier": "quick",
+      "description": "Ecosystem quick smoke (registered from HARNESS_ECOSYSTEM at init; adapt to this repo)",
+      "command": "${NPM_BIN:-npm} run typecheck",
+      "requiresAgentId": true
+    },
+    {
+      "id": "api-health",
+      "kind": "test",
+      "tier": "quick",
+      "description": "API health endpoint for the slot's primary app",
+      "script": "stages/api-health.sh",
+      "requiresAgentId": true
+    },
+    {
+      "id": "unit-tests",
+      "kind": "test",
+      "tier": "full",
+      "description": "Unit tests",
+      "command": "${NPM_BIN:-npm} test",
+      "requiresAgentId": true
+    },
+    {
+      "id": "lint",
+      "kind": "test",
+      "tier": "full",
+      "description": "Lint",
+      "command": "${NPM_BIN:-npm} run lint",
+      "requiresAgentId": true
+    },
+    {
+      "id": "readiness",
+      "kind": "test",
+      "tier": "full",
+      "description": "Project readiness smoke (HARNESS_READINESS_CMD)",
+      "script": "stages/readiness.sh",
+      "requiresAgentId": true
     }
+  ],
+  "verificationStages": [
+    "typecheck",
+    "api-health",
+    "unit-tests",
+    "lint",
+    "readiness"
   ]
 }

--- a/src/templates/har-boilerplate/verify.sh
+++ b/src/templates/har-boilerplate/verify.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
-# Progressive verification pipeline for an agent environment.
+# Verification pipeline for an agent environment.
 # Outputs JSON to stdout (machine contract), human-readable progress to stderr.
-# Passing steps omit `output`. `har env verify` streams progress only.
 #
 # Usage: ./.har/verify.sh <agent-id> [--full]
 #
-# Quick (default): ecosystem smoke + health only
-# Full (--full):   + conventional tests, lint, readiness, and every registered
-#                  stage in stages.json verificationStages (see .har/STAGES.md)
-# Stock steps are examples. Replace them during adaptation to match this repo.
+# The pipeline is data: .har/stages.json's verificationStages list, in order.
+# Quick (default) runs the stages marked tier "quick"; --full runs the whole
+# list. Customize verification by editing stages.json or adding a stage script
+# (see .har/STAGES.md) — never by editing this file.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,8 +26,6 @@ for arg in "${@:2}"; do
 done
 
 validate_agent_id "$AGENT_ID"
-
-API_PORT=$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))
 
 ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
   echo "No .env.agent.${AGENT_ID} found." >&2
@@ -54,203 +51,6 @@ else
   echo "    Registry: missing (${REG_FILE})" >&2
 fi
 
-OVERALL_PASS=true
-START_TOTAL=$(now_ms)
-RESULTS_JSON="[]"
-
-run_step() {
-  local name="$1"
-  local cmd="$2"
-  local start end elapsed exit_code output
-
-  printf "  → %-40s" "$name..." >&2
-  start=$(now_ms)
-
-  set +e
-  output=$(cd "$WORK_DIR" && set -a && . "$ENV_FILE" && set +a && eval "$cmd" 2>&1)
-  exit_code=$?
-  set -e
-
-  end=$(now_ms)
-  elapsed=$(( end - start ))
-
-  local pass_bool
-  if [ "$exit_code" = "0" ]; then
-    echo "✓ (${elapsed}ms)" >&2
-    pass_bool="true"
-  else
-    echo "✗ (${elapsed}ms)" >&2
-    echo "$output" | head -30 | sed 's/^/    /' >&2
-    pass_bool="false"
-    OVERALL_PASS=false
-  fi
-
-  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
-
-  if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
-    return 1
-  fi
-}
-
-run_http_step() {
-  local name="$1"
-  local url="$2"
-  local start end elapsed exit_code output
-
-  printf "  → %-40s" "$name..." >&2
-  start=$(now_ms)
-
-  set +e
-  output=$(curl -sf "$url" 2>&1)
-  exit_code=$?
-  set -e
-
-  end=$(now_ms)
-  elapsed=$(( end - start ))
-
-  local pass_bool
-  if [ "$exit_code" = "0" ]; then
-    echo "✓ (${elapsed}ms)" >&2
-    pass_bool="true"
-  else
-    echo "✗ (${elapsed}ms)" >&2
-    pass_bool="false"
-    OVERALL_PASS=false
-  fi
-
-  record_step_result "$name" "$pass_bool" "$elapsed" "$output"
-
-  if [ "$pass_bool" = "false" ] && [ -z "$FULL" ]; then
-    return 1
-  fi
-}
-
-node_package_script_exists() {
-  local script="$1"
-  "${NODE_BIN:-node}" -e "
-const fs = require('fs');
-const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-const script = process.argv[1];
-process.exit(pkg.scripts && pkg.scripts[script] ? 0 : 1);
-" "$script"
-}
-
-run_node_script_or_skip() {
-  local name="$1"
-  local script="$2"
-  if node_package_script_exists "$script"; then
-    run_step "$name" "${NPM_BIN:-npm} run ${script}"
-  else
-    run_step "$name" "echo 'No ${script} script configured; skipping.'"
-  fi
-}
-
-run_node_quick_smoke() {
-  if node_package_script_exists typecheck; then
-    run_step "node-typecheck" '${NPM_BIN:-npm} run typecheck'
-  elif node_package_script_exists build; then
-    run_step "node-build" '${NPM_BIN:-npm} run build'
-  else
-    run_step "node-package-load" '${NODE_BIN:-node} -e "require(\"./package.json\")"'
-  fi
-}
-
-run_quick_smoke() {
-  case "${HARNESS_ECOSYSTEM:-none}" in
-    node)
-      run_node_quick_smoke
-      ;;
-    python)
-      run_step "python-compile" '${PYTHON_BIN:-python3} -m compileall -q .'
-      ;;
-    go)
-      run_step "go-build" '${GO_BIN:-go} build ./...'
-      ;;
-    rust)
-      run_step "rust-check" '${CARGO_BIN:-cargo} check'
-      ;;
-    java)
-      run_step "java-compile" 'if [ -x ./mvnw ]; then ./mvnw -q -DskipTests compile; elif command -v mvn >/dev/null 2>&1; then mvn -q -DskipTests compile; elif [ -x ./gradlew ]; then ./gradlew classes; elif command -v gradle >/dev/null 2>&1; then gradle classes; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi'
-      ;;
-    ruby)
-      run_step "ruby-smoke" '${RUBY_BIN:-ruby} -e "puts RUBY_VERSION"'
-      ;;
-    custom|none|*)
-      run_step "smoke-not-configured" 'echo "No stock smoke for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."'
-      ;;
-  esac
-}
-
-run_full_checks() {
-  case "${HARNESS_ECOSYSTEM:-none}" in
-    node)
-      run_node_script_or_skip "unit-tests" test || true
-      run_node_script_or_skip "lint" lint || true
-      ;;
-    python)
-      run_step "unit-tests" 'if ${PYTHON_BIN:-python3} -c "import pytest" >/dev/null 2>&1; then ${PYTHON_BIN:-python3} -m pytest -q; else echo "pytest not installed; adapt verify.sh for this Python repo."; fi' || true
-      ;;
-    go)
-      run_step "unit-tests" '${GO_BIN:-go} test ./...' || true
-      ;;
-    rust)
-      run_step "unit-tests" '${CARGO_BIN:-cargo} test' || true
-      ;;
-    java)
-      run_step "unit-tests" 'if [ -x ./mvnw ]; then ./mvnw -q test; elif command -v mvn >/dev/null 2>&1; then mvn -q test; elif [ -x ./gradlew ]; then ./gradlew test; elif command -v gradle >/dev/null 2>&1; then gradle test; else echo "No Maven/Gradle command found; adapt verify.sh for this Java repo."; fi' || true
-      ;;
-    ruby)
-      run_step "unit-tests" 'if command -v "${BUNDLE_BIN:-bundle}" >/dev/null 2>&1 && [ -f Gemfile ]; then "${BUNDLE_BIN:-bundle}" exec rake test 2>/dev/null || "${BUNDLE_BIN:-bundle}" exec rspec; else echo "No Ruby test command detected; adapt verify.sh for this Ruby repo."; fi' || true
-      ;;
-    custom|none|*)
-      run_step "unit-tests" 'echo "No stock full checks for HARNESS_ECOSYSTEM=${HARNESS_ECOSYSTEM:-none}; adapt .har/verify.sh for this repo."' || true
-      ;;
-  esac
-}
-
-# Emit the results JSON and exit non-zero when any step failed. Quick mode
-# calls this at the first failing step (stopping early); the full pipeline
-# runs every step and calls it once at the end.
-emit_results() {
-  END_TOTAL=$(now_ms)
-  TOTAL_MS=$(( END_TOTAL - START_TOTAL ))
-
-  node -e "
-const results = $RESULTS_JSON;
-const overall = results.length > 0 && results.every(r => r.pass);
-const out = {
-  status: overall ? 'pass' : 'fail',
-  agent_id: $AGENT_ID,
-  total_ms: $TOTAL_MS,
-  stages: results,
-};
-process.stdout.write(JSON.stringify(out, null, 2) + '\n');
-" 2>/dev/null || echo "{\"status\":\"fail\",\"agent_id\":${AGENT_ID},\"stages\":[]}"
-
-  if [ "$OVERALL_PASS" = "false" ]; then
-    exit 1
-  fi
-}
-
-# ── Verification stages ─────────────────────────────────────────────────────
-# These stock steps are intentionally generic conventions. Adapt this section
-# to the repository's real commands from package.json, Makefile, CI, pyproject,
-# Cargo.toml, go.mod, pom.xml, etc.
-run_quick_smoke || emit_results
-run_http_step "api-health" "http://localhost:${API_PORT}${HARNESS_HEALTH_CHECK_PATH}" || emit_results
-
-if [ -n "$FULL" ]; then
-  run_full_checks
-  run_step "readiness" "run_readiness_if_configured \"$AGENT_ID\"" || true
-  # Registered verification stages from .har/stages.json (see .har/STAGES.md).
-  # Every stage listed in verificationStages with a registered script/command
-  # runs here -- plugins and custom stages alike.
-  while IFS=$'\t' read -r STAGE_ID STAGE_CMD; do
-    [ -n "$STAGE_ID" ] || continue
-    run_step "$STAGE_ID" "$STAGE_CMD" || true
-  done < <(list_registered_verification_stage_commands "$SCRIPT_DIR" "$AGENT_ID")
-fi
-
-# ── Output results ────────────────────────────────────────────────────────────
-
-emit_results
+export HAR_HARNESS_DIR="$SCRIPT_DIR"
+export WORK_DIR API_PORT
+exec node "$SCRIPT_DIR/lib/verify-runner.mjs" --agent "$AGENT_ID" ${FULL:+--full}

--- a/src/templates/plugins/gitleaks/template.manifest.json
+++ b/src/templates/plugins/gitleaks/template.manifest.json
@@ -16,15 +16,30 @@
         "kind": "directory",
         "description": "Redacted JSON findings report and scan log"
       }
-    ]
+    ],
+    "tier": "full"
   },
   "files": [
-    { "src": ".har/stages/secrets-scan.sh", "dest": ".har/stages/secrets-scan.sh", "executable": true },
-    { "src": ".har/stages/GITLEAKS.md",     "dest": ".har/stages/GITLEAKS.md" }
+    {
+      "src": ".har/stages/secrets-scan.sh",
+      "dest": ".har/stages/secrets-scan.sh",
+      "executable": true
+    },
+    {
+      "src": ".har/stages/GITLEAKS.md",
+      "dest": ".har/stages/GITLEAKS.md"
+    }
   ],
   "optionalFiles": [
-    { "src": ".gitleaks.toml",                "dest": ".gitleaks.toml" },
-    { "src": ".github/workflows/gitleaks.yml", "dest": ".github/workflows/gitleaks.yml", "skipFlag": "skipCi" }
+    {
+      "src": ".gitleaks.toml",
+      "dest": ".gitleaks.toml"
+    },
+    {
+      "src": ".github/workflows/gitleaks.yml",
+      "dest": ".github/workflows/gitleaks.yml",
+      "skipFlag": "skipCi"
+    }
   ],
   "nextSteps": [
     "Install gitleaks: brew install gitleaks — or a release binary from https://github.com/gitleaks/gitleaks/releases",

--- a/src/templates/plugins/kerno/template.manifest.json
+++ b/src/templates/plugins/kerno/template.manifest.json
@@ -2,10 +2,6 @@
   "id": "kerno",
   "stageId": "backend-validation",
   "verificationStages": [
-    "typecheck",
-    "unit-tests",
-    "api-health",
-    "lint",
     "backend-validation"
   ],
   "stage": {
@@ -24,15 +20,30 @@
         "path": ".har/artifacts/backend-validation/report.json",
         "kind": "report"
       }
-    ]
+    ],
+    "tier": "full"
   },
   "files": [
-    { "src": ".har/stages/backend-validation.sh", "dest": ".har/stages/backend-validation.sh", "executable": true },
-    { "src": ".har/stages/KERNO.md", "dest": ".har/stages/KERNO.md" },
-    { "src": "README.md", "dest": "tests/kerno/README.md" }
+    {
+      "src": ".har/stages/backend-validation.sh",
+      "dest": ".har/stages/backend-validation.sh",
+      "executable": true
+    },
+    {
+      "src": ".har/stages/KERNO.md",
+      "dest": ".har/stages/KERNO.md"
+    },
+    {
+      "src": "README.md",
+      "dest": "tests/kerno/README.md"
+    }
   ],
   "optionalFiles": [
-    { "src": ".github/workflows/kerno.yml", "dest": ".github/workflows/kerno.yml", "skipFlag": "skipCi" }
+    {
+      "src": ".github/workflows/kerno.yml",
+      "dest": ".github/workflows/kerno.yml",
+      "skipFlag": "skipCi"
+    }
   ],
   "nextSteps": [
     "npm install -g @kerno/cli",

--- a/src/templates/plugins/playwright/template.manifest.json
+++ b/src/templates/plugins/playwright/template.manifest.json
@@ -2,10 +2,6 @@
   "id": "playwright",
   "stageId": "browser-e2e",
   "verificationStages": [
-    "typecheck",
-    "unit-tests",
-    "api-health",
-    "lint",
     "browser-e2e"
   ],
   "stage": {
@@ -24,19 +20,46 @@
         "path": ".har/artifacts/browser-e2e/playwright-report",
         "kind": "report"
       }
-    ]
+    ],
+    "tier": "full"
   },
   "files": [
-    { "src": ".har/stages/browser-e2e.sh", "dest": ".har/stages/browser-e2e.sh", "executable": true },
-    { "src": ".har/stages/PLAYWRIGHT.md", "dest": ".har/stages/PLAYWRIGHT.md" },
-    { "src": "playwright.config.js", "dest": "playwright.config.js" },
-    { "src": "tests/frontend/smoke.spec.js", "dest": "tests/frontend/smoke.spec.js" },
-    { "src": "tests/api/health.spec.js", "dest": "tests/api/health.spec.js" },
-    { "src": "tests/a11y/smoke.spec.js", "dest": "tests/a11y/smoke.spec.js" },
-    { "src": "README.md", "dest": "tests/playwright/README.md" }
+    {
+      "src": ".har/stages/browser-e2e.sh",
+      "dest": ".har/stages/browser-e2e.sh",
+      "executable": true
+    },
+    {
+      "src": ".har/stages/PLAYWRIGHT.md",
+      "dest": ".har/stages/PLAYWRIGHT.md"
+    },
+    {
+      "src": "playwright.config.js",
+      "dest": "playwright.config.js"
+    },
+    {
+      "src": "tests/frontend/smoke.spec.js",
+      "dest": "tests/frontend/smoke.spec.js"
+    },
+    {
+      "src": "tests/api/health.spec.js",
+      "dest": "tests/api/health.spec.js"
+    },
+    {
+      "src": "tests/a11y/smoke.spec.js",
+      "dest": "tests/a11y/smoke.spec.js"
+    },
+    {
+      "src": "README.md",
+      "dest": "tests/playwright/README.md"
+    }
   ],
   "optionalFiles": [
-    { "src": ".github/workflows/playwright.yml", "dest": ".github/workflows/playwright.yml", "skipFlag": "skipCi" }
+    {
+      "src": ".github/workflows/playwright.yml",
+      "dest": ".github/workflows/playwright.yml",
+      "skipFlag": "skipCi"
+    }
   ],
   "merge": {
     "package.json": "package.fragment.json"

--- a/src/templates/plugins/rocketsim/template.manifest.json
+++ b/src/templates/plugins/rocketsim/template.manifest.json
@@ -2,9 +2,6 @@
   "id": "rocketsim",
   "stageId": "rocketsim-flows",
   "verificationStages": [
-    "build",
-    "unit-tests",
-    "lint",
     "rocketsim-flows"
   ],
   "stage": {
@@ -19,13 +16,28 @@
         "kind": "directory",
         "description": "Screenshots, per-flow results, and run summary"
       }
-    ]
+    ],
+    "tier": "full"
   },
   "files": [
-    { "src": ".har/stages/rocketsim-flows.sh", "dest": ".har/stages/rocketsim-flows.sh", "executable": true },
-    { "src": ".har/stages/ROCKETSIM.md",       "dest": ".har/stages/ROCKETSIM.md" },
-    { "src": "flows/README.md",                "dest": "flows/README.md" },
-    { "src": "flows/example-smoke.sh",         "dest": "flows/example-smoke.sh", "executable": true }
+    {
+      "src": ".har/stages/rocketsim-flows.sh",
+      "dest": ".har/stages/rocketsim-flows.sh",
+      "executable": true
+    },
+    {
+      "src": ".har/stages/ROCKETSIM.md",
+      "dest": ".har/stages/ROCKETSIM.md"
+    },
+    {
+      "src": "flows/README.md",
+      "dest": "flows/README.md"
+    },
+    {
+      "src": "flows/example-smoke.sh",
+      "dest": "flows/example-smoke.sh",
+      "executable": true
+    }
   ],
   "nextSteps": [
     "rocketsim doctor",

--- a/src/templates/plugins/semgrep/template.manifest.json
+++ b/src/templates/plugins/semgrep/template.manifest.json
@@ -2,9 +2,6 @@
   "id": "semgrep",
   "stageId": "sast",
   "verificationStages": [
-    "typecheck",
-    "unit-tests",
-    "lint",
     "sast"
   ],
   "stage": {
@@ -23,14 +20,26 @@
         "path": ".har/artifacts/sast/semgrep.json",
         "kind": "report"
       }
-    ]
+    ],
+    "tier": "full"
   },
   "files": [
-    { "src": ".har/stages/sast.sh", "dest": ".har/stages/sast.sh", "executable": true },
-    { "src": ".har/stages/SEMGREP.md", "dest": ".har/stages/SEMGREP.md" }
+    {
+      "src": ".har/stages/sast.sh",
+      "dest": ".har/stages/sast.sh",
+      "executable": true
+    },
+    {
+      "src": ".har/stages/SEMGREP.md",
+      "dest": ".har/stages/SEMGREP.md"
+    }
   ],
   "optionalFiles": [
-    { "src": ".github/workflows/semgrep.yml", "dest": ".github/workflows/semgrep.yml", "skipFlag": "skipCi" }
+    {
+      "src": ".github/workflows/semgrep.yml",
+      "dest": ".github/workflows/semgrep.yml",
+      "skipFlag": "skipCi"
+    }
   ],
   "nextSteps": [
     "pipx install semgrep   # or: pip install semgrep / brew install semgrep",

--- a/src/templates/plugins/trivy/template.manifest.json
+++ b/src/templates/plugins/trivy/template.manifest.json
@@ -2,9 +2,6 @@
   "id": "trivy",
   "stageId": "vuln-scan",
   "verificationStages": [
-    "typecheck",
-    "unit-tests",
-    "lint",
     "vuln-scan"
   ],
   "stage": {
@@ -23,15 +20,30 @@
         "path": ".har/artifacts/vuln-scan/report.json",
         "kind": "report"
       }
-    ]
+    ],
+    "tier": "full"
   },
   "files": [
-    { "src": ".har/stages/vuln-scan.sh", "dest": ".har/stages/vuln-scan.sh", "executable": true },
-    { "src": ".har/stages/TRIVY.md",     "dest": ".har/stages/TRIVY.md" },
-    { "src": ".trivyignore",             "dest": ".trivyignore" }
+    {
+      "src": ".har/stages/vuln-scan.sh",
+      "dest": ".har/stages/vuln-scan.sh",
+      "executable": true
+    },
+    {
+      "src": ".har/stages/TRIVY.md",
+      "dest": ".har/stages/TRIVY.md"
+    },
+    {
+      "src": ".trivyignore",
+      "dest": ".trivyignore"
+    }
   ],
   "optionalFiles": [
-    { "src": ".github/workflows/trivy.yml", "dest": ".github/workflows/trivy.yml", "skipFlag": "skipCi" }
+    {
+      "src": ".github/workflows/trivy.yml",
+      "dest": ".github/workflows/trivy.yml",
+      "skipFlag": "skipCi"
+    }
   ],
   "nextSteps": [
     "Install trivy: brew install trivy (or https://trivy.dev/latest/getting-started/installation/)",

--- a/src/templates/runtime-bundles/pm2-runtime/stages/api-health.sh
+++ b/src/templates/runtime-bundles/pm2-runtime/stages/api-health.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# API health check for the slot's primary application. Registered as the
+# `api-health` verification stage (tier: quick) on web profiles.
+set -euo pipefail
+
+AGENT_ID="${1:?Usage: api-health.sh <agent-id>}"
+
+PORT="${API_PORT:-$(( ${HARNESS_API_BASE_PORT:?HARNESS_API_BASE_PORT not set} + AGENT_ID * 10 ))}"
+exec curl -sf "http://localhost:${PORT}${HARNESS_HEALTH_CHECK_PATH:-/health}"

--- a/src/templates/runtime-bundles/shared-kernel/STAGES.md
+++ b/src/templates/runtime-bundles/shared-kernel/STAGES.md
@@ -73,10 +73,17 @@ The scaffolded skeleton implements all of this — replace its TODO block.
 
 ## Verification membership
 
-Listing a stage id in `verificationStages` is what includes it in
-`har env verify <id> --full`. Ids that match a registered stage run via their
-script/command; ids without a registry entry (e.g. `typecheck`, `api-health`)
-are inline steps owned by `.har/verify.sh`. Lifecycle kinds
+`verificationStages` is the single namespace for the verification pipeline:
+every id listed must resolve to a registered stage of kind `test` or `custom`,
+and the list order is the execution order. There are no inline steps — the
+ecosystem defaults (`typecheck`, `unit-tests`, `lint`, `readiness`, and
+`api-health` on web profiles) are ordinary registered stages, written at init
+from `HARNESS_ECOSYSTEM`.
+
+Each stage may declare `"tier": "quick" | "full"` (default `full`). Plain
+`har env verify <id>` runs the `quick`-tier stages; `--full` runs the whole
+list. Unresolvable ids are reported by validation (and `har env doctor`) and
+skipped with a warning at run time. Lifecycle kinds
 (`setup`/`launch`/`reset`/`teardown`/`inspect`) and `verify` itself never run
 as part of verification, even if listed.
 

--- a/src/templates/runtime-bundles/shared-kernel/lib/verify-runner.mjs
+++ b/src/templates/runtime-bundles/shared-kernel/lib/verify-runner.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Verification runner: executes the stages.json verification plan.
+// Invoked by .har/verify.sh after it sources harness.env and the agent env
+// file (so the full slot environment is inherited). Replaces the bash
+// run_step/run_http_step/RESULTS_JSON plumbing: step names may contain any
+// characters, no result is ever silently dropped, and stage env vars are
+// passed as real environment entries instead of eval'd shell prefixes.
+//
+// Usage: verify-runner.mjs --agent <id> [--full]
+// Env:   HAR_HARNESS_DIR (the .har dir), WORK_DIR (step cwd)
+//
+// Contract (stdout): { status, agent_id, total_ms, stages: [{name, pass, ms, output?}] }
+// Quick mode stops at the first failing step; full mode runs the whole plan.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const RUNNABLE_KINDS = new Set(['test', 'custom']);
+
+const args = process.argv.slice(2);
+const full = args.includes('--full');
+const agentIdx = args.indexOf('--agent');
+const agentId = agentIdx >= 0 ? Number(args[agentIdx + 1]) : NaN;
+if (!Number.isInteger(agentId)) {
+  process.stderr.write('verify-runner: --agent <id> is required\n');
+  process.exit(2);
+}
+
+const harnessDir = process.env.HAR_HARNESS_DIR;
+const workDir = process.env.WORK_DIR;
+if (!harnessDir || !workDir) {
+  process.stderr.write('verify-runner: HAR_HARNESS_DIR and WORK_DIR must be set\n');
+  process.exit(2);
+}
+
+let registry;
+try {
+  registry = JSON.parse(readFileSync(join(harnessDir, 'stages.json'), 'utf8'));
+} catch (err) {
+  process.stderr.write(`verify-runner: cannot read ${join(harnessDir, 'stages.json')}: ${err.message}\n`);
+  process.exit(2);
+}
+
+const ids = Array.isArray(registry.verificationStages) ? registry.verificationStages : [];
+const stages = Array.isArray(registry.stages) ? registry.stages : [];
+
+const plan = [];
+const phantoms = [];
+for (const id of ids) {
+  const stage = stages.find((s) => s && s.id === id);
+  if (!stage || !RUNNABLE_KINDS.has(stage.kind)) {
+    phantoms.push(id);
+    continue;
+  }
+  if (!full && stage.tier !== 'quick') continue;
+  plan.push(stage);
+}
+
+for (const id of phantoms) {
+  process.stderr.write(
+    `  ! verificationStages id "${id}" has no registered runnable stage — fix .har/stages.json (har env doctor reports this)\n`,
+  );
+}
+
+function stepCommand(stage) {
+  if (stage.script) {
+    const script = resolve(harnessDir, stage.script);
+    const quoted = `'${script.replace(/'/g, "'\\''")}'`;
+    return stage.requiresAgentId === false ? quoted : `${quoted} ${agentId}`;
+  }
+  if (stage.command) {
+    return stage.command.split('{agentId}').join(String(agentId));
+  }
+  return null;
+}
+
+const results = [];
+let overallPass = true;
+const startTotal = Date.now();
+
+for (const stage of plan) {
+  const cmd = stepCommand(stage);
+  if (cmd === null) {
+    results.push({ name: stage.id, pass: false, ms: 0, output: 'stage has neither script nor command' });
+    overallPass = false;
+    if (!full) break;
+    continue;
+  }
+
+  process.stderr.write(`  → ${`${stage.id}...`.padEnd(40)}`);
+  const start = Date.now();
+  const child = spawnSync('bash', ['-c', cmd], {
+    cwd: stage.cwd ? resolve(workDir, stage.cwd) : workDir,
+    env: { ...process.env, ...(stage.env ?? {}), HAR_AGENT_ID: String(agentId) },
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const ms = Date.now() - start;
+  const output = `${child.stdout ?? ''}${child.stderr ?? ''}`.trim();
+  const pass = child.status === 0;
+
+  if (pass) {
+    process.stderr.write(`✓ (${ms}ms)\n`);
+    results.push({ name: stage.id, pass: true, ms });
+  } else {
+    process.stderr.write(`✗ (${ms}ms)\n`);
+    for (const line of output.split('\n').slice(0, 30)) {
+      process.stderr.write(`    ${line}\n`);
+    }
+    results.push({
+      name: stage.id,
+      pass: false,
+      ms,
+      output: output.split('\n').slice(0, 50).join('\n'),
+    });
+    overallPass = false;
+    if (!full) break;
+  }
+}
+
+const out = {
+  status: overallPass && results.length > 0 ? 'pass' : 'fail',
+  agent_id: agentId,
+  total_ms: Date.now() - startTotal,
+  stages: results,
+};
+process.stdout.write(`${JSON.stringify(out, null, 2)}\n`);
+process.exit(out.status === 'pass' ? 0 : 1);

--- a/src/templates/runtime-bundles/shared-kernel/stages/readiness.sh
+++ b/src/templates/runtime-bundles/shared-kernel/stages/readiness.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Project readiness smoke: runs HARNESS_READINESS_CMD from harness.env, an
+# optional project-owned "agent usable" check beyond health. Registered as the
+# `readiness` verification stage (tier: full).
+set -euo pipefail
+
+AGENT_ID="${1:?Usage: readiness.sh <agent-id>}"
+
+if [ -z "${HARNESS_READINESS_CMD:-}" ]; then
+  echo "No HARNESS_READINESS_CMD configured; skipping readiness smoke."
+  exit 0
+fi
+
+eval "${HARNESS_READINESS_CMD//\{agentId\}/$AGENT_ID}"

--- a/tests/custom-stage.test.ts
+++ b/tests/custom-stage.test.ts
@@ -82,16 +82,16 @@ describe('addCustomStage', () => {
 
   it('refuses to replace an existing stage without force', () => {
     const repoPath = makeTempHarness('har-custom-dup');
-    addCustomStage(repoPath, { id: 'lint', command: 'npm run lint' });
+    addCustomStage(repoPath, { id: 'custom-lint', command: 'npm run lint' });
 
-    expect(() => addCustomStage(repoPath, { id: 'lint', command: 'npm run lint' })).toThrow(
+    expect(() => addCustomStage(repoPath, { id: 'custom-lint', command: 'npm run lint' })).toThrow(
       /already registered/,
     );
 
-    addCustomStage(repoPath, { id: 'lint', command: 'npm run lint:ci', force: true });
+    addCustomStage(repoPath, { id: 'custom-lint', command: 'npm run lint:ci', force: true });
     const registry = readStageRegistry(repoPath);
-    expect(registry.stages.filter((s) => s.id === 'lint')).toHaveLength(1);
-    expect(registry.stages.find((s) => s.id === 'lint')?.command).toBe('npm run lint:ci');
+    expect(registry.stages.filter((s) => s.id === 'custom-lint')).toHaveLength(1);
+    expect(registry.stages.find((s) => s.id === 'custom-lint')?.command).toBe('npm run lint:ci');
   });
 
   it('requires an existing harness', () => {

--- a/tests/harness-contract.test.ts
+++ b/tests/harness-contract.test.ts
@@ -116,8 +116,8 @@ describe('harness stage contract', () => {
     expect(manifest.profile).toBe('cli');
 
     const verifyScript = fs.readFileSync(path.join(repoPath, '.har', 'verify.sh'), 'utf8');
-    expect(verifyScript).toContain('run_quick_smoke');
-    expect(verifyScript).toContain('HARNESS_ECOSYSTEM');
+    expect(verifyScript).toContain('lib/verify-runner.mjs');
+    expect(verifyScript).not.toContain('run_quick_smoke');
     expect(verifyScript).not.toContain("echo 'TODO:");
 
     const registry = readStageRegistry(repoPath);

--- a/tests/ios-verify-code-signing.test.ts
+++ b/tests/ios-verify-code-signing.test.ts
@@ -4,37 +4,31 @@ import { resolveTemplatesDir } from '../src/utils/paths';
 
 const IOS_TEMPLATE = path.join(resolveTemplatesDir(), 'har-boilerplate-ios');
 
-/**
- * Body of a `run_step "<name>" '<command>'` block. Step commands are
- * single-quoted in verify.sh and contain no single quote of their own.
- */
-function runStepCommand(script: string, name: string): string {
-  const marker = `run_step "${name}" '`;
-  const start = script.indexOf(marker);
-  expect(start).toBeGreaterThanOrEqual(0);
-  const from = start + marker.length;
-  const end = script.indexOf("'", from);
-  expect(end).toBeGreaterThan(from);
-  return script.slice(from, end);
+/** Command of a verification stage registered in the iOS template stages.json. */
+function stageCommand(name: string): string {
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(IOS_TEMPLATE, 'stages.json'), 'utf8'),
+  ) as { stages: Array<{ id: string; command?: string }> };
+  const stage = registry.stages.find((s) => s.id === name);
+  expect(stage?.command).toBeTruthy();
+  return stage?.command ?? '';
 }
 
-describe('iOS verify.sh code signing', () => {
-  const verify = fs.readFileSync(path.join(IOS_TEMPLATE, 'verify.sh'), 'utf8');
-
-  it('disables code signing for the compile-only build step', () => {
-    expect(runStepCommand(verify, 'build')).toContain('CODE_SIGNING_ALLOWED=NO');
+describe('iOS verification stage code signing', () => {
+  it('disables code signing for the compile-only build stage', () => {
+    expect(stageCommand('build')).toContain('CODE_SIGNING_ALLOWED=NO');
   });
 
   // Tests install and run the host app on the simulator. Unsigned means no
   // entitlements, so an app using iCloud, KVS, or push traps on launch before the
   // test harness connects — every test in the bundle is lost.
-  it('leaves code signing alone for the unit-tests step', () => {
-    const unitTests = runStepCommand(verify, 'unit-tests');
+  it('leaves code signing alone for the unit-tests stage', () => {
+    const unitTests = stageCommand('unit-tests');
     expect(unitTests).toContain('xcodebuild} test');
     expect(unitTests).not.toContain('CODE_SIGNING');
   });
 
-  it('keeps the agent doc xcodebuild examples in step with verify.sh', () => {
+  it('keeps the agent doc xcodebuild examples in step with the stage commands', () => {
     const doc = fs.readFileSync(path.join(IOS_TEMPLATE, 'CLAUDE.agent.md'), 'utf8');
     const examples = doc.split('\n').filter((line) => line.startsWith('xcodebuild '));
     const build = examples.filter((line) => line.includes('xcodebuild build'));

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -22,6 +22,8 @@ function makeTempRepo(name: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
 }
 
+import { findPhantomVerificationStageIds } from '../src/harness/verification';
+
 describe('plugins', () => {
   it('applies playwright plugin to a scaffolded harness', () => {
     const repoPath = makeTempRepo('har-playwright');
@@ -53,7 +55,7 @@ describe('plugins', () => {
       script: 'stages/browser-e2e.sh',
     });
     expect(registry.verificationStages).toEqual(
-      expect.arrayContaining(['typecheck', 'unit-tests', 'api-health', 'lint', 'browser-e2e']),
+      expect.arrayContaining(['typecheck', 'unit-tests', 'lint', 'readiness', 'browser-e2e']),
     );
 
     const pkg = JSON.parse(fs.readFileSync(path.join(repoPath, 'package.json'), 'utf8')) as {
@@ -85,8 +87,8 @@ describe('plugins', () => {
     });
     expect(registry.verificationStages).toEqual(expect.arrayContaining(['rocketsim-flows']));
 
+    expect(findPhantomVerificationStageIds(registry)).toEqual([]);
     const verify = registry.stages.find((s) => s.id === 'verify');
-    expect(verify?.description).toContain('rocketsim-flows');
     expect(verify?.description).not.toContain('browser-e2e');
   });
 
@@ -116,8 +118,7 @@ describe('plugins', () => {
     });
     expect(registry.verificationStages).toEqual(expect.arrayContaining(['backend-validation']));
 
-    const verify = registry.stages.find((s) => s.id === 'verify');
-    expect(verify?.description).toContain('backend-validation');
+    expect(findPhantomVerificationStageIds(registry)).toEqual([]);
   });
 
   it('applies gitleaks plugin to a scaffolded harness', () => {
@@ -146,8 +147,7 @@ describe('plugins', () => {
     });
     expect(registry.verificationStages).toEqual(expect.arrayContaining(['secrets-scan']));
 
-    const verify = registry.stages.find((s) => s.id === 'verify');
-    expect(verify?.description).toContain('secrets-scan');
+    expect(findPhantomVerificationStageIds(registry)).toEqual([]);
   });
 
   it('applies trivy plugin to a scaffolded harness', () => {
@@ -175,8 +175,7 @@ describe('plugins', () => {
     });
     expect(registry.verificationStages).toEqual(expect.arrayContaining(['vuln-scan']));
 
-    const verify = registry.stages.find((s) => s.id === 'verify');
-    expect(verify?.description).toContain('vuln-scan');
+    expect(findPhantomVerificationStageIds(registry)).toEqual([]);
   });
 
   it('applies semgrep plugin to a scaffolded harness', () => {
@@ -204,8 +203,7 @@ describe('plugins', () => {
     });
     expect(registry.verificationStages).toEqual(expect.arrayContaining(['sast']));
 
-    const verify = registry.stages.find((s) => s.id === 'verify');
-    expect(verify?.description).toContain('sast');
+    expect(findPhantomVerificationStageIds(registry)).toEqual([]);
   });
 
   it('every shipped plugin manifest passes schema validation', () => {

--- a/tests/provision-toolchain.test.ts
+++ b/tests/provision-toolchain.test.ts
@@ -260,16 +260,13 @@ describe('provision-toolchain.sh template contract', () => {
     expect(fs.readFileSync(PROVISION_SCRIPT, 'utf8')).toContain('lib/node-pm.sh');
   });
 
-  it('verify.sh dispatches stock smoke by ecosystem', () => {
+  it('verify.sh delegates to the stage-registry runner (no inline ecosystem tables)', () => {
     for (const profile of ['har-boilerplate', 'har-boilerplate-cli'] as const) {
       const verifyPath = path.join(resolveTemplatesDir(), profile, 'verify.sh');
       const content = fs.readFileSync(verifyPath, 'utf8');
-      expect(content).toContain('run_quick_smoke');
-      expect(content).toContain('HARNESS_ECOSYSTEM');
-      expect(content).toContain('python-compile');
-      expect(content).toContain('go-build');
-      expect(content).toContain('rust-check');
-      expect(content).not.toMatch(/run_step "[^"]+" "npm /);
+      expect(content).toContain('lib/verify-runner.mjs');
+      expect(content).not.toContain('run_quick_smoke');
+      expect(content).not.toContain('run_full_checks');
     }
   });
 

--- a/tests/verification-plan.test.ts
+++ b/tests/verification-plan.test.ts
@@ -1,0 +1,215 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { HarnessStageRegistrySchema } from '../src/harness/schema';
+import {
+  deriveEcosystemDefaultStages,
+  ensureEcosystemVerificationStages,
+  findPhantomVerificationStageIds,
+  resolveVerificationPlan,
+} from '../src/harness/verification';
+
+const RUNNER = path.join(
+  __dirname,
+  '..',
+  'src',
+  'templates',
+  'runtime-bundles',
+  'shared-kernel',
+  'lib',
+  'verify-runner.mjs',
+);
+
+function makeRegistry(overrides: Record<string, unknown>) {
+  return HarnessStageRegistrySchema.parse({
+    version: '1',
+    agentSlots: { min: 1, max: 3 },
+    stages: [],
+    ...overrides,
+  });
+}
+
+describe('resolveVerificationPlan', () => {
+  const registry = makeRegistry({
+    verificationStages: ['b', 'a', 'ghost', 'c'],
+    stages: [
+      { id: 'a', kind: 'test', tier: 'quick', command: 'true' },
+      { id: 'b', kind: 'test', tier: 'full', command: 'true' },
+      { id: 'c', kind: 'custom', command: 'true' },
+      { id: 'verify', kind: 'verify', command: './.har/verify.sh {agentId}' },
+    ],
+  });
+
+  it('honors verificationStages order and resolves every id', () => {
+    const plan = resolveVerificationPlan(registry, { full: true });
+    expect(plan.steps.map((s) => s.id)).toEqual(['b', 'a', 'c']);
+    expect(plan.phantomIds).toEqual(['ghost']);
+  });
+
+  it('quick mode keeps only tier "quick" stages', () => {
+    const plan = resolveVerificationPlan(registry, { full: false });
+    expect(plan.steps.map((s) => s.id)).toEqual(['a']);
+  });
+
+  it('treats non-runnable kinds as phantoms', () => {
+    const reg = makeRegistry({
+      verificationStages: ['verify'],
+      stages: [{ id: 'verify', kind: 'verify', command: './.har/verify.sh {agentId}' }],
+    });
+    expect(findPhantomVerificationStageIds(reg)).toEqual(['verify']);
+  });
+});
+
+describe('deriveEcosystemDefaultStages', () => {
+  it('derives node stages from package.json scripts', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-eco-'));
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify({ scripts: { typecheck: 'tsc', test: 'jest' } }),
+    );
+    const defaults = deriveEcosystemDefaultStages('node', dir);
+    const typecheck = defaults.stages.find((s) => s.id === 'typecheck');
+    expect(typecheck?.tier).toBe('quick');
+    expect(typecheck?.command).toContain('run typecheck');
+    const tests = defaults.stages.find((s) => s.id === 'unit-tests');
+    expect(tests?.tier).toBe('full');
+    expect(tests?.command).toContain('npm} test');
+  });
+
+  it('falls back to build smoke when no typecheck script exists', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-eco-'));
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ scripts: { build: 'x' } }));
+    const defaults = deriveEcosystemDefaultStages('node', dir);
+    expect(defaults.stages.find((s) => s.id === 'typecheck')?.command).toContain('run build');
+  });
+
+  it('covers the non-node ecosystems as data', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-eco-'));
+    expect(
+      deriveEcosystemDefaultStages('python', dir).stages.find((s) => s.id === 'typecheck')?.command,
+    ).toContain('compileall');
+    expect(
+      deriveEcosystemDefaultStages('go', dir).stages.find((s) => s.id === 'typecheck')?.command,
+    ).toContain('go} build');
+    expect(
+      deriveEcosystemDefaultStages('rust', dir).stages.find((s) => s.id === 'typecheck')?.command,
+    ).toContain('cargo} check');
+  });
+});
+
+describe('ensureEcosystemVerificationStages', () => {
+  function makeHarness(ecosystem: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-ensure-'));
+    fs.mkdirSync(path.join(dir, '.har'));
+    fs.writeFileSync(
+      path.join(dir, '.har', 'harness.env'),
+      `export HARNESS_PROJECT_NAME=fixture\nexport HARNESS_ECOSYSTEM=${ecosystem}\nexport HARNESS_AGENT_SLOT_MIN=1\nexport HARNESS_AGENT_SLOT_MAX=3\n`,
+    );
+    fs.mkdirSync(path.join(dir, '.har', 'stages'));
+    fs.writeFileSync(path.join(dir, '.har', 'stages', 'readiness.sh'), '#!/usr/bin/env bash\n');
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ scripts: { test: 'jest' } }));
+    return dir;
+  }
+
+  it('fills missing default stages without clobbering customized ones', () => {
+    const dir = makeHarness('node');
+    const custom = {
+      version: '1',
+      agentSlots: { min: 1, max: 3 },
+      verificationStages: ['unit-tests', 'browser-e2e'],
+      stages: [
+        { id: 'unit-tests', kind: 'test', tier: 'full', command: 'my custom test runner' },
+        { id: 'browser-e2e', kind: 'test', tier: 'full', script: 'stages/browser-e2e.sh' },
+      ],
+    };
+    fs.writeFileSync(path.join(dir, '.har', 'stages.json'), JSON.stringify(custom, null, 2));
+
+    expect(ensureEcosystemVerificationStages(dir)).toBe(true);
+    const registry = JSON.parse(fs.readFileSync(path.join(dir, '.har', 'stages.json'), 'utf8'));
+
+    // customized stage untouched
+    expect(registry.stages.find((s: { id: string }) => s.id === 'unit-tests').command).toBe(
+      'my custom test runner',
+    );
+    // missing defaults registered
+    expect(registry.stages.some((s: { id: string }) => s.id === 'typecheck')).toBe(true);
+    expect(registry.stages.some((s: { id: string }) => s.id === 'readiness')).toBe(true);
+    // defaults inserted ahead of extras, existing relative order preserved
+    const ids = registry.verificationStages as string[];
+    expect(ids.indexOf('typecheck')).toBeLessThan(ids.indexOf('unit-tests'));
+    expect(ids.indexOf('unit-tests')).toBeLessThan(ids.indexOf('browser-e2e'));
+    // idempotent
+    expect(ensureEcosystemVerificationStages(dir)).toBe(false);
+  });
+});
+
+describe('verify-runner.mjs', () => {
+  function runRunner(registry: unknown, args: string[]) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-runner-'));
+    const harnessDir = path.join(dir, '.har');
+    fs.mkdirSync(harnessDir);
+    fs.writeFileSync(path.join(harnessDir, 'stages.json'), JSON.stringify(registry, null, 2));
+    return spawnSync('node', [RUNNER, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, HAR_HARNESS_DIR: harnessDir, WORK_DIR: dir },
+    });
+  }
+
+  it('records failing output containing quotes without dropping results', () => {
+    const registry = {
+      verificationStages: ['sq.quote-step', 'never-runs-quick'],
+      stages: [
+        {
+          id: 'sq.quote-step',
+          kind: 'test',
+          tier: 'quick',
+          command: `echo "it's a \\"quoted\\" \`backtick\` failure"; exit 1`,
+        },
+        { id: 'never-runs-quick', kind: 'test', tier: 'quick', command: 'true' },
+      ],
+    };
+    const res = runRunner(registry, ['--agent', '2']);
+    expect(res.status).toBe(1);
+    const out = JSON.parse(res.stdout);
+    expect(out.status).toBe('fail');
+    expect(out.agent_id).toBe(2);
+    expect(out.stages).toHaveLength(1); // quick mode stops at first failure
+    expect(out.stages[0].name).toBe('sq.quote-step');
+    expect(out.stages[0].pass).toBe(false);
+    expect(out.stages[0].output).toContain(`it's a "quoted"  failure`);
+  });
+
+  it('full mode runs the whole plan in order and passes stage env without eval', () => {
+    const registry = {
+      verificationStages: ['second', 'first'],
+      stages: [
+        {
+          id: 'second',
+          kind: 'test',
+          tier: 'full',
+          command: 'echo "env=$STEP_ENV agent=$HAR_AGENT_ID"',
+          env: { STEP_ENV: `tricky 'value' with spaces` },
+        },
+        { id: 'first', kind: 'test', tier: 'quick', command: 'true' },
+      ],
+    };
+    const res = runRunner(registry, ['--agent', '1', '--full']);
+    expect(res.status).toBe(0);
+    const out = JSON.parse(res.stdout);
+    expect(out.status).toBe('pass');
+    expect(out.stages.map((s: { name: string }) => s.name)).toEqual(['second', 'first']);
+  });
+
+  it('warns about phantom ids and keeps running', () => {
+    const registry = {
+      verificationStages: ['ghost', 'real'],
+      stages: [{ id: 'real', kind: 'test', tier: 'quick', command: 'true' }],
+    };
+    const res = runRunner(registry, ['--agent', '1']);
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain('ghost');
+    const out = JSON.parse(res.stdout);
+    expect(out.stages.map((s: { name: string }) => s.name)).toEqual(['real']);
+  });
+});

--- a/tests/verify-shell-output.test.ts
+++ b/tests/verify-shell-output.test.ts
@@ -41,9 +41,6 @@ node -e "const r=$RESULTS_JSON;process.stdout.write(String(r.length)+':'+r.every
     '.har/verify.sh',
     'control/.har/verify.sh',
     'docs/.har/verify.sh',
-    'src/templates/har-boilerplate/verify.sh',
-    'src/templates/har-boilerplate-cli/verify.sh',
-    'src/templates/har-boilerplate-ios/verify.sh',
   ];
 
   it.each(verifyPaths)('%s records steps without embedding passing-step output', (relPath) => {

--- a/tests/verify-shell-timing.test.ts
+++ b/tests/verify-shell-timing.test.ts
@@ -22,9 +22,6 @@ describe('verify.sh portable timing', () => {
   const verifyPaths = [
     '.har/verify.sh',
     'control/.har/verify.sh',
-    'src/templates/har-boilerplate/verify.sh',
-    'src/templates/har-boilerplate-cli/verify.sh',
-    'src/templates/har-boilerplate-ios/verify.sh',
     'src/templates/plugins/playwright/.har/stages/browser-e2e.sh',
     'src/templates/plugins/rocketsim/.har/stages/rocketsim-flows.sh',
     'src/templates/plugins/kerno/.har/stages/backend-validation.sh',


### PR DESCRIPTION
Closes #231

**Stack 3/4** — based on #273. M1 (Contract) stack: #230 → #233 → #231 → #232.

- `tier: "quick" | "full"` on stage registry entries; template `stages.json` (all 3 profiles) ships tiered ecosystem defaults
- `run_quick_smoke`/`run_full_checks` inline case tables deleted; defaults registered as ordinary stages at init/maintain (`ensureEcosystemVerificationStages`, 1.0-contract harnesses only — pre-1.0 no-op until #241)
- One namespace: every `verificationStages` id resolves to a registered stage, order = execution order; `resolveVerificationPlan`/`findPhantomVerificationStageIds` exposed for doctor (#232)
- All 6 bundled plugin manifests list only their own stage ids; stage list no longer serialized into the verify stage description
- `run_step`/`run_http_step`/JSON plumbing → shared-kernel `lib/verify-runner.mjs`: quotes survive, no silent result drops, real timestamps, env passed as environment (no `eval`); profile `verify.sh` files are thin iterators
- fixture-e2e M1 asserts: verificationStages all resolve, quick tier present, verify.sh delegates to the runner

Gate: full verify green in-slot; M1 milestone gate run from the stack tip (see #225 handoff comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)