### PR TITLE
fix(control): hex-encode OTLP trace ids and keep a session on one agent id

### DIFF
--- a/control/src/server/otel-ingest-session-context.test.ts
+++ b/control/src/server/otel-ingest-session-context.test.ts
@@ -14,8 +14,31 @@ interface FakeSlot {
   updatedAt: number;
 }
 
+interface FakeSessionRow {
+  repositoryId: string;
+  sessionKey: string;
+  agentId: number;
+  timestamp: number;
+}
+
 const repos = [{ id: 'repo-1', path: '/home/user/project' }];
 let slots: FakeSlot[] = [];
+let sessionEvents: FakeSessionRow[] = [];
+let sessionUsages: FakeSessionRow[] = [];
+
+function findSessionRow(
+  rows: FakeSessionRow[],
+  where: { repositoryId: string; sessionKey: string },
+): FakeSessionRow | null {
+  return (
+    rows
+      .filter(
+        (row) =>
+          row.repositoryId === where.repositoryId && row.sessionKey === where.sessionKey,
+      )
+      .sort((a, b) => a.timestamp - b.timestamp)[0] ?? null
+  );
+}
 
 vi.mock('@/lib/db', () => ({
   prisma: {
@@ -23,6 +46,18 @@ vi.mock('@/lib/db', () => ({
       findMany: vi.fn(async () => repos),
       findUnique: vi.fn(async ({ where }: { where: { path: string } }) =>
         repos.find((r) => r.path === where.path) ?? null,
+      ),
+    },
+    agentSessionEvent: {
+      findFirst: vi.fn(
+        async ({ where }: { where: { repositoryId: string; sessionKey: string } }) =>
+          findSessionRow(sessionEvents, where),
+      ),
+    },
+    agentSessionUsage: {
+      findFirst: vi.fn(
+        async ({ where }: { where: { repositoryId: string; sessionKey: string } }) =>
+          findSessionRow(sessionUsages, where),
       ),
     },
     agentSlot: {
@@ -70,6 +105,8 @@ function makeSlot(overrides: Partial<FakeSlot>): FakeSlot {
 describe('resolveSessionContext — Cursor on the main checkout', () => {
   beforeEach(() => {
     slots = [];
+    sessionEvents = [];
+    sessionUsages = [];
   });
 
   it('attributes to the one active worktree when correlation is unambiguous', async () => {
@@ -163,6 +200,74 @@ describe('resolveSessionContext — Cursor on the main checkout', () => {
       branch: 'fix/y',
       workUnitId: 'WU-2',
     });
+  });
+
+  it('keeps a session on the agent id it was first attributed to', async () => {
+    slots = [
+      makeSlot({ slotId: 4, workDir: '/home/user/worktrees/project-a', updatedAt: 1 }),
+      makeSlot({ slotId: 5, workDir: '/home/user/worktrees/project-b', updatedAt: 2 }),
+    ];
+    sessionEvents = [
+      {
+        repositoryId: 'repo-1',
+        sessionKey: 'session-uuid',
+        agentId: 4,
+        timestamp: 1,
+      },
+    ];
+
+    const { context } = await resolveSessionContext(
+      {},
+      {
+        'gen_ai.client.workspace': '/home/user/project',
+        'session.id': 'session-uuid',
+        'otelhook.provider.id': 'claude-code',
+      },
+    );
+
+    expect(context).toMatchObject({
+      sessionKey: 'session-uuid',
+      agentId: 4,
+      agentTool: 'claude_code',
+    });
+  });
+
+  it('falls back to persisted usage when the session has no events yet', async () => {
+    slots = [makeSlot({ slotId: 3, workDir: '/home/user/worktrees/project-a', updatedAt: 9 })];
+    sessionUsages = [
+      { repositoryId: 'repo-1', sessionKey: 'session-uuid', agentId: 2, timestamp: 1 },
+    ];
+
+    const { context } = await resolveSessionContext(
+      {},
+      { 'gen_ai.client.workspace': '/home/user/project', 'session.id': 'session-uuid' },
+    );
+
+    expect(context).toMatchObject({ sessionKey: 'session-uuid', agentId: 2 });
+  });
+
+  it('does not let a pin override the slot whose worktree the session ran in', async () => {
+    slots = [
+      makeSlot({
+        slotId: 2,
+        workDir: '/home/user/worktrees/project-abcd-har-agent-2-xyz',
+        worktreePath: '/home/user/worktrees/project-abcd-har-agent-2-xyz',
+        branch: 'feat/x',
+        updatedAt: 1,
+      }),
+    ];
+    sessionEvents = [
+      { repositoryId: 'repo-1', sessionKey: 'feat/x', agentId: 5, timestamp: 1 },
+    ];
+
+    const { context } = await resolveSessionContext(
+      {},
+      {
+        'gen_ai.client.workspace': '/home/user/worktrees/project-abcd-har-agent-2-xyz',
+      },
+    );
+
+    expect(context).toMatchObject({ agentId: 2 });
   });
 
   it('refuses harSessionKey-only attribution when agent tool is unknown', async () => {

--- a/control/src/server/otel-ingest-session-context.test.ts
+++ b/control/src/server/otel-ingest-session-context.test.ts
@@ -24,7 +24,6 @@ interface FakeSessionRow {
 const repos = [{ id: 'repo-1', path: '/home/user/project' }];
 let slots: FakeSlot[] = [];
 let sessionEvents: FakeSessionRow[] = [];
-let sessionUsages: FakeSessionRow[] = [];
 
 function findSessionRow(
   rows: FakeSessionRow[],
@@ -52,12 +51,6 @@ vi.mock('@/lib/db', () => ({
       findFirst: vi.fn(
         async ({ where }: { where: { repositoryId: string; sessionKey: string } }) =>
           findSessionRow(sessionEvents, where),
-      ),
-    },
-    agentSessionUsage: {
-      findFirst: vi.fn(
-        async ({ where }: { where: { repositoryId: string; sessionKey: string } }) =>
-          findSessionRow(sessionUsages, where),
       ),
     },
     agentSlot: {
@@ -106,7 +99,6 @@ describe('resolveSessionContext — Cursor on the main checkout', () => {
   beforeEach(() => {
     slots = [];
     sessionEvents = [];
-    sessionUsages = [];
   });
 
   it('attributes to the one active worktree when correlation is unambiguous', async () => {
@@ -230,20 +222,6 @@ describe('resolveSessionContext — Cursor on the main checkout', () => {
       agentId: 4,
       agentTool: 'claude_code',
     });
-  });
-
-  it('falls back to persisted usage when the session has no events yet', async () => {
-    slots = [makeSlot({ slotId: 3, workDir: '/home/user/worktrees/project-a', updatedAt: 9 })];
-    sessionUsages = [
-      { repositoryId: 'repo-1', sessionKey: 'session-uuid', agentId: 2, timestamp: 1 },
-    ];
-
-    const { context } = await resolveSessionContext(
-      {},
-      { 'gen_ai.client.workspace': '/home/user/project', 'session.id': 'session-uuid' },
-    );
-
-    expect(context).toMatchObject({ sessionKey: 'session-uuid', agentId: 2 });
   });
 
   it('does not let a pin override the slot whose worktree the session ran in', async () => {

--- a/control/src/server/otel-ingest.test.ts
+++ b/control/src/server/otel-ingest.test.ts
@@ -306,32 +306,16 @@ describe('normalizeOtelId', () => {
   const traceHex = '0123456789abcdef0123456789abcdef';
   const spanHex = '0011223344556677';
 
-  it('passes an OTLP/JSON hex id through, lowercased', () => {
+  it('accepts hex, protobuf base64 and raw bytes', () => {
     expect(normalizeOtelId(traceHex.toUpperCase(), 16)).toBe(traceHex);
-    expect(normalizeOtelId(spanHex, 8)).toBe(spanHex);
-  });
-
-  it('decodes the protobuf base64 form to hex', () => {
-    expect(normalizeOtelId(Buffer.from(traceHex, 'hex').toString('base64'), 16)).toBe(traceHex);
     expect(normalizeOtelId(Buffer.from(spanHex, 'hex').toString('base64'), 8)).toBe(spanHex);
+    expect(normalizeOtelId(new Uint8Array(Buffer.from(spanHex, 'hex')), 8)).toBe(spanHex);
   });
 
-  it('hex-encodes raw byte shapes instead of reading them as text', () => {
-    const bytes = Buffer.from(spanHex, 'hex');
-    expect(normalizeOtelId(bytes, 8)).toBe(spanHex);
-    expect(normalizeOtelId(new Uint8Array(bytes), 8)).toBe(spanHex);
-    expect(normalizeOtelId(Array.from(bytes), 8)).toBe(spanHex);
-    expect(normalizeOtelId({ type: 'Buffer', data: Array.from(bytes) }, 8)).toBe(spanHex);
-  });
-
-  it('treats absent, empty and all-zero ids as no id', () => {
+  it('has no id for absent, all-zero or unreadable values', () => {
     expect(normalizeOtelId(undefined, 8)).toBe('');
     expect(normalizeOtelId('', 8)).toBe('');
     expect(normalizeOtelId(Buffer.alloc(8), 8)).toBe('');
-    expect(normalizeOtelId(Buffer.alloc(0).toString('base64'), 8)).toBe('');
-  });
-
-  it('drops a lossy UTF-8 reading of the bytes rather than storing mojibake', () => {
     expect(normalizeOtelId(Buffer.from(traceHex, 'hex').toString('utf8'), 16)).toBe('');
   });
 });
@@ -414,13 +398,6 @@ describe('extractSpans over a protobuf-decoded OTLP payload', () => {
     expect(detectAgentTool(child.attributes)).toBe('claude_code');
   });
 
-  it('keeps the span identity out of the canonical source id as hex', () => {
-    const decoded = decodeOtlpProtobufJson('trace', protobufTraceBody());
-    const [, child] = extractSpans(decoded);
-    expect(canonicalizeOtelSpan(child).sourceEventId).toBe(
-      `span:${traceId.toString('hex')}:${childSpanId.toString('hex')}`,
-    );
-  });
 });
 
 describe('extractLogRecords ids', () => {
@@ -454,20 +431,5 @@ describe('extractLogRecords ids', () => {
     expect(records[0].traceId).toBe(traceId.toString('hex'));
     expect(records[0].spanId).toBe(spanId.toString('hex'));
     expect(records[0].parentSpanId).toBeUndefined();
-  });
-});
-
-describe('detectAgentTool provider precedence', () => {
-  it('reads the provider id off a record own attributes', () => {
-    expect(detectAgentTool({ 'otelhook.provider.id': 'claude-code' })).toBe('claude_code');
-  });
-
-  it('does not let the exporter service name outvote the provider id', () => {
-    expect(
-      detectAgentTool({
-        'otelhook.provider.id': 'claude-code',
-        'service.name': 'har-ide-agent',
-      }),
-    ).toBe('claude_code');
   });
 });

--- a/control/src/server/otel-ingest.test.ts
+++ b/control/src/server/otel-ingest.test.ts
@@ -1,12 +1,16 @@
+import { createRequire } from 'node:module';
 import { describe, expect, it } from 'vitest';
 import {
   canonicalizeOtelLogRecord,
   canonicalizeOtelSpan,
   canonicalSpanSequence,
+  decodeOtlpProtobufJson,
   detectAgentTool,
   extractLogRecords,
   extractPromptText,
   extractResponseText,
+  extractSpans,
+  normalizeOtelId,
   type AttrMap,
 } from './otel-ingest';
 
@@ -103,8 +107,8 @@ describe('canonical OTLP log facts', () => {
         scopeLogs: [{
           logRecords: [{
             eventName: 'sdk.log.name',
-            traceId: 'trace-1',
-            spanId: 'span-1',
+            traceId: '9f8e7d6c5b4a39281706f5e4d3c2b1a0',
+            spanId: '0a1b2c3d4e5f6071',
             timeUnixNano: '1786701600000000000',
             attributes: [
               { key: 'otelhook.event.id', value: { stringValue: 'evt-9' } },
@@ -134,7 +138,10 @@ describe('canonical OTLP log facts', () => {
       correlationId: 'tool-call-1',
       payload: { body: { stringValue: '{"ok":true}' } },
     });
-    expect(record).toMatchObject({ traceId: 'trace-1', spanId: 'span-1' });
+    expect(record).toMatchObject({
+      traceId: '9f8e7d6c5b4a39281706f5e4d3c2b1a0',
+      spanId: '0a1b2c3d4e5f6071',
+    });
   });
 
   it('keeps reasoning disclosure metadata without exposing a withheld body', () => {
@@ -292,5 +299,175 @@ describe('detectAgentTool', () => {
     expect(detectAgentTool({ 'otelhook.provider.id': 'claude-code' })).toBe('claude_code');
     expect(detectAgentTool({ 'otelhook.agent.name': 'claude-code' })).toBe('claude_code');
     expect(detectAgentTool({ 'gen_ai.client.name': 'cursor' })).toBe('cursor');
+  });
+});
+
+describe('normalizeOtelId', () => {
+  const traceHex = '0123456789abcdef0123456789abcdef';
+  const spanHex = '0011223344556677';
+
+  it('passes an OTLP/JSON hex id through, lowercased', () => {
+    expect(normalizeOtelId(traceHex.toUpperCase(), 16)).toBe(traceHex);
+    expect(normalizeOtelId(spanHex, 8)).toBe(spanHex);
+  });
+
+  it('decodes the protobuf base64 form to hex', () => {
+    expect(normalizeOtelId(Buffer.from(traceHex, 'hex').toString('base64'), 16)).toBe(traceHex);
+    expect(normalizeOtelId(Buffer.from(spanHex, 'hex').toString('base64'), 8)).toBe(spanHex);
+  });
+
+  it('hex-encodes raw byte shapes instead of reading them as text', () => {
+    const bytes = Buffer.from(spanHex, 'hex');
+    expect(normalizeOtelId(bytes, 8)).toBe(spanHex);
+    expect(normalizeOtelId(new Uint8Array(bytes), 8)).toBe(spanHex);
+    expect(normalizeOtelId(Array.from(bytes), 8)).toBe(spanHex);
+    expect(normalizeOtelId({ type: 'Buffer', data: Array.from(bytes) }, 8)).toBe(spanHex);
+  });
+
+  it('treats absent, empty and all-zero ids as no id', () => {
+    expect(normalizeOtelId(undefined, 8)).toBe('');
+    expect(normalizeOtelId('', 8)).toBe('');
+    expect(normalizeOtelId(Buffer.alloc(8), 8)).toBe('');
+    expect(normalizeOtelId(Buffer.alloc(0).toString('base64'), 8)).toBe('');
+  });
+
+  it('drops a lossy UTF-8 reading of the bytes rather than storing mojibake', () => {
+    expect(normalizeOtelId(Buffer.from(traceHex, 'hex').toString('utf8'), 16)).toBe('');
+  });
+});
+
+describe('extractSpans over a protobuf-decoded OTLP payload', () => {
+  const traceId = Buffer.from('bbb1a2c3d4e5f60718293a4b5c6d7e8f', 'hex');
+  const parentSpanId = Buffer.from('1122334455667788', 'hex');
+  const childSpanId = Buffer.from('99aabbccddeeff00', 'hex');
+
+  function protobufTraceBody(): Buffer {
+    const root = createRequire(import.meta.url)(
+      '@opentelemetry/otlp-transformer/build/src/generated/root.js',
+    ) as {
+      opentelemetry: {
+        proto: {
+          collector: {
+            trace: {
+              v1: {
+                ExportTraceServiceRequest: {
+                  fromObject: (value: unknown) => unknown;
+                  encode: (message: unknown) => { finish: () => Uint8Array };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+    const request = root.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+    const message = request.fromObject({
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [{ key: 'service.name', value: { stringValue: 'har-ide-agent' } }],
+          },
+          scopeSpans: [
+            {
+              spans: [
+                {
+                  traceId,
+                  spanId: parentSpanId,
+                  name: 'prompt',
+                  attributes: [
+                    { key: 'otelhook.provider.id', value: { stringValue: 'claude-code' } },
+                  ],
+                },
+                {
+                  traceId,
+                  spanId: childSpanId,
+                  parentSpanId,
+                  name: 'tool Bash',
+                  attributes: [
+                    { key: 'otelhook.provider.id', value: { stringValue: 'claude-code' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    return Buffer.from(request.encode(message).finish());
+  }
+
+  it('yields hex ids and a child that links to its parent', () => {
+    const decoded = decodeOtlpProtobufJson('trace', protobufTraceBody());
+    const spans = extractSpans(decoded);
+
+    expect(spans).toHaveLength(2);
+    for (const span of spans) {
+      expect(span.traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(span.spanId).toMatch(/^[0-9a-f]{16}$/);
+    }
+
+    const [parent, child] = spans;
+    expect(parent.traceId).toBe(traceId.toString('hex'));
+    expect(parent.parentSpanId).toBeNull();
+    expect(child.parentSpanId).toBe(parent.spanId);
+    expect(child.attributes['otelhook.provider.id']).toBe('claude-code');
+    expect(detectAgentTool(child.attributes)).toBe('claude_code');
+  });
+
+  it('keeps the span identity out of the canonical source id as hex', () => {
+    const decoded = decodeOtlpProtobufJson('trace', protobufTraceBody());
+    const [, child] = extractSpans(decoded);
+    expect(canonicalizeOtelSpan(child).sourceEventId).toBe(
+      `span:${traceId.toString('hex')}:${childSpanId.toString('hex')}`,
+    );
+  });
+});
+
+describe('extractLogRecords ids', () => {
+  it('hex-encodes the base64 ids a protobuf-decoded log record carries', () => {
+    const traceId = Buffer.from('aaaabbbbccccddddeeeeffff00001111', 'hex');
+    const spanId = Buffer.from('0f0e0d0c0b0a0908', 'hex');
+    const records = extractLogRecords({
+      resourceLogs: [
+        {
+          resource: { attributes: [] },
+          scopeLogs: [
+            {
+              logRecords: [
+                {
+                  timeUnixNano: '1700000000000000000',
+                  traceId: traceId.toString('base64'),
+                  spanId: spanId.toString('base64'),
+                  parentSpanId: Buffer.alloc(8).toString('base64'),
+                  attributes: [
+                    { key: 'otelhook.provider.id', value: { stringValue: 'claude-code' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].traceId).toBe(traceId.toString('hex'));
+    expect(records[0].spanId).toBe(spanId.toString('hex'));
+    expect(records[0].parentSpanId).toBeUndefined();
+  });
+});
+
+describe('detectAgentTool provider precedence', () => {
+  it('reads the provider id off a record own attributes', () => {
+    expect(detectAgentTool({ 'otelhook.provider.id': 'claude-code' })).toBe('claude_code');
+  });
+
+  it('does not let the exporter service name outvote the provider id', () => {
+    expect(
+      detectAgentTool({
+        'otelhook.provider.id': 'claude-code',
+        'service.name': 'har-ide-agent',
+      }),
+    ).toBe('claude_code');
   });
 });

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -60,7 +60,7 @@ function loadOtlpProtobufDecoder(
   }
 }
 
-function decodeOtlpProtobufJson(
+export function decodeOtlpProtobufJson(
   kind: 'trace' | 'logs' | 'metrics',
   body: Buffer,
 ): unknown | null {
@@ -71,7 +71,9 @@ function decodeOtlpProtobufJson(
     return decoder.toObject(message, {
       longs: String,
       enums: String,
-      bytes: (value: Uint8Array) => Buffer.from(value).toString('hex'),
+      // protobufjs honours only String (base64) or Array here; a converter
+      // function is ignored and yields raw Buffers. normalizeOtelId re-hexes.
+      bytes: String,
       defaults: true,
       arrays: true,
       objects: true,
@@ -79,6 +81,38 @@ function decodeOtlpProtobufJson(
   } catch {
     return null;
   }
+}
+
+const HEX_ONLY = /^[0-9a-f]+$/;
+
+function bytesToHexId(bytes: Uint8Array): string {
+  if (bytes.length === 0 || bytes.every((b) => b === 0)) return '';
+  return Buffer.from(bytes).toString('hex');
+}
+
+/**
+ * OTLP trace/span ids are bytes; only their hex form survives JSON, a database
+ * column or an id comparison. Accepts every shape a decoder can hand us —
+ * protobuf base64, OTLP/JSON hex, Buffer, byte array — and drops anything else
+ * rather than storing a lossy UTF-8 reading of the bytes.
+ */
+export function normalizeOtelId(value: unknown, byteLength: number): string {
+  if (value == null) return '';
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase();
+    if (lower.length === byteLength * 2 && HEX_ONLY.test(lower)) return lower;
+    const decoded = Buffer.from(value, 'base64');
+    if (decoded.length === byteLength) return bytesToHexId(decoded);
+    if (lower.length % 2 === 0 && HEX_ONLY.test(lower)) return lower;
+    return '';
+  }
+  if (value instanceof Uint8Array) return bytesToHexId(value);
+  if (Array.isArray(value)) return bytesToHexId(Uint8Array.from(value as number[]));
+  if (typeof value === 'object') {
+    const data = (value as { data?: unknown }).data;
+    if (Array.isArray(data)) return bytesToHexId(Uint8Array.from(data as number[]));
+  }
+  return '';
 }
 
 export interface AttrMap {
@@ -363,6 +397,32 @@ async function defaultAgentIdForRepo(repositoryId: string): Promise<number> {
   return active?.slotId ?? 1;
 }
 
+/**
+ * The agent id a session was already attributed to.
+ *
+ * Slot attribution for a workspace outside any session worktree is a guess from
+ * the repo's live slots, and that guess moves as slots come and go — the same
+ * session then splits across agent ids and renders as several partial streams.
+ * The first attribution a session got wins for the rest of its life.
+ */
+async function pinnedAgentIdForSession(
+  repositoryId: string,
+  sessionKey: string,
+): Promise<number | undefined> {
+  if (!sessionKey) return undefined;
+  const event = await prisma.agentSessionEvent.findFirst({
+    where: { repositoryId, sessionKey },
+    orderBy: { timestamp: 'asc' },
+    select: { agentId: true },
+  });
+  if (event) return event.agentId;
+  const usage = await prisma.agentSessionUsage.findFirst({
+    where: { repositoryId, sessionKey },
+    select: { agentId: true },
+  });
+  return usage?.agentId;
+}
+
 interface ActiveSlotAttribution {
   agentId: number;
   workDir?: string;
@@ -450,13 +510,15 @@ export async function resolveSessionContext(
     const byRepo = await resolveRepositoryByWorkspacePath(workspace);
     if (byRepo) {
       const activeSlot = await resolveUnambiguousActiveSlot(byRepo.repositoryId);
+      const sessionKey =
+        harSessionKey || providerSessionId || `ide:${normalizePath(byRepo.path)}`;
       return {
         context: {
           repositoryId: byRepo.repositoryId,
-          sessionKey:
-            harSessionKey || providerSessionId || `ide:${normalizePath(byRepo.path)}`,
+          sessionKey,
           agentId:
             explicitAgentId ??
+            (await pinnedAgentIdForSession(byRepo.repositoryId, sessionKey)) ??
             activeSlot?.agentId ??
             (await defaultAgentIdForRepo(byRepo.repositoryId)),
           agentTool: tool ?? 'cursor',
@@ -482,13 +544,15 @@ export async function resolveSessionContext(
     const byId = await resolveRepositoryByWorkspaceId(workspaceId);
     if (byId) {
       const activeSlot = await resolveUnambiguousActiveSlot(byId.repositoryId);
+      const sessionKey =
+        harSessionKey || providerSessionId || `ide:${normalizePath(byId.path)}`;
       return {
         context: {
           repositoryId: byId.repositoryId,
-          sessionKey:
-            harSessionKey || providerSessionId || `ide:${normalizePath(byId.path)}`,
+          sessionKey,
           agentId:
             explicitAgentId ??
+            (await pinnedAgentIdForSession(byId.repositoryId, sessionKey)) ??
             activeSlot?.agentId ??
             (await defaultAgentIdForRepo(byId.repositoryId)),
           agentTool: tool ?? 'cursor',
@@ -528,7 +592,10 @@ export async function resolveSessionContext(
       context: {
         repositoryId,
         sessionKey: harSessionKey,
-        agentId: explicitAgentId ?? 1,
+        agentId:
+          explicitAgentId ??
+          (await pinnedAgentIdForSession(repositoryId, harSessionKey)) ??
+          1,
         agentTool: tool,
         workDir: resource['har.work_dir']
           ? String(resource['har.work_dir'])
@@ -1018,15 +1085,10 @@ export function extractLogRecords(payload: unknown): ParsedLogRecord[] {
               attributes.sequence ??
               seq,
           ),
-          traceId: record.traceId || record.trace_id
-            ? String(record.traceId ?? record.trace_id)
-            : undefined,
-          spanId: record.spanId || record.span_id
-            ? String(record.spanId ?? record.span_id)
-            : undefined,
-          parentSpanId: record.parentSpanId || record.parent_span_id
-            ? String(record.parentSpanId ?? record.parent_span_id)
-            : undefined,
+          traceId: normalizeOtelId(record.traceId ?? record.trace_id, 16) || undefined,
+          spanId: normalizeOtelId(record.spanId ?? record.span_id, 8) || undefined,
+          parentSpanId:
+            normalizeOtelId(record.parentSpanId ?? record.parent_span_id, 8) || undefined,
         });
       }
     }
@@ -1286,7 +1348,7 @@ interface ParsedSpan {
   attributes: AttrMap;
 }
 
-function extractSpans(payload: unknown): ParsedSpan[] {
+export function extractSpans(payload: unknown): ParsedSpan[] {
   const out: ParsedSpan[] = [];
   if (!payload || typeof payload !== 'object') return out;
   const root = payload as {
@@ -1312,11 +1374,9 @@ function extractSpans(payload: unknown): ParsedSpan[] {
         const record = span as Record<string, unknown>;
         out.push({
           resource,
-          traceId: String(record.traceId ?? record.trace_id ?? ''),
-          spanId: String(record.spanId ?? record.span_id ?? ''),
-          parentSpanId: record.parentSpanId || record.parent_span_id
-            ? String(record.parentSpanId ?? record.parent_span_id)
-            : null,
+          traceId: normalizeOtelId(record.traceId ?? record.trace_id, 16),
+          spanId: normalizeOtelId(record.spanId ?? record.span_id, 8),
+          parentSpanId: normalizeOtelId(record.parentSpanId ?? record.parent_span_id, 8) || null,
           name: String(record.name ?? 'span'),
           startTime: otelTimeToDate(record.startTimeUnixNano ?? record.start_time_unix_nano),
           endTime: record.endTimeUnixNano || record.end_time_unix_nano

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -71,8 +71,7 @@ export function decodeOtlpProtobufJson(
     return decoder.toObject(message, {
       longs: String,
       enums: String,
-      // protobufjs honours only String (base64) or Array here; a converter
-      // function is ignored and yields raw Buffers. normalizeOtelId re-hexes.
+      // protobufjs ignores a converter function here and returns raw Buffers.
       bytes: String,
       defaults: true,
       arrays: true,
@@ -83,36 +82,18 @@ export function decodeOtlpProtobufJson(
   }
 }
 
-const HEX_ONLY = /^[0-9a-f]+$/;
-
-function bytesToHexId(bytes: Uint8Array): string {
-  if (bytes.length === 0 || bytes.every((b) => b === 0)) return '';
-  return Buffer.from(bytes).toString('hex');
-}
-
-/**
- * OTLP trace/span ids are bytes; only their hex form survives JSON, a database
- * column or an id comparison. Accepts every shape a decoder can hand us —
- * protobuf base64, OTLP/JSON hex, Buffer, byte array — and drops anything else
- * rather than storing a lossy UTF-8 reading of the bytes.
- */
+/** Hex form of an OTLP id — hex passes through, base64 and bytes convert, '' when neither. */
 export function normalizeOtelId(value: unknown, byteLength: number): string {
-  if (value == null) return '';
-  if (typeof value === 'string') {
-    const lower = value.toLowerCase();
-    if (lower.length === byteLength * 2 && HEX_ONLY.test(lower)) return lower;
-    const decoded = Buffer.from(value, 'base64');
-    if (decoded.length === byteLength) return bytesToHexId(decoded);
-    if (lower.length % 2 === 0 && HEX_ONLY.test(lower)) return lower;
-    return '';
-  }
-  if (value instanceof Uint8Array) return bytesToHexId(value);
-  if (Array.isArray(value)) return bytesToHexId(Uint8Array.from(value as number[]));
-  if (typeof value === 'object') {
-    const data = (value as { data?: unknown }).data;
-    if (Array.isArray(data)) return bytesToHexId(Uint8Array.from(data as number[]));
-  }
-  return '';
+  const bytes =
+    typeof value === 'string'
+      ? /^[0-9a-f]{2,}$/i.test(value) && value.length === byteLength * 2
+        ? Buffer.from(value, 'hex')
+        : Buffer.from(value, 'base64')
+      : value instanceof Uint8Array
+        ? Buffer.from(value)
+        : null;
+  if (!bytes || bytes.length !== byteLength || bytes.every((b) => b === 0)) return '';
+  return bytes.toString('hex');
 }
 
 export interface AttrMap {
@@ -398,29 +379,20 @@ async function defaultAgentIdForRepo(repositoryId: string): Promise<number> {
 }
 
 /**
- * The agent id a session was already attributed to.
- *
- * Slot attribution for a workspace outside any session worktree is a guess from
- * the repo's live slots, and that guess moves as slots come and go — the same
- * session then splits across agent ids and renders as several partial streams.
- * The first attribution a session got wins for the rest of its life.
+ * Slot attribution outside a session worktree is a guess from the repo's live
+ * slots, and that guess moves as slots come and go. First attribution wins.
  */
 async function pinnedAgentIdForSession(
   repositoryId: string,
   sessionKey: string,
 ): Promise<number | undefined> {
   if (!sessionKey) return undefined;
-  const event = await prisma.agentSessionEvent.findFirst({
+  const first = await prisma.agentSessionEvent.findFirst({
     where: { repositoryId, sessionKey },
     orderBy: { timestamp: 'asc' },
     select: { agentId: true },
   });
-  if (event) return event.agentId;
-  const usage = await prisma.agentSessionUsage.findFirst({
-    where: { repositoryId, sessionKey },
-    select: { agentId: true },
-  });
-  return usage?.agentId;
+  return first?.agentId;
 }
 
 interface ActiveSlotAttribution {

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -71,7 +71,6 @@ export function decodeOtlpProtobufJson(
     return decoder.toObject(message, {
       longs: String,
       enums: String,
-      // protobufjs ignores a converter function here and returns raw Buffers.
       bytes: String,
       defaults: true,
       arrays: true,
@@ -82,7 +81,6 @@ export function decodeOtlpProtobufJson(
   }
 }
 
-/** Hex form of an OTLP id — hex passes through, base64 and bytes convert, '' when neither. */
 export function normalizeOtelId(value: unknown, byteLength: number): string {
   const bytes =
     typeof value === 'string'
@@ -378,10 +376,6 @@ async function defaultAgentIdForRepo(repositoryId: string): Promise<number> {
   return active?.slotId ?? 1;
 }
 
-/**
- * Slot attribution outside a session worktree is a guess from the repo's live
- * slots, and that guess moves as slots come and go. First attribution wins.
- */
 async function pinnedAgentIdForSession(
   repositoryId: string,
   sessionKey: string,

--- a/control/src/server/trajectory-projections.ts
+++ b/control/src/server/trajectory-projections.ts
@@ -132,6 +132,9 @@ export async function projectTrajectoryRecord(record: AgentTrajectoryRecord): Pr
         attributes: redactSecretAttributes(attributes) as Prisma.InputJsonValue,
       },
       update: {
+        sessionKey: record.sessionKey,
+        agentId: record.agentId,
+        agentTool: record.agentTool,
         parentSpanId: record.parentSpanId,
         endTime: endTime && Number.isFinite(endTime.getTime()) ? endTime : undefined,
         attributes: redactSecretAttributes(attributes) as Prisma.InputJsonValue,

--- a/control/src/server/trajectory-projections.ts
+++ b/control/src/server/trajectory-projections.ts
@@ -132,9 +132,6 @@ export async function projectTrajectoryRecord(record: AgentTrajectoryRecord): Pr
         attributes: redactSecretAttributes(attributes) as Prisma.InputJsonValue,
       },
       update: {
-        sessionKey: record.sessionKey,
-        agentId: record.agentId,
-        agentTool: record.agentTool,
         parentSpanId: record.parentSpanId,
         endTime: endTime && Number.isFinite(endTime.getTime()) ? endTime : undefined,
         attributes: redactSecretAttributes(attributes) as Prisma.InputJsonValue,


### PR DESCRIPTION
Two identity defects in Mission Control's OTLP ingest that make one agent session render as several partial ones.

## 1. Trace/span ids were raw bytes read as UTF-8

Every span and trajectory record stored the 16-byte trace id and 8-byte span id as a lossy UTF-8 reading of the bytes:

```json
{ "traceId": "?y???B??P?{d;?", "spanId": "dc?b?ch", "parentSpanId": "4{9????" }
```

The cause is a protobufjs detail: `toObject` honours only `String` (base64) or `Array` for its `bytes` conversion option, so the converter function the decoder passed was silently ignored and returned `Buffer`s, which `String()` then decoded as text. Each invalid sequence collapses to U+FFFD, so the ids could not be recovered, joined to a parent span, or compared — and `AgentSessionSpan` is uniquely keyed on `(repositoryId, traceId, spanId)`.

Fixed by decoding as base64 and normalising ids to hex in one place (`normalizeOtelId`), applied at both extraction sites.

## 2. One session split across agent ids

A workspace outside any session worktree (an agent running in the main checkout) has no slot to match, so the agent id came from the repo's live slots — a guess that changes as slots come and go. Records from a single session landed under different agent ids and, since stream identity includes the agent id, rendered as two partial streams with a wrong duration each.

A session is now pinned to the agent id it was first attributed to. The pin applies only where the id would otherwise be a guess: an explicit `har.agent_id` and a real worktree match still win.

## Verification

Beyond the unit tests, live hook traffic was captured as raw protobuf and replayed through the patched extractor: 102 real spans, **0 malformed trace ids, 0 malformed span ids, 0 malformed parents**. The hook derives its ids deterministically (sha256 over `otelhook/trace`, the provider id and the session id, truncated to 32 chars, plus the `session`-family span id); the hex now decoded is byte-exact against that derivation for three real sessions, which is to say a child's `parentSpanId` is exactly the session span's id and the pair links up.

## Notes for reviewers

- Ids that are neither hex nor base64 of the right length are now dropped rather than stored. One existing test fixture used the placeholder `traceId: 'trace-1'` and was updated to a realistic hex id; real exporters send bytes or hex.
- Rows already written with lossy ids cannot be recovered and are left alone; they age out with retention.
- A session that ran outside any slot still carries a slot number, just a stable one. Representing "no slot" needs `agentId` to stop being `min(1)` in `@har/schemas` and is left for a follow-up.
