### PR TITLE
fix: bill a repeated Claude message id once and count every slot transcript

### DIFF
--- a/src/core/usage-harvest/claude.ts
+++ b/src/core/usage-harvest/claude.ts
@@ -52,6 +52,11 @@ export interface ModelUsageTotals {
   tokensTotal: number;
 }
 
+interface NestedUsage {
+  usage: Record<string, unknown>;
+  model?: string;
+}
+
 function extractClaudeUsageFromRecords(records: unknown[]): {
   tokensInput: number;
   tokensOutput: number;
@@ -67,6 +72,13 @@ function extractClaudeUsageFromRecords(records: unknown[]): {
   let costUsd: number | null = null;
   const modelBreakdown: Record<string, ModelUsageTotals> = {};
 
+  // One assistant message is written across several records — a text record, one
+  // per tool call — and every one of them repeats the same `usage`. Keyed by
+  // message id so a repeat is not a second charge; only records with no id at
+  // all are summed as they come.
+  const billed = new Map<string, NestedUsage>();
+  const unkeyed: NestedUsage[] = [];
+
   for (const record of records) {
     if (!record || typeof record !== 'object') continue;
     const payload = record as Record<string, unknown>;
@@ -79,44 +91,58 @@ function extractClaudeUsageFromRecords(records: unknown[]): {
       tokensCacheCreation = Number(usage.cache_creation_input_tokens ?? 0);
       if (payload.total_cost_usd != null) costUsd = Number(payload.total_cost_usd);
     }
-    // Some transcripts nest usage on message/assistant events — accumulate when present.
+    // Some transcripts nest usage on message/assistant events — collect when present.
     const message = payload.message as
-      | { usage?: Record<string, unknown>; model?: string }
+      | { usage?: Record<string, unknown>; model?: string; id?: string }
       | undefined;
     const nestedUsage = (payload.usage ?? message?.usage) as
       | Record<string, unknown>
       | undefined;
     if (nestedUsage && payload.type !== 'result') {
-      const i = Number(nestedUsage.input_tokens ?? 0);
-      const o = Number(nestedUsage.output_tokens ?? 0);
-      const cr = Number(nestedUsage.cache_read_input_tokens ?? 0);
-      const cc = Number(nestedUsage.cache_creation_input_tokens ?? 0);
-      tokensInput += i;
-      tokensOutput += o;
-      tokensCacheRead += cr;
-      tokensCacheCreation += cc;
       const model = typeof message?.model === 'string' ? message.model : undefined;
-      if (model && model !== '<synthetic>') {
-        const totals = (modelBreakdown[model] ??= {
-          tokensInput: 0,
-          tokensOutput: 0,
-          tokensCacheRead: 0,
-          tokensCacheCreation: 0,
-          tokensTotal: 0,
-        });
-        totals.tokensInput += i;
-        totals.tokensOutput += o;
-        totals.tokensCacheRead += cr;
-        totals.tokensCacheCreation += cc;
-        totals.tokensTotal += i + o + cr + cc;
-      }
+      const entry: NestedUsage = { usage: nestedUsage, model };
+      if (typeof message?.id === 'string' && message.id) billed.set(message.id, entry);
+      else unkeyed.push(entry);
+    }
+  }
+
+  for (const { usage, model } of [...billed.values(), ...unkeyed]) {
+    const i = Number(usage.input_tokens ?? 0);
+    const o = Number(usage.output_tokens ?? 0);
+    const cr = Number(usage.cache_read_input_tokens ?? 0);
+    const cc = Number(usage.cache_creation_input_tokens ?? 0);
+    tokensInput += i;
+    tokensOutput += o;
+    tokensCacheRead += cr;
+    tokensCacheCreation += cc;
+    if (model && model !== '<synthetic>') {
+      const totals = (modelBreakdown[model] ??= {
+        tokensInput: 0,
+        tokensOutput: 0,
+        tokensCacheRead: 0,
+        tokensCacheCreation: 0,
+        tokensTotal: 0,
+      });
+      totals.tokensInput += i;
+      totals.tokensOutput += o;
+      totals.tokensCacheRead += cr;
+      totals.tokensCacheCreation += cc;
+      totals.tokensTotal += i + o + cr + cc;
     }
   }
 
   return { tokensInput, tokensOutput, tokensCacheRead, tokensCacheCreation, costUsd, modelBreakdown };
 }
 
-function findMatchingClaudeTranscripts(slot: HarvestSlotContext): Array<{ filePath: string; records: unknown[]; mtimeMs: number }> {
+interface TranscriptMatch {
+  filePath: string;
+  records: unknown[];
+  mtimeMs: number;
+  /** Matched the slot's own work dir, rather than the repo-path fallback. */
+  primary: boolean;
+}
+
+function findMatchingClaudeTranscripts(slot: HarvestSlotContext): TranscriptMatch[] {
   const primaryTargets = [slot.workDir, slot.worktreePath].filter(Boolean) as string[];
   const fallbackTargets =
     slot.includeRepoPathFallback && slot.repoPath && !primaryTargets.includes(slot.repoPath)
@@ -127,8 +153,8 @@ function findMatchingClaudeTranscripts(slot: HarvestSlotContext): Array<{ filePa
   const root = claudeProjectsRoot();
   if (!fs.existsSync(root)) return [];
 
-  const primary: Array<{ filePath: string; records: unknown[]; mtimeMs: number }> = [];
-  const fallback: Array<{ filePath: string; records: unknown[]; mtimeMs: number }> = [];
+  const primary: TranscriptMatch[] = [];
+  const fallback: TranscriptMatch[] = [];
 
   for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
@@ -157,8 +183,9 @@ function findMatchingClaudeTranscripts(slot: HarvestSlotContext): Array<{ filePa
           }
         }
       }
-      if (primaryHit) primary.push({ filePath, records, mtimeMs: stat.mtimeMs });
-      else if (fallbackHit) fallback.push({ filePath, records, mtimeMs: stat.mtimeMs });
+      if (primaryHit) primary.push({ filePath, records, mtimeMs: stat.mtimeMs, primary: true });
+      else if (fallbackHit)
+        fallback.push({ filePath, records, mtimeMs: stat.mtimeMs, primary: false });
     }
   }
 
@@ -237,23 +264,23 @@ export function harvestClaudeUsage(slot: HarvestSlotContext): AgentSessionUsage 
     createdAt: slot.sessionCreatedAt,
   });
 
-  let best: ReturnType<typeof extractClaudeUsageFromRecords> | null = null;
-  for (const match of matches) {
-    const usage = extractClaudeUsageFromRecords(match.records);
-    if (
-      usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead === 0 &&
-      (usage.costUsd == null || usage.costUsd === 0)
-    ) {
-      continue;
-    }
-    best = usage;
-    break;
+  // Every transcript of the slot, not just the newest one: a slot is reused
+  // across sessions and each of them was a real charge. The repo-path fallback
+  // stays a fallback — main-checkout work is only this slot's when the slot has
+  // no transcript of its own, so the two tiers are never summed together.
+  const own = matches.filter((match) => match.primary);
+  const usable = own.length > 0 ? own : matches;
+  const usage = extractClaudeUsageFromRecords(usable.flatMap((match) => match.records));
+  if (
+    usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead === 0 &&
+    (usage.costUsd == null || usage.costUsd === 0)
+  ) {
+    return null;
   }
 
-  if (!best) return null;
   const now = new Date().toISOString();
   const tokensTotal =
-    best.tokensInput + best.tokensOutput + best.tokensCacheRead + best.tokensCacheCreation;
+    usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead + usage.tokensCacheCreation;
 
   return {
     sessionKey,
@@ -262,14 +289,14 @@ export function harvestClaudeUsage(slot: HarvestSlotContext): AgentSessionUsage 
     workDir: slot.workDir,
     branch: slot.branch,
     suffix: slot.suffix,
-    tokensInput: best.tokensInput,
-    tokensOutput: best.tokensOutput,
-    tokensCacheRead: best.tokensCacheRead,
-    tokensCacheCreation: best.tokensCacheCreation,
+    tokensInput: usage.tokensInput,
+    tokensOutput: usage.tokensOutput,
+    tokensCacheRead: usage.tokensCacheRead,
+    tokensCacheCreation: usage.tokensCacheCreation,
     tokensTotal,
-    costUsd: best.costUsd,
-    ...(Object.keys(best.modelBreakdown).length > 0
-      ? { modelBreakdown: best.modelBreakdown }
+    costUsd: usage.costUsd,
+    ...(Object.keys(usage.modelBreakdown).length > 0
+      ? { modelBreakdown: usage.modelBreakdown }
       : {}),
     sources: ['harvest'],
     firstSeenAt: slot.sessionCreatedAt ?? now,

--- a/src/core/usage-harvest/claude.ts
+++ b/src/core/usage-harvest/claude.ts
@@ -72,10 +72,8 @@ function extractClaudeUsageFromRecords(records: unknown[]): {
   let costUsd: number | null = null;
   const modelBreakdown: Record<string, ModelUsageTotals> = {};
 
-  // One assistant message is written across several records — a text record, one
-  // per tool call — and every one of them repeats the same `usage`. Keyed by
-  // message id so a repeat is not a second charge; only records with no id at
-  // all are summed as they come.
+  // Claude Code repeats one message's `usage` on every record it splits that
+  // message across.
   const billed = new Map<string, NestedUsage>();
   const unkeyed: NestedUsage[] = [];
 
@@ -138,7 +136,6 @@ interface TranscriptMatch {
   filePath: string;
   records: unknown[];
   mtimeMs: number;
-  /** Matched the slot's own work dir, rather than the repo-path fallback. */
   primary: boolean;
 }
 
@@ -264,10 +261,8 @@ export function harvestClaudeUsage(slot: HarvestSlotContext): AgentSessionUsage 
     createdAt: slot.sessionCreatedAt,
   });
 
-  // Every transcript of the slot, not just the newest one: a slot is reused
-  // across sessions and each of them was a real charge. The repo-path fallback
-  // stays a fallback — main-checkout work is only this slot's when the slot has
-  // no transcript of its own, so the two tiers are never summed together.
+  // Main-checkout work is only this slot's when the slot has no transcript of its
+  // own, so the fallback tier is never summed with the primary one.
   const own = matches.filter((match) => match.primary);
   const usable = own.length > 0 ? own : matches;
   const usage = extractClaudeUsageFromRecords(usable.flatMap((match) => match.records));

--- a/tests/usage-harvest.test.ts
+++ b/tests/usage-harvest.test.ts
@@ -111,8 +111,6 @@ describe('usage harvest claude', () => {
     const workDir = '/home/user/worktrees/main-abcd-har-agent-3-dd44';
     const project = path.join(tmp, encodeClaudeProjectDir(workDir));
     fs.mkdirSync(project, { recursive: true });
-    // Claude Code writes one message across several records — a text record and
-    // one per tool call — each repeating the same usage.
     const message = (id: string) => ({
       type: 'assistant',
       message: {

--- a/tests/usage-harvest.test.ts
+++ b/tests/usage-harvest.test.ts
@@ -107,6 +107,92 @@ describe('usage harvest claude', () => {
     });
   });
 
+  it('bills a repeated assistant message id once', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-3-dd44';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    // Claude Code writes one message across several records — a text record and
+    // one per tool call — each repeating the same usage.
+    const message = (id: string) => ({
+      type: 'assistant',
+      message: {
+        id,
+        role: 'assistant',
+        model: 'claude-opus-5',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 100,
+          cache_read_input_tokens: 1000,
+          cache_creation_input_tokens: 50,
+        },
+      },
+    });
+    fs.writeFileSync(
+      path.join(project, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: workDir }),
+        JSON.stringify(message('msg_a')),
+        JSON.stringify(message('msg_a')),
+        JSON.stringify(message('msg_b')),
+        JSON.stringify(message('msg_b')),
+      ].join('\n') + '\n',
+    );
+
+    const usage = harvestClaudeUsage({
+      agentId: 3,
+      workDir,
+      branch: 'main-abcd-har-agent-3-dd44',
+      suffix: 'dd44',
+      repoPath: '/home/user/repo',
+    });
+
+    expect(usage).not.toBeNull();
+    expect(usage!.tokensInput).toBe(20);
+    expect(usage!.tokensOutput).toBe(200);
+    expect(usage!.tokensCacheRead).toBe(2000);
+    expect(usage!.tokensCacheCreation).toBe(100);
+    expect(usage!.tokensTotal).toBe(2320);
+    expect(usage!.modelBreakdown).toEqual({
+      'claude-opus-5': {
+        tokensInput: 20,
+        tokensOutput: 200,
+        tokensCacheRead: 2000,
+        tokensCacheCreation: 100,
+        tokensTotal: 2320,
+      },
+    });
+  });
+
+  it('counts every transcript in the slot, not just the newest', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-4-ee55';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    const message = (id: string, output: number) =>
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          id,
+          role: 'assistant',
+          model: 'claude-opus-5',
+          usage: { input_tokens: 1, output_tokens: output },
+        },
+      });
+    fs.writeFileSync(path.join(project, 'older.jsonl'), message('msg_old', 10) + '\n');
+    fs.writeFileSync(path.join(project, 'newer.jsonl'), message('msg_new', 70) + '\n');
+
+    const usage = harvestClaudeUsage({
+      agentId: 4,
+      workDir,
+      branch: 'main-abcd-har-agent-4-ee55',
+      suffix: 'ee55',
+      repoPath: '/home/user/repo',
+    });
+
+    expect(usage).not.toBeNull();
+    expect(usage!.tokensOutput).toBe(80);
+    expect(usage!.tokensInput).toBe(2);
+  });
+
   it('does not harvest a parent cwd session into a child worktree slot', () => {
     const homeDir = '/home/antoine';
     const workDir = '/home/antoine/worktrees/main-abcd-har-agent-2-xy12';
@@ -246,6 +332,42 @@ describe('usage harvest claude', () => {
 
     fs.utimesSync(path.join(worktreeProject, 'worktree.jsonl'), 1000, 1000);
     fs.utimesSync(path.join(checkoutProject, 'checkout.jsonl'), 2000, 2000);
+
+    const usage = harvestClaudeUsage({
+      agentId: 1,
+      workDir: worktree,
+      worktreePath: worktree,
+      branch: 'main-2b19-har-agent-1-5wrz',
+      suffix: '5wrz',
+      repoPath,
+      includeRepoPathFallback: true,
+    });
+
+    expect(usage!.tokensOutput).toBe(7);
+  });
+
+  it('sums the slot own transcripts without adding the main-checkout fallback', () => {
+    const repoPath = '/home/user/Documents/Kerno/fecore';
+    const worktree = '/home/user/worktrees/main-2b19-har-agent-1-5wrz';
+    const message = (id: string, output: number) =>
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          id,
+          role: 'assistant',
+          model: 'claude-opus-5',
+          usage: { output_tokens: output },
+        },
+      });
+
+    const checkoutProject = path.join(tmp, encodeClaudeProjectDir(repoPath));
+    fs.mkdirSync(checkoutProject, { recursive: true });
+    fs.writeFileSync(path.join(checkoutProject, 'checkout.jsonl'), message('msg_c', 500) + '\n');
+
+    const worktreeProject = path.join(tmp, encodeClaudeProjectDir(worktree));
+    fs.mkdirSync(worktreeProject, { recursive: true });
+    fs.writeFileSync(path.join(worktreeProject, 'first.jsonl'), message('msg_1', 3) + '\n');
+    fs.writeFileSync(path.join(worktreeProject, 'second.jsonl'), message('msg_2', 4) + '\n');
 
     const usage = harvestClaudeUsage({
       agentId: 1,


### PR DESCRIPTION
## Problem

Claude Code writes one assistant message across several transcript records — a text record plus one per tool call — and **every one of those records repeats the same `usage` object**. `extractClaudeUsageFromRecords` summed all of them, so every token and cost figure derived from the harvest ran roughly 2× high.

Measured over 178 real transcripts: **21,456 duplicate records, every single one carrying identical usage** (zero with differing usage).

| | summing every record | deduped by message id | inflation |
|---|---|---|---|
| tokensInput | 239,629 | 87,714 | 2.73× |
| tokensOutput | 38,393,005 | 15,964,508 | 2.40× |
| tokensCacheRead | 8,652,148,901 | 4,397,485,265 | 1.97× |
| tokensCacheCreation | 127,318,351 | 53,483,394 | 2.38× |
| **total** | **8,818,099,886** | **4,467,020,881** | **1.97×** |

Median per-transcript inflation 2.08×, max 3.52×. Cost inherits it exactly — the per-token rates are correct, so `costUsd` was wrong only because the counts were.

A second defect pulled the other way: `harvestClaudeUsage` stopped at the first non-empty transcript (`best = usage; break;`), so a slot reused across sessions reported one of them and silently discarded the rest. The two bugs are fixed together because either one alone still leaves the number wrong — and aggregating an inflating sum would have multiplied the error.

## Changes

- Nested usage is collected into a `Map` keyed by `message.id` (last record wins) and folded once, so a repeated message is billed once. Records with no id are still summed as they come.
- `harvestClaudeUsage` aggregates **every** transcript of the slot in a single extraction pass — which also means a message id appearing in two transcripts is billed once.
- The repo-path fallback stays a fallback. Main-checkout transcripts count only when the slot has no transcript of its own, so the two tiers are never summed together; `findMatchingClaudeTranscripts` now carries that tier on each match instead of flattening it away. (The existing `prefers the worktree transcript over the main checkout` test caught this — a naive aggregation broke it.)

## Verification

End to end against a fixture of two transcripts in one slot (2 messages × 2 records = 2,320 tokens, plus 1 message × 3 records = 81):

| CLI | input | output | cache read | cache write | total |
|---|---|---|---|---|---|
| released 0.64.0 | 3 | 21 | 210 | 9 | 243 |
| this branch | 21 | 207 | 2,070 | 103 | **2,401** |
| truth | 21 | 207 | 2,070 | 103 | **2,401** |

Three new tests in `tests/usage-harvest.test.ts`: a repeated message id billed once, every transcript in a slot counted, and the slot's own transcripts summed without the main-checkout fallback being added on top.

`npm run typecheck` and `npm run lint` clean. `npx jest` — 651 passed; the 13 failures in `control-repo-path`, `hooks`, `plugins`, `provision-toolchain` and `slot-registry` are pre-existing and reproduce identically on a stashed tree.

## Deliberately out of scope

The `type === 'result'` branch has its own problem — it *assigns* rather than accumulates and folds `cache_read_input_tokens` into `tokensInput`, giving that field two different meanings depending on the path. It is inert for Claude Code transcripts (none carry `result` records) and fixing it changes behaviour for a second transcript format, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)