### PR TITLE
feat!: two-signal drift — user-edited vs upstream-updated (#237)

### DIFF
--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -328,7 +328,60 @@ milestone_asserts() {
       echo "    shim verify writes validation records (commit gate satisfiable from any surface) ✓"
       ;;
     M3)
-      echo "──> M3 asserts: plugin/eject (extend when #239/#240 land)"
+      echo "──> M3 asserts: two-signal drift (#237)"
+      # Fresh 1.0 scaffold: adapt a file, finalize — drift must be zero.
+      echo "# repo-specific adaptation (M3 gate)" >> "$FRESH/.har/verify.sh"
+      har "$FRESH" env maintain --finalize --summary "M3 drift assert: adapted verify.sh" >/dev/null 2>&1 \
+        || fail "M3: maintain --finalize failed on fresh scaffold"
+      har "$FRESH" env maintain >/dev/null 2>&1 || true
+      node -e '
+        const fs = require("fs");
+        const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (r.actions.length !== 0) {
+          console.error("M3: freshly finalized harness reports drift actions:", r.actions.map(a=>`${a.file}(${a.kind})`).join(", "));
+          process.exit(1);
+        }
+        if (r.adapted.length !== 0) {
+          console.error("M3: finalize did not bless adapted files:", r.adapted.join(", "));
+          process.exit(1);
+        }
+      ' "$FRESH/.har/maintain/drift-report.json" \
+        || fail "M3: adapted+finalized harness is not drift-clean"
+      echo "    adapted + finalized harness reports zero drift ✓"
+
+      # Post-finalize user edit → adapted (informational), never an action.
+      echo "# post-finalize edit (M3 gate)" >> "$FRESH/.har/verify.sh"
+      har "$FRESH" env maintain >/dev/null 2>&1 || true
+      node -e '
+        const fs = require("fs");
+        const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (!r.adapted.includes("verify.sh")) { console.error("M3: post-finalize edit not reported as adapted"); process.exit(1); }
+        if (r.actions.some(a => a.file === "verify.sh")) { console.error("M3: user-adapted file raised a drift action"); process.exit(1); }
+      ' "$FRESH/.har/maintain/drift-report.json" \
+        || fail "M3: user-adapted signal wrong"
+      echo "    post-finalize edit → user-adapted, no action ✓"
+
+      # Upstream update on a user-adapted file → conflict (simulated by
+      # rewinding the recorded template baseline in the manifest).
+      node -e '
+        const fs = require("fs");
+        const p = process.argv[1];
+        const m = JSON.parse(fs.readFileSync(p, "utf8"));
+        m.templateChecksums["verify.sh"] = "0000000000000000";
+        fs.writeFileSync(p, JSON.stringify(m, null, 2) + "\n");
+      ' "$FRESH/.har/manifest.json"
+      har "$FRESH" env maintain >/dev/null 2>&1 || true
+      node -e '
+        const fs = require("fs");
+        const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        const a = r.actions.find(a => a.file === "verify.sh");
+        if (!a || a.kind !== "conflict") { console.error("M3: upstream update on adapted file is not a conflict:", a && a.kind); process.exit(1); }
+      ' "$FRESH/.har/maintain/drift-report.json" \
+        || fail "M3: conflict signal wrong"
+      har "$FRESH" env maintain --finalize --summary "M3 drift assert: reset baseline" >/dev/null 2>&1 || true
+      echo "    upstream update on adapted file → conflict ✓"
+
+      echo "──> M3 asserts: hooks/eject/plugins (extend when #238/#239/#240 land)"
       ;;
     M4|M5)
       echo "──> $MILESTONE asserts: migration (extend when #241 lands)"

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -49,6 +49,12 @@ export const HarnessManifestSchema = z.object({
   adaptationSummary: z.string().optional(),
   profile: z.enum(['default', 'cli', 'ios']).optional(),
   fileChecksums: z.record(z.string()).optional(),
+  /**
+   * Checksums of the composed bundled templates at last init/finalize —
+   * baseline for the upstream-updated drift signal (#237). Keyed by installed
+   * file name, same key space as fileChecksums.
+   */
+  templateChecksums: z.record(z.string()).optional(),
   scaffoldedAgentFiles: z.array(ScaffoldedAgentFileSchema).optional(),
 });
 

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -1475,8 +1475,16 @@ function printValidation(result: {
 }
 
 function printDrift(drift: HarnessDriftResult): void {
-  if (drift.checksumMismatch.length > 0) {
-    warn(`  Drift (template changed): ${drift.checksumMismatch.join(', ')}`);
+  if (drift.conflict.length > 0) {
+    warn(`  Conflict (upstream updated AND user edited — merge): ${drift.conflict.join(', ')}`);
+  }
+  if (drift.upstreamUpdated.length > 0) {
+    warn(`  Upstream template updates: ${drift.upstreamUpdated.join(', ')}`);
+  }
+  if (drift.userAdapted.length > 0) {
+    info(
+      `  Adapted locally (current with upstream — finalize to bless): ${drift.userAdapted.join(', ')}`,
+    );
   }
   if (drift.missing.length > 0) {
     warn(`  Missing from .har/: ${drift.missing.join(', ')}`);
@@ -1497,24 +1505,32 @@ function printDrift(drift: HarnessDriftResult): void {
     warn('  Canonical source is .har/stages.json — har env maintain --finalize syncs harness.env.');
   }
   if (
-    drift.checksumMismatch.length === 0 &&
+    drift.conflict.length === 0 &&
+    drift.upstreamUpdated.length === 0 &&
     drift.missing.length === 0 &&
     drift.extra.length === 0 &&
     drift.missingPortVars.length === 0 &&
     !drift.agentSlotMismatch
   ) {
-    success('  Harness matches bundled templates');
+    success(
+      drift.userAdapted.length > 0
+        ? '  No actionable drift (local adaptations are current with upstream)'
+        : '  Harness matches bundled templates',
+    );
   }
 }
 
 function printMaintainBundleSummary(report: MaintainBundleReport): void {
   const missing = report.actions.filter((a) => a.kind === 'missing').length;
-  const drifted = report.actions.filter((a) => a.kind === 'drift').length;
+  const upstream = report.actions.filter((a) => a.kind === 'upstream-updated').length;
+  const conflicts = report.actions.filter((a) => a.kind === 'conflict').length;
   const pluginMissing = report.pluginActions.filter((a) => a.kind === 'missing').length;
   const pluginDrifted = report.pluginActions.filter((a) => a.kind === 'drift').length;
   const stale = report.stale.length;
   info(`Maintenance bundle: .har/maintain/`);
-  info(`  Harness: ${missing} missing, ${drifted} drifted, ${stale} stale`);
+  info(
+    `  Harness: ${missing} missing, ${upstream} upstream-updated, ${conflicts} conflict(s), ${report.adapted.length} adapted (no action), ${stale} stale`,
+  );
   if (report.pluginDrift.length > 0) {
     info(
       `  Plugins (${report.pluginDrift.map((p) => p.pluginId).join(', ')}): ${pluginMissing} missing, ${pluginDrifted} drifted`,

--- a/src/harness/drift.ts
+++ b/src/harness/drift.ts
@@ -22,9 +22,36 @@ const CLI_EXPECTED_ABSENT = new Set([
   'attach.sh',
 ]);
 
+export type DriftFileStatus =
+  | 'unchanged'
+  | 'user-adapted'
+  | 'upstream-updated'
+  | 'conflict';
+
+/** Per-file cross product of the two drift signals (#237). */
+export interface DriftFileEntry {
+  file: string;
+  status: DriftFileStatus;
+  /** Signal 1 — installed file differs from fileChecksums recorded at last finalize. */
+  userEdited: boolean;
+  /**
+   * Signal 2 — bundled template differs from templateChecksums recorded at last
+   * finalize. `null` = no template baseline in the manifest (pre-#237 finalize);
+   * upstream updates cannot be detected until the next `maintain --finalize`.
+   */
+  upstreamUpdated: boolean | null;
+}
+
 export interface HarnessDriftResult {
+  /** Two-signal detail for every template-tracked file present in .har/. */
+  files: DriftFileEntry[];
   missing: string[];
-  checksumMismatch: string[];
+  /** User edited since last finalize; template unchanged. Informational, not an action. */
+  userAdapted: string[];
+  /** Template updated since last finalize; user did not touch the file. */
+  upstreamUpdated: string[];
+  /** Both signals fired — needs a real merge. */
+  conflict: string[];
   extra: string[];
   unchanged: string[];
   /** Port-allocation knobs from harness.env that the bundled template expects. */
@@ -121,19 +148,50 @@ export function missingPortDocumentationVars(
 
 const substituteProjectName = substituteTemplateTokens;
 
+function projectNameFor(resolvedRepoPath: string): string {
+  return path.basename(resolvedRepoPath).toLowerCase().replace(/[^a-z0-9]/g, '_');
+}
+
+/**
+ * Checksums of the composed bundled templates, keyed by installed file name
+ * (same key space as manifest fileChecksums). Recorded into the manifest at
+ * init/finalize as the baseline for the upstream-updated signal.
+ */
+export function computeTemplateChecksums(
+  repoPath: string,
+  profile: HarnessProfile,
+): Record<string, string> {
+  const resolved = path.resolve(repoPath);
+  const projectName = projectNameFor(resolved);
+  const checksums: Record<string, string> = {};
+  for (const [file, entry] of composeProfileTemplateMap(profile)) {
+    let content = readComposedTemplateContent(entry);
+    if (file === 'harness.env') {
+      content = substituteProjectName(content, projectName);
+    }
+    checksums[harnessFileForTemplate(file)] = computeFileChecksum(content);
+  }
+  return checksums;
+}
+
 export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
   const resolved = path.resolve(repoPath);
   const manifest = readManifest(resolved);
   const profile: HarnessProfile = manifest?.profile ?? 'default';
   const harnessDir = getHarnessDir(resolved);
-  const projectName = path.basename(resolved).toLowerCase().replace(/[^a-z0-9]/g, '_');
-  // Composed bundle set (shared kernel → runtime bundle → overlay). Drift keeps
-  // comparing top-level files only, matching the pre-composition behavior.
+  const projectName = projectNameFor(resolved);
+  // Composed bundle set (shared kernel → runtime bundle → overlay), including
+  // subdirectory entries (stages/…) — drift recurses into .har/stages/ (#237).
   const composed = composeProfileTemplateMap(profile);
-  const templateFiles = [...composed.keys()].filter((f) => !f.includes('/')).sort();
+  const templateFiles = [...composed.keys()].sort();
+  const fileBaseline = manifest?.fileChecksums;
+  const templateBaseline = manifest?.templateChecksums;
 
+  const files: DriftFileEntry[] = [];
   const missing: string[] = [];
-  const checksumMismatch: string[] = [];
+  const userAdapted: string[] = [];
+  const upstreamUpdated: string[] = [];
+  const conflict: string[] = [];
   const extra: string[] = [];
   const unchanged: string[] = [];
 
@@ -150,13 +208,39 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
       continue;
     }
 
-    const harnessChecksum = computeFileChecksum(fs.readFileSync(harnessPath, 'utf8'));
+    const installedChecksum = computeFileChecksum(fs.readFileSync(harnessPath, 'utf8'));
     const templateChecksum = computeFileChecksum(templateContent);
-    if (harnessChecksum === templateChecksum) {
-      unchanged.push(harnessFile);
-    } else {
-      checksumMismatch.push(harnessFile);
-    }
+    const recordedFile = fileBaseline?.[harnessFile];
+    const recordedTemplate = templateBaseline?.[harnessFile];
+
+    // Signal 1 — user-edited since last finalize. Without a recorded file
+    // checksum (no finalize yet), any divergence from the template counts.
+    const userEdited =
+      recordedFile !== undefined
+        ? installedChecksum !== recordedFile
+        : installedChecksum !== templateChecksum;
+
+    // Signal 2 — upstream template moved since last finalize. Without a
+    // recorded template baseline (pre-#237 manifest) upstream updates are
+    // undetectable: report `null`, never guess — a finalize-blessed adaptation
+    // must not resurface as drift noise.
+    const upstream: boolean | null =
+      recordedTemplate !== undefined ? templateChecksum !== recordedTemplate : null;
+
+    const status: DriftFileStatus =
+      userEdited && upstream
+        ? 'conflict'
+        : userEdited
+          ? 'user-adapted'
+          : upstream
+            ? 'upstream-updated'
+            : 'unchanged';
+
+    files.push({ file: harnessFile, status, userEdited, upstreamUpdated: upstream });
+    if (status === 'unchanged') unchanged.push(harnessFile);
+    else if (status === 'user-adapted') userAdapted.push(harnessFile);
+    else if (status === 'upstream-updated') upstreamUpdated.push(harnessFile);
+    else conflict.push(harnessFile);
   }
 
   if (fs.existsSync(harnessDir)) {
@@ -188,8 +272,11 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
   const agentSlotMismatch = detectAgentSlotEnvMismatch(resolved);
 
   return {
+    files,
     missing,
-    checksumMismatch,
+    userAdapted,
+    upstreamUpdated,
+    conflict,
     extra,
     unchanged,
     missingPortVars,

--- a/src/harness/generator.ts
+++ b/src/harness/generator.ts
@@ -5,6 +5,7 @@ import { info, success } from '../utils/logging';
 import { resolveTemplateFile } from '../utils/paths';
 import { ensureRootGitignorePatterns } from '../core/gitignore';
 import { HARNESS_GITIGNORE_TEMPLATE, writeHarnessGitignore } from './gitignore-template';
+import { computeTemplateChecksums } from './drift';
 import { createManifest, writeManifest, DEFAULT_HAR_DIR, readManifest } from './manifest';
 import { ensurePluginLedgerScaffold } from './plugin-ledger';
 import {
@@ -134,6 +135,7 @@ export function scaffoldHarnessBoilerplate(
         : 'Boilerplate copied — adapt with your coding agent (see .har/ADAPT-PROMPT.md).',
     undefined,
     profile,
+    computeTemplateChecksums(repoPath, profile),
   );
   writeManifest(repoPath, manifest);
 
@@ -156,7 +158,14 @@ export function finalizeHarness(
   stack?: { language?: string; packageManager?: string; database?: string },
 ): void {
   const existing = readManifest(repoPath);
-  const manifest = createManifest(repoPath, adaptationSummary, stack, existing?.profile);
+  const profile = existing?.profile ?? 'default';
+  const manifest = createManifest(
+    repoPath,
+    adaptationSummary,
+    stack,
+    existing?.profile,
+    computeTemplateChecksums(repoPath, profile),
+  );
   writeManifest(repoPath, manifest);
   success('Harness adaptation complete.');
 }

--- a/src/harness/maintain-bundle.ts
+++ b/src/harness/maintain-bundle.ts
@@ -22,7 +22,7 @@ import { detectInstructionFiles } from './instruction-files';
 
 export const MAINTAIN_DIR = 'maintain';
 
-export type MaintainActionKind = 'missing' | 'drift';
+export type MaintainActionKind = 'missing' | 'upstream-updated' | 'conflict';
 
 export interface MaintainAction {
   file: string;
@@ -53,6 +53,8 @@ export interface MaintainBundleReport {
   generatedAt: string;
   profile: HarnessProfile;
   actions: MaintainAction[];
+  /** User-adapted files that are current with upstream — informational, no action needed. */
+  adapted: string[];
   pluginDrift: PluginDriftResult[];
   pluginActions: PluginDriftAction[];
   stale: MaintainStaleFile[];
@@ -113,13 +115,13 @@ function actionHint(file: string, kind: MaintainActionKind): string {
     }
     return `Copy/adapt from maintain/templates/${file} into .har/${file}.`;
   }
-  if (file === 'verify.sh') {
-    return 'Merge template upgrades into .har/verify.sh — do not blind-overwrite repo-specific checks.';
+  if (kind === 'conflict') {
+    return `Upstream template AND your local edits both changed — read maintain/diffs/${file}.diff and merge carefully; keep repo-specific customizations.`;
   }
   if (file === 'harness.env') {
-    return 'Merge template changes; keep repo-specific commands and add any missing port vars.';
+    return 'Upstream template updated; merge changes — keep repo-specific values and add any missing port vars.';
   }
-  return `Read maintain/diffs/${file}.diff and merge into .har/${file}.`;
+  return `Upstream template updated since your last finalize — read maintain/diffs/${file}.diff and apply into .har/${file}.`;
 }
 
 function createUnifiedDiff(
@@ -160,19 +162,20 @@ function buildActions(
     });
   }
 
-  for (const file of drift.checksumMismatch) {
+  const upstreamAffected: Array<[string, MaintainActionKind]> = [
+    ...drift.upstreamUpdated.map((f): [string, MaintainActionKind] => [f, 'upstream-updated']),
+    ...drift.conflict.map((f): [string, MaintainActionKind] => [f, 'conflict']),
+  ];
+  for (const [file, kind] of upstreamAffected) {
     const installedPath = path.join(harnessDir, file);
-    const installedRel = `maintain/installed/${file}`;
-    const templateRel = `maintain/templates/${file}`;
-    const diffRel = `maintain/diffs/${file}.diff`;
 
     actions.push({
       file,
-      kind: 'drift',
-      template: templateRel,
-      installed: fs.existsSync(installedPath) ? installedRel : undefined,
-      diff: diffRel,
-      hint: actionHint(file, 'drift'),
+      kind,
+      template: `maintain/templates/${file}`,
+      installed: fs.existsSync(installedPath) ? `maintain/installed/${file}` : undefined,
+      diff: `maintain/diffs/${file}.diff`,
+      hint: actionHint(file, kind),
     });
   }
 
@@ -257,10 +260,19 @@ function buildReadme(report: MaintainBundleReport): string {
     }
   }
 
-  lines.push('', '## Drift actions', '');
+  lines.push(
+    '',
+    '## Drift actions',
+    '',
+    'Drift is two signals: **user-edited** (your file changed since the last finalize) and',
+    '**upstream-updated** (the bundled template changed since the last finalize). Only',
+    '`upstream-updated` and `conflict` (both signals) need action — files you adapted and',
+    'finalized are *not* drift.',
+    '',
+  );
 
   if (report.actions.length === 0) {
-    lines.push('No missing or drifted harness template files.');
+    lines.push('No missing files and no upstream template updates.');
   } else {
     lines.push('| File | Status | Reference |');
     lines.push('|------|--------|-----------|');
@@ -271,6 +283,17 @@ function buildReadme(report: MaintainBundleReport): string {
           : `diffs/${action.file}.diff`;
       lines.push(`| ${action.file} | ${action.kind} | ${ref} |`);
     }
+  }
+
+  if (report.adapted.length > 0) {
+    lines.push(
+      '',
+      '### Adapted files (current with upstream — no action)',
+      '',
+      ...report.adapted.map((f) => `- \`${f}\``),
+      '',
+      'These carry local edits since the last finalize. Run `har env maintain --finalize` to bless them as the new baseline.',
+    );
   }
 
   lines.push('', '## Plugin drift (installed verification plugins)', '');
@@ -378,7 +401,7 @@ function writeBundleArtifacts(
     fs.mkdirSync(dir, { recursive: true });
   }
 
-  const affectedFiles = [...drift.missing, ...drift.checksumMismatch];
+  const affectedFiles = [...drift.missing, ...drift.upstreamUpdated, ...drift.conflict];
   for (const file of affectedFiles) {
     const templateContent = readBundledTemplateContent(repoPath, profile, file);
     writeFileSafe(path.join(bundleDir, 'templates', file), templateContent);
@@ -483,6 +506,7 @@ export function buildMaintainBundle(
     generatedAt: new Date().toISOString(),
     profile,
     actions: buildActions(repoPath, profile, drift),
+    adapted: [...drift.userAdapted].sort((a, b) => a.localeCompare(b)),
     pluginDrift,
     pluginActions,
     stale: buildStale(drift),
@@ -528,7 +552,16 @@ export function formatMaintainBundlePromptSection(report: MaintainBundleReport):
   }
 
   if (report.actions.length > 0) {
-    lines.push('### Drift actions', '', '| File | Status | Reference |', '|------|--------|-----------|');
+    lines.push(
+      '### Drift actions',
+      '',
+      'Two-signal drift: `upstream-updated` = the bundled template moved since your last finalize',
+      '(apply the diff); `conflict` = the template moved **and** you edited the file (merge, keep',
+      'repo-specific customizations); `missing` = a template file is absent from `.har/`.',
+      '',
+      '| File | Status | Reference |',
+      '|------|--------|-----------|',
+    );
     for (const action of report.actions) {
       const ref =
         action.kind === 'missing'
@@ -537,6 +570,18 @@ export function formatMaintainBundlePromptSection(report: MaintainBundleReport):
       lines.push(`| ${action.file} | ${action.kind} | ${ref} |`);
     }
     lines.push('');
+  }
+
+  if (report.adapted.length > 0) {
+    lines.push(
+      '### Adapted files (no action)',
+      '',
+      'Local edits since the last finalize, with no upstream template change. Do **not** revert these to',
+      'the stock template — finalize blesses them as the new baseline.',
+      '',
+      ...report.adapted.map((f) => `- \`${f}\``),
+      '',
+    );
   }
 
   if (report.pluginActions.length > 0) {

--- a/src/harness/manifest.ts
+++ b/src/harness/manifest.ts
@@ -42,6 +42,9 @@ export function computeFileChecksum(content: string): string {
   return crypto.createHash('sha256').update(content).digest('hex').slice(0, 16);
 }
 
+/** Subdirectories of .har/ whose files are part of the adaptation surface. */
+const CHECKSUM_SUBDIRS = ['stages'];
+
 export function computeHarnessChecksums(harnessDir: string): Record<string, string> {
   const checksums: Record<string, string> = {};
   if (!fs.existsSync(harnessDir)) return checksums;
@@ -51,6 +54,16 @@ export function computeHarnessChecksums(harnessDir: string): Record<string, stri
     const full = path.join(harnessDir, entry.name);
     checksums[entry.name] = computeFileChecksum(fs.readFileSync(full, 'utf8'));
   }
+
+  for (const subdir of CHECKSUM_SUBDIRS) {
+    const dir = path.join(harnessDir, subdir);
+    if (!fs.existsSync(dir)) continue;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      const rel = `${subdir}/${entry.name}`;
+      checksums[rel] = computeFileChecksum(fs.readFileSync(path.join(dir, entry.name), 'utf8'));
+    }
+  }
   return checksums;
 }
 
@@ -59,6 +72,7 @@ export function createManifest(
   adaptationSummary?: string,
   stack?: HarnessManifest['stack'],
   profile?: HarnessManifest['profile'],
+  templateChecksums?: Record<string, string>,
 ): HarnessManifest {
   const now = new Date().toISOString();
   const harnessDir = getHarnessDir(repoPath);
@@ -71,12 +85,15 @@ export function createManifest(
     adaptationSummary,
     profile,
     fileChecksums: computeHarnessChecksums(harnessDir),
+    templateChecksums,
   };
 }
 
 export function updateManifest(
   existing: HarnessManifest,
-  updates: Partial<Pick<HarnessManifest, 'adaptationSummary' | 'stack' | 'fileChecksums'>>,
+  updates: Partial<
+    Pick<HarnessManifest, 'adaptationSummary' | 'stack' | 'fileChecksums' | 'templateChecksums'>
+  >,
 ): HarnessManifest {
   return {
     ...existing,

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -44,7 +44,9 @@ export const DescribeProjectOutputSchema = z.object({
   harnessDrift: z
     .object({
       missing: z.array(z.string()),
-      checksumMismatch: z.array(z.string()),
+      userAdapted: z.array(z.string()),
+      upstreamUpdated: z.array(z.string()),
+      conflict: z.array(z.string()),
       extra: z.array(z.string()),
       unchanged: z.array(z.string()),
     })

--- a/src/templates/adaptation-prompt-maintain.md
+++ b/src/templates/adaptation-prompt-maintain.md
@@ -15,7 +15,10 @@ Compare the current repo against the existing harness:
 - Root manifests, CI, Docker, README
 - New or changed test, lint, build, migrate, or seed commands
 - New services, ports, or environment variables
-- Review `.har/maintain/drift-report.json` (template drift, **missing port documentation vars**)
+- Review `.har/maintain/drift-report.json` (two-signal drift, **missing port documentation vars**).
+  Drift statuses: `upstream-updated` (bundled template moved since your last finalize — apply the diff),
+  `conflict` (template moved **and** the file was edited locally — merge, keep repo customizations),
+  `adapted` (local edits only — **no action**, never revert to stock; finalize blesses them).
 
 ## Step 2 — Update `.har/` files
 

--- a/tests/drift-two-signal.test.ts
+++ b/tests/drift-two-signal.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { compareHarnessToTemplate, computeTemplateChecksums } from '../src/harness/drift';
+import { finalizeHarness, scaffoldHarnessBoilerplate } from '../src/harness/generator';
+import { readManifest } from '../src/harness/manifest';
+
+describe('two-signal drift (#237)', () => {
+  const tmpDirs: string[] = [];
+
+  function scaffoldRepo(prefix: string): string {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    tmpDirs.push(repoPath);
+    scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'default' });
+    return repoPath;
+  }
+
+  afterAll(() => {
+    for (const dir of tmpDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('freshly scaffolded harness reports zero drift', () => {
+    const repoPath = scaffoldRepo('har-two-signal-fresh-');
+    const drift = compareHarnessToTemplate(repoPath);
+
+    expect(drift.userAdapted).toEqual([]);
+    expect(drift.upstreamUpdated).toEqual([]);
+    expect(drift.conflict).toEqual([]);
+    expect(drift.missing).toEqual([]);
+    expect(drift.unchanged.length).toBeGreaterThan(0);
+  });
+
+  it('adapted-then-finalized harness with no upstream changes reports zero drift', () => {
+    const repoPath = scaffoldRepo('har-two-signal-adapted-');
+    const verifyPath = path.join(repoPath, '.har', 'verify.sh');
+    fs.writeFileSync(verifyPath, fs.readFileSync(verifyPath, 'utf8') + '\n# repo-specific check\n');
+
+    finalizeHarness(repoPath, 'Adapted verify.sh for repo-specific checks');
+    const drift = compareHarnessToTemplate(repoPath);
+
+    expect(drift.userAdapted).toEqual([]);
+    expect(drift.upstreamUpdated).toEqual([]);
+    expect(drift.conflict).toEqual([]);
+    const entry = drift.files.find((f) => f.file === 'verify.sh');
+    expect(entry?.status).toBe('unchanged');
+  });
+
+  it('post-finalize user edit reports user-adapted, not upstream drift', () => {
+    const repoPath = scaffoldRepo('har-two-signal-edit-');
+    const verifyPath = path.join(repoPath, '.har', 'verify.sh');
+    fs.writeFileSync(verifyPath, fs.readFileSync(verifyPath, 'utf8') + '\n# later edit\n');
+
+    const drift = compareHarnessToTemplate(repoPath);
+    const entry = drift.files.find((f) => f.file === 'verify.sh');
+    expect(entry?.status).toBe('user-adapted');
+    expect(entry?.userEdited).toBe(true);
+    expect(entry?.upstreamUpdated).toBe(false);
+  });
+
+  it('upstream template update on a user-adapted file reports conflict', () => {
+    const repoPath = scaffoldRepo('har-two-signal-conflict-');
+    const manifestPath = path.join(repoPath, '.har', 'manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.templateChecksums['verify.sh'] = '0000000000000000';
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+    const verifyPath = path.join(repoPath, '.har', 'verify.sh');
+    fs.writeFileSync(verifyPath, fs.readFileSync(verifyPath, 'utf8') + '\n# local edit\n');
+
+    const drift = compareHarnessToTemplate(repoPath);
+    expect(drift.conflict).toContain('verify.sh');
+    const entry = drift.files.find((f) => f.file === 'verify.sh');
+    expect(entry?.userEdited).toBe(true);
+    expect(entry?.upstreamUpdated).toBe(true);
+  });
+
+  it('recurses into .har/stages/ for both signals', () => {
+    const repoPath = scaffoldRepo('har-two-signal-stages-');
+    const templateChecksums = computeTemplateChecksums(repoPath, 'default');
+    const stageFiles = Object.keys(templateChecksums).filter((f) => f.startsWith('stages/'));
+    expect(stageFiles.length).toBeGreaterThan(0);
+
+    const manifest = readManifest(repoPath);
+    expect(Object.keys(manifest?.fileChecksums ?? {})).toEqual(
+      expect.arrayContaining(stageFiles),
+    );
+
+    const stageFile = stageFiles[0];
+    const stagePath = path.join(repoPath, '.har', stageFile);
+    fs.writeFileSync(stagePath, fs.readFileSync(stagePath, 'utf8') + '\n# stage edit\n');
+
+    const drift = compareHarnessToTemplate(repoPath);
+    expect(drift.userAdapted).toContain(stageFile);
+    // Registered user stages that are not template files are user-owned — never "extra".
+    expect(drift.extra.filter((f) => f.startsWith('stages/'))).toEqual([]);
+  });
+
+  it('legacy manifest without templateChecksums reports upstream signal as unknown', () => {
+    const repoPath = scaffoldRepo('har-two-signal-legacy-');
+    const manifestPath = path.join(repoPath, '.har', 'manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    delete manifest.templateChecksums;
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+    const verifyPath = path.join(repoPath, '.har', 'verify.sh');
+    fs.writeFileSync(verifyPath, fs.readFileSync(verifyPath, 'utf8') + '\n# local edit\n');
+
+    const drift = compareHarnessToTemplate(repoPath);
+    const edited = drift.files.find((f) => f.file === 'verify.sh');
+    expect(edited?.status).toBe('user-adapted');
+    expect(edited?.upstreamUpdated).toBeNull();
+    const untouched = drift.files.find((f) => f.file === 'launch.sh');
+    expect(untouched?.status).toBe('unchanged');
+    expect(untouched?.upstreamUpdated).toBeNull();
+    expect(drift.conflict).toEqual([]);
+    expect(drift.upstreamUpdated).toEqual([]);
+  });
+});

--- a/tests/maintain-bundle.test.ts
+++ b/tests/maintain-bundle.test.ts
@@ -38,7 +38,7 @@ describe('maintain bundle', () => {
     expect(fs.existsSync(path.join(bundleDir, 'validation.json'))).toBe(true);
   });
 
-  it('creates diffs for drifted files', () => {
+  it('reports user edits as adapted (no action) — two-signal drift (#237)', () => {
     const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-maintain-drift-'));
     scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'cli' });
     const launchPath = path.join(repoPath, '.har', 'launch.sh');
@@ -46,15 +46,42 @@ describe('maintain bundle', () => {
 
     const drift = compareHarnessToTemplate(repoPath);
     const validation = validateHarness(repoPath);
+    const { report } = buildMaintainBundle(repoPath, validation, drift);
+
+    // User edited, template unchanged → informational, never a drift action.
+    expect(report.actions.find((a) => a.file === 'launch.sh')).toBeUndefined();
+    expect(report.adapted).toContain('launch.sh');
+  });
+
+  it('creates diffs for upstream-updated and conflict files — two-signal drift (#237)', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-maintain-upstream-'));
+    scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'cli' });
+
+    // Simulate "template moved since finalize" by rewinding the recorded
+    // template baseline for launch.sh (upstream-updated) and verify.sh
+    // (conflict: baseline rewound AND user edit).
+    const manifestPath = path.join(repoPath, '.har', 'manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.templateChecksums['launch.sh'] = '0000000000000000';
+    manifest.templateChecksums['verify.sh'] = '0000000000000000';
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+    const verifyPath = path.join(repoPath, '.har', 'verify.sh');
+    fs.writeFileSync(verifyPath, fs.readFileSync(verifyPath, 'utf8') + '\n# local edit\n');
+
+    const drift = compareHarnessToTemplate(repoPath);
+    expect(drift.upstreamUpdated).toContain('launch.sh');
+    expect(drift.conflict).toContain('verify.sh');
+
+    const validation = validateHarness(repoPath);
     const { bundleDir, report } = buildMaintainBundle(repoPath, validation, drift);
 
-    const launchAction = report.actions.find((a) => a.file === 'launch.sh');
-    expect(launchAction?.kind).toBe('drift');
+    expect(report.actions.find((a) => a.file === 'launch.sh')?.kind).toBe('upstream-updated');
+    expect(report.actions.find((a) => a.file === 'verify.sh')?.kind).toBe('conflict');
     expect(fs.existsSync(path.join(bundleDir, 'installed', 'launch.sh'))).toBe(true);
     expect(fs.existsSync(path.join(bundleDir, 'templates', 'launch.sh'))).toBe(true);
-    expect(fs.existsSync(path.join(bundleDir, 'diffs', 'launch.sh.diff'))).toBe(true);
-    const diff = fs.readFileSync(path.join(bundleDir, 'diffs', 'launch.sh.diff'), 'utf8');
-    expect(diff).toContain('drift marker');
+    expect(fs.existsSync(path.join(bundleDir, 'diffs', 'verify.sh.diff'))).toBe(true);
+    const diff = fs.readFileSync(path.join(bundleDir, 'diffs', 'verify.sh.diff'), 'utf8');
+    expect(diff).toContain('local edit');
   });
 
   it('lists stale extra files', () => {
@@ -134,6 +161,7 @@ describe('adaptation prompts with maintain bundle', () => {
           hint: 'Add this file.',
         },
       ],
+      adapted: [],
       pluginDrift: [],
       pluginActions: [],
       stale: [{ file: 'legacy.sh', hint: 'Delete after merge.' }],

--- a/tests/profile-composition.test.ts
+++ b/tests/profile-composition.test.ts
@@ -95,7 +95,13 @@ describe('adaptation prompt is generated, not templated', () => {
     );
 
     const drift = compareHarnessToTemplate(repoPath);
-    const flagged = [...drift.missing, ...drift.checksumMismatch, ...drift.extra];
+    const flagged = [
+      ...drift.missing,
+      ...drift.userAdapted,
+      ...drift.upstreamUpdated,
+      ...drift.conflict,
+      ...drift.extra,
+    ];
     expect(flagged.filter((f) => f.startsWith('ADAPT-PROMPT'))).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #237

**Stack 1/4** — based on `v1`. Next in stack: #238 (lifecycle hooks).

Two-signal drift replaces template-vs-installed diffing: signal 1 (user-edited: installed vs `fileChecksums` at last finalize) × signal 2 (upstream-updated: current template vs `templateChecksums` recorded at finalize) → per-file status `unchanged / user-adapted / upstream-updated / conflict`. Drift recurses into `.har/stages/`; maintain bundle + ADAPT-PROMPT rewritten around the two signals (user-adapted files are informational, never actions). Legacy manifests without a template baseline report signal 2 as unknown rather than guessing.

**BREAKING CHANGE**: the meaning of drift changes; `checksumMismatch` is removed from the drift result/MCP payload in favor of `files[]`, `userAdapted`, `upstreamUpdated`, `conflict`.

Gate: M3 milestone gate (full verify + fixture-e2e with M3 asserts) runs from the top of the stack — result posted on #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)