### PR TITLE
feat: lifecycle hooks — sanctioned user-owned extension points (#238)

### DIFF
--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -381,7 +381,54 @@ milestone_asserts() {
       har "$FRESH" env maintain --finalize --summary "M3 drift assert: reset baseline" >/dev/null 2>&1 || true
       echo "    upstream update on adapted file → conflict ✓"
 
-      echo "──> M3 asserts: hooks/eject/plugins (extend when #238/#239/#240 land)"
+      echo "──> M3 asserts: lifecycle hooks (#238)"
+      # Hooks land in the runtime, so the fresh 1.0 scaffold honors them with
+      # zero adaptation: drop scripts into .har/hooks/ and drive the lifecycle.
+      local hooks_bindir="$ART_DIR/bin"
+      mkdir -p "$hooks_bindir"
+      printf '#!/usr/bin/env bash\nexec node "%s" "$@"\n' "$HAR_CLI" > "$hooks_bindir/har"
+      chmod +x "$hooks_bindir/har"
+      local hook_log="$FRESH/.hook-fired"
+      rm -f "$hook_log"
+      mkdir -p "$FRESH/.har/hooks"
+      printf '#!/usr/bin/env bash\necho "$HAR_HOOK:$AGENT_ID:$HAR_HOOK_CONTRACT" >> %q\n' "$hook_log" \
+        > "$FRESH/.har/hooks/pre-launch.sh"
+      cp "$FRESH/.har/hooks/pre-launch.sh" "$FRESH/.har/hooks/post-teardown.sh"
+      chmod +x "$FRESH/.har/hooks/pre-launch.sh" "$FRESH/.har/hooks/post-teardown.sh"
+
+      (cd "$FRESH" && "$hooks_bindir/har" env teardown 1 >/dev/null 2>&1) || true
+      rm -f "$hook_log"
+      (cd "$FRESH" && "$hooks_bindir/har" env launch 1 >/dev/null) \
+        || fail "M3: launch failed with hooks installed"
+      grep -q '^pre-launch:1:1$' "$hook_log" 2>/dev/null \
+        || fail "M3: pre-launch hook did not fire with the v1 env contract"
+      echo "    pre-launch hook fires with the v1 contract ✓"
+
+      # A failing pre-verify hook must abort verify with attribution.
+      printf '#!/usr/bin/env bash\nexit 42\n' > "$FRESH/.har/hooks/pre-verify.sh"
+      chmod +x "$FRESH/.har/hooks/pre-verify.sh"
+      local hook_verify_out
+      if hook_verify_out=$(cd "$FRESH" && "$hooks_bindir/har" env verify 1 2>&1); then
+        fail "M3: verify passed despite a failing pre-verify hook"
+      fi
+      echo "$hook_verify_out" | grep -q 'pre-verify hook failed (exit 42)' \
+        || fail "M3: verify failure not attributed to the pre-verify hook"
+      rm -f "$FRESH/.har/hooks/pre-verify.sh"
+      echo "    failing pre-verify hook blocks verify with attribution ✓"
+
+      (cd "$FRESH" && "$hooks_bindir/har" env teardown 1 --delete-branch >/dev/null) \
+        || fail "M3: teardown failed with hooks installed"
+      grep -q '^post-teardown:1:1$' "$hook_log" 2>/dev/null \
+        || fail "M3: post-teardown hook did not fire"
+      echo "    post-teardown hook fires ✓"
+
+      # Hooks are user-owned: doctor stays green with hooks installed.
+      (cd "$FRESH" && "$hooks_bindir/har" env doctor >/dev/null 2>&1) \
+        || fail "M3: doctor red with valid hooks installed"
+      echo "    doctor green with hooks installed ✓"
+      rm -rf "$FRESH/.har/hooks" "$hook_log"
+
+      echo "──> M3 asserts: eject/plugins (extend when #239/#240 land)"
       ;;
     M4|M5)
       echo "──> $MILESTONE asserts: migration (extend when #241 lands)"

--- a/packages/schemas/src/harness-env.ts
+++ b/packages/schemas/src/harness-env.ts
@@ -69,6 +69,9 @@ export const HarnessEnvSchema = z.object({
   HARNESS_AGENT_SLOT_MIN: intString.optional(),
   HARNESS_AGENT_SLOT_MAX: intString.optional(),
 
+  // Lifecycle hooks (#238): what a failing post-* hook does ('warn' default)
+  HARNESS_HOOK_POST_FAILURE: z.enum(['warn', 'fail']).optional(),
+
   HARNESS_ECOSYSTEM: z.enum(HARNESS_ECOSYSTEMS).optional(),
   HARNESS_INSTALL_CMD: z.string().optional(),
   HARNESS_NODE_PACKAGE_MANAGER: z.enum(HARNESS_NODE_PACKAGE_MANAGERS).optional(),

--- a/src/harness/doctor.ts
+++ b/src/harness/doctor.ts
@@ -6,6 +6,7 @@ import { getHarnessDir } from './manifest';
 import { HarnessStage, HarnessStageRegistry, PortLane } from './schema';
 import { readStageRegistry } from './stages';
 import { findPhantomVerificationStageIds } from './verification';
+import { LIFECYCLE_HOOKS } from '../runtime/hooks';
 
 /**
  * `har env doctor` — harness contract validation (#232).
@@ -22,7 +23,8 @@ export type DoctorCheckId =
   | 'lifecycle-stages'
   | 'verification-ids'
   | 'port-lanes'
-  | 'slot-registry';
+  | 'slot-registry'
+  | 'hooks';
 
 export type DoctorContract = '1.0' | 'pre-1.0' | 'none';
 
@@ -66,6 +68,7 @@ const CHECK_LABELS: Record<DoctorCheckId, string> = {
   'verification-ids': 'verificationStages ids',
   'port-lanes': 'infra port lanes',
   'slot-registry': 'slot registry worktrees',
+  hooks: 'lifecycle hooks (.har/hooks)',
 };
 
 /** Legacy helper functions whose presence marks a pre-1.0 harness.env. */
@@ -310,6 +313,35 @@ export function runDoctor(repoPath: string): DoctorReport {
         message: `Slot ${entry.agentId} (${entry.status}) points at a missing worktree: ${dir}`,
         remedy: `Run \`har env teardown ${entry.agentId}\` (or \`har env cleanup\`) to clear the stale session`,
       });
+    }
+  }
+
+  // 8. Lifecycle hooks (#238): user-owned scripts — validated for shape only
+  // (recognized name, executable), never compared against templates.
+  const hooksDir = path.join(harnessDir, 'hooks');
+  if (fs.existsSync(hooksDir)) {
+    for (const file of fs.readdirSync(hooksDir).sort()) {
+      const full = path.join(hooksDir, file);
+      if (!fs.statSync(full).isFile() || !file.endsWith('.sh')) continue;
+      if (!(LIFECYCLE_HOOKS as readonly string[]).includes(file.replace(/\.sh$/, ''))) {
+        findings.push({
+          check: 'hooks',
+          severity: 'warning',
+          file: `hooks/${file}`,
+          message: `hooks/${file} is not a recognized lifecycle hook (expected one of: ${LIFECYCLE_HOOKS.map((h) => `${h}.sh`).join(', ')})`,
+          remedy: 'Rename it to a supported hook, or keep helper scripts outside .har/hooks/',
+        });
+        continue;
+      }
+      if (!(fs.statSync(full).mode & 0o111)) {
+        findings.push({
+          check: 'hooks',
+          severity: 'warning',
+          file: `hooks/${file}`,
+          message: `Hook hooks/${file} is not executable`,
+          remedy: `chmod +x .har/hooks/${file}`,
+        });
+      }
     }
   }
 

--- a/src/harness/drift.ts
+++ b/src/harness/drift.ts
@@ -246,6 +246,8 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
   if (fs.existsSync(harnessDir)) {
     for (const file of fs.readdirSync(harnessDir)) {
       const full = path.join(harnessDir, file);
+      // Directories are skipped, which also keeps `.har/hooks/` (#238) out of
+      // drift entirely: hooks are user-owned, never compared to templates.
       if (!fs.statSync(full).isFile()) continue;
       if (
         file === 'manifest.json' ||

--- a/src/runtime/hooks.ts
+++ b/src/runtime/hooks.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { ExecFn } from './exec';
+
+/**
+ * Lifecycle hooks (#238): optional user-owned scripts in `.har/hooks/` the
+ * runtime calls at fixed points. Hooks are the sanctioned place for custom
+ * launch/verify/teardown behavior — never drift-checked against templates.
+ */
+
+export const LIFECYCLE_HOOKS = [
+  'pre-launch',
+  'post-launch',
+  'pre-verify',
+  'pre-teardown',
+  'post-teardown',
+] as const;
+
+export type LifecycleHook = (typeof LIFECYCLE_HOOKS)[number];
+
+/**
+ * Version of the env contract hooks receive (HAR_HOOK_CONTRACT). Bump only
+ * when an existing variable changes meaning — additions are backwards-safe.
+ */
+export const HOOK_CONTRACT_VERSION = '1';
+
+export const HOOKS_DIR = 'hooks';
+
+export function lifecycleHookPath(harnessDir: string, hook: LifecycleHook): string {
+  return path.join(harnessDir, HOOKS_DIR, `${hook}.sh`);
+}
+
+export interface HookContext {
+  harnessDir: string;
+  agentId: number;
+  /** Session work dir; the repo root for hooks that run before a session exists. */
+  workDir?: string;
+  /** The slot's .env.agent.<id> file, once generated. */
+  envFile?: string;
+  /** Per-slot app ports (exported as HAR_PORT_<NAME>). */
+  ports?: Record<string, number | string>;
+  /** Injectable runner (tests). Defaults to spawning bash with inherited output. */
+  exec?: ExecFn;
+  /** Progress sink, called only when a hook file actually exists. */
+  log?: (message: string) => void;
+}
+
+export interface HookResult {
+  /** False when no hook file exists (nothing was run). */
+  ran: boolean;
+  code: number;
+  /** Path of the hook that ran, relative to the repo (for attribution). */
+  file?: string;
+}
+
+/**
+ * The env contract (v1) every hook receives:
+ *   HAR_HOOK, HAR_HOOK_CONTRACT, AGENT_ID, HAR_HARNESS_DIR,
+ *   WORK_DIR / ENV_FILE when the session has them,
+ *   HAR_PORT_<NAME> for each allocated app port.
+ */
+export function hookEnv(hook: LifecycleHook, context: HookContext): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HAR_HOOK: hook,
+    HAR_HOOK_CONTRACT: HOOK_CONTRACT_VERSION,
+    AGENT_ID: String(context.agentId),
+    HAR_HARNESS_DIR: context.harnessDir,
+  };
+  if (context.workDir) env.WORK_DIR = context.workDir;
+  if (context.envFile) env.ENV_FILE = context.envFile;
+  for (const [name, value] of Object.entries(context.ports ?? {})) {
+    env[`HAR_PORT_${name.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`] = String(value);
+  }
+  return env;
+}
+
+/** Hook attribution string for failure messages: `.har/hooks/<hook>.sh`. */
+export function hookDisplayPath(hook: LifecycleHook): string {
+  return `.har/${HOOKS_DIR}/${hook}.sh`;
+}
+
+/**
+ * Run a lifecycle hook if `.har/hooks/<hook>.sh` exists. Hooks run through
+ * bash (executability is a doctor warning, not a runtime trap) from the work
+ * dir, with output streaming to the user.
+ */
+export function runLifecycleHook(hook: LifecycleHook, context: HookContext): HookResult {
+  const file = lifecycleHookPath(context.harnessDir, hook);
+  if (!fs.existsSync(file)) return { ran: false, code: 0 };
+  context.log?.(`Running ${hookDisplayPath(hook)}...`);
+  const env = hookEnv(hook, context);
+  const cwd = context.workDir ?? path.dirname(context.harnessDir);
+  if (context.exec) {
+    const result = context.exec('bash', [file], { cwd, env });
+    return { ran: true, code: result.code, file: hookDisplayPath(hook) };
+  }
+  const result = spawnSync('bash', [file], {
+    cwd,
+    env,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  return { ran: true, code: result.status ?? 1, file: hookDisplayPath(hook) };
+}
+
+/**
+ * post-* hook failure policy (HARNESS_HOOK_POST_FAILURE): 'warn' (default)
+ * reports and continues; 'fail' fails the operation like a pre-* hook.
+ */
+export function postHookFailureMode(env: Record<string, string>): 'warn' | 'fail' {
+  return env.HARNESS_HOOK_POST_FAILURE === 'fail' ? 'fail' : 'warn';
+}

--- a/src/runtime/launch.ts
+++ b/src/runtime/launch.ts
@@ -31,6 +31,7 @@ import {
   HttpStatusFn,
 } from './process';
 import { pkgExec } from './node-pm';
+import { postHookFailureMode, runLifecycleHook } from './hooks';
 import { acquireSimulator, perSlotEnabled, releaseSimulator } from './xcode-sim';
 import { runSetupInfra } from './setup';
 
@@ -138,6 +139,22 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
   const appPorts = preflight.ports;
   if (pm === 'pm2' && appPorts) {
     log(`Ports: frontend=${appPorts.frontend} api=${appPorts.api} debug=${appPorts.debug}`);
+  }
+
+  // ── pre-launch hook (#238) — before infra/session, WORK_DIR is the repo root ─
+  const preLaunchHook = runLifecycleHook('pre-launch', {
+    harnessDir,
+    agentId,
+    workDir: repoRoot,
+    ports: appPorts ?? undefined,
+    exec: options.exec,
+    log,
+  });
+  if (preLaunchHook.ran && preLaunchHook.code !== 0) {
+    errorLine(
+      `ERROR: pre-launch hook failed (exit ${preLaunchHook.code}): ${preLaunchHook.file}`,
+    );
+    return { code: preLaunchHook.code || 1 };
   }
 
   // ── Shared infra (compose, template DB, simulator toolchain) ────────────────
@@ -382,6 +399,27 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
     }
 
     writeRegistry('active');
+
+    // ── post-launch hook (#238) — session is up; failure policy is config ──────
+    const postLaunchHook = runLifecycleHook('post-launch', {
+      harnessDir,
+      agentId,
+      workDir: session.workDir,
+      envFile: session.envFile,
+      ports: portsJson,
+      exec: options.exec,
+      log,
+    });
+    if (postLaunchHook.ran && postLaunchHook.code !== 0) {
+      if (postHookFailureMode(env) === 'fail') {
+        throw new Error(
+          `post-launch hook failed (exit ${postLaunchHook.code}): ${postLaunchHook.file}`,
+        );
+      }
+      errorLine(
+        `WARN: post-launch hook failed (exit ${postLaunchHook.code}): ${postLaunchHook.file} — continuing (HARNESS_HOOK_POST_FAILURE=warn)`,
+      );
+    }
 
     if (options.claude && pm === 'pm2') {
       const tmux = tmuxSessionName(projectName, agentId);

--- a/src/runtime/teardown.ts
+++ b/src/runtime/teardown.ts
@@ -13,6 +13,7 @@ import { GitRunner, removeSessionWorktree } from './worktree';
 import { detectProcessManager } from './launch';
 import { releaseSimulator } from './xcode-sim';
 import { loadInfraState } from '../core/slot-ports';
+import { postHookFailureMode, runLifecycleHook } from './hooks';
 
 export interface TeardownSessionOptions {
   repoPath: string;
@@ -52,6 +53,20 @@ export async function teardownSession(options: TeardownSessionOptions): Promise<
     session?.worktreePath || path.join(homeDir, 'worktrees', `${projectName}-agent-${agentId}`);
   const workDir = session?.workDir ?? '';
   const branch = session?.branch ?? '';
+
+  // ── pre-teardown hook (#238) — session resources still exist ────────────────
+  const preHook = runLifecycleHook('pre-teardown', {
+    harnessDir,
+    agentId,
+    workDir: workDir || repoRoot,
+    envFile: workDir ? path.join(workDir, `.env.agent.${agentId}`) : undefined,
+    exec: options.exec,
+    log: (message) => out(`==> ${message}`),
+  });
+  if (preHook.ran && preHook.code !== 0) {
+    out(`ERROR: pre-teardown hook failed (exit ${preHook.code}): ${preHook.file}`);
+    return { code: preHook.code || 1 };
+  }
 
   if (pm === 'pm2') {
     deleteAgentProcesses({
@@ -105,6 +120,24 @@ export async function teardownSession(options: TeardownSessionOptions): Promise<
   }
 
   removeSlotRegistry(repoRoot, agentId);
+
+  // ── post-teardown hook (#238) — everything is gone; failure policy is config ─
+  const postHook = runLifecycleHook('post-teardown', {
+    harnessDir,
+    agentId,
+    workDir: repoRoot,
+    exec: options.exec,
+    log: (message) => out(`==> ${message}`),
+  });
+  if (postHook.ran && postHook.code !== 0) {
+    if (postHookFailureMode(env) === 'fail') {
+      out(`ERROR: post-teardown hook failed (exit ${postHook.code}): ${postHook.file}`);
+      return { code: postHook.code || 1 };
+    }
+    out(
+      `WARN: post-teardown hook failed (exit ${postHook.code}): ${postHook.file} — continuing (HARNESS_HOOK_POST_FAILURE=warn)`,
+    );
+  }
 
   out(`✓ Agent ${agentId} torn down`);
   return { code: 0 };

--- a/src/runtime/verify.ts
+++ b/src/runtime/verify.ts
@@ -5,6 +5,7 @@ import { getHarnessDir, resolveHarnessRoot } from '../harness/manifest';
 import { resolveAgentEnvFile } from '../core/slot-status';
 import { readSlotRegistry } from '../core/slot-registry';
 import { detectProcessManager } from './launch';
+import { lifecycleHookPath } from './hooks';
 
 export interface VerifyPlan {
   /** Bash program that sources the agent env and execs the stage runner. */
@@ -112,6 +113,9 @@ export function buildVerifyPlan(
       : `==> Verifying agent ${agentId} (work dir: \${WORK_DIR})...`;
 
   const xcBlock = pm === 'simulator' ? XC_BLOCK : API_PORT_BLOCK;
+  // Lifecycle hook (#238): user-owned pre-verify runs before the stage runner,
+  // with the same exported contract; a non-zero exit fails verify with attribution.
+  const preVerifyHook = lifecycleHookPath(harnessDir, 'pre-verify');
 
   const shellCommand = `set -euo pipefail
 set -a
@@ -129,6 +133,16 @@ else
 fi
 export HAR_HARNESS_DIR=${JSON.stringify(harnessDir)}
 export WORK_DIR AGENT_ID
+ENV_FILE=${JSON.stringify(envFile)}
+export ENV_FILE
+if [ -f ${JSON.stringify(preVerifyHook)} ]; then
+  echo "==> Running .har/hooks/pre-verify.sh..." >&2
+  (cd "$WORK_DIR" && HAR_HOOK=pre-verify HAR_HOOK_CONTRACT=1 bash ${JSON.stringify(preVerifyHook)}) || {
+    hook_code=$?
+    echo "ERROR: pre-verify hook failed (exit $hook_code): .har/hooks/pre-verify.sh" >&2
+    exit "$hook_code"
+  }
+fi
 ${xcBlock}
 exec node ${JSON.stringify(resolveVerifyRunner(harnessDir))} --agent ${agentId}${full ? ' --full' : ''}`;
 

--- a/src/templates/adaptation-prompt-init.md
+++ b/src/templates/adaptation-prompt-init.md
@@ -136,6 +136,23 @@ If the user ran `har env add-plugin playwright` (or `@playwright/test` is in pac
 
 See `.har/stages/PLAYWRIGHT.md` when present.
 
+### Custom lifecycle behavior — `.har/hooks/` (optional)
+
+Need something custom at launch/verify/teardown time (warm a cache, prep test
+fixtures, prepare screenshots, clean up external resources)? Do **not** edit
+harness machinery — drop an executable script into `.har/hooks/`:
+
+`pre-launch.sh` · `post-launch.sh` · `pre-verify.sh` · `pre-teardown.sh` · `post-teardown.sh`
+
+Hooks receive a stable env contract (`HAR_HOOK_CONTRACT=1`): `AGENT_ID`,
+`WORK_DIR`, `ENV_FILE` (once the session has one), `HAR_HARNESS_DIR`, and
+`HAR_PORT_<NAME>` for allocated ports. A failing `pre-*` hook aborts the
+operation with attribution; `post-*` failures warn by default (set
+`HARNESS_HOOK_POST_FAILURE=fail` in `harness.env` to make them fatal). Hooks
+are user-owned: never drift-checked; `har env doctor` only validates names and
+executability. Use registered stages for verification steps; use hooks for
+lifecycle side effects.
+
 ### `.har/CLAUDE.agent.md`
 Detailed agent instructions: commands, credentials, architecture, definition of done.
 

--- a/src/templates/adaptation-prompt-maintain.md
+++ b/src/templates/adaptation-prompt-maintain.md
@@ -63,6 +63,17 @@ Look specifically for drift introduced since the last adaptation:
 Update `.har/CLAUDE.agent.md` with skipped setup steps, substitutes, credentials,
 and the repo-specific definition of "agent usable."
 
+### Custom lifecycle behavior — `.har/hooks/`
+
+Custom launch/verify/teardown needs belong in lifecycle hooks, never in edits
+to harness machinery: `.har/hooks/pre-launch.sh`, `post-launch.sh`,
+`pre-verify.sh`, `pre-teardown.sh`, `post-teardown.sh`. Hooks receive
+`AGENT_ID`, `WORK_DIR`, `ENV_FILE`, `HAR_HARNESS_DIR`, and `HAR_PORT_<NAME>`
+(contract `HAR_HOOK_CONTRACT=1`). Failing `pre-*` hooks abort the operation;
+`post-*` failures warn unless `HARNESS_HOOK_POST_FAILURE=fail`. Hooks are
+user-owned and never drift-checked — if a past adaptation patched machinery
+scripts for a lifecycle side effect, move that code into a hook.
+
 ### HAR platform upgrades checklist
 
 When upgrading `@osfactory/har` or adopting new harness standards:

--- a/tests/harness-doctor.test.ts
+++ b/tests/harness-doctor.test.ts
@@ -202,3 +202,44 @@ describe('har env doctor (#232)', () => {
     expect(text).toContain('Doctor: FAIL');
   });
 });
+
+describe('doctor lifecycle hooks check (#238)', () => {
+  it('passes silently with valid executable hooks', () => {
+    const repo = makeRepo();
+    const hooksDir = path.join(repo, '.har', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    const hook = path.join(hooksDir, 'pre-launch.sh');
+    fs.writeFileSync(hook, '#!/usr/bin/env bash\ntrue\n');
+    fs.chmodSync(hook, 0o755);
+    const report = runDoctor(repo);
+    expect(report.findings.filter((f) => f.check === 'hooks')).toEqual([]);
+    expect(report.checks.find((c) => c.id === 'hooks')?.status).toBe('pass');
+  });
+
+  it('warns on a non-executable hook', () => {
+    const repo = makeRepo();
+    const hooksDir = path.join(repo, '.har', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-verify.sh'), '#!/usr/bin/env bash\ntrue\n');
+    fs.chmodSync(path.join(hooksDir, 'pre-verify.sh'), 0o644);
+    const report = runDoctor(repo);
+    const findings = report.findings.filter((f) => f.check === 'hooks');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toContain('not executable');
+    expect(report.ok).toBe(true); // warning, not error
+  });
+
+  it('warns on an unrecognized hook name', () => {
+    const repo = makeRepo();
+    const hooksDir = path.join(repo, '.har', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    const hook = path.join(hooksDir, 'mid-launch.sh');
+    fs.writeFileSync(hook, '#!/usr/bin/env bash\ntrue\n');
+    fs.chmodSync(hook, 0o755);
+    const report = runDoctor(repo);
+    const findings = report.findings.filter((f) => f.check === 'hooks');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain('not a recognized lifecycle hook');
+  });
+});

--- a/tests/profile-composition.test.ts
+++ b/tests/profile-composition.test.ts
@@ -105,3 +105,19 @@ describe('adaptation prompt is generated, not templated', () => {
     expect(flagged.filter((f) => f.startsWith('ADAPT-PROMPT'))).toEqual([]);
   });
 });
+
+describe('lifecycle hooks are user-owned (#238)', () => {
+  it('.har/hooks/ scripts never appear in drift', () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-hooks-drift-'));
+    tmpDirs.push(repoPath);
+    scaffoldHarnessBoilerplate(repoPath, { profile: 'cli' });
+    const hooksDir = path.join(repoPath, '.har', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(path.join(hooksDir, 'pre-launch.sh'), '#!/usr/bin/env bash\ntrue\n');
+    fs.chmodSync(path.join(hooksDir, 'pre-launch.sh'), 0o755);
+
+    const drift = compareHarnessToTemplate(repoPath);
+    const flagged = [...drift.missing, ...drift.checksumMismatch, ...drift.extra];
+    expect(flagged.filter((f) => f.includes('hooks'))).toEqual([]);
+  });
+});

--- a/tests/runtime-hooks.test.ts
+++ b/tests/runtime-hooks.test.ts
@@ -1,0 +1,189 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import {
+  HOOK_CONTRACT_VERSION,
+  LIFECYCLE_HOOKS,
+  hookEnv,
+  lifecycleHookPath,
+  postHookFailureMode,
+  runLifecycleHook,
+} from '../src/runtime/hooks';
+import { buildVerifyPlan } from '../src/runtime/verify';
+import { teardownSession } from '../src/runtime/teardown';
+
+function makeRepo(): { repo: string; harnessDir: string } {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-hooks-'));
+  const harnessDir = path.join(repo, '.har');
+  fs.mkdirSync(path.join(harnessDir, 'hooks'), { recursive: true });
+  fs.writeFileSync(
+    path.join(harnessDir, 'harness.env'),
+    'export HARNESS_PROJECT_NAME=hooks-fixture\n',
+  );
+  return { repo, harnessDir };
+}
+
+function writeHook(harnessDir: string, name: string, body: string): string {
+  const file = path.join(harnessDir, 'hooks', `${name}.sh`);
+  fs.writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+describe('lifecycle hooks (#238)', () => {
+  it('exposes the five sanctioned hook points', () => {
+    expect([...LIFECYCLE_HOOKS]).toEqual([
+      'pre-launch',
+      'post-launch',
+      'pre-verify',
+      'pre-teardown',
+      'post-teardown',
+    ]);
+  });
+
+  it('does nothing when the hook file does not exist', () => {
+    const { harnessDir } = makeRepo();
+    const log = jest.fn();
+    const result = runLifecycleHook('pre-launch', { harnessDir, agentId: 1, log });
+    expect(result).toEqual({ ran: false, code: 0 });
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('hookEnv carries the versioned contract (AGENT_ID, WORK_DIR, ENV_FILE, ports)', () => {
+    const { harnessDir } = makeRepo();
+    const env = hookEnv('post-launch', {
+      harnessDir,
+      agentId: 3,
+      workDir: '/tmp/wd',
+      envFile: '/tmp/wd/.env.agent.3',
+      ports: { frontend: 3030, api: 8030, 'minio-console': 19001 },
+    });
+    expect(env.HAR_HOOK).toBe('post-launch');
+    expect(env.HAR_HOOK_CONTRACT).toBe(HOOK_CONTRACT_VERSION);
+    expect(env.AGENT_ID).toBe('3');
+    expect(env.HAR_HARNESS_DIR).toBe(harnessDir);
+    expect(env.WORK_DIR).toBe('/tmp/wd');
+    expect(env.ENV_FILE).toBe('/tmp/wd/.env.agent.3');
+    expect(env.HAR_PORT_FRONTEND).toBe('3030');
+    expect(env.HAR_PORT_API).toBe('8030');
+    expect(env.HAR_PORT_MINIO_CONSOLE).toBe('19001');
+  });
+
+  it('runs an existing hook through bash and reports its exit code', () => {
+    const { harnessDir } = makeRepo();
+    const file = writeHook(harnessDir, 'pre-launch', 'exit 7');
+    const log = jest.fn();
+    const exec = jest.fn(() => ({ stdout: '', code: 7 }));
+    const result = runLifecycleHook('pre-launch', { harnessDir, agentId: 1, exec, log });
+    expect(result).toEqual({ ran: true, code: 7, file: '.har/hooks/pre-launch.sh' });
+    expect(exec).toHaveBeenCalledWith(
+      'bash',
+      [file],
+      expect.objectContaining({ env: expect.objectContaining({ HAR_HOOK: 'pre-launch' }) }),
+    );
+    expect(log).toHaveBeenCalledWith('Running .har/hooks/pre-launch.sh...');
+  });
+
+  it('executes for real (spawn path): env contract reaches the script', () => {
+    const { repo, harnessDir } = makeRepo();
+    const marker = path.join(repo, 'hook-ran.txt');
+    writeHook(
+      harnessDir,
+      'post-teardown',
+      `echo "$HAR_HOOK:$AGENT_ID:$HAR_HOOK_CONTRACT" > ${JSON.stringify(marker)}`,
+    );
+    const result = runLifecycleHook('post-teardown', { harnessDir, agentId: 4, workDir: repo });
+    expect(result.code).toBe(0);
+    expect(fs.readFileSync(marker, 'utf8').trim()).toBe(`post-teardown:4:${HOOK_CONTRACT_VERSION}`);
+  });
+
+  it('post-hook failure policy defaults to warn, opt-in fail', () => {
+    expect(postHookFailureMode({})).toBe('warn');
+    expect(postHookFailureMode({ HARNESS_HOOK_POST_FAILURE: 'warn' })).toBe('warn');
+    expect(postHookFailureMode({ HARNESS_HOOK_POST_FAILURE: 'fail' })).toBe('fail');
+  });
+
+  it('lifecycleHookPath points into .har/hooks/', () => {
+    const { harnessDir } = makeRepo();
+    expect(lifecycleHookPath(harnessDir, 'pre-verify')).toBe(
+      path.join(harnessDir, 'hooks', 'pre-verify.sh'),
+    );
+  });
+});
+
+describe('pre-verify hook in the verify plan (#238)', () => {
+  function makeVerifyRepo(): { repo: string; harnessDir: string } {
+    const { repo, harnessDir } = makeRepo();
+    fs.writeFileSync(path.join(repo, '.env.agent.1'), 'AGENT_ID=1\n');
+    // A stand-in stage runner so the plan can execute end-to-end in the test.
+    fs.mkdirSync(path.join(harnessDir, 'lib'), { recursive: true });
+    fs.writeFileSync(
+      path.join(harnessDir, 'lib', 'verify-runner.mjs'),
+      'console.log("RUNNER-RAN");\n',
+    );
+    return { repo, harnessDir };
+  }
+
+  it('plan exports ENV_FILE and guards the runner behind the hook', () => {
+    const { repo } = makeVerifyRepo();
+    const plan = buildVerifyPlan(repo, 1, [], process.env);
+    expect(plan.shellCommand).toContain('hooks/pre-verify.sh');
+    expect(plan.shellCommand).toContain('export ENV_FILE');
+    expect(plan.shellCommand).toContain('ERROR: pre-verify hook failed');
+  });
+
+  it('a failing pre-verify hook aborts verify with its exit code', () => {
+    const { repo, harnessDir } = makeVerifyRepo();
+    writeHook(harnessDir, 'pre-verify', 'echo "hook says no" >&2; exit 9');
+    const plan = buildVerifyPlan(repo, 1, [], process.env);
+    let code = 0;
+    let output = '';
+    try {
+      output = execSync(plan.shellCommand, {
+        cwd: plan.cwd,
+        shell: '/bin/bash',
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      const e = err as { status?: number; stdout?: string; stderr?: string };
+      code = e.status ?? 1;
+      output = `${e.stdout ?? ''}${e.stderr ?? ''}`;
+    }
+    expect(code).toBe(9);
+    expect(output).toContain('pre-verify hook failed (exit 9)');
+    expect(output).not.toContain('RUNNER-RAN');
+  });
+
+  it('a passing pre-verify hook lets the runner execute', () => {
+    const { repo, harnessDir } = makeVerifyRepo();
+    writeHook(harnessDir, 'pre-verify', 'true');
+    const plan = buildVerifyPlan(repo, 1, [], process.env);
+    const output = execSync(plan.shellCommand, {
+      cwd: plan.cwd,
+      shell: '/bin/bash',
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    expect(output).toContain('RUNNER-RAN');
+  });
+});
+
+describe('teardown hooks (#238)', () => {
+  it('a failing pre-teardown hook aborts teardown before any resource is touched', async () => {
+    const { repo, harnessDir } = makeRepo();
+    writeHook(harnessDir, 'pre-teardown', 'exit 3');
+    const lines: string[] = [];
+    const exec = jest.fn(() => ({ stdout: '', code: 3 }));
+    const result = await teardownSession({
+      repoPath: repo,
+      agentId: 1,
+      out: (m) => lines.push(m),
+      exec,
+    });
+    expect(result.code).toBe(3);
+    expect(lines.join('\n')).toContain('pre-teardown hook failed (exit 3)');
+    expect(lines.join('\n')).not.toContain('torn down');
+  });
+});


### PR DESCRIPTION
Closes #238

**Stack 2/4** — based on #280 (#237 two-signal drift).

Five optional user-owned hook points — `.har/hooks/pre-launch.sh`, `post-launch.sh`, `pre-verify.sh`, `pre-teardown.sh`, `post-teardown.sh` — run by the runtime with a versioned env contract (`HAR_HOOK_CONTRACT=1`: `HAR_HOOK`, `AGENT_ID`, `WORK_DIR`, `ENV_FILE`, `HAR_HARNESS_DIR`, `HAR_PORT_<NAME>`). `pre-*` failures abort the operation with attribution; `post-*` warn by default (`HARNESS_HOOK_POST_FAILURE=fail` makes them fatal, schema-validated). Doctor gains a `hooks` check (warn-only — hooks are user-owned); `.har/hooks/` is never drift-checked; adapt prompts document hooks as the sanctioned alternative to editing machinery.

Gate: M3 milestone gate runs from the top of the stack — result posted on #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)