### PR TITLE
fix(control): stop dropping persisted telemetry silently and page the egress collections

### DIFF
--- a/control/prisma/schema.prisma
+++ b/control/prisma/schema.prisma
@@ -111,6 +111,7 @@ model AgentSessionEvent {
 
   @@unique([repositoryId, sessionKey, agentTool, eventName, sequence])
   @@index([repositoryId, agentId, timestamp])
+  @@index([repositoryId, createdAt, id])
   @@index([timestamp])
 }
 
@@ -134,6 +135,7 @@ model AgentSessionSpan {
 
   @@unique([repositoryId, traceId, spanId])
   @@index([repositoryId, agentId, startTime])
+  @@index([repositoryId, createdAt, id])
 }
 
 model AgentTrajectoryRecord {
@@ -167,6 +169,7 @@ model AgentTrajectoryRecord {
   @@unique([repositoryId, source, sourceEventId, contentKey])
   @@index([repositoryId, agentId, sessionKey, agentTool, sequence, eventTimestamp, source])
   @@index([repositoryId, agentId, sessionKey, agentTool, createdAt])
+  @@index([repositoryId, createdAt, id])
 }
 
 model Run {

--- a/control/src/app/api/repos/[id]/events/route.ts
+++ b/control/src/app/api/repos/[id]/events/route.ts
@@ -2,13 +2,14 @@ import { NextResponse } from 'next/server';
 import type { Prisma } from '@prisma/client';
 import { SyncSessionEventsInputSchema } from '@har/schemas';
 import { listSessionEventsForRepo, syncSessionEvents } from '@/server/session-events';
+import { pageParams } from '@/server/pagination';
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const events = await listSessionEventsForRepo(id);
+  const events = await listSessionEventsForRepo(id, pageParams(new URL(request.url)));
   return NextResponse.json({ events });
 }
 

--- a/control/src/app/api/repos/[id]/spans/route.ts
+++ b/control/src/app/api/repos/[id]/spans/route.ts
@@ -1,20 +1,13 @@
 import { NextResponse } from 'next/server';
 import { listSessionSpansForRepo } from '@/server/session-spans';
+import { pageParams } from '@/server/pagination';
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const url = new URL(request.url);
-  const since = url.searchParams.get('since');
-  const requestedLimit = Number(url.searchParams.get('limit'));
-  const spans = await listSessionSpansForRepo(id, {
-    since,
-    ...(Number.isFinite(requestedLimit) && requestedLimit > 0
-      ? { limit: requestedLimit }
-      : {}),
-  });
+  const spans = await listSessionSpansForRepo(id, pageParams(new URL(request.url)));
   return NextResponse.json({
     spans: spans.map((span) => ({
       ...span,

--- a/control/src/app/api/repos/[id]/trajectory/route.ts
+++ b/control/src/app/api/repos/[id]/trajectory/route.ts
@@ -3,20 +3,13 @@ import {
   listTrajectoryForRepo,
   serializeTrajectoryForEgress,
 } from '@/server/trajectory-ledger';
+import { pageParams } from '@/server/pagination';
 
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const url = new URL(request.url);
-  const since = url.searchParams.get('since');
-  const requestedLimit = Number(url.searchParams.get('limit'));
-  const records = await listTrajectoryForRepo(id, {
-    since,
-    ...(Number.isFinite(requestedLimit) && requestedLimit > 0
-      ? { limit: requestedLimit }
-      : {}),
-  });
+  const records = await listTrajectoryForRepo(id, pageParams(new URL(request.url)));
   return NextResponse.json({ records: records.map(serializeTrajectoryForEgress) });
 }

--- a/control/src/server/pagination.test.ts
+++ b/control/src/server/pagination.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { clampPageLimit, createdAtKeyset, pageParams } from './pagination';
+
+describe('createdAtKeyset', () => {
+  it('matches everything without a watermark', () => {
+    expect(createdAtKeyset({})).toEqual({});
+    expect(createdAtKeyset({ since: null })).toEqual({});
+  });
+
+  it('ignores an unparseable watermark rather than dropping every row', () => {
+    expect(createdAtKeyset({ since: 'not-a-date' })).toEqual({});
+  });
+
+  it('filters on createdAt alone when no cursor id is given', () => {
+    expect(createdAtKeyset({ since: '2026-01-01T00:00:00.000Z' })).toEqual({
+      createdAt: { gt: new Date('2026-01-01T00:00:00.000Z') },
+    });
+  });
+
+  it('pages on (createdAt, id) so a same-millisecond batch is not skipped', () => {
+    expect(createdAtKeyset({ since: '2026-01-01T00:00:00.000Z', sinceId: 'row-2' })).toEqual({
+      OR: [
+        { createdAt: { gt: new Date('2026-01-01T00:00:00.000Z') } },
+        { createdAt: new Date('2026-01-01T00:00:00.000Z'), id: { gt: 'row-2' } },
+      ],
+    });
+  });
+});
+
+describe('clampPageLimit', () => {
+  it('falls back when no limit is requested', () => {
+    expect(clampPageLimit(undefined, 1_000, 5_000)).toBe(1_000);
+  });
+
+  it('caps a greedy request and floors a useless one', () => {
+    expect(clampPageLimit(999_999, 1_000, 5_000)).toBe(5_000);
+    expect(clampPageLimit(0, 1_000, 5_000)).toBe(1);
+  });
+});
+
+describe('pageParams', () => {
+  it('reads the cursor and limit off the query', () => {
+    const url = new URL('http://x/api?since=2026-01-01T00:00:00.000Z&sinceId=row-1&limit=250');
+    expect(pageParams(url)).toEqual({
+      since: '2026-01-01T00:00:00.000Z',
+      sinceId: 'row-1',
+      limit: 250,
+    });
+  });
+
+  it('omits a non-numeric limit so the lister keeps its default', () => {
+    expect(pageParams(new URL('http://x/api?limit=abc'))).toEqual({ since: null, sinceId: null });
+  });
+});

--- a/control/src/server/pagination.ts
+++ b/control/src/server/pagination.ts
@@ -1,0 +1,29 @@
+/** Filtering on `createdAt` alone skips rows when a page boundary lands inside a
+ * batch that shares a millisecond, so a caller with a cursor id pages on
+ * `(createdAt, id)`. */
+export function createdAtKeyset(options: { since?: string | null; sinceId?: string | null }) {
+  const since = options.since ? new Date(options.since) : null;
+  if (!since || !Number.isFinite(since.getTime())) return {};
+  const sinceId = options.sinceId?.trim();
+  if (!sinceId) return { createdAt: { gt: since } };
+  return {
+    OR: [{ createdAt: { gt: since } }, { createdAt: since, id: { gt: sinceId } }],
+  };
+}
+
+export function clampPageLimit(
+  requested: number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  return Math.max(1, Math.min(requested ?? fallback, max));
+}
+
+export function pageParams(url: URL): { since: string | null; sinceId: string | null; limit?: number } {
+  const requestedLimit = Number(url.searchParams.get('limit'));
+  return {
+    since: url.searchParams.get('since'),
+    sinceId: url.searchParams.get('sinceId'),
+    ...(Number.isFinite(requestedLimit) && requestedLimit > 0 ? { limit: requestedLimit } : {}),
+  };
+}

--- a/control/src/server/session-events-egress.test.ts
+++ b/control/src/server/session-events-egress.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const eventFindMany = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    agentSessionEvent: {
+      findMany: (...args: unknown[]) => eventFindMany(...args),
+    },
+  },
+}));
+
+import { listSessionEventsForRepo } from './session-events';
+
+describe('listSessionEventsForRepo', () => {
+  beforeEach(() => eventFindMany.mockReset());
+
+  it('reads oldest-first on createdAt so a caller can walk forward', async () => {
+    eventFindMany.mockResolvedValue([]);
+    await listSessionEventsForRepo('repo-1');
+    expect(eventFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { repositoryId: 'repo-1' },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        take: 1_000,
+      }),
+    );
+  });
+
+  it('pages from the caller cursor', async () => {
+    eventFindMany.mockResolvedValue([]);
+    await listSessionEventsForRepo('repo-1', {
+      since: '2026-01-01T00:00:00.000Z',
+      sinceId: 'ev-9',
+      limit: 2,
+    });
+    expect(eventFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          repositoryId: 'repo-1',
+          OR: [
+            { createdAt: { gt: new Date('2026-01-01T00:00:00.000Z') } },
+            { createdAt: new Date('2026-01-01T00:00:00.000Z'), id: { gt: 'ev-9' } },
+          ],
+        },
+        take: 2,
+      }),
+    );
+  });
+
+  it('caps an unbounded request', async () => {
+    eventFindMany.mockResolvedValue([]);
+    await listSessionEventsForRepo('repo-1', { limit: 999_999 });
+    expect(eventFindMany).toHaveBeenCalledWith(expect.objectContaining({ take: 5_000 }));
+  });
+});

--- a/control/src/server/session-events.ts
+++ b/control/src/server/session-events.ts
@@ -2,6 +2,7 @@ import type { Prisma } from '@prisma/client';
 import { AgentTrajectoryRecordSchema } from '@har/schemas';
 import { prisma } from '@/lib/db';
 import { boundTrajectoryPayload } from '@/lib/trajectory-privacy';
+import { clampPageLimit, createdAtKeyset } from '@/server/pagination';
 
 export interface SessionEventInput {
   sessionKey: string;
@@ -71,11 +72,17 @@ export async function listSessionEventsForSlot(repositoryId: string, agentId: nu
   });
 }
 
-export async function listSessionEventsForRepo(repositoryId: string) {
+const REPO_EVENTS_LIMIT = 1_000;
+const REPO_EVENTS_MAX_LIMIT = 5_000;
+
+export async function listSessionEventsForRepo(
+  repositoryId: string,
+  options: { since?: string | null; sinceId?: string | null; limit?: number } = {},
+) {
   return prisma.agentSessionEvent.findMany({
-    where: { repositoryId },
-    orderBy: { timestamp: 'desc' },
-    take: 200,
+    where: { repositoryId, ...createdAtKeyset(options) },
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    take: clampPageLimit(options.limit, REPO_EVENTS_LIMIT, REPO_EVENTS_MAX_LIMIT),
   });
 }
 

--- a/control/src/server/session-spans.ts
+++ b/control/src/server/session-spans.ts
@@ -1,21 +1,17 @@
 import type { AgentSessionSpan } from '@prisma/client';
 import { prisma } from '@/lib/db';
+import { clampPageLimit, createdAtKeyset } from '@/server/pagination';
 
 const REPO_SPANS_LIMIT = 1_000;
 const REPO_SPANS_MAX_LIMIT = 5_000;
 
 export async function listSessionSpansForRepo(
   repositoryId: string,
-  options: { since?: string | null; limit?: number } = {},
+  options: { since?: string | null; sinceId?: string | null; limit?: number } = {},
 ): Promise<AgentSessionSpan[]> {
-  const limit = Math.max(1, Math.min(options.limit ?? REPO_SPANS_LIMIT, REPO_SPANS_MAX_LIMIT));
-  const since = options.since ? new Date(options.since) : null;
   return prisma.agentSessionSpan.findMany({
-    where: {
-      repositoryId,
-      ...(since && Number.isFinite(since.getTime()) ? { createdAt: { gt: since } } : {}),
-    },
+    where: { repositoryId, ...createdAtKeyset(options) },
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-    take: limit,
+    take: clampPageLimit(options.limit, REPO_SPANS_LIMIT, REPO_SPANS_MAX_LIMIT),
   });
 }

--- a/control/src/server/trajectory-ledger.ts
+++ b/control/src/server/trajectory-ledger.ts
@@ -3,6 +3,7 @@ import { Prisma, type AgentTrajectoryRecord } from '@prisma/client';
 import { createHash } from 'node:crypto';
 import { prisma } from '@/lib/db';
 import { boundTrajectoryPayload, trajectoryPolicy } from '@/lib/trajectory-privacy';
+import { clampPageLimit, createdAtKeyset } from '@/server/pagination';
 import type {
   SerializedTrajectoryPage,
   SerializedTrajectoryRecord,
@@ -355,20 +356,12 @@ const REPO_TRAJECTORY_MAX_LIMIT = 5_000;
 
 export async function listTrajectoryForRepo(
   repositoryId: string,
-  options: { since?: string | null; limit?: number } = {},
+  options: { since?: string | null; sinceId?: string | null; limit?: number } = {},
 ): Promise<AgentTrajectoryRecord[]> {
-  const limit = Math.max(
-    1,
-    Math.min(options.limit ?? REPO_TRAJECTORY_LIMIT, REPO_TRAJECTORY_MAX_LIMIT),
-  );
-  const since = options.since ? new Date(options.since) : null;
   return prisma.agentTrajectoryRecord.findMany({
-    where: {
-      repositoryId,
-      ...(since && Number.isFinite(since.getTime()) ? { createdAt: { gt: since } } : {}),
-    },
+    where: { repositoryId, ...createdAtKeyset(options) },
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-    take: limit,
+    take: clampPageLimit(options.limit, REPO_TRAJECTORY_LIMIT, REPO_TRAJECTORY_MAX_LIMIT),
   });
 }
 

--- a/src/cli/commands/control.ts
+++ b/src/cli/commands/control.ts
@@ -589,7 +589,7 @@ async function handleSync(argv: {
     }
   }
 
-  const { synced, failed, results } = await syncReposWithControl({
+  const { synced, failed, incomplete, results } = await syncReposWithControl({
     repoPaths,
     apiUrl: argv.apiUrl,
     dryRun: argv.dryRun,
@@ -599,7 +599,9 @@ async function handleSync(argv: {
   });
 
   if (argv.json) {
-    process.stdout.write(JSON.stringify({ ok: failed === 0, synced, failed, results }, null, 2) + '\n');
+    process.stdout.write(
+      JSON.stringify({ ok: failed === 0, synced, failed, incomplete, results }, null, 2) + '\n',
+    );
     if (failed > 0) return finishCommand(1);
     return;
   }
@@ -609,22 +611,32 @@ async function handleSync(argv: {
       for (const target of result.targets) {
         const record = findPortalTargetRecord(target.alias);
         const label = record ? displayPortalTargetLabel(record) : target.alias;
-        if (target.ok) {
-          success(`Synced ${result.repoPath} → ${label}`);
-        } else {
+        if (!target.ok) {
           warn(`Failed ${result.repoPath} → ${label}: ${target.error}`);
+        } else if (target.warnings && target.warnings.length > 0) {
+          warn(`Synced ${result.repoPath} → ${label} — incomplete`);
+        } else {
+          success(`Synced ${result.repoPath} → ${label}`);
         }
       }
       continue;
     }
-    if (result.ok) {
-      success(`Synced ${result.repoPath}`);
-    } else {
+    if (!result.ok) {
       warn(`Failed ${result.repoPath}: ${result.error}`);
+    } else if (result.warnings && result.warnings.length > 0) {
+      warn(`Synced ${result.repoPath} — incomplete`);
+    } else {
+      success(`Synced ${result.repoPath}`);
     }
   }
-  if (synced > 0) {
-    success(`Synced ${synced} ${synced === 1 ? 'repository' : 'repositories'}`);
+  if (synced > incomplete) {
+    const complete = synced - incomplete;
+    success(`Synced ${complete} ${complete === 1 ? 'repository' : 'repositories'}`);
+  }
+  if (incomplete > 0) {
+    warn(
+      `${incomplete} ${incomplete === 1 ? 'repository' : 'repositories'} synced with incomplete telemetry — see the warnings above`,
+    );
   }
   if (failed > 0) {
     warn(`${failed} ${failed === 1 ? 'repository' : 'repositories'} could not be synced`);

--- a/src/core/control-api-read.ts
+++ b/src/core/control-api-read.ts
@@ -1,0 +1,100 @@
+import * as path from 'path';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const RETRY_DELAY_MS = 250;
+const DEFAULT_PAGE_SIZE = 1_000;
+const MAX_PAGES = 20;
+
+export type ControlRead<T> = { ok: true; data: T } | { ok: false; error: string };
+
+export type PagedControlRead<Row> =
+  | { ok: true; rows: Row[]; truncated: boolean }
+  | { ok: false; error: string };
+
+export interface ChannelReadFailure {
+  channel: string;
+  reason: string;
+}
+
+function numberFromEnv(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+async function attempt<T>(url: string): Promise<{ read: ControlRead<T>; retryable: boolean }> {
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: AbortSignal.timeout(numberFromEnv('HAR_CONTROL_READ_TIMEOUT_MS', DEFAULT_TIMEOUT_MS)),
+    });
+    if (!response.ok) {
+      return {
+        read: { ok: false, error: `HTTP ${response.status}` },
+        retryable: response.status >= 500,
+      };
+    }
+    return { read: { ok: true, data: (await response.json()) as T }, retryable: false };
+  } catch (err: unknown) {
+    return {
+      read: { ok: false, error: err instanceof Error ? err.message : String(err) },
+      retryable: true,
+    };
+  }
+}
+
+export async function readControlJson<T>(url: string): Promise<ControlRead<T>> {
+  const first = await attempt<T>(url);
+  if (first.read.ok || !first.retryable) return first.read;
+  await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+  return (await attempt<T>(url)).read;
+}
+
+export async function readControlPages<Row>(options: {
+  url: string;
+  since: string | null;
+  rows: (data: unknown) => Row[];
+  cursor: (row: Row) => { createdAt?: string | null; id?: string | null };
+}): Promise<PagedControlRead<Row>> {
+  const limit = numberFromEnv('HAR_CONTROL_READ_PAGE_SIZE', DEFAULT_PAGE_SIZE);
+  const collected: Row[] = [];
+  let since = options.since;
+  let sinceId: string | null = null;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const query = new URLSearchParams({ limit: String(limit) });
+    if (since) query.set('since', since);
+    if (sinceId) query.set('sinceId', sinceId);
+
+    const read = await readControlJson<unknown>(`${options.url}?${query.toString()}`);
+    if (!read.ok) return { ok: false, error: read.error };
+
+    const rows = options.rows(read.data);
+    collected.push(...rows);
+    if (rows.length < limit) return { ok: true, rows: collected, truncated: false };
+
+    const last = options.cursor(rows[rows.length - 1]);
+    const nextSince = last.createdAt ?? null;
+    const nextSinceId = last.id ?? null;
+    if (!nextSince || (nextSince === since && nextSinceId === sinceId)) {
+      return { ok: true, rows: collected, truncated: false };
+    }
+    since = nextSince;
+    sinceId = nextSinceId;
+  }
+
+  return { ok: true, rows: collected, truncated: true };
+}
+
+export async function resolveControlRepoId(
+  apiUrl: string,
+  repoPath: string,
+): Promise<ControlRead<string | null>> {
+  const repos = await readControlJson<{ id: string; path: string }[]>(`${apiUrl}/api/repos`);
+  if (!repos.ok) return repos;
+  if (!Array.isArray(repos.data)) return { ok: false, error: 'unexpected /api/repos payload' };
+  const target = path.resolve(repoPath);
+  return {
+    ok: true,
+    data: repos.data.find((repo) => path.resolve(repo.path) === target)?.id ?? null,
+  };
+}

--- a/src/core/control-persisted-trajectory.ts
+++ b/src/core/control-persisted-trajectory.ts
@@ -1,11 +1,14 @@
-import * as path from 'path';
 import type { AgentTrajectoryRecord } from '../harness/schema';
 import { AgentTrajectoryRecordSchema } from '../harness/schema';
 import { selectSince } from './portal-watermark';
-
-const FETCH_TIMEOUT_MS = 5000;
+import {
+  ChannelReadFailure,
+  readControlPages,
+  resolveControlRepoId,
+} from './control-api-read';
 
 export interface PersistedSpanRow {
+  id?: string;
   sessionKey: string;
   agentId: number;
   agentTool: string;
@@ -34,26 +37,6 @@ export interface PortalSpan {
   startTime: string;
   endTime?: string;
   attributes?: Record<string, unknown>;
-}
-
-async function getJson<T>(url: string): Promise<T | null> {
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!response.ok) return null;
-    return (await response.json()) as T;
-  } catch {
-    return null;
-  }
-}
-
-async function resolveControlRepoId(apiUrl: string, repoPath: string): Promise<string | null> {
-  const repos = await getJson<{ id: string; path: string }[]>(`${apiUrl}/api/repos`);
-  if (!Array.isArray(repos)) return null;
-  const target = path.resolve(repoPath);
-  return repos.find((repo) => path.resolve(repo.path) === target)?.id ?? null;
 }
 
 function optional<T>(value: T | null | undefined): T | undefined {
@@ -116,11 +99,15 @@ export interface PersistedTrajectoryRequest {
   spans: { since: string | null } | false;
 }
 
+type TrajectoryRow = Record<string, unknown> & { id?: string; createdAt?: string };
+
 export interface PersistedTrajectory {
   records: AgentTrajectoryRecord[];
   spans: PortalSpan[];
   recordsMaxSyncedAt: string | null;
   spansMaxSyncedAt: string | null;
+  failures: ChannelReadFailure[];
+  truncated: string[];
 }
 
 export async function fetchPersistedTrajectory(
@@ -133,30 +120,51 @@ export async function fetchPersistedTrajectory(
     spans: [],
     recordsMaxSyncedAt: null,
     spansMaxSyncedAt: null,
+    failures: [],
+    truncated: [],
   };
   if (!request.records && !request.spans) return empty;
 
-  const repoId = await resolveControlRepoId(apiUrl, repoPath);
-  if (!repoId) return empty;
+  const repo = await resolveControlRepoId(apiUrl, repoPath);
+  if (!repo.ok) return { ...empty, failures: [{ channel: 'repos', reason: repo.error }] };
+  if (!repo.data) return empty;
 
-  const [trajectoryResponse, spansResponse] = await Promise.all([
+  const [trajectoryRead, spansRead] = await Promise.all([
     request.records
-      ? getJson<{ records: (Record<string, unknown> & { createdAt?: string })[] }>(
-          `${apiUrl}/api/repos/${repoId}/trajectory`,
-        )
+      ? readControlPages<TrajectoryRow>({
+          url: `${apiUrl}/api/repos/${repo.data}/trajectory`,
+          since: request.records.since,
+          rows: (data) => (data as { records?: TrajectoryRow[] } | null)?.records ?? [],
+          cursor: (row) => ({ createdAt: row.createdAt, id: row.id }),
+        })
       : null,
     request.spans
-      ? getJson<{ spans: PersistedSpanRow[] }>(`${apiUrl}/api/repos/${repoId}/spans`)
+      ? readControlPages<PersistedSpanRow>({
+          url: `${apiUrl}/api/repos/${repo.data}/spans`,
+          since: request.spans.since,
+          rows: (data) => (data as { spans?: PersistedSpanRow[] } | null)?.spans ?? [],
+          cursor: (row) => ({ createdAt: row.createdAt, id: row.id }),
+        })
       : null,
   ]);
 
+  const failures: ChannelReadFailure[] = [];
+  const truncated: string[] = [];
+  if (trajectoryRead && !trajectoryRead.ok) {
+    failures.push({ channel: 'trajectory', reason: trajectoryRead.error });
+  } else if (trajectoryRead?.ok && trajectoryRead.truncated) {
+    truncated.push('trajectory');
+  }
+  if (spansRead && !spansRead.ok) failures.push({ channel: 'spans', reason: spansRead.error });
+  else if (spansRead?.ok && spansRead.truncated) truncated.push('spans');
+
   const trajectory = selectSince(
-    trajectoryResponse?.records ?? [],
+    trajectoryRead?.ok ? trajectoryRead.rows : [],
     request.records ? request.records.since : null,
     (row) => row.createdAt ?? null,
   );
   const spans = selectSince(
-    spansResponse?.spans ?? [],
+    spansRead?.ok ? spansRead.rows : [],
     request.spans ? request.spans.since : null,
     (row) => row.createdAt ?? null,
   );
@@ -169,5 +177,7 @@ export async function fetchPersistedTrajectory(
     spans: spans.selected.map(toPortalSpan),
     recordsMaxSyncedAt: trajectory.maxSyncedAt,
     spansMaxSyncedAt: spans.maxSyncedAt,
+    failures,
+    truncated,
   };
 }

--- a/src/core/control-persisted-usage.ts
+++ b/src/core/control-persisted-usage.ts
@@ -1,8 +1,11 @@
-import * as path from 'path';
 import type { AgentSessionEvent, AgentSessionUsage, AgentTool, UsageSource } from '../harness/schema';
 import { selectSince } from './portal-watermark';
-
-const FETCH_TIMEOUT_MS = 3000;
+import {
+  ChannelReadFailure,
+  readControlJson,
+  readControlPages,
+  resolveControlRepoId,
+} from './control-api-read';
 
 interface PersistedUsageRow {
   sessionKey: string;
@@ -26,7 +29,8 @@ interface PersistedUsageRow {
   updatedAt?: string | null;
 }
 
-interface PersistedEventRow {
+export interface PersistedEventRow {
+  id?: string;
   sessionKey: string;
   agentId: number;
   agentTool: string;
@@ -41,26 +45,6 @@ interface PersistedEventRow {
   workUnitId?: string | null;
   attemptId?: string | null;
   createdAt?: string | null;
-}
-
-async function getJson<T>(url: string): Promise<T | null> {
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!response.ok) return null;
-    return (await response.json()) as T;
-  } catch {
-    return null;
-  }
-}
-
-async function resolveControlRepoId(apiUrl: string, repoPath: string): Promise<string | null> {
-  const repos = await getJson<{ id: string; path: string }[]>(`${apiUrl}/api/repos`);
-  if (!Array.isArray(repos)) return null;
-  const target = path.resolve(repoPath);
-  return repos.find((repo) => path.resolve(repo.path) === target)?.id ?? null;
 }
 
 function optionalString(value: string | null | undefined): string | undefined {
@@ -127,38 +111,65 @@ function maxTimestamp(a: string | null, b: string | null): string | null {
   return a > b ? a : b;
 }
 
+export interface PersistedPortalTelemetry {
+  usage: AgentSessionUsage[];
+  events: AgentSessionEvent[];
+  maxSyncedAt: string | null;
+  failures: ChannelReadFailure[];
+  truncated: string[];
+}
+
 /**
- * Best-effort read of persisted telemetry from a locally-reachable Mission
- * Control. Returns empty when the control API is unreachable or the repo is not
- * registered there, so a portal sync always falls back to the live-slot
- * harvest. Never throws.
- *
- * When `since` is set, only rows changed after it are returned — usage by its
- * cumulative `updatedAt` (a live session that gained tokens re-syncs even
- * though its event time looks old), events by their append-only `createdAt`.
- * `maxSyncedAt` is the newest timestamp among the returned rows, for advancing
- * the caller's watermark to the max actually sent.
+ * Usage is selected on its cumulative `updatedAt` — a live session that gained
+ * tokens re-syncs even though its event time looks old — and events on their
+ * append-only `createdAt`, which Mission Control also pages on.
  */
 export async function fetchPersistedPortalTelemetry(
   repoPath: string,
   apiUrl: string,
   options?: { since?: string | null },
-): Promise<{ usage: AgentSessionUsage[]; events: AgentSessionEvent[]; maxSyncedAt: string | null }> {
-  const repoId = await resolveControlRepoId(apiUrl, repoPath);
-  if (!repoId) return { usage: [], events: [], maxSyncedAt: null };
+): Promise<PersistedPortalTelemetry> {
+  const empty = { usage: [], events: [], maxSyncedAt: null, failures: [], truncated: [] };
+
+  const repo = await resolveControlRepoId(apiUrl, repoPath);
+  if (!repo.ok) {
+    return { ...empty, failures: [{ channel: 'repos', reason: repo.error }] };
+  }
+  if (!repo.data) return empty;
 
   const since = options?.since ?? null;
-  const [usageResponse, eventsResponse] = await Promise.all([
-    getJson<{ usage: PersistedUsageRow[] }>(`${apiUrl}/api/repos/${repoId}/usage`),
-    getJson<{ events: PersistedEventRow[] }>(`${apiUrl}/api/repos/${repoId}/events`),
+  const [usageRead, eventsRead] = await Promise.all([
+    readControlJson<{ usage?: PersistedUsageRow[] }>(`${apiUrl}/api/repos/${repo.data}/usage`),
+    readControlPages<PersistedEventRow>({
+      url: `${apiUrl}/api/repos/${repo.data}/events`,
+      since,
+      rows: (data) => (data as { events?: PersistedEventRow[] } | null)?.events ?? [],
+      cursor: (row) => ({ createdAt: row.createdAt, id: row.id }),
+    }),
   ]);
 
-  const usage = selectSince(usageResponse?.usage ?? [], since, (row) => row.updatedAt ?? row.lastSeenAt);
-  const events = selectSince(eventsResponse?.events ?? [], since, (row) => row.createdAt ?? row.timestamp);
+  const failures: ChannelReadFailure[] = [];
+  const truncated: string[] = [];
+  if (!usageRead.ok) failures.push({ channel: 'usage', reason: usageRead.error });
+  if (!eventsRead.ok) failures.push({ channel: 'events', reason: eventsRead.error });
+  else if (eventsRead.truncated) truncated.push('events');
+
+  const usage = selectSince(
+    usageRead.ok ? (usageRead.data?.usage ?? []) : [],
+    since,
+    (row) => row.updatedAt ?? row.lastSeenAt,
+  );
+  const events = selectSince(
+    eventsRead.ok ? eventsRead.rows : [],
+    since,
+    (row) => row.createdAt ?? row.timestamp,
+  );
 
   return {
     usage: usage.selected.map(normalizeUsage),
     events: events.selected.map(normalizeEvent),
     maxSyncedAt: maxTimestamp(usage.maxSyncedAt, events.maxSyncedAt),
+    failures,
+    truncated,
   };
 }

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -46,6 +46,7 @@ import { warn } from '../utils/logging';
 import { harvestEventsForSlot, harvestUsageForSlot, omitHarvestEventsWhenOtelPresent, omitHarvestWhenOtelPresent } from './usage-harvest';
 import { buildSessionKey } from './telemetry-env';
 import { fetchPersistedPortalTelemetry } from './control-persisted-usage';
+import type { ChannelReadFailure } from './control-api-read';
 import { fetchPersistedTrajectory } from './control-persisted-trajectory';
 import { dedupePortalEvents, mergePortalUsage } from './portal-usage-merge';
 import { enrichUsageWithPricing } from '../harness/schema';
@@ -75,7 +76,8 @@ export interface SyncRepoResult {
   repoPath: string;
   ok: boolean;
   error?: string;
-  targets?: Array<{ alias: string; ok: boolean; error?: string }>;
+  warnings?: string[];
+  targets?: Array<{ alias: string; ok: boolean; error?: string; warnings?: string[] }>;
 }
 
 export interface ControlRegisterOptions extends ControlSyncOptions {
@@ -372,18 +374,39 @@ function modelsFromBreakdown(
   }));
 }
 
+interface TelemetryCollection {
+  usage: Record<string, unknown>[];
+  events: Record<string, unknown>[];
+  maxSyncedAt: string | null;
+  failures: ChannelReadFailure[];
+  truncated: string[];
+}
+
+function describeReadFailures(repoPath: string, failures: ChannelReadFailure[]): string {
+  const detail = failures.map((f) => `${f.channel} (${f.reason})`).join(', ');
+  return (
+    `${path.basename(repoPath)}: could not read ${detail} from Mission Control — ` +
+    'that telemetry is missing from this sync and its watermark is held, so the next sync retries it.'
+  );
+}
+
+function describeTruncatedReads(repoPath: string, channels: string[]): string {
+  return (
+    `${path.basename(repoPath)}: ${channels.join(', ')} hit the read page cap — ` +
+    'the remainder syncs on the next run.'
+  );
+}
+
 async function collectPortalTelemetry(
   repoPath: string,
   slots: EnvironmentStatus['slots'],
   controlApiUrl: string,
   since: string | null,
   portal?: PortalTarget,
-): Promise<{
-  usage: Record<string, unknown>[];
-  events: Record<string, unknown>[];
-  maxSyncedAt: string | null;
-}> {
-  if (!isTelemetryEnabled()) return { usage: [], events: [], maxSyncedAt: null };
+): Promise<TelemetryCollection> {
+  if (!isTelemetryEnabled()) {
+    return { usage: [], events: [], maxSyncedAt: null, failures: [], truncated: [] };
+  }
   try {
     const userEmail = resolvePortalUserEmail(portal);
     const fallbackAgentId =
@@ -451,9 +474,23 @@ async function collectPortalTelemetry(
       dropNullFields({ ...event }),
     );
 
-    return { usage, events, maxSyncedAt: persisted.maxSyncedAt };
-  } catch {
-    return { usage: [], events: [], maxSyncedAt: null };
+    return {
+      usage,
+      events,
+      maxSyncedAt: persisted.maxSyncedAt,
+      failures: persisted.failures,
+      truncated: persisted.truncated,
+    };
+  } catch (err: unknown) {
+    return {
+      usage: [],
+      events: [],
+      maxSyncedAt: null,
+      failures: [
+        { channel: 'telemetry', reason: err instanceof Error ? err.message : String(err) },
+      ],
+      truncated: [],
+    };
   }
 }
 
@@ -468,6 +505,8 @@ async function buildPortalPayload(
   runs: RunRecord[];
   events: Record<string, unknown>[];
   maxSyncedAt: string | null;
+  failures: ChannelReadFailure[];
+  truncated: string[];
 }> {
   const runs = listRuns(repoPath);
   const status = collectEnvironmentStatus(repoPath);
@@ -481,7 +520,7 @@ async function buildPortalPayload(
   // Attribute runs/validations to the syncing member so the portal can resolve
   // a real user FK instead of the lossy (repo, agentId) derivation.
   const userEmail = resolvePortalUserEmail(portal);
-  const { usage, events, maxSyncedAt } = await collectPortalTelemetry(
+  const { usage, events, maxSyncedAt, failures, truncated } = await collectPortalTelemetry(
     repoPath,
     status.slots,
     controlApiUrl,
@@ -489,7 +528,13 @@ async function buildPortalPayload(
     portal,
   );
 
-  if (full && isTelemetryEnabled() && usage.length === 0 && runs.some((r) => r.agentId != null)) {
+  if (
+    full &&
+    isTelemetryEnabled() &&
+    failures.length === 0 &&
+    usage.length === 0 &&
+    runs.some((r) => r.agentId != null)
+  ) {
     warn(
       `${path.basename(repoPath)}: agent runs found but no usage harvested — attribution will be missing. ` +
         'This happens when agent sessions ran outside the har worktree slot (e.g. in the main checkout). ' +
@@ -522,7 +567,7 @@ async function buildPortalPayload(
     ? runs.map((run) => ({ ...run, userEmail }))
     : runs;
 
-  return { syncBody, runs: runsPayload, events, maxSyncedAt };
+  return { syncBody, runs: runsPayload, events, maxSyncedAt, failures, truncated };
 }
 
 export async function isControlApiReachable(apiUrl = getControlApiUrl()): Promise<boolean> {
@@ -582,19 +627,30 @@ export async function syncReposWithControl(options: {
   cloud?: boolean;
   full?: boolean;
   portalTargets?: string[];
-}): Promise<{ synced: number; failed: number; results: SyncRepoResult[] }> {
+}): Promise<{
+  synced: number;
+  failed: number;
+  incomplete: number;
+  results: SyncRepoResult[];
+}> {
   const apiUrl = options.apiUrl ?? getControlApiUrl();
   const results: SyncRepoResult[] = [];
   let synced = 0;
   let failed = 0;
+  let incomplete = 0;
 
   for (const repoPath of options.repoPaths) {
     const destinationAliases = destinationAliasesForSync(repoPath, options.portalTargets);
     if (destinationAliases.length > 1) {
-      const targetResults: Array<{ alias: string; ok: boolean; error?: string }> = [];
+      const targetResults: Array<{
+        alias: string;
+        ok: boolean;
+        error?: string;
+        warnings?: string[];
+      }> = [];
       for (const alias of destinationAliases) {
         try {
-          await withTimeout(
+          const outcome = await withTimeout(
             syncRepoWithControl({
               repoPath,
               apiUrl,
@@ -606,7 +662,11 @@ export async function syncReposWithControl(options: {
             EXPLICIT_SYNC_TIMEOUT_MS,
             'control sync',
           );
-          targetResults.push({ alias, ok: true });
+          targetResults.push({
+            alias,
+            ok: true,
+            ...(outcome.warnings.length > 0 ? { warnings: outcome.warnings } : {}),
+          });
         } catch (err: unknown) {
           targetResults.push({
             alias,
@@ -618,12 +678,13 @@ export async function syncReposWithControl(options: {
       const ok = targetResults.every((entry) => entry.ok);
       if (ok) synced++;
       else failed++;
+      if (ok && targetResults.some((entry) => entry.warnings)) incomplete++;
       results.push({ repoPath, ok, targets: targetResults, error: ok ? undefined : 'one or more targets failed' });
       continue;
     }
 
     try {
-      await withTimeout(
+      const outcome = await withTimeout(
         syncRepoWithControl({
           repoPath,
           apiUrl,
@@ -636,14 +697,19 @@ export async function syncReposWithControl(options: {
         'control sync',
       );
       synced++;
-      results.push({ repoPath, ok: true });
+      if (outcome.warnings.length > 0) incomplete++;
+      results.push({
+        repoPath,
+        ok: true,
+        ...(outcome.warnings.length > 0 ? { warnings: outcome.warnings } : {}),
+      });
     } catch (err: unknown) {
       failed++;
       results.push({ repoPath, ok: false, error: err instanceof Error ? err.message : String(err) });
     }
   }
 
-  return { synced, failed, results };
+  return { synced, failed, incomplete, results };
 }
 
 function destinationAliasesForSync(repoPath: string, explicit?: string[]): string[] {
@@ -760,8 +826,8 @@ async function syncRepoWithPortal(
   options: ControlSyncOptions & { repoPath: string },
   controlApiUrl: string,
   portal: PortalTarget,
-): Promise<void> {
-  if (!isRepoPortalSyncEnabled(options.repoPath)) return;
+): Promise<string[]> {
+  if (!isRepoPortalSyncEnabled(options.repoPath)) return [];
 
   const { repoPath, dryRun, full } = options;
   const watermarkKey = watermarkKeyForTarget(portal);
@@ -776,7 +842,7 @@ async function syncRepoWithPortal(
     }
   }
   const runsSince = rewindSince(stored?.lastSyncedAt ?? null);
-  const { syncBody, runs, events, maxSyncedAt } = await buildPortalPayload(
+  const { syncBody, runs, events, maxSyncedAt, failures, truncated } = await buildPortalPayload(
     repoPath,
     controlApiUrl,
     since,
@@ -802,11 +868,21 @@ async function syncRepoWithPortal(
   for (const batch of chunkBySerializedSize(events, maxSyncBatchBytes())) {
     await postPortal(portal, '/api/otel', { path: repoPath, events: batch }, dryRun);
   }
-  if (!dryRun && maxSyncedAt) {
+  // Usage and events share one watermark: advancing it on one channel's rows
+  // strands the other's for good when its read failed.
+  if (!dryRun && maxSyncedAt && failures.length === 0) {
     writePortalWatermark(repoPath, watermarkKey, maxSyncedAt);
   }
 
-  await syncTrajectoryWithPortal(portal, repoPath, controlApiUrl, dryRun, full);
+  const warnings: string[] = [];
+  if (failures.length > 0) warnings.push(describeReadFailures(repoPath, failures));
+  if (truncated.length > 0) warnings.push(describeTruncatedReads(repoPath, truncated));
+
+  warnings.push(
+    ...(await syncTrajectoryWithPortal(portal, repoPath, controlApiUrl, dryRun, full)),
+  );
+  for (const message of warnings) warn(message);
+  return warnings;
 }
 
 async function syncTrajectoryWithPortal(
@@ -815,14 +891,14 @@ async function syncTrajectoryWithPortal(
   controlApiUrl: string,
   dryRun: boolean | undefined,
   full: boolean | undefined,
-): Promise<void> {
+): Promise<string[]> {
   const wantRecords = isPortalTrajectoryEnabledForTarget(portal);
   const wantSpans = isTelemetryEnabled();
-  if (!wantRecords && !wantSpans) return;
+  if (!wantRecords && !wantSpans) return [];
 
   const recordsTarget = trajectoryWatermarkTarget(portal);
   const spansTarget = spansWatermarkTarget(portal);
-  const { records, spans, recordsMaxSyncedAt, spansMaxSyncedAt } =
+  const { records, spans, recordsMaxSyncedAt, spansMaxSyncedAt, failures, truncated } =
     await fetchPersistedTrajectory(repoPath, controlApiUrl, {
       records: wantRecords
         ? {
@@ -848,10 +924,13 @@ async function syncTrajectoryWithPortal(
         : false,
     });
 
+  const failedChannel = (channel: string) =>
+    failures.some((failure) => failure.channel === channel || failure.channel === 'repos');
+
   for (const batch of chunkBySerializedSize(spans, maxSyncBatchBytes())) {
     await postPortal(portal, '/api/otel', { path: repoPath, spans: batch }, dryRun);
   }
-  if (!dryRun && spansMaxSyncedAt) {
+  if (!dryRun && spansMaxSyncedAt && !failedChannel('spans')) {
     writePortalWatermark(repoPath, spansTarget, spansMaxSyncedAt);
   }
 
@@ -872,12 +951,19 @@ async function syncTrajectoryWithPortal(
       break;
     }
   }
-  if (!dryRun && recordsLanded && recordsMaxSyncedAt) {
+  if (!dryRun && recordsLanded && recordsMaxSyncedAt && !failedChannel('trajectory')) {
     writePortalWatermark(repoPath, recordsTarget, recordsMaxSyncedAt);
   }
+
+  return [
+    ...(failures.length > 0 ? [describeReadFailures(repoPath, failures)] : []),
+    ...(truncated.length > 0 ? [describeTruncatedReads(repoPath, truncated)] : []),
+  ];
 }
 
-export async function syncRepoWithControl(options: ControlSyncOptions): Promise<void> {
+export async function syncRepoWithControl(
+  options: ControlSyncOptions,
+): Promise<{ warnings: string[] }> {
   const repoPath = canonicalizeControlRepoPath(options.repoPath);
   const apiUrl = options.apiUrl ?? getControlApiUrl();
 
@@ -908,23 +994,24 @@ export async function syncRepoWithControl(options: ControlSyncOptions): Promise<
     if (!response.ok) {
       throw new Error(`Cloud sync failed: ${response.status}`);
     }
-    return;
+    return { warnings: [] };
   }
 
   await syncRepoWithLocalControl({ ...options, repoPath, apiUrl });
 
-  if (!isRepoPortalSyncEnabled(repoPath)) return;
+  if (!isRepoPortalSyncEnabled(repoPath)) return { warnings: [] };
 
   const resolved = resolvePortalTargetsForRepo({
     repoPath,
     explicitTargets: options.portalTargets,
   });
-  if (!resolved) return;
+  if (!resolved) return { warnings: [] };
 
+  const warnings: string[] = [];
   const failures: Array<{ alias: string; error: string }> = [];
   for (const portal of resolved.targets) {
     try {
-      await syncRepoWithPortal({ ...options, repoPath }, apiUrl, portal);
+      warnings.push(...(await syncRepoWithPortal({ ...options, repoPath }, apiUrl, portal)));
     } catch (err: unknown) {
       failures.push({
         alias: portal.alias ?? portal.identityKey,
@@ -933,7 +1020,7 @@ export async function syncRepoWithControl(options: ControlSyncOptions): Promise<
     }
   }
 
-  if (failures.length === 0) return;
+  if (failures.length === 0) return { warnings };
   if (failures.length === resolved.targets.length && failures.length === 1) {
     throw new Error(failures[0].error);
   }

--- a/tests/control-persisted-trajectory.test.ts
+++ b/tests/control-persisted-trajectory.test.ts
@@ -174,6 +174,8 @@ describe('fetchPersistedTrajectory', () => {
       spans: [],
       recordsMaxSyncedAt: null,
       spansMaxSyncedAt: null,
+      failures: [],
+      truncated: [],
     });
   });
 
@@ -186,7 +188,7 @@ describe('fetchPersistedTrajectory', () => {
     expect(result.recordsMaxSyncedAt).toBeNull();
   });
 
-  it('returns empty instead of throwing when control is unreachable', async () => {
+  it('reports the failure instead of throwing when control is unreachable', async () => {
     (global as unknown as { fetch: unknown }).fetch = jest.fn(async () => {
       throw new Error('ECONNREFUSED');
     });
@@ -196,7 +198,132 @@ describe('fetchPersistedTrajectory', () => {
       spans: [],
       recordsMaxSyncedAt: null,
       spansMaxSyncedAt: null,
+      failures: [{ channel: 'repos', reason: 'ECONNREFUSED' }],
+      truncated: [],
     });
+  });
+
+  it('reports a failed channel without watermarking it, and keeps the other', async () => {
+    mockControl({ records: [ledgerRow()], spans: [spanRow()], trajectoryStatus: 500 });
+
+    const result = await fetchPersistedTrajectory('/repo/x', API, BOTH);
+
+    expect(result.failures).toEqual([{ channel: 'trajectory', reason: 'HTTP 500' }]);
+    expect(result.records).toEqual([]);
+    expect(result.recordsMaxSyncedAt).toBeNull();
+    expect(result.spans).toHaveLength(1);
+    expect(result.spansMaxSyncedAt).toBe('2026-01-04T00:00:00.000Z');
+  });
+
+  it('passes the watermark to control instead of filtering a capped page locally', async () => {
+    const fetchMock = mockControl({ spans: [spanRow()] });
+
+    await fetchPersistedTrajectory('/repo/x', API, {
+      records: false,
+      spans: { since: '2026-01-03T00:00:00.000Z' },
+    });
+
+    const spansCall = fetchMock.mock.calls.map(([url]) => String(url)).find((url) => url.includes('/spans'));
+    expect(spansCall).toContain('since=2026-01-03T00%3A00%3A00.000Z');
+    expect(spansCall).toContain('limit=');
+  });
+
+  it('walks spans forward page by page on a (createdAt, id) cursor', async () => {
+    process.env.HAR_CONTROL_READ_PAGE_SIZE = '2';
+    const pages = [
+      [
+        spanRow({ id: 's1', spanId: 'span-1', createdAt: '2026-01-01T00:00:00.000Z' }),
+        spanRow({ id: 's2', spanId: 'span-2', createdAt: '2026-01-01T00:00:00.000Z' }),
+      ],
+      [spanRow({ id: 's3', spanId: 'span-3', createdAt: '2026-01-02T00:00:00.000Z' })],
+    ];
+    const fetchMock = jest.fn(async (url: string) => {
+      const target = String(url);
+      if (target.includes('/api/repos') && !target.includes('/spans')) {
+        return { ok: true, status: 200, json: async () => [{ id: 'local-repo-1', path: '/repo/x' }] };
+      }
+      return { ok: true, status: 200, json: async () => ({ spans: pages.shift() ?? [] }) };
+    });
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    try {
+      const result = await fetchPersistedTrajectory('/repo/x', API, {
+        records: false,
+        spans: { since: null },
+      });
+
+      expect(result.spans.map((span) => span.spanId)).toEqual(['span-1', 'span-2', 'span-3']);
+      expect(result.truncated).toEqual([]);
+      expect(result.spansMaxSyncedAt).toBe('2026-01-02T00:00:00.000Z');
+      const second = fetchMock.mock.calls.map(([url]) => String(url)).filter((url) => url.includes('/spans'))[1];
+      expect(second).toContain('since=2026-01-01T00%3A00%3A00.000Z');
+      expect(second).toContain('sinceId=s2');
+    } finally {
+      delete process.env.HAR_CONTROL_READ_PAGE_SIZE;
+    }
+  });
+
+  it('reports truncation when the page cap is reached with rows pending', async () => {
+    process.env.HAR_CONTROL_READ_PAGE_SIZE = '1';
+    let issued = 0;
+    const fetchMock = jest.fn(async (url: string) => {
+      const target = String(url);
+      if (target.includes('/api/repos') && !target.includes('/spans')) {
+        return { ok: true, status: 200, json: async () => [{ id: 'local-repo-1', path: '/repo/x' }] };
+      }
+      issued += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          spans: [
+            spanRow({
+              id: `s${issued}`,
+              spanId: `span-${issued}`,
+              createdAt: new Date(Date.UTC(2026, 0, issued)).toISOString(),
+            }),
+          ],
+        }),
+      };
+    });
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    try {
+      const result = await fetchPersistedTrajectory('/repo/x', API, {
+        records: false,
+        spans: { since: null },
+      });
+
+      expect(result.spans).toHaveLength(20);
+      expect(result.truncated).toEqual(['spans']);
+      expect(result.spansMaxSyncedAt).toBe('2026-01-20T00:00:00.000Z');
+    } finally {
+      delete process.env.HAR_CONTROL_READ_PAGE_SIZE;
+    }
+  });
+
+  it('stops instead of looping when control ignores the cursor', async () => {
+    process.env.HAR_CONTROL_READ_PAGE_SIZE = '1';
+    const fetchMock = jest.fn(async (url: string) => {
+      const target = String(url);
+      if (target.includes('/api/repos') && !target.includes('/spans')) {
+        return { ok: true, status: 200, json: async () => [{ id: 'local-repo-1', path: '/repo/x' }] };
+      }
+      return { ok: true, status: 200, json: async () => ({ spans: [spanRow()] }) };
+    });
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+
+    try {
+      const result = await fetchPersistedTrajectory('/repo/x', API, {
+        records: false,
+        spans: { since: null },
+      });
+
+      expect(fetchMock.mock.calls.filter(([url]) => String(url).includes('/spans'))).toHaveLength(2);
+      expect(result.truncated).toEqual([]);
+    } finally {
+      delete process.env.HAR_CONTROL_READ_PAGE_SIZE;
+    }
   });
 
   it('drops null span fields rather than forwarding them', async () => {

--- a/tests/control-persisted-usage.test.ts
+++ b/tests/control-persisted-usage.test.ts
@@ -4,7 +4,7 @@ type Route = { status: number; json?: unknown };
 
 function routedFetch(routes: Record<string, Route>): jest.Mock {
   const fn = jest.fn(async (url: string) => {
-    const path = url.replace('http://localhost:3847', '');
+    const path = url.replace('http://localhost:3847', '').split('?')[0];
     const route = routes[path] ?? { status: 404 };
     return {
       ok: route.status >= 200 && route.status < 300,
@@ -28,10 +28,16 @@ describe('fetchPersistedPortalTelemetry', () => {
   it('returns empty when Mission Control does not know the repo', async () => {
     routedFetch({ '/api/repos': { status: 200, json: [{ id: 'r1', path: '/other/repo' }] } });
     const result = await fetchPersistedPortalTelemetry('/repo/x', API);
-    expect(result).toEqual({ usage: [], events: [], maxSyncedAt: null });
+    expect(result).toEqual({
+      usage: [],
+      events: [],
+      maxSyncedAt: null,
+      failures: [],
+      truncated: [],
+    });
   });
 
-  it('returns empty (never throws) when the control API is unreachable', async () => {
+  it('reports the failure (never throws) when the control API is unreachable', async () => {
     const fn = jest.fn(async () => {
       throw new Error('ECONNREFUSED');
     });
@@ -40,6 +46,8 @@ describe('fetchPersistedPortalTelemetry', () => {
       usage: [],
       events: [],
       maxSyncedAt: null,
+      failures: [{ channel: 'repos', reason: 'ECONNREFUSED' }],
+      truncated: [],
     });
   });
 
@@ -181,6 +189,87 @@ describe('fetchPersistedPortalTelemetry', () => {
     expect(result.usage.map((u) => u.sessionKey)).toEqual(['grew']);
     expect(result.events.map((e) => e.sessionKey)).toEqual(['new-ev']);
     expect(result.maxSyncedAt).toBe('2026-01-05T00:00:00.000Z');
+  });
+
+  it('reports a failed channel instead of syncing it as empty', async () => {
+    routedFetch({
+      '/api/repos': { status: 200, json: [{ id: 'repo-1', path: '/repo/x' }] },
+      '/api/repos/repo-1/usage': { status: 500 },
+      '/api/repos/repo-1/events': {
+        status: 200,
+        json: { events: [eventRow('ev', '2026-01-04T00:00:00.000Z', '2026-01-01T00:00:00.000Z')] },
+      },
+    });
+
+    const result = await fetchPersistedPortalTelemetry('/repo/x', API);
+
+    expect(result.failures).toEqual([{ channel: 'usage', reason: 'HTTP 500' }]);
+    expect(result.usage).toEqual([]);
+    expect(result.events).toHaveLength(1);
+  });
+
+  it('retries a channel that fails on a cold first hit', async () => {
+    let usageHits = 0;
+    const fn = jest.fn(async (url: string) => {
+      const target = String(url);
+      if (target.endsWith('/api/repos')) {
+        return { ok: true, status: 200, json: async () => [{ id: 'repo-1', path: '/repo/x' }] };
+      }
+      if (target.includes('/usage')) {
+        usageHits += 1;
+        if (usageHits === 1) throw new Error('The operation was aborted due to timeout');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            usage: [usageRow('woke', '2026-01-05T00:00:00.000Z', '2026-01-05T00:00:00.000Z')],
+          }),
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({ events: [] }) };
+    });
+    (global as unknown as { fetch: unknown }).fetch = fn;
+
+    const result = await fetchPersistedPortalTelemetry('/repo/x', API);
+
+    expect(usageHits).toBe(2);
+    expect(result.failures).toEqual([]);
+    expect(result.usage.map((row) => row.sessionKey)).toEqual(['woke']);
+  });
+
+  it('asks control for events after the watermark and walks the pages', async () => {
+    process.env.HAR_CONTROL_READ_PAGE_SIZE = '1';
+    const pages = [
+      [eventRow('first', '2026-01-03T00:00:00.000Z', '2026-01-01T00:00:00.000Z')],
+      [eventRow('second', '2026-01-04T00:00:00.000Z', '2026-01-01T00:00:00.000Z')],
+      [],
+    ];
+    const fn = jest.fn(async (url: string) => {
+      const target = String(url);
+      if (target.endsWith('/api/repos')) {
+        return { ok: true, status: 200, json: async () => [{ id: 'repo-1', path: '/repo/x' }] };
+      }
+      if (target.includes('/events')) {
+        return { ok: true, status: 200, json: async () => ({ events: pages.shift() ?? [] }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ usage: [] }) };
+    });
+    (global as unknown as { fetch: unknown }).fetch = fn;
+
+    try {
+      const result = await fetchPersistedPortalTelemetry('/repo/x', API, {
+        since: '2026-01-02T00:00:00.000Z',
+      });
+
+      expect(result.events.map((event) => event.sessionKey)).toEqual(['first', 'second']);
+      expect(result.maxSyncedAt).toBe('2026-01-04T00:00:00.000Z');
+      const eventCalls = fn.mock.calls.map(([url]) => String(url)).filter((url) => url.includes('/events'));
+      expect(eventCalls[0]).toContain('since=2026-01-02T00%3A00%3A00.000Z');
+      expect(eventCalls[1]).toContain('since=2026-01-03T00%3A00%3A00.000Z');
+      expect(eventCalls[1]).toContain('sinceId=first');
+    } finally {
+      delete process.env.HAR_CONTROL_READ_PAGE_SIZE;
+    }
   });
 
   it('sends nothing when no row changed since the watermark', async () => {

--- a/tests/control-portal-sync.test.ts
+++ b/tests/control-portal-sync.test.ts
@@ -42,7 +42,13 @@ jest.mock('../src/core/usage-harvest', () => {
   };
 });
 jest.mock('../src/core/control-persisted-usage', () => ({
-  fetchPersistedPortalTelemetry: jest.fn(async () => ({ usage: [], events: [], maxSyncedAt: null })),
+  fetchPersistedPortalTelemetry: jest.fn(async () => ({
+    usage: [],
+    events: [],
+    maxSyncedAt: null,
+    failures: [],
+    truncated: [],
+  })),
 }));
 jest.mock('../src/core/portal-watermark', () => ({
   ...jest.requireActual('../src/core/portal-watermark'),
@@ -66,6 +72,8 @@ jest.mock('../src/core/control-persisted-trajectory', () => ({
     spans: [],
     recordsMaxSyncedAt: null,
     spansMaxSyncedAt: null,
+    failures: [],
+    truncated: [],
   })),
 }));
 jest.mock('../src/harness/manifest', () => ({
@@ -119,7 +127,7 @@ function resetPayloadMocks(): void {
   listValidationBindingsMock.mockReturnValue([]);
   harvestUsageForSlotMock.mockReturnValue([]);
   harvestEventsForSlotMock.mockReturnValue([]);
-  fetchPersistedPortalTelemetryMock.mockResolvedValue({ usage: [], events: [], maxSyncedAt: null });
+  fetchPersistedPortalTelemetryMock.mockResolvedValue({ usage: [], events: [], maxSyncedAt: null, failures: [], truncated: [] });
   readPortalWatermarkMock.mockReset();
   readPortalWatermarkMock.mockReturnValue(null);
   writePortalWatermarkMock.mockReset();
@@ -676,6 +684,8 @@ describe('syncRepoWithControl — portal full payload', () => {
         },
       ],
       events: [],
+      failures: [],
+      truncated: [],
     });
     const fetchMock = mockFetch({ status: 200 });
 
@@ -728,6 +738,8 @@ describe('syncRepoWithControl — portal full payload', () => {
         },
       ],
       events: [],
+      failures: [],
+      truncated: [],
     });
     const fetchMock = mockFetch({ status: 200 });
 
@@ -758,6 +770,8 @@ describe('syncRepoWithControl — portal full payload', () => {
           source: 'harvest',
         },
       ],
+      failures: [],
+      truncated: [],
     });
     const fetchMock = mockFetch({ status: 200 });
 
@@ -821,6 +835,8 @@ describe('syncRepoWithControl — portal watermark', () => {
       usage: [],
       events: [],
       maxSyncedAt: '2026-01-09T00:00:00.000Z',
+      failures: [],
+      truncated: [],
     });
     mockFetch({ status: 200 });
 
@@ -842,6 +858,8 @@ describe('syncRepoWithControl — portal watermark', () => {
       usage: [],
       events: [],
       maxSyncedAt: '2026-01-09T00:00:00.000Z',
+      failures: [],
+      truncated: [],
     });
     mockFetch({ status: 200 });
 
@@ -860,7 +878,7 @@ describe('syncRepoWithControl — portal watermark', () => {
 
   it('does not advance the watermark when nothing new was sent', async () => {
     readPortalWatermarkMock.mockReturnValue('2026-01-02T00:00:00.000Z');
-    fetchPersistedPortalTelemetryMock.mockResolvedValue({ usage: [], events: [], maxSyncedAt: null });
+    fetchPersistedPortalTelemetryMock.mockResolvedValue({ usage: [], events: [], maxSyncedAt: null, failures: [], truncated: [] });
     mockFetch({ status: 200 });
 
     await syncRepoWithControl({ repoPath: '/repo/x' });
@@ -868,11 +886,51 @@ describe('syncRepoWithControl — portal watermark', () => {
     expect(writePortalWatermarkMock).not.toHaveBeenCalled();
   });
 
+  it('holds the watermark and warns when a telemetry channel could not be read', async () => {
+    readPortalWatermarkMock.mockReturnValue('2026-01-02T00:00:00.000Z');
+    fetchPersistedPortalTelemetryMock.mockResolvedValue({
+      usage: [],
+      events: [],
+      maxSyncedAt: '2026-01-09T00:00:00.000Z',
+      failures: [{ channel: 'usage', reason: 'HTTP 500' }],
+      truncated: [],
+    });
+    mockFetch({ status: 200 });
+
+    const outcome = await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(writePortalWatermarkMock).not.toHaveBeenCalled();
+    expect(outcome.warnings).toHaveLength(1);
+    expect(outcome.warnings[0]).toContain('usage (HTTP 500)');
+  });
+
+  it('reports a truncated read while still advancing what it did send', async () => {
+    fetchPersistedPortalTelemetryMock.mockResolvedValue({
+      usage: [],
+      events: [],
+      maxSyncedAt: '2026-01-09T00:00:00.000Z',
+      failures: [],
+      truncated: ['events'],
+    });
+    mockFetch({ status: 200 });
+
+    const outcome = await syncRepoWithControl({ repoPath: '/repo/x' });
+
+    expect(writePortalWatermarkMock).toHaveBeenCalledWith(
+      '/repo/x',
+      'https://portal.example.com',
+      '2026-01-09T00:00:00.000Z',
+    );
+    expect(outcome.warnings[0]).toContain('page cap');
+  });
+
   it('does not advance the watermark on dry-run', async () => {
     fetchPersistedPortalTelemetryMock.mockResolvedValue({
       usage: [],
       events: [],
       maxSyncedAt: '2026-01-09T00:00:00.000Z',
+      failures: [],
+      truncated: [],
     });
     mockFetch({ status: 200 });
 
@@ -1027,6 +1085,8 @@ describe('syncRepoWithControl — attached destinations', () => {
       usage: [],
       events: [],
       maxSyncedAt: '2026-03-01T00:00:00.000Z',
+      failures: [],
+      truncated: [],
     });
     listRunsMock.mockReturnValue([
       {

--- a/tests/control-portal-trajectory.test.ts
+++ b/tests/control-portal-trajectory.test.ts
@@ -31,7 +31,13 @@ jest.mock('../src/core/usage-harvest', () => {
   };
 });
 jest.mock('../src/core/control-persisted-usage', () => ({
-  fetchPersistedPortalTelemetry: jest.fn(async () => ({ usage: [], events: [], maxSyncedAt: null })),
+  fetchPersistedPortalTelemetry: jest.fn(async () => ({
+    usage: [],
+    events: [],
+    maxSyncedAt: null,
+    failures: [],
+    truncated: [],
+  })),
 }));
 jest.mock('../src/core/control-persisted-trajectory', () => ({
   fetchPersistedTrajectory: jest.fn(),
@@ -151,6 +157,8 @@ beforeEach(() => {
     spans: [SPAN],
     recordsMaxSyncedAt: '2026-01-02T00:00:00.000Z',
     spansMaxSyncedAt: '2026-01-03T00:00:00.000Z',
+    failures: [],
+    truncated: [],
   });
 });
 
@@ -206,6 +214,8 @@ describe('trajectory forwarding', () => {
       spans: [SPAN],
       recordsMaxSyncedAt: null,
       spansMaxSyncedAt: '2026-01-03T00:00:00.000Z',
+      failures: [],
+      truncated: [],
     });
     const fetchMock = mockFetch();
 
@@ -251,7 +261,9 @@ describe('trajectory forwarding', () => {
   it('keeps the records watermark when the portal has no trajectory endpoint', async () => {
     const fetchMock = mockFetch({ '/api/trajectory': 404 });
 
-    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).resolves.toBeUndefined();
+    await expect(syncRepoWithControl({ repoPath: '/repo/x' })).resolves.toEqual({
+      warnings: [],
+    });
 
     expect(portalCall(fetchMock, '/api/trajectory')).toBeDefined();
     expect(writePortalWatermarkMock).not.toHaveBeenCalledWith(

--- a/tests/control-sync-repos.test.ts
+++ b/tests/control-sync-repos.test.ts
@@ -137,7 +137,7 @@ describe('syncReposWithControl', () => {
 
   it('returns zeroes for an empty selection', async () => {
     const result = await syncReposWithControl({ repoPaths: [] });
-    expect(result).toEqual({ synced: 0, failed: 0, results: [] });
+    expect(result).toEqual({ synced: 0, failed: 0, incomplete: 0, results: [] });
   });
 
   it('makes no network calls in dry-run mode', async () => {


### PR DESCRIPTION
## Why

Two failure modes in `har control sync`, found while auditing what the portal actually receives.

**A telemetry read failure was indistinguishable from "nothing to send."** `getJson` returned `null` on a 3s timeout, a non-2xx and a transport error alike, and `collectPortalTelemetry` wrapped the whole harvest in `catch { return empty }`. A cold Mission Control or a loaded host cost a sync every usage row and event, printed `✓ Synced`, and — since usage and events share one watermark — could advance that watermark past rows it never sent. Observed on three consecutive `--full` runs against the same repo: 1 usage row / 0 events, then 44 / 200, then 1 / 0, while Mission Control held the data the whole time.

**Each read forwarded one capped page.** `/events` returned the newest 200 ordered `timestamp desc`; `/spans` returned the oldest 1,000 ordered `createdAt asc`. So the two channels covered disjoint sessions (0 of 9 keys in common), and `--full` — the thing you reach for when the data looks wrong — re-sent the *oldest* spans, a five-hour window 20 days before the sync.

## What changed

**Reads report why they failed** — `src/core/control-api-read.ts` (new) returns `{ok, data} | {ok: false, error}`, with the timeout raised 3s → 10s (`HAR_CONTROL_READ_TIMEOUT_MS`) and one retry on timeout/transport/5xx so a merely-cold route stops reading as missing data. `resolveControlRepoId` is de-duplicated out of both readers into it.

**A failed channel is visible and costs no data** — both readers return `failures[]`; the sync warns naming the channel and reason, holds that channel's watermark (either of usage/events holds their shared key), prints `⚠ Synced <repo> — incomplete` instead of `✓ Synced`, and counts it in the summary. `--json` gains `incomplete` and per-result `warnings`. Exit code is unchanged: 0 for incomplete, 1 for failed.

**Collections are paged forward** — `/events` now accepts `since`/`sinceId`/`limit` and returns `[createdAt asc, id asc]`; `/spans` and `/trajectory` gained the same `(createdAt, id)` keyset cursor, so a page boundary inside a same-millisecond insert batch neither skips nor stalls. Core walks each channel until a short page, reports `truncated` when it hits the page cap (default 20 pages) and advances the watermark to what it did send, so the remainder resumes next sync. A control API that ignores the cursor is detected and stops instead of looping.

`@@index([repositoryId, createdAt, id])` added to `AgentSessionEvent`, `AgentSessionSpan` and `AgentTrajectoryRecord` for the forward walk.

## Measured against real data

Patched control app run against a copy of a control DB holding **20,265 spans / 3,879 events** for one repo, with the sync pointed at a logging sink:

| | before | after |
| -- | -- | -- |
| events forwarded | 200 (newest) | **3,879** |
| spans forwarded | 1,000, all from a 5-hour window 20 days back | **20,000, ending at the newest** |
| session keys in both channels | 0 of 9 | **148 of 148** |
| rows past the page cap | silently absent | warned, and the next delta sync forwarded exactly the remaining **265** |

With `/usage` and `/spans` forced to 500:

\`\`\`
⚠ har: could not read usage (HTTP 500) from Mission Control — that telemetry is missing
  from this sync and its watermark is held, so the next sync retries it.
⚠ Synced /Users/…/har — incomplete
⚠ 2 repositories synced with incomplete telemetry — see the warnings above
\`\`\`

…and the watermark file was byte-identical before and after.

## Tests

`tests/control-persisted-usage.test.ts`, `tests/control-persisted-trajectory.test.ts` — multi-page walk, cursor in the query, short-page stop, page-cap truncation, cursor-ignored guard, failed channel reported with no watermark, retry-then-succeed on a cold hit. `tests/control-portal-sync.test.ts` — watermark held on failure, advanced on truncation, warning surfaced. `control/src/server/pagination.test.ts` and `session-events-egress.test.ts` — keyset/limit clamping and ordering.

## Reviewer notes

- `/events` ordering flips desc → asc. The only consumer of that GET is core's sync (the Mission Control UI reads the per-slot endpoints).
- Page cap is 20 pages × 1,000 rows per channel per sync, so a very deep backlog now drains over a couple of syncs rather than one — and says so instead of going quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)