### PR TITLE
feat: har env eject — explicit runtime ownership for power users (#239)

### DIFF
--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -428,7 +428,53 @@ milestone_asserts() {
       echo "    doctor green with hooks installed ✓"
       rm -rf "$FRESH/.har/hooks" "$hook_log"
 
-      echo "──> M3 asserts: eject/plugins (extend when #239/#240 land)"
+      echo "──> M3 asserts: explicit runtime ownership via eject (#239)"
+      if ! har "$FRESH" env eject --help >/dev/null 2>&1; then
+        echo "    SKIP: har env eject not available yet (#239 not landed in this build)"
+      else
+        # Eject on the fresh scaffold: vendored runtime + user-owned scripts,
+        # recorded in the manifest, doctor still green, adopt reverses it.
+        har "$FRESH" env eject --yes || fail "M3: har env eject failed"
+        [ -f "$FRESH/.har/runtime/har.cjs" ] || fail "M3: eject did not vendor .har/runtime/har.cjs"
+        grep -q 'runtime/har.cjs' "$FRESH/.har/launch.sh" \
+          || fail "M3: ejected launch.sh does not execute the vendored runtime"
+        if grep -q 'exec har env' "$FRESH/.har/launch.sh"; then
+          fail "M3: ejected launch.sh still delegates to an installed har"
+        fi
+        node -e '
+          const m = require(process.argv[1]);
+          if (m.ejected !== true || !m.ejectedVersion) { console.error("M3: manifest missing ejected/ejectedVersion"); process.exit(1); }
+        ' "$FRESH/.har/manifest.json" || fail "M3: eject not recorded in manifest.json"
+        echo "    eject vendors runtime, rewrites scripts, records the choice ✓"
+
+        har "$FRESH" env doctor >/dev/null 2>&1 || fail "M3: doctor red on an intact ejected harness"
+        echo "    doctor green on ejected harness ✓"
+
+        # Owned mode: an edited ejected script must NOT appear as drift.
+        echo '# fixture user tweak' >> "$FRESH/.har/launch.sh"
+        if har "$FRESH" env maintain 2>&1 | grep -q 'Drift (template changed).*launch\.sh'; then
+          fail "M3: edited ejected launch.sh still reported as upstream drift"
+        fi
+        echo "    ejected scripts are user-owned — no drift nagging ✓"
+
+        # Ejected scripts run the vendored runtime directly (no har on PATH).
+        (cd "$FRESH" && ./.har/preflight.sh 1 >/dev/null) \
+          || fail "M3: ejected ./.har/preflight.sh failed to run the vendored runtime"
+        echo "    ejected scripts execute the vendored runtime standalone ✓"
+
+        # Reversible: adopt restores managed shims and clears the record.
+        har "$FRESH" env adopt || fail "M3: har env adopt failed"
+        [ ! -d "$FRESH/.har/runtime" ] || fail "M3: adopt left .har/runtime/ behind"
+        grep -q 'exec har env launch' "$FRESH/.har/launch.sh" \
+          || fail "M3: adopt did not restore the managed launch.sh shim"
+        node -e '
+          const m = require(process.argv[1]);
+          if (m.ejected || m.ejectedVersion) { console.error("M3: adopt did not clear eject flags"); process.exit(1); }
+        ' "$FRESH/.har/manifest.json" || fail "M3: adopt did not clear the manifest record"
+        har "$FRESH" env doctor >/dev/null 2>&1 || fail "M3: doctor red after adopt"
+        echo "    adopt restores managed shims and clears the record ✓"
+      fi
+      echo "──> M3 asserts: plugins (extend when #240 lands)"
       ;;
     M4|M5)
       echo "──> $MILESTONE asserts: migration (extend when #241 lands)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,8 @@ Intentional holes (human-only, no MCP tool):
   agent must free its own slot with complete/teardown instead.
 - `har env add-stage --custom` — authoring a project stage is an adaptation task done in
   the checkout, not a tool call; agents edit `.har/stages.json` + `stages/` directly.
+- `har env eject` / `har env adopt` — taking (or returning) ownership of the runtime
+  scripts is a deliberate human policy decision with an interactive confirmation.
 - Hooks / commit-gate onboarding (`har hooks …`, init/maintain onboarding prompts) —
   installs git hooks and records user policy preferences; a policy decision for humans.
 - Onboarding/preferences, telemetry toggles, and portal login (`har onboard`,

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -56,6 +56,8 @@ With `--yes` and no `--agent-slots`, the profile template default is kept.
 | `complete <id>` | Full verify, record validation, teardown, keep branch |
 | `teardown <id>` | Free a slot without a completion validation; keep branch |
 | `doctor` | Validate the harness contract (schema, stages, scripts, port lanes) |
+| `eject` | Vendor the runtime into `.har/runtime/` and own the scripts yourself |
+| `adopt` | Return an ejected harness to managed shims |
 | `status` | Inspect all slots |
 | `logs <id> [service]` | Show recent logs for a slot (optionally one service) |
 | `agent <id> <command>` | Per-slot ops: `status`, `logs`, `restart`, `psql`, `health`, `url`, `reset-db`, `slow-queries`, `exec`, `attach` |
@@ -183,8 +185,32 @@ coherent (no overlaps, defaults inside scan ranges), and slot registry entries
 point at existing worktrees. Every finding carries a remedy. Doctor also runs
 automatically inside `har env maintain` and before every `launch` — a broken
 adaptation blocks the launch instead of failing mid-session. Pre-1.0 harnesses
-report contract findings as warnings until they migrate. MCP twin:
-`har_doctor`.
+report contract findings as warnings until they migrate. On an ejected
+harness, doctor additionally checks the vendored runtime exists and the
+user-owned scripts are executable. MCP twin: `har_doctor`.
+
+### Eject and adopt
+
+```bash
+har env eject [--yes]
+har env adopt
+```
+
+`eject` is the explicit, supported path for power users who want to own the
+runtime scripts: it vendors the complete HAR runtime bundle into
+`.har/runtime/` and rewrites the `.har/*.sh` scripts to execute it directly
+with node — no `har` on PATH, no npx fallback. The choice is recorded in
+`.har/manifest.json` (`ejected`, `ejectedVersion`). From then on those files
+are user-owned: `maintain` reports no upstream drift for them, and upstream
+fixes reach them only by re-ejecting. Support covers issues reproducible with
+the managed shims; changes made to an ejected runtime are yours to maintain.
+Config surface files (`harness.env`, `stages.json`, `stages/`, docs) stay
+managed either way.
+
+`adopt` reverses it: regenerates the managed shims, removes `.har/runtime/`,
+and clears the manifest record, preserving the config surface. Both commands
+are deliberately CLI-only (no MCP twin) — runtime ownership is a human policy
+decision with an interactive confirmation (`--yes` for automation).
 
 ### Status and runs
 

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -48,6 +48,10 @@ export const HarnessManifestSchema = z.object({
     .optional(),
   adaptationSummary: z.string().optional(),
   profile: z.enum(['default', 'cli', 'ios']).optional(),
+  /** `har env eject` (#239): the user owns the runtime scripts + .har/runtime/. */
+  ejected: z.boolean().optional(),
+  /** @osfactory/har version whose runtime was vendored at eject time. */
+  ejectedVersion: z.string().optional(),
   fileChecksums: z.record(z.string()).optional(),
   /**
    * Checksums of the composed bundled templates at last init/finalize —

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -36,6 +36,7 @@ import { listRuns, getRun } from '../../core/runs';
 import { runAgentOp } from '../../runtime';
 import { addWorkUnitLinks, parseWorkLinkSpec } from '../../core/work-units';
 import { resolveHarnessRoot } from '../../harness/manifest';
+import { adoptHarness, ejectHarness } from '../../harness/eject';
 import { formatDoctorReport, runDoctor, summarizeDoctorReport } from '../../harness/doctor';
 import {
   confirmCleanupSelection,
@@ -418,6 +419,26 @@ export const envCommand = {
         handleDoctor,
       )
       .command(
+        'eject',
+        'Vendor the HAR runtime into .har/ and own the scripts yourself (reversible: har env adopt)',
+        (y: Argv) =>
+          y
+            .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+            .option('yes', {
+              alias: 'y',
+              type: 'boolean',
+              default: false,
+              describe: 'Skip the confirmation prompt',
+            }),
+        handleEject,
+      )
+      .command(
+        'adopt',
+        'Return an ejected harness to managed shims (removes .har/runtime/, keeps your config)',
+        (y: Argv) => y.option('repo', { type: 'string', default: '.', describe: 'Path to the repository' }),
+        handleAdopt,
+      )
+      .command(
         'status',
         'Show status of all running agents',
         (y: Argv) =>
@@ -537,7 +558,7 @@ export const envCommand = {
       )
       .demandCommand(
         1,
-        'Please specify a subcommand: init, maintain, add-plugin, add-stage, launch, recover, verify, complete, teardown, doctor, status, logs, run-stage, artifacts, cleanup, runs',
+        'Please specify a subcommand: init, maintain, add-plugin, add-stage, launch, recover, verify, complete, teardown, doctor, eject, adopt, status, logs, run-stage, artifacts, cleanup, runs',
       )
       .epilog(HAR_ENV_EPILOG),
   handler: () => {},
@@ -1251,6 +1272,63 @@ export async function handleDoctor(argv: { repo: string; json?: boolean }): Prom
   return finishCommand(report.ok ? 0 : 1);
 }
 
+async function confirm(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+  const readline = await import('readline');
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  const answer = await new Promise<string>((resolve) => rl.question(question, resolve));
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+export async function handleEject(argv: { repo: string; yes: boolean }): Promise<void> {
+  const repoPath = resolveHarnessRoot(path.resolve(argv.repo));
+
+  header('har env eject');
+  warn('This vendors the complete HAR runtime into .har/runtime/ and rewrites the');
+  warn('.har/*.sh scripts to execute it directly — from then on YOU OWN those files:');
+  warn('  • har env maintain will no longer update them (no upstream drift reports)');
+  warn('  • upstream fixes and features reach you only by re-ejecting or adopting');
+  warn('  • support covers issues reproducible with managed shims; changes you make');
+  warn('    to the ejected runtime are yours to maintain');
+  warn('Config files (harness.env, stages.json, stages/, hooks, docs) stay managed.');
+  info('Reversible anytime: `har env adopt` (or `har env init --force`).');
+
+  if (!argv.yes) {
+    const ok = await confirm('Eject the runtime and own the scripts yourself? [y/N] ');
+    if (!ok) {
+      info('Aborted — nothing changed. Pass --yes to skip this prompt.');
+      return finishCommand(1);
+    }
+  }
+
+  try {
+    const result = ejectHarness(repoPath);
+    success(`Ejected @osfactory/har@${result.version} → .har/runtime/`);
+    info(`  Rewritten as user-owned: ${result.scripts.map((s) => `.har/${s}`).join(', ')}`);
+    info('  Recorded in .har/manifest.json (ejected: true) — commit .har/ to keep it.');
+    info('  Return to managed shims anytime: har env adopt');
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    return finishCommand(1);
+  }
+  return finishCommand(0);
+}
+
+export async function handleAdopt(argv: { repo: string }): Promise<void> {
+  const repoPath = resolveHarnessRoot(path.resolve(argv.repo));
+  try {
+    const result = adoptHarness(repoPath);
+    success('Returned to managed shims — .har/runtime/ removed, eject flag cleared.');
+    info(`  Regenerated: ${result.scripts.map((s) => `.har/${s}`).join(', ')}`);
+    info('  Config surface files (harness.env, stages.json, stages/, docs) were not touched.');
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    return finishCommand(1);
+  }
+  return finishCommand(0);
+}
+
 export async function handleStatus(argv: { repo: string; json?: boolean }): Promise<void> {
   const repoPath = path.resolve(argv.repo);
 
@@ -1475,6 +1553,9 @@ function printValidation(result: {
 }
 
 function printDrift(drift: HarnessDriftResult): void {
+  if (drift.ownedByUser.length > 0) {
+    info(`  User-owned (ejected, never drift-checked): ${drift.ownedByUser.join(', ')}`);
+  }
   if (drift.conflict.length > 0) {
     warn(`  Conflict (upstream updated AND user edited — merge): ${drift.conflict.join(', ')}`);
   }

--- a/src/harness/doctor.ts
+++ b/src/harness/doctor.ts
@@ -1,8 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { listSlotRegistryEntries } from '../core/slot-registry';
+import { EJECTED_RUNTIME_BUNDLE, EJECTED_RUNTIME_DIR } from './eject';
 import { readValidatedHarnessEnv } from './env';
-import { getHarnessDir } from './manifest';
+import { getHarnessDir, readManifest } from './manifest';
+import { RUNTIME_SHIM_FILES } from './template-tokens';
 import { HarnessStage, HarnessStageRegistry, PortLane } from './schema';
 import { readStageRegistry } from './stages';
 import { findPhantomVerificationStageIds } from './verification';
@@ -24,7 +26,8 @@ export type DoctorCheckId =
   | 'verification-ids'
   | 'port-lanes'
   | 'slot-registry'
-  | 'hooks';
+  | 'hooks'
+  | 'ejected-runtime';
 
 export type DoctorContract = '1.0' | 'pre-1.0' | 'none';
 
@@ -69,6 +72,7 @@ const CHECK_LABELS: Record<DoctorCheckId, string> = {
   'port-lanes': 'infra port lanes',
   'slot-registry': 'slot registry worktrees',
   hooks: 'lifecycle hooks (.har/hooks)',
+  'ejected-runtime': 'ejected runtime (user-owned)',
 };
 
 /** Legacy helper functions whose presence marks a pre-1.0 harness.env. */
@@ -301,7 +305,39 @@ export function runDoctor(repoPath: string): DoctorReport {
     }
   }
 
-  // 7. Slot registry entries point at existing worktrees
+  // 7. Ejected runtime (#239): the vendored runtime the user-owned scripts
+  // execute must exist and the scripts must be executable. Not ejected → skip.
+  const manifest = readManifest(repoPath);
+  if (!manifest?.ejected) {
+    skipped.add('ejected-runtime');
+  } else {
+    const runtimeRel = path.join(EJECTED_RUNTIME_DIR, EJECTED_RUNTIME_BUNDLE);
+    const runtimePath = path.join(harnessDir, runtimeRel);
+    if (!fs.existsSync(runtimePath)) {
+      findings.push({
+        check: 'ejected-runtime',
+        severity: 'error',
+        file: runtimeRel,
+        message: `Harness is ejected but the vendored runtime .har/${runtimeRel} is missing`,
+        remedy: 'Restore it from git, re-run `har env eject`, or return to managed shims with `har env adopt`',
+      });
+    }
+    for (const shim of RUNTIME_SHIM_FILES) {
+      const shimPath = path.join(harnessDir, shim);
+      if (!fs.existsSync(shimPath)) continue; // missing lifecycle scripts are caught above
+      if (!(fs.statSync(shimPath).mode & 0o111)) {
+        findings.push({
+          check: 'ejected-runtime',
+          severity: 'warning',
+          file: shim,
+          message: `Ejected script ${shim} is not executable`,
+          remedy: `chmod +x .har/${shim}`,
+        });
+      }
+    }
+  }
+
+  // 8. Slot registry entries point at existing worktrees
   for (const entry of listSlotRegistryEntries(repoPath)) {
     if (entry.status === 'completed') continue;
     const dir = entry.worktreePath ?? entry.workDir;

--- a/src/harness/drift.ts
+++ b/src/harness/drift.ts
@@ -14,7 +14,7 @@ import {
 } from './manifest';
 import { detectAgentSlotEnvMismatch } from './stages';
 import { composeProfileTemplateMap, readComposedTemplateContent } from './profiles';
-import { substituteTemplateTokens } from './template-tokens';
+import { RUNTIME_SHIM_FILES, substituteTemplateTokens } from './template-tokens';
 
 const CLI_EXPECTED_ABSENT = new Set([
   'ecosystem.agent.template.cjs',
@@ -54,6 +54,12 @@ export interface HarnessDriftResult {
   conflict: string[];
   extra: string[];
   unchanged: string[];
+  /**
+   * User-owned files never compared to upstream templates: on an ejected
+   * harness (#239), the runtime scripts and vendored runtime belong to the
+   * user and report no drift.
+   */
+  ownedByUser: string[];
   /** Port-allocation knobs from harness.env that the bundled template expects. */
   missingPortVars: string[];
   /** stages.json agentSlots disagree with HARNESS_AGENT_SLOT_* in harness.env. */
@@ -165,10 +171,11 @@ export function computeTemplateChecksums(
   const projectName = projectNameFor(resolved);
   const checksums: Record<string, string> = {};
   for (const [file, entry] of composeProfileTemplateMap(profile)) {
-    let content = readComposedTemplateContent(entry);
-    if (file === 'harness.env') {
-      content = substituteProjectName(content, projectName);
-    }
+    // Render generation-time tokens for every file — the comparison in
+    // compareHarnessToTemplate hashes rendered templates, so the recorded
+    // baseline must be rendered the same way or fresh shims (__HAR_VERSION__)
+    // report false upstream updates.
+    const content = substituteProjectName(readComposedTemplateContent(entry), projectName);
     checksums[harnessFileForTemplate(file)] = computeFileChecksum(content);
   }
   return checksums;
@@ -194,14 +201,26 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
   const conflict: string[] = [];
   const extra: string[] = [];
   const unchanged: string[] = [];
+  const ownedByUser: string[] = [];
+  // Ejected harness (#239): the runtime scripts are user-owned — a present
+  // script is never drift, only a missing one still is (the harness is broken).
+  const ejected = manifest?.ejected === true;
+  const userOwnedFiles = new Set<string>(ejected ? RUNTIME_SHIM_FILES : []);
 
   for (const file of templateFiles) {
     const harnessFile = harnessFileForTemplate(file);
     const harnessPath = path.join(harnessDir, harnessFile);
-    let templateContent = readComposedTemplateContent(composed.get(file)!);
-    if (file === 'harness.env') {
-      templateContent = substituteProjectName(templateContent, projectName);
+    if (userOwnedFiles.has(harnessFile) && fs.existsSync(harnessPath)) {
+      ownedByUser.push(harnessFile);
+      continue;
     }
+    // Render generation-time tokens (__PROJECT_NAME__, __HAR_VERSION__) so the
+    // comparison matches what the generator actually wrote — otherwise every
+    // fresh shim reports false drift against its own unrendered template.
+    const templateContent = substituteProjectName(
+      readComposedTemplateContent(composed.get(file)!),
+      projectName,
+    );
 
     if (!fs.existsSync(harnessPath)) {
       missing.push(harnessFile);
@@ -281,6 +300,7 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
     conflict,
     extra,
     unchanged,
+    ownedByUser,
     missingPortVars,
     agentSlotMismatch,
   };

--- a/src/harness/eject.ts
+++ b/src/harness/eject.ts
@@ -1,0 +1,200 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getHarPackageVersion } from '../core/package-version';
+import { computeHarnessChecksums, getHarnessDir, readManifest, writeManifest } from './manifest';
+import type { HarnessProfile } from './profiles';
+import { composeProfileTemplateMap, readComposedTemplateContent } from './profiles';
+import { RUNTIME_SHIM_FILES, substituteTemplateTokens } from './template-tokens';
+
+/**
+ * `har env eject` (#239) — explicit runtime ownership for power users.
+ *
+ * Ejecting vendors the packaged runtime (the same bundle `har` itself runs)
+ * into `.har/runtime/` and rewrites the `.har/*.sh` scripts to execute it
+ * directly with node — no `har` on PATH, no npx network fallback. From that
+ * point the scripts and the vendored runtime are user-owned: drift/maintain
+ * stop comparing them to upstream templates, while `har env doctor` keeps
+ * validating the contract (stages resolve, env schema, registry shape).
+ *
+ * Reversible: `har env adopt` (or `har env init --force`) restores managed
+ * shims and removes `.har/runtime/`.
+ */
+
+export const EJECTED_RUNTIME_DIR = 'runtime';
+export const EJECTED_RUNTIME_BUNDLE = 'har.cjs';
+
+export interface EjectResult {
+  scripts: string[];
+  runtimeFile: string;
+  version: string;
+}
+
+export interface AdoptResult {
+  scripts: string[];
+}
+
+/** Locate the built runtime bundle for both bundled (dist/index.js) and dev (tsx) runs. */
+export function resolveRuntimeBundleSource(): string | null {
+  if (process.env.HAR_EJECT_RUNTIME_SOURCE) {
+    return fs.existsSync(process.env.HAR_EJECT_RUNTIME_SOURCE)
+      ? process.env.HAR_EJECT_RUNTIME_SOURCE
+      : null;
+  }
+  const candidates = [
+    // Bundled CLI: __dirname is dist/ and index.js is the self-contained runtime.
+    path.join(__dirname, 'index.js'),
+    // Dev (tsx src/…): fall back to a previously built dist/ at the repo root.
+    path.resolve(__dirname, '..', '..', 'dist', 'index.js'),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * The managed shim's delegate line (`exec har env launch "$@"`, `exec har env
+ * verify "$@" --json`, …) is the arg-convention contract each script must
+ * keep. Ejected scripts reuse it verbatim against the vendored runtime.
+ */
+function shimDelegateArgs(templateContent: string): string | null {
+  const match = templateContent.match(/^\s*exec har env (.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+function usageLine(templateContent: string): string | null {
+  const match = templateContent.match(/^# Usage: (.+)$/m);
+  return match ? `# Usage: ${match[1].trim()}` : null;
+}
+
+function buildEjectedScript(name: string, delegateArgs: string, usage: string | null, version: string): string {
+  return [
+    '#!/usr/bin/env bash',
+    `# EJECTED runtime (har env eject, @osfactory/har@${version}) — you own this file`,
+    '# and .har/runtime/. HAR maintain/drift will not update them; har env doctor',
+    '# still validates the harness contract. Return to managed shims: har env adopt.',
+    ...(usage ? [usage] : []),
+    'set -euo pipefail',
+    'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+    `export HAR_PACKAGE_VERSION="\${HAR_PACKAGE_VERSION:-${version}}"`,
+    `exec node "$SCRIPT_DIR/${EJECTED_RUNTIME_DIR}/${EJECTED_RUNTIME_BUNDLE}" env ${delegateArgs}`,
+    '',
+  ].join('\n');
+}
+
+const RUNTIME_README = (version: string): string => `# .har/runtime/ — ejected HAR runtime
+
+This directory was created by \`har env eject\`. It contains the complete HAR
+runtime bundle (@osfactory/har@${version}) that the \`.har/*.sh\` scripts execute
+directly with node. You own these files:
+
+- HAR will never update them — \`har env maintain\` treats them as user-owned
+  and reports no upstream drift for them.
+- \`har env doctor\` still validates the harness contract (harness.env schema,
+  stages.json registry, stage scripts, port lanes).
+- Support expectation: issues reproducible with the managed shims are
+  supported; behavior you change in an ejected runtime is yours to maintain.
+- Lifecycle commands that manage templates (\`init\`, \`maintain\`, \`eject\`,
+  \`adopt\`, plugins) still require an installed \`har\`.
+
+Return to managed shims (removes this directory, regenerates \`.har/*.sh\`):
+
+    har env adopt
+
+`;
+
+/** Vendors the runtime into .har/runtime/ and rewrites the shims to execute it. */
+export function ejectHarness(repoPath: string): EjectResult {
+  const resolved = path.resolve(repoPath);
+  const harnessDir = getHarnessDir(resolved);
+  const manifest = readManifest(resolved);
+  if (!manifest) {
+    throw new Error('No .har/manifest.json found. Run "har env init" first.');
+  }
+  if (manifest.ejected) {
+    throw new Error(
+      `Harness is already ejected (@osfactory/har@${manifest.ejectedVersion ?? 'unknown'}). ` +
+        'Run "har env adopt" first to return to managed shims.',
+    );
+  }
+
+  const bundleSource = resolveRuntimeBundleSource();
+  if (!bundleSource) {
+    throw new Error('Cannot locate the built HAR runtime bundle (dist/index.js). Run npm run build.');
+  }
+
+  const version = getHarPackageVersion();
+  const profile: HarnessProfile = manifest.profile ?? 'default';
+  const composed = composeProfileTemplateMap(profile);
+
+  const runtimeDir = path.join(harnessDir, EJECTED_RUNTIME_DIR);
+  fs.mkdirSync(runtimeDir, { recursive: true });
+  const runtimeFile = path.join(runtimeDir, EJECTED_RUNTIME_BUNDLE);
+  fs.copyFileSync(bundleSource, runtimeFile);
+  fs.chmodSync(runtimeFile, 0o755);
+  fs.writeFileSync(path.join(runtimeDir, 'README.md'), RUNTIME_README(version));
+
+  const scripts: string[] = [];
+  for (const shim of RUNTIME_SHIM_FILES) {
+    const source = composed.get(shim);
+    if (!source) continue;
+    const templateContent = readComposedTemplateContent(source);
+    const delegateArgs = shimDelegateArgs(templateContent);
+    if (!delegateArgs) continue;
+    const scriptPath = path.join(harnessDir, shim);
+    fs.writeFileSync(scriptPath, buildEjectedScript(shim, delegateArgs, usageLine(templateContent), version));
+    fs.chmodSync(scriptPath, 0o755);
+    scripts.push(shim);
+  }
+
+  writeManifest(resolved, {
+    ...manifest,
+    ejected: true,
+    ejectedVersion: version,
+    fileChecksums: computeHarnessChecksums(harnessDir),
+    updatedAt: new Date().toISOString(),
+  });
+
+  return { scripts, runtimeFile, version };
+}
+
+/** Reverses eject: regenerates managed shims and removes .har/runtime/. */
+export function adoptHarness(repoPath: string): AdoptResult {
+  const resolved = path.resolve(repoPath);
+  const harnessDir = getHarnessDir(resolved);
+  const manifest = readManifest(resolved);
+  if (!manifest) {
+    throw new Error('No .har/manifest.json found. Run "har env init" first.');
+  }
+  if (!manifest.ejected) {
+    throw new Error('Harness is not ejected — the managed shims are already in place.');
+  }
+
+  const profile: HarnessProfile = manifest.profile ?? 'default';
+  const composed = composeProfileTemplateMap(profile);
+  const projectName = path.basename(resolved).toLowerCase().replace(/[^a-z0-9]/g, '_');
+
+  const scripts: string[] = [];
+  for (const shim of RUNTIME_SHIM_FILES) {
+    const source = composed.get(shim);
+    if (!source) continue;
+    const rendered = substituteTemplateTokens(readComposedTemplateContent(source), projectName);
+    const scriptPath = path.join(harnessDir, shim);
+    fs.writeFileSync(scriptPath, rendered);
+    fs.chmodSync(scriptPath, 0o755);
+    scripts.push(shim);
+  }
+
+  fs.rmSync(path.join(harnessDir, EJECTED_RUNTIME_DIR), { recursive: true, force: true });
+
+  const rest = { ...manifest };
+  delete rest.ejected;
+  delete rest.ejectedVersion;
+  writeManifest(resolved, {
+    ...rest,
+    fileChecksums: computeHarnessChecksums(harnessDir),
+    updatedAt: new Date().toISOString(),
+  });
+
+  return { scripts };
+}

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -49,6 +49,8 @@ export const DescribeProjectOutputSchema = z.object({
       conflict: z.array(z.string()),
       extra: z.array(z.string()),
       unchanged: z.array(z.string()),
+      /** User-owned files on an ejected harness (#239) — present, never drift. */
+      ownedByUser: z.array(z.string()).optional(),
     })
     .nullable(),
 });

--- a/tests/eject.test.ts
+++ b/tests/eject.test.ts
@@ -1,0 +1,168 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getHarPackageVersion } from '../src/core/package-version';
+import { runDoctor } from '../src/harness/doctor';
+import { compareHarnessToTemplate } from '../src/harness/drift';
+import {
+  adoptHarness,
+  ejectHarness,
+  EJECTED_RUNTIME_BUNDLE,
+  EJECTED_RUNTIME_DIR,
+} from '../src/harness/eject';
+import { scaffoldHarnessBoilerplate } from '../src/harness/generator';
+import { readManifest } from '../src/harness/manifest';
+import { RUNTIME_SHIM_FILES } from '../src/harness/template-tokens';
+
+/**
+ * #239 acceptance: ejecting is a deliberate, recorded, reversible choice.
+ * Eject vendors the runtime into .har/runtime/, rewrites the scripts as
+ * user-owned direct executors, and flips the manifest; drift treats owned
+ * files as never-drifted; doctor validates the ejected runtime; adopt
+ * restores managed shims while preserving the config surface.
+ */
+describe('har env eject / adopt (#239)', () => {
+  let repo: string;
+  let runtimeStub: string;
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-eject-'));
+    runtimeStub = path.join(repo, 'fake-dist-index.js');
+    fs.writeFileSync(runtimeStub, '#!/usr/bin/env node\n// stub runtime bundle\n');
+    process.env.HAR_EJECT_RUNTIME_SOURCE = runtimeStub;
+    scaffoldHarnessBoilerplate(path.join(repo, 'proj'), { profile: 'default' });
+  });
+
+  afterEach(() => {
+    delete process.env.HAR_EJECT_RUNTIME_SOURCE;
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  const proj = () => path.join(repo, 'proj');
+  const har = (...p: string[]) => path.join(repo, 'proj', '.har', ...p);
+
+  it('vendors the runtime, rewrites scripts, and records the choice in the manifest', () => {
+    const result = ejectHarness(proj());
+
+    expect(result.version).toBe(getHarPackageVersion());
+    expect(fs.existsSync(har(EJECTED_RUNTIME_DIR, EJECTED_RUNTIME_BUNDLE))).toBe(true);
+    expect(fs.existsSync(har(EJECTED_RUNTIME_DIR, 'README.md'))).toBe(true);
+
+    expect(result.scripts.sort()).toEqual([...RUNTIME_SHIM_FILES].sort());
+    for (const shim of RUNTIME_SHIM_FILES) {
+      const content = fs.readFileSync(har(shim), 'utf8');
+      expect(content).toContain(`runtime/${EJECTED_RUNTIME_BUNDLE}`);
+      expect(content).toContain('EJECTED runtime');
+      // Ownership means determinism: no PATH har, no npx network fallback.
+      expect(content).not.toContain('exec har env');
+      expect(content).not.toContain('npx');
+      expect(fs.statSync(har(shim)).mode & 0o111).not.toBe(0);
+    }
+    // The delegate line keeps the managed shim's exact argument convention.
+    expect(fs.readFileSync(har('verify.sh'), 'utf8')).toContain('env verify "$@" --json');
+    expect(fs.readFileSync(har('launch.sh'), 'utf8')).toContain('env launch "$@"');
+    expect(fs.readFileSync(har('agent-cli.sh'), 'utf8')).toContain('env agent "$@"');
+
+    const manifest = readManifest(proj());
+    expect(manifest?.ejected).toBe(true);
+    expect(manifest?.ejectedVersion).toBe(getHarPackageVersion());
+  });
+
+  it('refuses to eject twice and to adopt a non-ejected harness', () => {
+    expect(() => adoptHarness(proj())).toThrow(/not ejected/);
+    ejectHarness(proj());
+    expect(() => ejectHarness(proj())).toThrow(/already ejected/);
+  });
+
+  it('drift treats ejected scripts as user-owned — edits are never drift', () => {
+    ejectHarness(proj());
+    fs.appendFileSync(har('launch.sh'), '\n# my custom pre-launch tweak\n');
+
+    const drift = compareHarnessToTemplate(proj());
+    expect(drift.ownedByUser.sort()).toEqual([...RUNTIME_SHIM_FILES].sort());
+    for (const shim of RUNTIME_SHIM_FILES) {
+      expect(drift.userAdapted).not.toContain(shim);
+      expect(drift.upstreamUpdated).not.toContain(shim);
+      expect(drift.conflict).not.toContain(shim);
+      expect(drift.missing).not.toContain(shim);
+      expect(drift.unchanged).not.toContain(shim);
+    }
+  });
+
+  it('a deleted ejected script still reports missing (broken harness, not ownership)', () => {
+    ejectHarness(proj());
+    fs.rmSync(har('teardown.sh'));
+    const drift = compareHarnessToTemplate(proj());
+    expect(drift.missing).toContain('teardown.sh');
+    expect(drift.ownedByUser).not.toContain('teardown.sh');
+  });
+
+  it('non-ejected harness reports no owned files and doctor skips the check', () => {
+    const drift = compareHarnessToTemplate(proj());
+    expect(drift.ownedByUser).toEqual([]);
+    // Fresh scaffold reports zero drift — rendered shims must be compared
+    // against rendered templates (pinned __HAR_VERSION__), not raw ones.
+    expect(drift.userAdapted).toEqual([]);
+    expect(drift.upstreamUpdated).toEqual([]);
+    expect(drift.conflict).toEqual([]);
+    const report = runDoctor(proj());
+    expect(report.checks.find((c) => c.id === 'ejected-runtime')?.status).toBe('skip');
+  });
+
+  it('doctor validates the ejected contract: green when intact, error on missing runtime', () => {
+    ejectHarness(proj());
+    let report = runDoctor(proj());
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((c) => c.id === 'ejected-runtime')?.status).toBe('pass');
+
+    fs.rmSync(har(EJECTED_RUNTIME_DIR, EJECTED_RUNTIME_BUNDLE));
+    report = runDoctor(proj());
+    expect(report.ok).toBe(false);
+    expect(
+      report.findings.some((f) => f.check === 'ejected-runtime' && f.severity === 'error'),
+    ).toBe(true);
+  });
+
+  it('doctor warns on a non-executable ejected script', () => {
+    ejectHarness(proj());
+    fs.chmodSync(har('verify.sh'), 0o644);
+    const report = runDoctor(proj());
+    expect(
+      report.findings.some(
+        (f) => f.check === 'ejected-runtime' && f.severity === 'warning' && f.file === 'verify.sh',
+      ),
+    ).toBe(true);
+  });
+
+  it('adopt restores managed shims, removes the runtime, and preserves config files', () => {
+    const envBefore = fs.readFileSync(har('harness.env'), 'utf8');
+    const stagesBefore = fs.readFileSync(har('stages.json'), 'utf8');
+
+    ejectHarness(proj());
+    const result = adoptHarness(proj());
+
+    expect(result.scripts.sort()).toEqual([...RUNTIME_SHIM_FILES].sort());
+    expect(fs.existsSync(har(EJECTED_RUNTIME_DIR))).toBe(false);
+    for (const shim of RUNTIME_SHIM_FILES) {
+      const content = fs.readFileSync(har(shim), 'utf8');
+      expect(content).toContain('exec har env');
+      expect(content).toContain(`npx --yes @osfactory/har@${getHarPackageVersion()}`);
+      expect(content).not.toContain('__HAR_VERSION__');
+      expect(fs.statSync(har(shim)).mode & 0o111).not.toBe(0);
+    }
+
+    const manifest = readManifest(proj());
+    expect(manifest?.ejected).toBeUndefined();
+    expect(manifest?.ejectedVersion).toBeUndefined();
+    expect(fs.readFileSync(har('harness.env'), 'utf8')).toBe(envBefore);
+    expect(fs.readFileSync(har('stages.json'), 'utf8')).toBe(stagesBefore);
+
+    const drift = compareHarnessToTemplate(proj());
+    expect(drift.ownedByUser).toEqual([]);
+    for (const shim of RUNTIME_SHIM_FILES) {
+      expect(drift.userAdapted).not.toContain(shim);
+      expect(drift.upstreamUpdated).not.toContain(shim);
+      expect(drift.conflict).not.toContain(shim);
+    }
+  });
+});

--- a/tests/harness-doctor.test.ts
+++ b/tests/harness-doctor.test.ts
@@ -57,7 +57,12 @@ describe('har env doctor (#232)', () => {
     expect(report.contract).toBe('1.0');
     expect(report.findings.filter((f) => f.severity === 'error')).toEqual([]);
     expect(report.ok).toBe(true);
-    expect(report.checks.every((c) => c.status === 'pass')).toBe(true);
+    // ejected-runtime (#239) is skipped on a non-ejected harness by design.
+    expect(
+      report.checks.every(
+        (c) => c.status === 'pass' || (c.id === 'ejected-runtime' && c.status === 'skip'),
+      ),
+    ).toBe(true);
     expect(summarizeDoctorReport(report)).toBeNull();
   });
 

--- a/tests/profile-composition.test.ts
+++ b/tests/profile-composition.test.ts
@@ -117,7 +117,13 @@ describe('lifecycle hooks are user-owned (#238)', () => {
     fs.chmodSync(path.join(hooksDir, 'pre-launch.sh'), 0o755);
 
     const drift = compareHarnessToTemplate(repoPath);
-    const flagged = [...drift.missing, ...drift.checksumMismatch, ...drift.extra];
+    const flagged = [
+      ...drift.missing,
+      ...drift.userAdapted,
+      ...drift.upstreamUpdated,
+      ...drift.conflict,
+      ...drift.extra,
+    ];
     expect(flagged.filter((f) => f.includes('hooks'))).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #239

**Stack 3/4** — based on #281 (#238 lifecycle hooks).

`har env eject` (big warning + y/N confirm, `--yes`) vendors the built runtime bundle into `.har/runtime/har.cjs` and rewrites the six `.har/*.sh` scripts to execute it directly — true ownership with no PATH/npx dependency, arg conventions preserved, pinned `HAR_PACKAGE_VERSION`. Records `ejected: true` + `ejectedVersion` in the manifest. Drift gains an `ownedByUser` bucket (present ejected scripts are never drift; deleted ones still report missing); doctor gains an `ejected-runtime` check; `har env adopt` reverses eject preserving config files (`init --force` stays the nuclear option). Eject/adopt are deliberately CLI-only (documented intentional MCP hole).

Also fixes a pre-existing #235 bug surfaced by the two-signal baseline: template checksums are now computed on rendered templates (`__HAR_VERSION__` etc.), so fresh scaffolds no longer false-report all six shims as drift.

Gate: M3 milestone gate runs from the top of the stack — result posted on #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)