### PR TITLE
feat: versioned manifest migrations + maintain-driven MIGRATE prompt (#241)

### DIFF
--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -497,8 +497,160 @@ milestone_asserts() {
       fi
       ;;
     M4|M5)
-      echo "──> $MILESTONE asserts: migration (extend when #241 lands)"
-      echo "    pending: maintain-driven migration of the pre-1.0 fixture harness"
+      echo "──> $MILESTONE asserts: pre-1.0 → 1.0 migration (#241)"
+      # The fixture clone ships a pre-1.0 adapted harness (vendored runtime
+      # bash, shell functions in harness.env, custom HARNESS_TEMPLATE_SQLITE
+      # key). Drive the full migration path on it: detect → prompt → apply →
+      # lift residue (this script plays the coding agent) → doctor → verify.
+      if ! har "$CLONE" env maintain --help 2>&1 | grep -q -- '--migrate'; then
+        echo "    SKIP: har env maintain --migrate not available yet (#241 not landed in this build)"
+      else
+        ensure_clone "$CLONE"   # reset to the pristine pre-1.0 shape
+        har "$CLONE" env cleanup >/dev/null 2>&1 || true
+        har "$CLONE" env teardown 1 >/dev/null 2>&1 || true
+
+        [ -f "$CLONE/.har/agent-slot.sh" ] || fail "M4: fixture clone lost its pre-1.0 shape (agent-slot.sh missing)"
+        grep -qE '^[a-zA-Z_][a-zA-Z0-9_]*\(\)' "$CLONE/.har/harness.env" \
+          || fail "M4: fixture harness.env carries no pre-1.0 shell functions"
+
+        # 1) Plain maintain: detect + prompt, but change NOTHING (compat window).
+        har "$CLONE" env maintain --yes >/dev/null 2>&1 || fail "M4: maintain failed on the pre-1.0 harness"
+        [ -f "$CLONE/.har/MIGRATE-PROMPT.md" ] || fail "M4: maintain wrote no MIGRATE-PROMPT.md"
+        [ -f "$CLONE/.har/migrate/plan.json" ] || fail "M4: maintain wrote no migration plan"
+        [ -f "$CLONE/.har/agent-slot.sh" ] || fail "M4: plain maintain deleted machinery — compat window violated"
+        if grep -q 'exec har env' "$CLONE/.har/launch.sh"; then
+          fail "M4: plain maintain rewrote launch.sh — compat window violated"
+        fi
+        grep -q 'HARNESS_TEMPLATE_SQLITE' "$CLONE/.har/MIGRATE-PROMPT.md" \
+          || fail "M4: MIGRATE prompt does not surface the custom HARNESS_TEMPLATE_SQLITE residue"
+        echo "    maintain detects pre-1.0, writes prompt+plan, changes nothing ✓"
+
+        # 2) Mechanical migration: shims in, machinery out, env pure, backups kept.
+        har "$CLONE" env maintain --migrate --yes >/dev/null 2>&1 || fail "M4: maintain --migrate failed"
+        local mig_script
+        for mig_script in launch.sh verify.sh teardown.sh setup-infra.sh; do
+          grep -q 'exec har env' "$CLONE/.har/$mig_script" \
+            || fail "M4: migrated .har/$mig_script is not a managed shim"
+        done
+        [ ! -f "$CLONE/.har/provision-toolchain.sh" ] || fail "M4: migration left runtime machinery .har/provision-toolchain.sh"
+        # agent-slot.sh is still sourced by the adapted stages/browser-e2e.sh:
+        # classify-and-lift keeps it (deleting would break the stage) and puts
+        # the rewrite on the prompt.
+        [ -f "$CLONE/.har/agent-slot.sh" ] \
+          || fail "M4: migration deleted agent-slot.sh while stages/browser-e2e.sh still sources it"
+        grep -q 'agent-slot.sh' "$CLONE/.har/MIGRATE-PROMPT.md" \
+          || fail "M4: retained machinery not surfaced in the MIGRATE prompt"
+        if grep -qE '^[a-zA-Z_][a-zA-Z0-9_]*\(\)' "$CLONE/.har/harness.env"; then
+          fail "M4: migrated harness.env still contains shell functions"
+        fi
+        [ -f "$CLONE/.har/migrate/backup/launch.sh" ] || fail "M4: migration kept no backup of launch.sh"
+        node -e '
+          const m = require(process.argv[1]);
+          if (m.runtimeVersion !== "1.0.0") { console.error("M4: manifest runtimeVersion not stamped:", m.runtimeVersion); process.exit(1); }
+          if (!m.migratedFrom) { console.error("M4: manifest migratedFrom not recorded"); process.exit(1); }
+        ' "$CLONE/.har/manifest.json" || fail "M4: migration not recorded in manifest.json"
+        echo "    mechanical migration: shims + pure config + backups + manifest stamp ✓"
+
+        # Custom verification ids whose commands lived in the vendored
+        # verify.sh case table must have been dropped from verificationStages
+        # (mechanically unresolvable) and surfaced as residue in the prompt.
+        node -e '
+          const fs = require("fs");
+          const r = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+          const ids = r.verificationStages ?? [];
+          for (const id of ["node-build", "api-health", "ml-tests"]) {
+            if (ids.includes(id)) { console.error(`M4: unresolvable verification id ${id} survived migration`); process.exit(1); }
+          }
+        ' "$CLONE/.har/stages.json" || fail "M4: phantom verification ids not reconciled"
+        grep -q 'node-build' "$CLONE/.har/MIGRATE-PROMPT.md" \
+          || fail "M4: dropped verification ids not surfaced in the MIGRATE prompt"
+        echo "    unresolvable verification ids dropped + surfaced as residue ✓"
+
+        # 3a) Residue lift — play the coding agent: re-register the vendored
+        # verify.sh case-table checks as plain stages.json command stages
+        # (commands read from the backup; api-health stays dropped — the
+        # packaged runtime's health check covers HARNESS_HEALTH_CHECK_PATH).
+        node -e '
+          const fs = require("fs");
+          const p = process.argv[1];
+          const r = JSON.parse(fs.readFileSync(p, "utf8"));
+          const add = [
+            { id: "node-build", kind: "test", description: "Production build (lifted from pre-1.0 verify.sh)", command: "NODE_ENV=production ${NPM_BIN:-npm} run build", artifacts: [] },
+            { id: "ml-tests", kind: "test", description: "ML test suite (lifted from pre-1.0 verify.sh)", command: "${NPM_BIN:-npm} run test:ml", artifacts: [] },
+          ];
+          for (const st of add) {
+            if (!r.stages.some((s) => s.id === st.id)) r.stages.push(st);
+            if (!r.verificationStages.includes(st.id)) r.verificationStages.push(st.id);
+          }
+          fs.writeFileSync(p, JSON.stringify(r, null, 2) + "\n");
+        ' "$CLONE/.har/stages.json" || fail "M4: could not re-register lifted verification stages"
+        echo "    residue lift: vendored verify checks re-registered as command stages ✓"
+
+        # 3b) Residue lift — play the coding agent: rewrite browser-e2e.sh
+        # against the 1.0 stage surface (WORK_DIR/ENV_FILE/AGENT_ID exported by
+        # the verify runner), then delete the retained agent-slot.sh.
+        node -e '
+          const fs = require("fs");
+          const p = process.argv[1];
+          let c = fs.readFileSync(p, "utf8");
+          const lines = c.split("\n");
+          const start = lines.findIndex((l) => l.startsWith("ENV_FILE=\"$(resolve_agent_env_file"));
+          const end = lines.findIndex((l, i) => i > start && l.trim() === "}");
+          if (start < 0 || end < 0) { console.error("browser-e2e.sh resolve block not found"); process.exit(1); }
+          lines.splice(start, end - start + 1,
+            "ENV_FILE=\"${ENV_FILE:-$REPO_ROOT/.env.agent.${AGENT_ID}}\"",
+            "[ -f \"$ENV_FILE\" ] || { echo \"No .env.agent.${AGENT_ID} found — launch slot ${AGENT_ID} first.\" >&2; exit 1; }");
+          c = lines.join("\n");
+          c = c.replace(/^source "\$HARNESS_DIR\/agent-slot\.sh"$/m, ": # agent-slot.sh retired (1.0 migration)\nnow_ms() { date +%s%3N; }");
+          c = c.replace("validate_agent_id \"$AGENT_ID\"", "[[ \"$AGENT_ID\" =~ ^[0-9]+$ ]] || { echo \"invalid agent id: $AGENT_ID\" >&2; exit 2; }");
+          c = c.replace("WORK_DIR=\"$(resolve_agent_work_dir \"$ENV_FILE\")\"", "WORK_DIR=\"${WORK_DIR:-$(cd \"$(dirname \"$ENV_FILE\")\" && pwd)}\"");
+          fs.writeFileSync(p, c);
+        ' "$CLONE/.har/stages/browser-e2e.sh" || fail "M4: could not rewrite browser-e2e.sh off agent-slot.sh"
+        if grep -E '^[[:space:]]*source .*agent-slot\.sh' "$CLONE/.har/stages/browser-e2e.sh" | grep -qv '^[[:space:]]*#'; then
+          fail "M4: browser-e2e.sh still sources agent-slot.sh after the lift"
+        fi
+        rm -f "$CLONE/.har/agent-slot.sh"
+        echo "    residue lift: browser-e2e.sh rewritten to the 1.0 surface, agent-slot.sh deleted ✓"
+
+        # 3c) Residue lift — play the coding agent: the pre-1.0 launch.sh cloned
+        # a per-slot SQLite DB from the template; per MIGRATE-PROMPT.md that
+        # behavior belongs in a post-launch lifecycle hook.
+        [ -f "$CLONE/.har/state/template/cars.sqlite" ] \
+          || fail "M4: SQLite template missing — Mode 1 should have provisioned it"
+        mkdir -p "$CLONE/.har/hooks"
+        cat > "$CLONE/.har/hooks/post-launch.sh" <<'HOOK'
+#!/usr/bin/env bash
+# Lifted from the pre-1.0 vendored launch.sh (migration residue, #241):
+# per-slot SQLite database cloned from the shared template.
+set -euo pipefail
+TEMPLATE="$HAR_HARNESS_DIR/state/template/cars.sqlite"
+[ -f "$TEMPLATE" ] || { echo "post-launch: missing SQLite template $TEMPLATE" >&2; exit 1; }
+mkdir -p "$WORK_DIR/data"
+[ -f "$WORK_DIR/data/cars.sqlite" ] || cp "$TEMPLATE" "$WORK_DIR/data/cars.sqlite"
+HOOK
+        chmod +x "$CLONE/.har/hooks/post-launch.sh"
+
+        # 4) Doctor must be green on the migrated harness (1.0 contract enforced).
+        har "$CLONE" env doctor >/dev/null 2>&1 || fail "M4: doctor red on the migrated harness"
+        echo "    doctor green on migrated harness (1.0 contract) ✓"
+
+        # 5) The muscle memory keeps working: full lifecycle on the migrated
+        # harness, driven end-to-end through the 1.0 runtime + shims.
+        local mig_marker="$ART_DIR/.m4-migrate-start"; touch "$mig_marker"
+        har "$CLONE" env launch 1 || fail "M4: launch failed on the migrated harness"
+        har "$CLONE" env verify 1 --full || fail "M4: full verify failed on the migrated harness"
+        har "$CLONE" env complete 1 --skip-verify || fail "M4: complete failed on the migrated harness"
+        find "$CLONE/.har/validations" -name '*.json' -newer "$mig_marker" | grep -q . \
+          || fail "M4: full verify on the migrated harness wrote no validation record"
+        echo "    migrated harness: launch → full verify → complete, records written ✓"
+
+        # 6) Finalize records the migration and clears the migration artifacts.
+        har "$CLONE" env maintain --finalize --summary "M4 gate: migrated pre-1.0 fixture harness to 1.0" \
+          >/dev/null 2>&1 || fail "M4: maintain --finalize failed post-migration"
+        [ ! -d "$CLONE/.har/migrate" ] || fail "M4: finalize left .har/migrate/ behind"
+        [ ! -f "$CLONE/.har/MIGRATE-PROMPT.md" ] || fail "M4: finalize left MIGRATE-PROMPT.md behind"
+        echo "    finalize clears migration artifacts ✓"
+      fi
       ;;
     generic)
       : ;;

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -48,6 +48,15 @@ export const HarnessManifestSchema = z.object({
     .optional(),
   adaptationSummary: z.string().optional(),
   profile: z.enum(['default', 'cli', 'ios']).optional(),
+  /**
+   * Harness runtime-contract version (#241) — the shape of the installed
+   * `.har/` surface (thin shims + pure config = '1.0.0'). Absent on pre-1.0
+   * harnesses; the migration registry (src/harness/migrations.ts) keys on it.
+   */
+  runtimeVersion: z.string().optional(),
+  /** Shape this harness was migrated from ('pre-1.0'), stamped at migration (#241). */
+  migratedFrom: z.string().optional(),
+  migratedAt: z.string().optional(),
   /** `har env eject` (#239): the user owns the runtime scripts + .har/runtime/. */
   ejected: z.boolean().optional(),
   /** @osfactory/har version whose runtime was vendored at eject time. */

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import type { Argv } from 'yargs';
 import { finishCommand } from '../finish-command';
 import { initHarness, maintainHarness, addPlugin } from '../../core/harness';
+import type { MaintainMigrationInfo } from '../../core/harness';
 import {
   listPluginIds,
 } from '../../harness/plugins';
@@ -145,6 +146,12 @@ export const envCommand = {
               type: 'boolean',
               default: false,
               describe: 'Record the completed manual adaptation in .har/manifest.json (updates file checksums)',
+            })
+            .option('migrate', {
+              type: 'boolean',
+              default: false,
+              describe:
+                'Apply the pending mechanical migration steps (pre-1.0 → 1.0; backups in .har/migrate/backup/)',
             })
             .option('summary', {
               type: 'string',
@@ -620,6 +627,7 @@ export async function handleMaintain(argv: {
   verbose: boolean;
   yes: boolean;
   finalize: boolean;
+  migrate?: boolean;
   summary?: string;
   /** Tri-state from yargs: unset | --cursor-rule | --no-cursor-rule */
   cursorRule?: boolean;
@@ -640,8 +648,15 @@ export async function handleMaintain(argv: {
       repoPath,
       verbose: argv.verbose,
       finalize: argv.finalize,
+      migrate: argv.migrate,
       summary: argv.summary,
     });
+
+    if (result.migration) {
+      printMigrationSummary(result.migration);
+    } else if (argv.migrate) {
+      info('No pending migration — the harness is already on the 1.0 shape.');
+    }
 
     divider();
     info('Validating harness...');
@@ -673,14 +688,23 @@ export async function handleMaintain(argv: {
       if (!result.validation.pass) {
         warn('Harness has validation errors — fix them before running --finalize.');
       }
-      await emitManualAdaptationPrompt(
-        repoPath,
-        'maintain',
-        'default',
-        result.bundle?.report,
-        argv.yes,
-      );
-      info('After your coding agent finishes adapting, record it with: har env maintain --finalize');
+      if (result.migration) {
+        info('Migration prompt for your coding agent (also saved to .har/MIGRATE-PROMPT.md):');
+        printAdaptationPrompt(result.migration.prompt);
+        await offerAdaptationPromptClipboard(result.migration.prompt, { autoYes: argv.yes });
+        info(
+          'After your coding agent finishes the migration, record it with: har env maintain --finalize',
+        );
+      } else {
+        await emitManualAdaptationPrompt(
+          repoPath,
+          'maintain',
+          'default',
+          result.bundle?.report,
+          argv.yes,
+        );
+        info('After your coding agent finishes adapting, record it with: har env maintain --finalize');
+      }
     }
 
     divider();
@@ -1567,6 +1591,32 @@ function printMaintainBundleSummary(report: MaintainBundleReport): void {
   }
   if (!report.validation.pass) {
     warn(`  Validation: ${report.validation.errors.length} error(s) — blocks --finalize`);
+  }
+}
+
+/** Loud pre-1.0 → 1.0 migration report (#241). */
+function printMigrationSummary(migration: MaintainMigrationInfo): void {
+  divider();
+  if (migration.applied) {
+    const applied = migration.appliedResult;
+    success(`Migration applied: ${migration.title}`);
+    if (applied) {
+      if (applied.written.length > 0) info(`  Rewritten: ${applied.written.join(', ')}`);
+      if (applied.deleted.length > 0) info(`  Removed:   ${applied.deleted.join(', ')}`);
+      info(`  Backups:   .har/migrate/backup/`);
+    }
+    info(`  Manifest stamped runtimeVersion=${migration.to}`);
+    if (migration.plan.residue.length > 0) {
+      warn(
+        `  ${migration.plan.residue.length} adapted item(s) need lifting into config/stages/hooks/plugins — see .har/MIGRATE-PROMPT.md`,
+      );
+    }
+  } else {
+    warn(`PRE-1.0 HARNESS DETECTED — migration available: ${migration.title}`);
+    warn('  Your vendored .har/*.sh scripts keep working for now (deprecated, compat window).');
+    info(`  Plan:    .har/migrate/plan.json`);
+    info(`  Prompt:  .har/MIGRATE-PROMPT.md (paste into your coding agent)`);
+    info(`  Apply mechanical steps: har env maintain --migrate`);
   }
 }
 

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -14,6 +14,14 @@ import { getVerificationStageIds, getAgentSlotRange, listStages, syncAgentSlotsT
 import { ensureEcosystemVerificationStages } from '../harness/verification';
 import { DoctorReport, runDoctor } from '../harness/doctor';
 import {
+  AppliedMigration,
+  MigrationPlan,
+  pendingMigrations,
+  removeMigrationArtifacts,
+  writeMigrationPlan,
+} from '../harness/migrations';
+import { buildMigrationPrompt, writeMigrationPrompt } from '../harness/migrate-prompt';
+import {
   applyPlugin,
   ApplyPluginOptions,
   ApplyPluginResult,
@@ -39,6 +47,22 @@ export interface MaintainHarnessOptions {
   verbose?: boolean;
   finalize?: boolean;
   summary?: string;
+  /** Apply the pending mechanical migration steps (#241). */
+  migrate?: boolean;
+}
+
+/** Pre-1.0 → 1.0 migration state surfaced by maintain (#241). */
+export interface MaintainMigrationInfo {
+  migrationId: string;
+  to: string;
+  title: string;
+  /** True when `--migrate` ran the mechanical steps this invocation. */
+  applied: boolean;
+  plan: MigrationPlan;
+  appliedResult?: AppliedMigration;
+  /** Absolute path of the generated .har/MIGRATE-PROMPT.md. */
+  promptPath: string;
+  prompt: string;
 }
 
 export interface MaintainHarnessResult {
@@ -47,6 +71,8 @@ export interface MaintainHarnessResult {
   /** Contract validation (#232) — runs automatically on every maintain. */
   doctor: DoctorReport;
   bundle?: MaintainBundleResult;
+  /** Set when the harness has (or just applied) a pending shape migration (#241). */
+  migration?: MaintainMigrationInfo;
 }
 
 export interface ProjectDescription {
@@ -132,6 +158,45 @@ export async function maintainHarness(options: MaintainHarnessOptions): Promise<
     throw new Error('No .har/ found. Run "har env init" first.');
   }
 
+  // Versioned migrations (#241): a pre-1.0 harness is detected on every
+  // maintain. Plain maintain only plans + writes the MIGRATE prompt (compat
+  // window — nothing changes); `--migrate` applies the mechanical steps with
+  // backups under .har/migrate/backup/.
+  let migration: MaintainMigrationInfo | undefined;
+  const pending = pendingMigrations(repoPath);
+  if (pending.length > 0 && !options.finalize) {
+    const next = pending[0];
+    if (options.migrate) {
+      const applied = next.apply(repoPath);
+      const prompt = buildMigrationPrompt(applied.plan, applied);
+      const promptPath = writeMigrationPrompt(repoPath, prompt);
+      migration = {
+        migrationId: next.id,
+        to: next.to,
+        title: next.title,
+        applied: true,
+        plan: applied.plan,
+        appliedResult: applied,
+        promptPath,
+        prompt,
+      };
+    } else {
+      const plan = next.plan(repoPath);
+      writeMigrationPlan(repoPath, plan);
+      const prompt = buildMigrationPrompt(plan, null);
+      const promptPath = writeMigrationPrompt(repoPath, prompt);
+      migration = {
+        migrationId: next.id,
+        to: next.to,
+        title: next.title,
+        applied: false,
+        plan,
+        promptPath,
+        prompt,
+      };
+    }
+  }
+
   ensureEcosystemVerificationStages(repoPath);
   const drift = compareHarnessToTemplate(repoPath);
   const validation = validateHarness(repoPath);
@@ -149,6 +214,12 @@ export async function maintainHarness(options: MaintainHarnessOptions): Promise<
       existing?.stack,
     );
     removeMaintainBundle(repoPath);
+    // Migration artifacts (backups, plan, prompt) are kept until the harness
+    // is actually on the 1.0 shape — finalize on a still-pre-1.0 harness must
+    // not destroy the only copy of the vendored scripts.
+    if (pendingMigrations(repoPath).length === 0) {
+      removeMigrationArtifacts(repoPath);
+    }
     return {
       validation,
       drift: compareHarnessToTemplate(repoPath),
@@ -163,6 +234,7 @@ export async function maintainHarness(options: MaintainHarnessOptions): Promise<
     drift,
     doctor: runDoctor(repoPath),
     bundle,
+    migration,
   };
 }
 

--- a/src/core/local-executor.ts
+++ b/src/core/local-executor.ts
@@ -254,6 +254,23 @@ function harnessScriptIsLegacy(repoPath: string, scriptName: string): boolean {
  * custom commands, pre-1.0 harnesses with their own runtime bash) so they keep
  * running as scripts/shell.
  */
+const warnedLegacyScripts = new Set<string>();
+
+/**
+ * Compat-window deprecation (#241): loud, once per script per process — the
+ * vendored script keeps running (grandfathering, #234), never breaks.
+ */
+function warnLegacyRuntimeScript(repoPath: string, scriptName: string): void {
+  const key = `${path.resolve(repoPath)}:${scriptName}`;
+  if (warnedLegacyScripts.has(key)) return;
+  warnedLegacyScripts.add(key);
+  process.stderr.write(
+    `DEPRECATED: .har/${scriptName} carries the pre-1.0 vendored runtime — it keeps working ` +
+      'for now, but 1.0 runs the runtime from the package. Run `har env maintain` to generate ' +
+      'the migration prompt (.har/MIGRATE-PROMPT.md).\n',
+  );
+}
+
 async function runPackageRuntimeStage(
   repoPath: string,
   stage: HarnessStage,
@@ -261,7 +278,10 @@ async function runPackageRuntimeStage(
   capture: boolean,
 ): Promise<StageResult | undefined> {
   const legacyScript = RUNTIME_SCRIPT_FOR_KIND[stage.kind];
-  if (legacyScript && harnessScriptIsLegacy(repoPath, legacyScript)) return undefined;
+  if (legacyScript && harnessScriptIsLegacy(repoPath, legacyScript)) {
+    warnLegacyRuntimeScript(repoPath, legacyScript);
+    return undefined;
+  }
   const started = Date.now();
   const finish = (exitCode: number, stdout: string, stderr: string, previewUrls?: Record<string, string>) =>
     buildStageResult({

--- a/src/harness/doctor.ts
+++ b/src/harness/doctor.ts
@@ -170,7 +170,7 @@ export function runDoctor(repoPath: string): DoctorReport {
         message: issue.message,
         remedy:
           contract === 'pre-1.0'
-            ? 'Pre-1.0 harness — migration to the 1.0 pure-config contract lands with `har env migrate` (#241)'
+            ? 'Pre-1.0 harness — run `har env maintain` to generate the MIGRATE prompt, then `har env maintain --migrate`'
             : undefined,
       });
     }
@@ -416,7 +416,7 @@ export function formatDoctorReport(report: DoctorReport): string {
   if (report.contract !== '1.0') {
     lines.push(
       report.contract === 'pre-1.0'
-        ? 'Contract: pre-1.0 harness — contract findings reported as warnings until migration (#241).'
+        ? 'Contract: pre-1.0 harness — contract findings reported as warnings until migrated (`har env maintain` → MIGRATE-PROMPT.md → `--migrate`).'
         : 'Contract: no harness.env found.',
     );
   }

--- a/src/harness/drift.ts
+++ b/src/harness/drift.ts
@@ -271,7 +271,8 @@ export function compareHarnessToTemplate(repoPath: string): HarnessDriftResult {
       if (
         file === 'manifest.json' ||
         file === 'plugins.json' ||
-        file.startsWith('ADAPT-PROMPT')
+        file.startsWith('ADAPT-PROMPT') ||
+        file.startsWith('MIGRATE-PROMPT')
       ) {
         continue;
       }

--- a/src/harness/manifest.ts
+++ b/src/harness/manifest.ts
@@ -5,6 +5,12 @@ import { HarnessManifest, HarnessManifestSchema } from './schema';
 import { writeFileSafe } from '../utils/file-ops';
 
 const MANIFEST_VERSION = '1';
+/**
+ * Runtime-contract version of the generated harness shape (#241): thin shims
+ * + pure config. Stamped at init/finalize/migration; the migration registry
+ * (migrations.ts) keys on it.
+ */
+export const HARNESS_RUNTIME_VERSION = '1.0.0';
 export const DEFAULT_HAR_DIR = '.har';
 
 const CHECKSUM_SKIP = new Set([
@@ -15,6 +21,7 @@ const CHECKSUM_SKIP = new Set([
   'AGENT.md.proposed',
   'AGENT.md.proposed.meta.json',
   'ADAPT-PROMPT.md',
+  'MIGRATE-PROMPT.md',
 ]);
 
 export function getHarnessDir(repoPath: string): string {
@@ -78,6 +85,7 @@ export function createManifest(
   const harnessDir = getHarnessDir(repoPath);
   return {
     version: MANIFEST_VERSION,
+    runtimeVersion: HARNESS_RUNTIME_VERSION,
     outputDir: DEFAULT_HAR_DIR,
     createdAt: now,
     updatedAt: now,

--- a/src/harness/migrate-prompt.ts
+++ b/src/harness/migrate-prompt.ts
@@ -1,0 +1,137 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveTemplateFile } from '../utils/paths';
+import { writeFileSafe } from '../utils/file-ops';
+import { getHarnessDir } from './manifest';
+import type { AppliedMigration, MigrationPlan } from './migrations';
+import { MIGRATE_BACKUP_DIR, MIGRATE_PLAN_FILE } from './migrations';
+
+export const MIGRATE_PROMPT_FILE = 'MIGRATE-PROMPT.md';
+
+const TARGET_LABEL: Record<string, string> = {
+  config: 'harness.env (config)',
+  stage: 'stages.json / .har/stages/',
+  hook: '.har/hooks/',
+  plugin: 'local plugin (.har/plugins/)',
+  review: 'review (likely nothing to keep)',
+};
+
+function residueTable(plan: MigrationPlan): string[] {
+  if (plan.residue.length === 0) {
+    return [
+      'No adapted-file residue detected — the mechanical migration covers everything.',
+      'Skim the backups under `.har/migrate/backup/` once to confirm, then continue with Step 5.',
+    ];
+  }
+  const lines = [
+    '| Source | Backup | Lift into | Why |',
+    '|--------|--------|-----------|-----|',
+  ];
+  for (const item of plan.residue) {
+    lines.push(
+      `| \`${item.source}\` | ${item.backup ? `\`${item.backup}\`` : '—'} | ${TARGET_LABEL[item.target] ?? item.target} | ${item.reason} |`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * The dynamic section of MIGRATE-PROMPT.md: what maintain detected, what the
+ * mechanical migration does (or did), and the residue only an agent can lift.
+ */
+export function buildMigrationSection(
+  plan: MigrationPlan,
+  applied: AppliedMigration | null,
+): string {
+  const lines: string[] = [];
+
+  if (applied) {
+    lines.push(
+      '## Step 1 — Mechanical migration: DONE',
+      '',
+      '`har env maintain --migrate` already ran. Every replaced or deleted file is backed up',
+      `under \`.har/${MIGRATE_BACKUP_DIR}/\`; the machine-readable plan is \`.har/${MIGRATE_PLAN_FILE}\`.`,
+      '',
+    );
+  } else {
+    lines.push(
+      '## Step 1 — Run the mechanical migration',
+      '',
+      '```',
+      'har env maintain --migrate',
+      '```',
+      '',
+      'This applies the steps below as code, backing every touched file up under',
+      `\`.har/${MIGRATE_BACKUP_DIR}/\` (plan: \`.har/${MIGRATE_PLAN_FILE}\`). Until you run it, the`,
+      'vendored pre-1.0 scripts keep working against this CLI (deprecated, not broken).',
+      '',
+    );
+  }
+
+  lines.push(`What the mechanical migration ${applied ? 'did' : 'will do'}:`, '');
+  if (plan.replaceWithShims.length > 0) {
+    lines.push(
+      `- Replace${applied ? 'd' : ''} with managed shims (same argument conventions): ${plan.replaceWithShims.map((f) => `\`${f}\``).join(', ')}`,
+    );
+  }
+  if (plan.deleteMachinery.length > 0) {
+    lines.push(
+      `- Delete${applied ? 'd' : ''} vendored runtime machinery (now lives in the package): ${plan.deleteMachinery.map((f) => `\`${f}\``).join(', ')}`,
+    );
+  }
+  if (plan.retainMachinery.length > 0) {
+    lines.push(
+      `- ${applied ? 'Kept' : 'Keep'} (for now) machinery still sourced by your stage/hook scripts: ${plan.retainMachinery.map((f) => `\`${f}\``).join(', ')} — see the residue table`,
+    );
+  }
+  if (plan.env) {
+    const env = plan.env;
+    const bits: string[] = [];
+    if (env.removedFunctions.length > 0) {
+      bits.push(`removed shell functions (${env.removedFunctions.join(', ')})`);
+    }
+    if (env.convertedFlags.length > 0) {
+      bits.push(`converted legacy infra flags → \`HARNESS_INFRA_SERVICES="${env.services.join(' ')}"\``);
+    }
+    if (env.droppedTriplets.length > 0) {
+      bits.push(
+        env.portLanes
+          ? `converted port triplets → \`HARNESS_INFRA_PORT_LANES="${env.portLanes}"\``
+          : `dropped ${env.droppedTriplets.length} unused legacy port-triplet exports`,
+      );
+    }
+    if (env.commentedKeys.length > 0) {
+      bits.push(`commented out custom keys (${env.commentedKeys.join(', ')})`);
+    }
+    lines.push(
+      `- Rewr${applied ? 'ote' : 'ite'} \`harness.env\` as pure schema-valid config${bits.length > 0 ? `: ${bits.join('; ')}` : ''}`,
+    );
+  }
+  lines.push(
+    `- Stamp${applied ? 'ed' : ''} \`manifest.json\` with \`runtimeVersion: ${plan.to}\` and re-baseline${applied ? 'd' : ''} drift checksums`,
+    '',
+  );
+
+  lines.push('## Step 2 — Residue: adapted files that carry real customization', '');
+  lines.push(...residueTable(plan), '');
+
+  return lines.join('\n');
+}
+
+function loadTemplate(): string {
+  const filePath = resolveTemplateFile('migration-prompt.md');
+  if (!filePath) {
+    throw new Error('Migration prompt template not found: migration-prompt.md. Run npm run build.');
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+export function buildMigrationPrompt(plan: MigrationPlan, applied: AppliedMigration | null): string {
+  return loadTemplate().replace('{{MIGRATION_SECTION}}', buildMigrationSection(plan, applied));
+}
+
+export function writeMigrationPrompt(repoPath: string, content: string): string {
+  const filePath = path.join(getHarnessDir(repoPath), MIGRATE_PROMPT_FILE);
+  writeFileSafe(filePath, content);
+  return filePath;
+}

--- a/src/harness/migrations.ts
+++ b/src/harness/migrations.ts
@@ -1,0 +1,626 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  HARNESS_ENV_KNOWN_KEYS,
+  LEGACY_PORT_TRIPLET_PATTERN,
+} from './schema';
+import {
+  computeFileChecksum,
+  computeHarnessChecksums,
+  getHarnessDir,
+  HARNESS_RUNTIME_VERSION,
+  readManifest,
+  writeManifest,
+} from './manifest';
+import type { HarnessProfile } from './profiles';
+import { composeProfileTemplateMap, readComposedTemplateContent } from './profiles';
+import { RUNTIME_SHIM_FILES, substituteTemplateTokens } from './template-tokens';
+import { computeTemplateChecksums } from './drift';
+import { readStageRegistry, writeStageRegistry } from './stages';
+import { findPhantomVerificationStageIds } from './verification';
+
+/**
+ * Versioned harness migrations (#241) — pre-1.0 → 1.0.
+ *
+ * The manifest's `runtimeVersion` records the shape of the installed `.har/`
+ * surface; this registry holds the migrations keyed on the version they bring
+ * a harness up to. Mechanical steps run as code (`har env maintain --migrate`);
+ * everything that needs judgment — lifting customizations out of vendored
+ * scripts into config/stages/hooks/local plugins — lands in the generated
+ * `.har/MIGRATE-PROMPT.md` for the user's coding agent.
+ *
+ * Flow: `har env maintain` on a pre-1.0 harness detects the old shape, writes
+ * the MIGRATE prompt, and changes nothing (compat window — the vendored
+ * scripts keep executing, loudly deprecated). The prompt's first step is
+ * `har env maintain --migrate`, which applies the mechanical steps with every
+ * touched file backed up under `.har/migrate/backup/`.
+ */
+
+export { HARNESS_RUNTIME_VERSION } from './manifest';
+
+export const MIGRATE_DIR = 'migrate';
+export const MIGRATE_BACKUP_DIR = path.join(MIGRATE_DIR, 'backup');
+export const MIGRATE_PLAN_FILE = path.join(MIGRATE_DIR, 'plan.json');
+
+/**
+ * Pre-1.0 runtime machinery superseded wholesale by the package runtime
+ * (#234). Deleted mechanically (after backup); an edit since the last
+ * finalize is flagged as residue for the MIGRATE prompt.
+ */
+export const LEGACY_MACHINERY_FILES = [
+  'agent-slot.sh',
+  'provision-toolchain.sh',
+  'simulator.sh',
+  'lib/infra.sh',
+  'lib/node-pm.sh',
+] as const;
+
+/** Helper functions pre-1.0 templates shipped inside harness.env / lib/. */
+const STOCK_ENV_FUNCTION_RE =
+  /^(har_infra_enabled|har_pg|har_node_[a-z_]+|har_pkg_exec)$/;
+
+/** Pre-1.0 shell function definitions (any name) in harness.env. */
+const ENV_FUNCTION_RE = /^([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{?/;
+
+/** Pre-1.0 boolean infra flags → compose service names. */
+const LEGACY_INFRA_FLAGS: Record<string, string> = {
+  HARNESS_INFRA_POSTGRES: 'db',
+  HARNESS_INFRA_DB: 'db',
+  HARNESS_INFRA_MINIO: 'minio',
+  HARNESS_INFRA_MAILPIT: 'mailpit',
+  HARNESS_INFRA_HEADLESS_BROWSER: 'headless-browser',
+  HARNESS_INFRA_BROWSER: 'headless-browser',
+};
+
+/** Triplet prefix (HARNESS_<PREFIX>_PORT_*) → port lane name. */
+const TRIPLET_LANES: Record<string, { lane: string; service: string }> = {
+  DB: { lane: 'db', service: 'db' },
+  MINIO: { lane: 'minio', service: 'minio' },
+  MINIO_CONSOLE: { lane: 'minio-console', service: 'minio' },
+  MAILPIT_WEB: { lane: 'mailpit-web', service: 'mailpit' },
+  MAILPIT_SMTP: { lane: 'mailpit-smtp', service: 'mailpit' },
+  BROWSER: { lane: 'browser', service: 'headless-browser' },
+};
+
+export type ResidueTarget = 'config' | 'stage' | 'hook' | 'plugin' | 'review';
+
+export interface MigrationResidueItem {
+  /** File (relative to .har/) or harness.env key the residue came from. */
+  source: string;
+  /** Backup path relative to .har/ when a backup will exist after apply. */
+  backup?: string;
+  reason: string;
+  /** Where the customization should land in the 1.0 model. */
+  target: ResidueTarget;
+}
+
+export interface HarnessEnvMigration {
+  /** Purified pure-config content. */
+  content: string;
+  removedFunctions: string[];
+  /** Function names that were project-specific, not shipped helpers. */
+  customFunctions: string[];
+  convertedFlags: string[];
+  /** Services derived from legacy boolean flags / existing list. */
+  services: string[];
+  /** HARNESS_INFRA_PORT_LANES value derived from legacy triplets ('' if none). */
+  portLanes: string;
+  droppedTriplets: string[];
+  /** Unknown HARNESS_* keys commented out (schema would reject them). */
+  commentedKeys: string[];
+  droppedShellLines: number;
+}
+
+export interface MigrationPlan {
+  id: string;
+  to: string;
+  profile: HarnessProfile;
+  /** Lifecycle entry scripts replaced by managed shims. */
+  replaceWithShims: string[];
+  /** Runtime machinery deleted (superseded by the package runtime). */
+  deleteMachinery: string[];
+  /** Machinery files edited since the last finalize (flagged, still deleted). */
+  editedMachinery: string[];
+  /**
+   * Machinery still referenced by surviving user-owned scripts (stage scripts,
+   * hooks) — retained instead of deleted so those scripts keep working, and
+   * flagged as residue: rewrite the script against the 1.0 surface (WORK_DIR /
+   * ENV_FILE / AGENT_ID are exported to stages), then delete the file.
+   */
+  retainMachinery: string[];
+  env: HarnessEnvMigration | null;
+  /**
+   * verificationStages ids with no registered runnable stage. Pre-1.0, the
+   * vendored verify.sh resolved these in its internal case table; the 1.0
+   * registry is authoritative, so they are dropped from verificationStages
+   * (keeping verify runnable) and re-registered via the MIGRATE prompt.
+   */
+  phantomVerificationIds: string[];
+  residue: MigrationResidueItem[];
+}
+
+export interface AppliedMigration {
+  plan: MigrationPlan;
+  backupDir: string;
+  /** Files written/deleted, relative to .har/. */
+  written: string[];
+  deleted: string[];
+}
+
+export interface HarnessMigration {
+  id: string;
+  /** Runtime version this migration brings a harness up to. */
+  to: string;
+  title: string;
+  detect(repoPath: string): boolean;
+  plan(repoPath: string): MigrationPlan;
+  apply(repoPath: string, plan?: MigrationPlan): AppliedMigration;
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/** Pre-1.0 markers in harness.env: shell functions or legacy port triplets. */
+export function harnessEnvIsPre10(content: string): boolean {
+  return (
+    /^\s*(har_infra_enabled|har_pg|har_node_[a-z_]+|har_pkg_exec)\s*\(\)/m.test(content) ||
+    /^export\s+HARNESS_[A-Z0-9_]+_PORT_(DEFAULT|SCAN_START|SCAN_END)=/m.test(content)
+  );
+}
+
+function scriptIsVendored(harnessDir: string, script: string): boolean {
+  const file = path.join(harnessDir, script);
+  if (!fs.existsSync(file)) return false;
+  const content = fs.readFileSync(file, 'utf8');
+  // Managed shims delegate to `har env`; ejected scripts (#239) execute the
+  // vendored runtime bundle the user owns — neither is pre-1.0 bash.
+  return !content.includes('exec har env') && !content.includes('runtime/har.cjs');
+}
+
+/**
+ * Shape detection for the pre-1.0 → 1.0 migration: vendored runtime bash in
+ * the lifecycle scripts, leftover runtime machinery files, or a shell-era
+ * harness.env. Ejected harnesses (#239) are user-owned 1.0 harnesses.
+ */
+export function isPre10Harness(repoPath: string): boolean {
+  const resolved = path.resolve(repoPath);
+  const harnessDir = getHarnessDir(resolved);
+  if (!fs.existsSync(harnessDir)) return false;
+  const manifest = readManifest(resolved);
+  if (manifest?.ejected) return false;
+
+  for (const file of LEGACY_MACHINERY_FILES) {
+    if (fs.existsSync(path.join(harnessDir, file))) return true;
+  }
+  for (const script of RUNTIME_SHIM_FILES) {
+    if (scriptIsVendored(harnessDir, script)) return true;
+  }
+  const envPath = path.join(harnessDir, 'harness.env');
+  if (fs.existsSync(envPath) && harnessEnvIsPre10(fs.readFileSync(envPath, 'utf8'))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Rewrite a pre-1.0 harness.env into pure schema-valid config:
+ * - shell functions dropped (shipped helpers silently; custom ones as residue)
+ * - legacy boolean infra flags → HARNESS_INFRA_SERVICES
+ * - legacy port triplets → HARNESS_INFRA_PORT_LANES (enabled services only)
+ * - unknown HARNESS_* keys commented out (the 1.0 schema rejects them)
+ * - any other shell code dropped
+ */
+export function migrateHarnessEnvContent(original: string): HarnessEnvMigration {
+  const lines = original.split('\n');
+  const out: string[] = [];
+  const removedFunctions: string[] = [];
+  const convertedFlags: string[] = [];
+  const droppedTriplets: string[] = [];
+  const commentedKeys: string[] = [];
+  const triplets: Record<string, { def?: number; start?: number; end?: number }> = {};
+  let services: string[] = [];
+  let hadServicesKey = false;
+  let hasLanesKey = false;
+  let droppedShellLines = 0;
+  let fnDepth = 0;
+
+  const ASSIGN_RE = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (fnDepth > 0) {
+      fnDepth += (trimmed.match(/{/g) ?? []).length;
+      fnDepth -= (trimmed.match(/}/g) ?? []).length;
+      if (fnDepth < 0) fnDepth = 0;
+      continue;
+    }
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      out.push(line);
+      continue;
+    }
+
+    const fnMatch = trimmed.match(ENV_FUNCTION_RE);
+    if (fnMatch) {
+      removedFunctions.push(fnMatch[1]);
+      fnDepth = Math.max(
+        (trimmed.match(/{/g) ?? []).length - (trimmed.match(/}/g) ?? []).length,
+        // `name() {` with the body on following lines still opens one block.
+        trimmed.endsWith('{') ? 1 : 0,
+      );
+      continue;
+    }
+
+    const assign = trimmed.match(ASSIGN_RE);
+    if (!assign) {
+      droppedShellLines++;
+      continue;
+    }
+
+    const [, key, rawValue] = assign;
+    const value = rawValue.replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
+
+    if (key === 'HARNESS_INFRA_SERVICES') {
+      hadServicesKey = true;
+      services = [...new Set([...services, ...value.split(/\s+/).filter(Boolean)])];
+      out.push(line);
+      continue;
+    }
+    if (key === 'HARNESS_INFRA_PORT_LANES') {
+      hasLanesKey = true;
+      out.push(line);
+      continue;
+    }
+    if (key in LEGACY_INFRA_FLAGS) {
+      convertedFlags.push(key);
+      if (value === 'true') services = [...new Set([...services, LEGACY_INFRA_FLAGS[key]])];
+      continue;
+    }
+    const tripletMatch = key.match(/^HARNESS_([A-Z0-9_]+)_PORT_(DEFAULT|SCAN_START|SCAN_END)$/);
+    if (tripletMatch && LEGACY_PORT_TRIPLET_PATTERN.test(key)) {
+      const [, prefix, part] = tripletMatch;
+      const slot = (triplets[prefix] ??= {});
+      const num = parseInt(value, 10);
+      if (part === 'DEFAULT') slot.def = num;
+      else if (part === 'SCAN_START') slot.start = num;
+      else slot.end = num;
+      droppedTriplets.push(key);
+      continue;
+    }
+    if ((HARNESS_ENV_KNOWN_KEYS as string[]).includes(key) || !key.startsWith('HARNESS_')) {
+      out.push(line);
+      continue;
+    }
+    // Unknown HARNESS_* key — the 1.0 schema rejects it. Preserve the value as
+    // a comment so a hook/stage that consumed it can be pointed at it.
+    commentedKeys.push(key);
+    out.push(`# [migrated 0.x — custom key, not in the 1.0 schema] ${trimmed}`);
+    out.push(
+      `#   → consume it from a lifecycle hook or stage script instead (see .har/MIGRATE-PROMPT.md)`,
+    );
+  }
+
+  // Legacy flags → services list (only when the file had no list already).
+  if (!hadServicesKey && services.length > 0) {
+    out.push('', `export HARNESS_INFRA_SERVICES="${services.join(' ')}"`);
+  }
+
+  // Triplets → lanes, but only lanes whose service is actually enabled —
+  // pre-1.0 templates shipped triplets for every service regardless of use.
+  const laneEntries: string[] = [];
+  if (!hasLanesKey) {
+    for (const [prefix, mapping] of Object.entries(TRIPLET_LANES)) {
+      const t = triplets[prefix];
+      if (!t || t.def === undefined || t.start === undefined || t.end === undefined) continue;
+      if (!services.includes(mapping.service)) continue;
+      laneEntries.push(`${mapping.lane}=${t.def}:${t.start}-${t.end}`);
+    }
+    if (laneEntries.length > 0) {
+      out.push('', `export HARNESS_INFRA_PORT_LANES="${laneEntries.join(' ')}"`);
+    }
+  }
+
+  // Collapse runs of 3+ blank lines left by removed blocks.
+  const content = out.join('\n').replace(/\n{3,}/g, '\n\n');
+
+  return {
+    content,
+    removedFunctions,
+    customFunctions: removedFunctions.filter((f) => !STOCK_ENV_FUNCTION_RE.test(f)),
+    convertedFlags,
+    services,
+    portLanes: laneEntries.join(' '),
+    droppedTriplets,
+    commentedKeys,
+    droppedShellLines,
+  };
+}
+
+const SCRIPT_RESIDUE_TARGET: Record<string, ResidueTarget> = {
+  'launch.sh': 'hook',
+  'teardown.sh': 'hook',
+  'setup-infra.sh': 'hook',
+  'verify.sh': 'stage',
+  'preflight.sh': 'review',
+  'agent-cli.sh': 'review',
+};
+
+function backupRel(file: string): string {
+  return path.join(MIGRATE_BACKUP_DIR, file);
+}
+
+function buildPre10Plan(repoPath: string): MigrationPlan {
+  const resolved = path.resolve(repoPath);
+  const harnessDir = getHarnessDir(resolved);
+  const manifest = readManifest(resolved);
+  const profile: HarnessProfile = manifest?.profile ?? 'default';
+  const composed = composeProfileTemplateMap(profile);
+  const fileBaseline = manifest?.fileChecksums ?? {};
+
+  const replaceWithShims: string[] = [];
+  const residue: MigrationResidueItem[] = [];
+
+  for (const script of RUNTIME_SHIM_FILES) {
+    if (!composed.has(script)) continue;
+    if (!scriptIsVendored(harnessDir, script) && fs.existsSync(path.join(harnessDir, script))) {
+      continue; // already a shim (or ejected — excluded upstream)
+    }
+    replaceWithShims.push(script);
+    if (fs.existsSync(path.join(harnessDir, script))) {
+      const target = SCRIPT_RESIDUE_TARGET[script] ?? 'review';
+      residue.push({
+        source: script,
+        backup: backupRel(script),
+        target,
+        reason:
+          target === 'stage'
+            ? 'Vendored verify pipeline replaced by the managed shim — project-specific verification steps belong in stages.json / .har/stages/ (bigger checks: a local plugin).'
+            : target === 'hook'
+              ? 'Vendored script replaced by the managed shim — project-specific launch/teardown/infra behavior belongs in .har/hooks/ lifecycle hooks.'
+              : 'Vendored script replaced by the managed shim — review the backup for project-specific behavior worth keeping.',
+      });
+    }
+  }
+
+  // User-owned scripts that survive migration and may source machinery.
+  const survivingScripts: string[] = [];
+  for (const dir of ['stages', 'hooks']) {
+    const full = path.join(harnessDir, dir);
+    if (!fs.existsSync(full)) continue;
+    for (const entry of fs.readdirSync(full)) {
+      if (entry.endsWith('.sh') || entry.endsWith('.mjs')) survivingScripts.push(path.join(dir, entry));
+    }
+  }
+  const referencedBy = (machineryFile: string): string[] =>
+    survivingScripts.filter((script) =>
+      fs.readFileSync(path.join(harnessDir, script), 'utf8').includes(path.basename(machineryFile)),
+    );
+
+  const deleteMachinery: string[] = [];
+  const editedMachinery: string[] = [];
+  const retainMachinery: string[] = [];
+  for (const file of LEGACY_MACHINERY_FILES) {
+    const full = path.join(harnessDir, file);
+    if (!fs.existsSync(full)) continue;
+    const refs = referencedBy(file);
+    if (refs.length > 0) {
+      // Deleting it would break the referencing script mid-migration — keep
+      // it and put the rewrite on the prompt instead (classify-and-lift).
+      retainMachinery.push(file);
+      residue.push({
+        source: file,
+        backup: backupRel(file),
+        target: 'stage',
+        reason: `Runtime machinery superseded by the package runtime, but still sourced by ${refs.map((r) => `\`${r}\``).join(', ')} — rewrite the script(s) against the 1.0 stage surface (stages receive exported WORK_DIR, ENV_FILE, AGENT_ID, HAR_HARNESS_DIR; the slot env file is already sourced), then delete .har/${file}.`,
+      });
+      continue;
+    }
+    deleteMachinery.push(file);
+    const recorded = fileBaseline[file];
+    const installed = computeFileChecksum(fs.readFileSync(full, 'utf8'));
+    if (recorded !== undefined && installed !== recorded) {
+      editedMachinery.push(file);
+      residue.push({
+        source: file,
+        backup: backupRel(file),
+        target: 'hook',
+        reason:
+          'Runtime machinery superseded by the package runtime, but this copy was edited since the last finalize — lift the patch into a lifecycle hook (or `har env eject` for full runtime ownership).',
+      });
+    }
+  }
+
+  let env: HarnessEnvMigration | null = null;
+  const envPath = path.join(harnessDir, 'harness.env');
+  if (fs.existsSync(envPath)) {
+    const content = fs.readFileSync(envPath, 'utf8');
+    if (harnessEnvIsPre10(content) || migrateHarnessEnvContent(content).commentedKeys.length > 0) {
+      env = migrateHarnessEnvContent(content);
+      for (const fn of env.customFunctions) {
+        residue.push({
+          source: `harness.env: ${fn}()`,
+          backup: backupRel('harness.env'),
+          target: 'hook',
+          reason:
+            'Project-defined shell function removed from harness.env (pure config in 1.0) — move the logic into a lifecycle hook or stage script.',
+        });
+      }
+      for (const key of env.commentedKeys) {
+        residue.push({
+          source: `harness.env: ${key}`,
+          backup: backupRel('harness.env'),
+          target: 'config',
+          reason:
+            'Custom key commented out (not in the 1.0 schema) — the hook/stage that consumes it can define the value locally, or map it onto a schema key.',
+        });
+      }
+    }
+  }
+
+  let phantomVerificationIds: string[] = [];
+  try {
+    phantomVerificationIds = findPhantomVerificationStageIds(readStageRegistry(resolved));
+  } catch {
+    // Unparseable stages.json is a doctor error, not a migration concern.
+  }
+  for (const id of phantomVerificationIds) {
+    residue.push({
+      source: `stages.json: verificationStages "${id}"`,
+      backup: backupRel('verify.sh'),
+      target: 'stage',
+      reason:
+        'Verification id with no registered stage — its command lived in the vendored verify.sh case table. Re-register it as a stages.json command stage (or a local plugin) with the command from the backup, or drop it if the packaged runtime already covers it.',
+    });
+  }
+
+  return {
+    id: 'config-surface',
+    to: HARNESS_RUNTIME_VERSION,
+    profile,
+    replaceWithShims,
+    deleteMachinery,
+    editedMachinery,
+    retainMachinery,
+    env,
+    phantomVerificationIds,
+    residue,
+  };
+}
+
+function applyPre10Plan(repoPath: string, plan?: MigrationPlan): AppliedMigration {
+  const resolved = path.resolve(repoPath);
+  const harnessDir = getHarnessDir(resolved);
+  const effective = plan ?? buildPre10Plan(resolved);
+  const backupDir = path.join(harnessDir, MIGRATE_BACKUP_DIR);
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  const backup = (file: string): void => {
+    const src = path.join(harnessDir, file);
+    if (!fs.existsSync(src)) return;
+    const dest = path.join(backupDir, file);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+  };
+
+  const written: string[] = [];
+  const deleted: string[] = [];
+  const projectName = path.basename(resolved).toLowerCase().replace(/[^a-z0-9]/g, '_');
+  const composed = composeProfileTemplateMap(effective.profile);
+
+  // 1. Vendored lifecycle scripts → managed shims (arg conventions preserved).
+  for (const script of effective.replaceWithShims) {
+    const source = composed.get(script);
+    if (!source) continue;
+    backup(script);
+    const rendered = substituteTemplateTokens(readComposedTemplateContent(source), projectName);
+    const dest = path.join(harnessDir, script);
+    fs.writeFileSync(dest, rendered);
+    fs.chmodSync(dest, 0o755);
+    written.push(script);
+  }
+
+  // 2. Runtime machinery → gone (the package runtime is the single implementation).
+  for (const file of effective.deleteMachinery) {
+    backup(file);
+    fs.rmSync(path.join(harnessDir, file), { force: true });
+    deleted.push(file);
+  }
+  const libDir = path.join(harnessDir, 'lib');
+  if (fs.existsSync(libDir) && fs.readdirSync(libDir).length === 0) {
+    fs.rmdirSync(libDir);
+    deleted.push('lib/');
+  }
+
+  // 3. verificationStages ids the registry cannot resolve (their commands
+  // lived in the vendored verify.sh) are dropped so verify --full keeps
+  // running; the MIGRATE prompt drives their re-registration as stages.
+  if (effective.phantomVerificationIds.length > 0) {
+    backup('stages.json');
+    const registry = readStageRegistry(resolved);
+    const drop = new Set(effective.phantomVerificationIds);
+    writeStageRegistry(resolved, {
+      ...registry,
+      verificationStages: (registry.verificationStages ?? []).filter((id) => !drop.has(id)),
+    });
+    written.push('stages.json');
+  }
+
+  // 4. harness.env → pure schema-valid config.
+  if (effective.env) {
+    backup('harness.env');
+    fs.writeFileSync(path.join(harnessDir, 'harness.env'), effective.env.content);
+    written.push('harness.env');
+  }
+
+  // 5. Stamp the manifest and re-baseline both drift signals: post-migration
+  // drift must report only what the user genuinely adapts from here on.
+  const manifest = readManifest(resolved);
+  if (manifest) {
+    writeManifest(resolved, {
+      ...manifest,
+      runtimeVersion: HARNESS_RUNTIME_VERSION,
+      migratedFrom: manifest.runtimeVersion ?? 'pre-1.0',
+      migratedAt: new Date().toISOString(),
+      fileChecksums: computeHarnessChecksums(harnessDir),
+      templateChecksums: computeTemplateChecksums(resolved, effective.profile),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  fs.writeFileSync(
+    path.join(harnessDir, MIGRATE_PLAN_FILE),
+    JSON.stringify({ ...effective, appliedAt: new Date().toISOString() }, null, 2) + '\n',
+  );
+
+  return { plan: effective, backupDir, written, deleted };
+}
+
+export const PRE_1_0_MIGRATION: HarnessMigration = {
+  id: 'config-surface',
+  to: HARNESS_RUNTIME_VERSION,
+  title: '.har/ becomes a configuration surface (pre-1.0 → 1.0)',
+  detect: isPre10Harness,
+  plan: buildPre10Plan,
+  apply: applyPre10Plan,
+};
+
+/**
+ * The migration registry, keyed on the runtime version each migration brings
+ * a harness up to. Platform-shape upgrades belong here as code — never as
+ * prose checklists in adaptation prompts.
+ */
+export const HARNESS_MIGRATIONS: HarnessMigration[] = [PRE_1_0_MIGRATION];
+
+/**
+ * Migrations this harness still needs, in registry (version) order. Shape
+ * detection is authoritative: a stamped runtimeVersion never masks a harness
+ * that still has the old shape on disk (e.g. a finalize ran before the
+ * migration did — the backups and prompt must survive that).
+ */
+export function pendingMigrations(repoPath: string): HarnessMigration[] {
+  return HARNESS_MIGRATIONS.filter((m) => m.detect(repoPath)).sort((a, b) =>
+    compareVersions(a.to, b.to),
+  );
+}
+
+/** Write the (not yet applied) plan to .har/migrate/plan.json for inspection. */
+export function writeMigrationPlan(repoPath: string, plan: MigrationPlan): string {
+  const harnessDir = getHarnessDir(path.resolve(repoPath));
+  const planPath = path.join(harnessDir, MIGRATE_PLAN_FILE);
+  fs.mkdirSync(path.dirname(planPath), { recursive: true });
+  fs.writeFileSync(planPath, JSON.stringify(plan, null, 2) + '\n');
+  return planPath;
+}
+
+/** Remove migration artifacts (plan, backups, prompt) — called by finalize. */
+export function removeMigrationArtifacts(repoPath: string): void {
+  const harnessDir = getHarnessDir(path.resolve(repoPath));
+  fs.rmSync(path.join(harnessDir, MIGRATE_DIR), { recursive: true, force: true });
+  fs.rmSync(path.join(harnessDir, 'MIGRATE-PROMPT.md'), { force: true });
+}

--- a/src/harness/verification.ts
+++ b/src/harness/verification.ts
@@ -74,7 +74,11 @@ function nodeSmokeCommand(repoPath: string): { id: string; command: string; desc
   if (scripts.build) {
     return {
       id: 'typecheck',
-      command: '${NPM_BIN:-npm} run build',
+      // NODE_ENV=production: verify exports the slot env file, whose
+      // NODE_ENV=development is meant for the dev server — framework builds
+      // (e.g. next build) break under it. Same pinning as the pre-1.0
+      // vendored node-build step.
+      command: 'NODE_ENV=production ${NPM_BIN:-npm} run build',
       description: 'Build smoke (no typecheck script; ecosystem quick smoke)',
     };
   }

--- a/src/runtime/infra.ts
+++ b/src/runtime/infra.ts
@@ -114,12 +114,12 @@ export function runPg(tool: string, args: string[], options: PgOptions): { stdou
 // ── Persisted infra state (.har/state/infra.env) ─────────────────────────────
 
 export const INFRA_LANES = [
-  { stateVar: 'AGENT_DB_PORT', lane: 'db', fallback: 15432, composeService: 'db' },
-  { stateVar: 'AGENT_MINIO_PORT', lane: 'minio', fallback: 19000, composeService: 'minio' },
-  { stateVar: 'AGENT_MINIO_CONSOLE_PORT', lane: 'minio-console', fallback: 19050 },
-  { stateVar: 'AGENT_BROWSER_PORT', lane: 'browser', fallback: 13001, composeService: 'headless-browser' },
-  { stateVar: 'AGENT_MAILPIT_WEB_PORT', lane: 'mailpit-web', fallback: 18025, composeService: 'mailpit' },
-  { stateVar: 'AGENT_MAILPIT_SMTP_PORT', lane: 'mailpit-smtp', fallback: 11025 },
+  { stateVar: 'AGENT_DB_PORT', lane: 'db', fallback: 15432, composeService: 'db', ownerService: 'db' },
+  { stateVar: 'AGENT_MINIO_PORT', lane: 'minio', fallback: 19000, composeService: 'minio', ownerService: 'minio' },
+  { stateVar: 'AGENT_MINIO_CONSOLE_PORT', lane: 'minio-console', fallback: 19050, ownerService: 'minio' },
+  { stateVar: 'AGENT_BROWSER_PORT', lane: 'browser', fallback: 13001, composeService: 'headless-browser', ownerService: 'headless-browser' },
+  { stateVar: 'AGENT_MAILPIT_WEB_PORT', lane: 'mailpit-web', fallback: 18025, composeService: 'mailpit', ownerService: 'mailpit' },
+  { stateVar: 'AGENT_MAILPIT_SMTP_PORT', lane: 'mailpit-smtp', fallback: 11025, ownerService: 'mailpit' },
 ] as const;
 
 export type InfraStateVar = (typeof INFRA_LANES)[number]['stateVar'];
@@ -228,8 +228,21 @@ export function resolveInfraPorts(
   options: Omit<ResolveInfraPortOptions, 'env' | 'current'> = {},
 ): InfraPorts {
   const ports = {} as InfraPorts;
-  for (const { stateVar, lane, fallback, ...rest } of INFRA_LANES) {
+  for (const { stateVar, lane, fallback, ownerService, ...rest } of INFRA_LANES) {
     const composeService = 'composeService' in rest ? rest.composeService : undefined;
+    // A lane whose service is not in HARNESS_INFRA_SERVICES never binds a
+    // port — record its default without requiring the port to be free, so an
+    // occupied host port for an unused service cannot fail launch (#241).
+    if (!infraEnabled(env, ownerService)) {
+      let laneInfo: InfraPortLane | undefined;
+      try {
+        laneInfo = infraPortLane(env, lane);
+      } catch {
+        laneInfo = undefined;
+      }
+      ports[stateVar] = persisted[stateVar] ?? laneInfo?.defaultPort ?? fallback;
+      continue;
+    }
     ports[stateVar] = resolveInfraPort(lane, fallback, composeService, {
       env,
       current: persisted[stateVar],

--- a/src/templates/adaptation-prompt-maintain.md
+++ b/src/templates/adaptation-prompt-maintain.md
@@ -74,37 +74,21 @@ to harness machinery: `.har/hooks/pre-launch.sh`, `post-launch.sh`,
 user-owned and never drift-checked — if a past adaptation patched machinery
 scripts for a lifecycle side effect, move that code into a hook.
 
-### HAR platform upgrades checklist
+### HAR platform upgrades
 
-When upgrading `@osfactory/har` or adopting new harness standards:
+Platform-shape upgrades are **code, not a checklist**: the har CLI carries a
+versioned migration registry keyed on the manifest's `runtimeVersion`.
+`har env maintain` detects an old harness shape, writes `.har/MIGRATE-PROMPT.md`,
+and `har env maintain --migrate` applies the mechanical steps (shims, pure-config
+`harness.env` with `HARNESS_INFRA_SERVICES` / `HARNESS_INFRA_PORT_LANES`
+conversions, machinery removal) with backups under `.har/migrate/backup/`.
 
-**Generator 0.5.0 — `AGENTS.md` (canonical agent guide):**
+If a `.har/MIGRATE-PROMPT.md` exists, **follow it instead of this prompt** and
+come back here afterwards. Two standing rules:
 
-- Repo-root **`AGENTS.md`** is now the shared HAR workflow contract (Codex auto-loads it). Do **not** create or keep **`AGENT.md`** (singular).
-- If **`AGENT.md` exists**: merge any unique project notes into `AGENTS.md`, ensure a **HAR / agent environment** section is present, then **delete `AGENT.md`**.
-- If **`AGENTS.md` is missing**: create it (HAR may already have scaffolded a managed section during `maintain` — fill **Project-specific notes** and keep the marked HAR section).
-- If **`AGENTS.md` already exists**: add or refresh the managed **HAR / agent environment** section only — do not wipe unrelated project guidance.
-- Keep **`CLAUDE.md`** as a **thin pointer** to `AGENTS.md` (Claude Code auto-loads `CLAUDE.md`). Never paste the full Cursor-rule / HAR workflow into `CLAUDE.md`.
-- Update links in `.har/CLAUDE.agent.md` and `.har/README.md` from `AGENT.md` → `AGENTS.md` if they still point at the legacy name.
-- Cursor still uses `.cursor/rules/har-workflow.mdc` (always-on); that rule should also say `AGENTS.md`.
-
-**Generator 0.4.0 — primary app & shared infra services:**
-
-- Migrate `harness.env` from boolean `HARNESS_INFRA_*` flags to the `HARNESS_INFRA_SERVICES` list (space-separated compose service names, e.g. `"db mailpit"`) (`har_infra_enabled` is provided by `.har/lib/infra.sh` — never define functions in `harness.env`). Update every script that still tests `HARNESS_INFRA_POSTGRES`-style flags (`setup-infra.sh`, `launch.sh`, `teardown.sh`, `agent-cli.sh`) to use `har_infra_enabled <service>`.
-- Set `HARNESS_PRIMARY_APP` in `harness.env` to the ONE app agents modify. Ensure `ecosystem.agent.template.cjs` starts only that app's processes. Move any other in-repo services agents depend on but don't change to shared infra: compose services in `docker-compose.agent.yml` or an optional `.har/ecosystem.shared.config.cjs` (processes `har-shared-<name>`; `setup-infra.sh` starts it when present — resync `setup-infra.sh` from the template to get this hook).
-- Prune `docker-compose.agent.yml` to only the services this project uses; delete unused menu services and volumes.
-- **Port & shared services:** ensure `.har/README.md` documents the allocation table and shared vs per-slot model; `harness.env` declares a `HARNESS_INFRA_PORT_LANES` lane for every service in `HARNESS_INFRA_SERVICES` (copy missing lanes from `.har/maintain/templates/harness.env` when drift reports them). Remove hardcoded ports from app code, tests, and `CLAUDE.agent.md`.
-- Run the **cleanup checklist**: no TODO placeholders, no env blocks for removed services in `env.template`, no dead script branches, `.har/README.md` file table matches the actual files, `CLAUDE.agent.md` shows only real URLs/ports and commands, unused files deleted.
-
-**Earlier standards:**
-
-- Add **Run history** section to repo-root `AGENTS.md` if missing (shell vs `har env`, worktree vs runs location)
-- Ensure `AGENTS.md` / `CLAUDE.agent.md` frame the harness as **how you run the project** (launch for manual testing/browser/screenshots; fix — don't work around — failing harness commands)
-- Ensure `launch.sh` installs dependencies in fresh worktrees and resolves the project subdirectory inside the worktree (`git rev-parse --show-prefix`) for monorepos
-- If the repo has multiple projects/harnesses, maintain the **"Harnesses in this repo"** table in root `AGENTS.md`, per-project pointer docs, and a single root Cursor rule
-- Remove dead boilerplate files (CLI profile: `ecosystem.agent.template.cjs`, `env.template`, `attach.sh`)
-- Align `harness.env` with worktree-default standard (`HARNESS_USE_WORKTREE=true`)
-- Verification customization lives in `stages.json` / `.har/stages/` — the top-level `*.sh` files are generated shims, safe to regenerate
+- Verification customization lives in `stages.json` / `.har/stages/` — the
+  top-level `*.sh` files are generated shims, safe to regenerate.
+- Repo-root agent docs (`AGENTS.md`, `CLAUDE.md`) follow Step 3 below.
 
 ## Step 3 — Refresh repo-root `AGENTS.md`
 

--- a/src/templates/migration-prompt.md
+++ b/src/templates/migration-prompt.md
@@ -1,0 +1,54 @@
+Migrate the `.har/` harness in this repository from the pre-1.0 shape to the 1.0 configuration surface.
+
+## What changes and why
+
+In 1.0 the harness machinery lives once, in the `@osfactory/har` package. `.har/` keeps only what is yours:
+
+- **config** — `harness.env` (pure `KEY=value`, schema-validated)
+- **stages** — `stages.json` + `.har/stages/*.sh` (verification as data)
+- **hooks** — `.har/hooks/{pre-launch,post-launch,pre-verify,pre-teardown,post-teardown}.sh` (custom lifecycle behavior)
+- **plugins** — `.har/plugins/<id>/` local plugins for anything bigger (`har plugin create <id>`)
+
+The `./.har/*.sh` entry points become thin shims (`exec har env … "$@"` with a pinned `npx` fallback), so every surface — raw scripts, `har env`, MCP tools — writes the same run/validation records. Your muscle memory (`./.har/launch.sh 1`, `./.har/verify.sh 1 --full`, `har env launch 1`) keeps working before, during, and after.
+
+{{MIGRATION_SECTION}}
+
+## Step 3 — Lift each residue item
+
+For every row in the residue table above, read its backup under `.har/migrate/backup/` and move the project-specific behavior into the 1.0 model:
+
+- **config** → a `harness.env` schema key (see `@har/schemas` HarnessEnvSchema). Custom keys the schema rejects: keep the value inside the hook/stage that consumes it.
+- **stage** → a `stages.json` entry (plain `command`, or a script in `.har/stages/`), listed in `verificationStages` if it gates verify.
+- **hook** → the matching `.har/hooks/<hook>.sh`. Hooks receive `HAR_HOOK`, `AGENT_ID`, `WORK_DIR`, `ENV_FILE`, `HAR_HARNESS_DIR`, `HAR_PORT_<NAME>` (contract `HAR_HOOK_CONTRACT=1`). Failing `pre-*` hooks abort the operation; `post-*` failures warn unless `HARNESS_HOOK_POST_FAILURE=fail`. Make hooks executable.
+- **plugin** → `har plugin create <id>` scaffolds a local plugin in `.har/plugins/<id>/`; then `har env add-plugin <id>`.
+- **review** → usually nothing to keep (the package runtime covers it) — confirm, then move on.
+
+Compare each backup against its replacement only for **project-specific** logic. Do not restore vendored machinery — that is what 1.0 removes.
+
+## Step 4 — Heavily customized harness? Consider eject
+
+If the backups show deep patches to the machinery itself (not just config/stages/hooks material), `har env eject` vendors the full runtime into `.har/runtime/` and hands you ownership of the scripts — explicit, supported, reversible with `har env adopt`. Prefer lifting into hooks when the patch is a lifecycle side effect; eject only when you truly need to own the runtime.
+
+## Step 5 — Verify the migration
+
+1. `har env doctor` — must pass (contract: 1.0, no errors).
+2. `har env maintain` — drift report should show only files you deliberately adapted.
+3. Full verify on **every configured agent slot** that is in use; at minimum:
+   - `har env launch 1`
+   - `har env verify 1 --full` (or `./.har/verify.sh 1 --full` — same records either way)
+   - `har env complete 1` (or `har env teardown 1`)
+4. Exercise anything you lifted into hooks/stages (e.g. per-slot data stores exist in the work dir, custom checks run in `--full`).
+
+## Step 6 — Finalize
+
+Record the migration and clean up the migration artifacts (`.har/migrate/`, this prompt):
+
+    har env maintain --finalize --summary "Migrated pre-1.0 harness to the 1.0 config surface: <what you lifted where>"
+
+## Rules
+
+1. Never edit `.har/manifest.json` by hand — it is managed by the har CLI.
+2. Do not delete `.har/migrate/backup/` until finalize — it is the only copy of the pre-1.0 adaptations.
+3. Keep `stages.json` stage ids stable — run records and Mission Control reference them.
+4. Update `.har/README.md` and `.har/CLAUDE.agent.md` if commands or workflow notes changed.
+5. Commit the migrated harness (shims, `harness.env`, `stages.json`, `.har/hooks/`) once verified — `.har/migrate/` and this prompt are transient and stay untracked.

--- a/tests/maintain-bundle.test.ts
+++ b/tests/maintain-bundle.test.ts
@@ -144,7 +144,10 @@ describe('adaptation prompts with maintain bundle', () => {
     expect(maintainPrompt).toContain('.har/maintain/');
     expect(maintainPrompt).toContain('Do **not** read files from the globally installed har package');
     expect(maintainPrompt).not.toContain('{{MAINTAIN_BUNDLE_SECTION}}');
-    expect(maintainPrompt).toContain('Generator 0.5.0');
+    // Platform upgrades are the migration registry now (#241), not prose.
+    expect(maintainPrompt).toContain('migration registry');
+    expect(maintainPrompt).toContain('MIGRATE-PROMPT.md');
+    expect(maintainPrompt).not.toContain('Generator 0.5.0');
     expect(maintainPrompt).toContain('AGENTS.md');
   });
 
@@ -188,6 +191,6 @@ describe('adaptation prompts with maintain bundle', () => {
     expect(maintainPrompt).toContain('Validation blockers');
     expect(maintainPrompt).toContain('Agent instruction files');
     expect(maintainPrompt).toContain('AGENT.md');
-    expect(maintainPrompt).toContain('Generator 0.5.0');
+    expect(maintainPrompt).toContain('migration registry');
   });
 });

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,0 +1,259 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { maintainHarness } from '../src/core/harness';
+import { runDoctor } from '../src/harness/doctor';
+import { scaffoldHarnessBoilerplate } from '../src/harness/generator';
+import { readManifest, writeManifest, HARNESS_RUNTIME_VERSION } from '../src/harness/manifest';
+import { MIGRATE_PROMPT_FILE } from '../src/harness/migrate-prompt';
+import {
+  isPre10Harness,
+  migrateHarnessEnvContent,
+  pendingMigrations,
+  PRE_1_0_MIGRATION,
+} from '../src/harness/migrations';
+
+/**
+ * #241 acceptance: a pre-1.0 harness is detected by maintain, the mechanical
+ * steps run as code (`--migrate`) with full backups, the residue only an
+ * agent can lift lands in MIGRATE-PROMPT.md, and nothing changes until the
+ * user opts in (compat window).
+ */
+describe('versioned harness migrations (#241)', () => {
+  let repo: string;
+
+  const proj = () => path.join(repo, 'proj');
+  const har = (...p: string[]) => path.join(proj(), '.har', ...p);
+
+  const PRE10_ENV = [
+    '# Shared harness configuration',
+    'export HARNESS_PROJECT_NAME=proj',
+    'export HARNESS_USE_WORKTREE=true',
+    'export HARNESS_FE_BASE_PORT=3010',
+    'export HARNESS_API_BASE_PORT=3010',
+    'export HARNESS_PORT_STEP=10',
+    'export HARNESS_HEALTH_CHECK_PATH=/api/health',
+    'export HARNESS_INFRA_POSTGRES=true',
+    'export HARNESS_TEMPLATE_SQLITE=.har/state/template/db.sqlite',
+    'export HARNESS_DB_PORT_DEFAULT=15432',
+    'export HARNESS_DB_PORT_SCAN_START=15432',
+    'export HARNESS_DB_PORT_SCAN_END=15499',
+    'export HARNESS_MINIO_PORT_DEFAULT=19000',
+    'export HARNESS_MINIO_PORT_SCAN_START=19000',
+    'export HARNESS_MINIO_PORT_SCAN_END=19099',
+    'har_infra_enabled() {',
+    '  case " ${HARNESS_INFRA_SERVICES:-} " in *" $1 "*) return 0;; esac',
+    '  return 1',
+    '}',
+    'my_custom_seed() {',
+    '  echo seeding',
+    '}',
+    '',
+  ].join('\n');
+
+  /** Devolve a fresh 1.0 scaffold into the pre-1.0 vendored shape. */
+  function makePre10(): void {
+    fs.writeFileSync(
+      har('launch.sh'),
+      '#!/usr/bin/env bash\n# vendored pre-1.0 runtime\nsource "$(dirname "$0")/harness.env"\nhar_infra_enabled db && echo db\necho custom-sqlite-clone\n',
+    );
+    fs.writeFileSync(har('verify.sh'), '#!/usr/bin/env bash\n# vendored verify pipeline\nrun_quick_smoke\n');
+    fs.writeFileSync(har('agent-slot.sh'), '#!/usr/bin/env bash\necho slot machinery\n');
+    fs.writeFileSync(har('provision-toolchain.sh'), '#!/usr/bin/env bash\necho provision\n');
+    fs.mkdirSync(har('lib'), { recursive: true });
+    fs.writeFileSync(har('lib', 'infra.sh'), 'har_infra_enabled() { return 1; }\n');
+    fs.writeFileSync(har('harness.env'), PRE10_ENV);
+    const manifest = readManifest(proj())!;
+    // Pre-1.0 manifests carry no runtimeVersion / template baseline; record
+    // the vendored files as the last-finalize baseline (adaptation blessed).
+    delete (manifest as Record<string, unknown>).runtimeVersion;
+    delete (manifest as Record<string, unknown>).templateChecksums;
+    writeManifest(proj(), manifest);
+  }
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-migrate-'));
+    scaffoldHarnessBoilerplate(proj(), { profile: 'default' });
+    makePre10();
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('detects the pre-1.0 shape and reports a pending migration', () => {
+    expect(isPre10Harness(proj())).toBe(true);
+    const pending = pendingMigrations(proj());
+    expect(pending.map((m) => m.id)).toEqual(['config-surface']);
+    expect(pending[0].to).toBe(HARNESS_RUNTIME_VERSION);
+  });
+
+  it('a fresh 1.0 scaffold has no pending migration', () => {
+    const clean = path.join(repo, 'clean');
+    scaffoldHarnessBoilerplate(clean, { profile: 'default' });
+    expect(isPre10Harness(clean)).toBe(false);
+    expect(pendingMigrations(clean)).toEqual([]);
+  });
+
+  it('an ejected harness is never treated as pre-1.0', () => {
+    const manifest = readManifest(proj())!;
+    writeManifest(proj(), { ...manifest, ejected: true, ejectedVersion: '1.0.0' });
+    expect(isPre10Harness(proj())).toBe(false);
+    expect(pendingMigrations(proj())).toEqual([]);
+  });
+
+  it('plan classifies scripts, machinery, and env residue', () => {
+    const plan = PRE_1_0_MIGRATION.plan(proj());
+    expect(plan.replaceWithShims).toContain('launch.sh');
+    expect(plan.replaceWithShims).toContain('verify.sh');
+    expect(plan.deleteMachinery).toEqual(
+      expect.arrayContaining(['agent-slot.sh', 'provision-toolchain.sh', 'lib/infra.sh']),
+    );
+    const sources = plan.residue.map((r) => r.source);
+    expect(sources).toContain('launch.sh');
+    expect(sources).toContain('verify.sh');
+    // Custom function and custom key are residue; the stock helper is not.
+    expect(sources).toContain('harness.env: my_custom_seed()');
+    expect(sources).toContain('harness.env: HARNESS_TEMPLATE_SQLITE');
+    expect(sources).not.toContain('harness.env: har_infra_enabled()');
+    const verifyResidue = plan.residue.find((r) => r.source === 'verify.sh');
+    expect(verifyResidue?.target).toBe('stage');
+    const launchResidue = plan.residue.find((r) => r.source === 'launch.sh');
+    expect(launchResidue?.target).toBe('hook');
+  });
+
+  it('drops verificationStages ids the registry cannot resolve and surfaces them as residue', async () => {
+    const stagesPath = har('stages.json');
+    const registry = JSON.parse(fs.readFileSync(stagesPath, 'utf8'));
+    registry.verificationStages = [...(registry.verificationStages ?? []), 'node-build'];
+    fs.writeFileSync(stagesPath, JSON.stringify(registry, null, 2) + '\n');
+
+    const plan = PRE_1_0_MIGRATION.plan(proj());
+    expect(plan.phantomVerificationIds).toContain('node-build');
+    expect(plan.residue.map((r) => r.source)).toContain('stages.json: verificationStages "node-build"');
+
+    await maintainHarness({ repoPath: proj(), migrate: true });
+    const after = JSON.parse(fs.readFileSync(stagesPath, 'utf8'));
+    expect(after.verificationStages).not.toContain('node-build');
+    // The pre-drop registry is preserved for the lift.
+    expect(fs.existsSync(har('migrate', 'backup', 'stages.json'))).toBe(true);
+  });
+
+  it('retains machinery still sourced by surviving stage scripts and flags the rewrite', async () => {
+    fs.mkdirSync(har('stages'), { recursive: true });
+    fs.writeFileSync(
+      har('stages', 'custom-e2e.sh'),
+      '#!/usr/bin/env bash\nsource "$(dirname "$0")/../agent-slot.sh"\nvalidate_agent_id "$1"\n',
+    );
+
+    const plan = PRE_1_0_MIGRATION.plan(proj());
+    expect(plan.retainMachinery).toEqual(['agent-slot.sh']);
+    expect(plan.deleteMachinery).not.toContain('agent-slot.sh');
+    const item = plan.residue.find((r) => r.source === 'agent-slot.sh');
+    expect(item?.reason).toContain('stages/custom-e2e.sh');
+
+    await maintainHarness({ repoPath: proj(), migrate: true });
+    // Referenced machinery survives; unreferenced machinery is gone.
+    expect(fs.existsSync(har('agent-slot.sh'))).toBe(true);
+    expect(fs.existsSync(har('provision-toolchain.sh'))).toBe(false);
+  });
+
+  it('migrateHarnessEnvContent purifies config and converts legacy shapes', () => {
+    const result = migrateHarnessEnvContent(PRE10_ENV);
+    expect(result.removedFunctions).toEqual(['har_infra_enabled', 'my_custom_seed']);
+    expect(result.customFunctions).toEqual(['my_custom_seed']);
+    expect(result.convertedFlags).toEqual(['HARNESS_INFRA_POSTGRES']);
+    expect(result.services).toEqual(['db']);
+    // db lane converted (service enabled); minio triplets dropped (not enabled).
+    expect(result.portLanes).toBe('db=15432:15432-15499');
+    expect(result.commentedKeys).toEqual(['HARNESS_TEMPLATE_SQLITE']);
+    expect(result.content).toContain('export HARNESS_INFRA_SERVICES="db"');
+    expect(result.content).toContain('export HARNESS_INFRA_PORT_LANES="db=15432:15432-15499"');
+    expect(result.content).toContain('# [migrated 0.x — custom key');
+    expect(result.content).not.toMatch(/^\s*har_infra_enabled\(\)/m);
+    expect(result.content).not.toMatch(/^export HARNESS_DB_PORT_DEFAULT=/m);
+    expect(result.content).not.toMatch(/^export HARNESS_INFRA_POSTGRES=/m);
+  });
+
+  it('plain maintain detects, writes plan + MIGRATE prompt, changes nothing (compat window)', async () => {
+    const vendoredLaunch = fs.readFileSync(har('launch.sh'), 'utf8');
+    const result = await maintainHarness({ repoPath: proj() });
+
+    expect(result.migration).toBeDefined();
+    expect(result.migration!.applied).toBe(false);
+    expect(fs.existsSync(har(MIGRATE_PROMPT_FILE))).toBe(true);
+    expect(fs.existsSync(har('migrate', 'plan.json'))).toBe(true);
+    // Nothing touched: the vendored runtime keeps working until --migrate.
+    expect(fs.readFileSync(har('launch.sh'), 'utf8')).toBe(vendoredLaunch);
+    expect(fs.existsSync(har('agent-slot.sh'))).toBe(true);
+    expect(result.migration!.prompt).toContain('har env maintain --migrate');
+    expect(result.migration!.prompt).toContain('HARNESS_TEMPLATE_SQLITE');
+  });
+
+  it('maintain --migrate applies mechanical steps with backups and stamps the manifest', async () => {
+    const result = await maintainHarness({ repoPath: proj(), migrate: true });
+    expect(result.migration?.applied).toBe(true);
+
+    // Shims in place, machinery gone, env pure.
+    expect(fs.readFileSync(har('launch.sh'), 'utf8')).toContain('exec har env launch');
+    expect(fs.readFileSync(har('verify.sh'), 'utf8')).toContain('exec har env verify');
+    expect(fs.existsSync(har('agent-slot.sh'))).toBe(false);
+    expect(fs.existsSync(har('provision-toolchain.sh'))).toBe(false);
+    // lib/infra.sh is machinery; lib/ itself may stay (1.0 still ships verify-runner.mjs).
+    expect(fs.existsSync(har('lib', 'infra.sh'))).toBe(false);
+    const env = fs.readFileSync(har('harness.env'), 'utf8');
+    expect(env).not.toMatch(/\(\)\s*\{/);
+    expect(env).toContain('HARNESS_INFRA_PORT_LANES');
+
+    // Every replaced/deleted file is backed up.
+    for (const file of ['launch.sh', 'verify.sh', 'agent-slot.sh', 'harness.env', 'lib/infra.sh']) {
+      expect(fs.existsSync(har('migrate', 'backup', file))).toBe(true);
+    }
+    expect(fs.readFileSync(har('migrate', 'backup', 'launch.sh'), 'utf8')).toContain(
+      'custom-sqlite-clone',
+    );
+
+    // Manifest stamped and re-baselined; shape now 1.0, nothing pending.
+    const manifest = readManifest(proj())!;
+    expect(manifest.runtimeVersion).toBe(HARNESS_RUNTIME_VERSION);
+    expect(manifest.migratedFrom).toBe('pre-1.0');
+    expect(manifest.templateChecksums).toBeDefined();
+    expect(isPre10Harness(proj())).toBe(false);
+    expect(pendingMigrations(proj())).toEqual([]);
+
+    // Doctor: 1.0 contract, no errors — the harness is coherent post-migration.
+    const doctor = runDoctor(proj());
+    expect(doctor.contract).toBe('1.0');
+    expect(doctor.findings.filter((f) => f.severity === 'error')).toEqual([]);
+
+    // Prompt regenerated in applied mode with the residue table.
+    const prompt = fs.readFileSync(har(MIGRATE_PROMPT_FILE), 'utf8');
+    expect(prompt).toContain('Mechanical migration: DONE');
+    expect(prompt).toContain('my_custom_seed');
+  });
+
+  it('post-migration drift is clean and finalize clears the migration artifacts', async () => {
+    await maintainHarness({ repoPath: proj(), migrate: true });
+    const after = await maintainHarness({ repoPath: proj() });
+    expect(after.migration).toBeUndefined();
+    expect(after.drift.upstreamUpdated).toEqual([]);
+    expect(after.drift.conflict).toEqual([]);
+
+    const final = await maintainHarness({
+      repoPath: proj(),
+      finalize: true,
+      summary: 'migrated to 1.0',
+    });
+    expect(final.validation.pass).toBe(true);
+    expect(fs.existsSync(har('migrate'))).toBe(false);
+    expect(fs.existsSync(har(MIGRATE_PROMPT_FILE))).toBe(false);
+  });
+
+  it('finalize on a still-pre-1.0 harness keeps the migration artifacts (backups are the only copy)', async () => {
+    await maintainHarness({ repoPath: proj() }); // plan + prompt only
+    await maintainHarness({ repoPath: proj(), finalize: true, summary: 'pre-1.0 finalize' }).catch(
+      () => undefined, // validation may fail on the vendored shape — irrelevant here
+    );
+    expect(fs.existsSync(har(MIGRATE_PROMPT_FILE))).toBe(true);
+  });
+});

--- a/tests/runtime-infra.test.ts
+++ b/tests/runtime-infra.test.ts
@@ -16,6 +16,7 @@ import {
   runPg,
   setupInfra,
   writeInfraState,
+  resolveInfraPorts,
 } from '../src/runtime/infra';
 
 const PORTS = {
@@ -169,6 +170,36 @@ describe('resolveInfraPort', () => {
       portInUse: () => false,
     });
     expect(port).toBe(13001);
+  });
+});
+
+describe('resolveInfraPorts', () => {
+  it('does not require a free port for lanes whose service is disabled (#241)', () => {
+    const { exec } = mockExec();
+    // Everything reads busy; no services enabled — pre-1.0 harnesses that
+    // dropped their unused legacy triplets must still launch.
+    const ports = resolveInfraPorts(
+      { HARNESS_PROJECT_NAME: 'proj', HARNESS_INFRA_SERVICES: '' },
+      {},
+      { exec, portInUse: () => true },
+    );
+    expect(ports.AGENT_DB_PORT).toBe(15432);
+    expect(ports.AGENT_MINIO_PORT).toBe(19000);
+  });
+
+  it('still scans (and fails loudly) for an enabled service with no free port', () => {
+    const { exec } = mockExec();
+    expect(() =>
+      resolveInfraPorts(
+        {
+          HARNESS_PROJECT_NAME: 'proj',
+          HARNESS_INFRA_SERVICES: 'db',
+          HARNESS_INFRA_PORT_LANES: 'db=15432:15432-15433',
+        },
+        {},
+        { exec, portInUse: () => true },
+      ),
+    ).toThrow('no free port in range 15432-15433');
   });
 });
 


### PR DESCRIPTION
Closes #241

**Stack 1/2** — based on `v1`. (#243 docs rewrite stacks on this.)

## What

- **Versioned manifest migrations**: `manifestVersion` re-introduced with a migration registry keyed on it — mechanical steps run as code (vendored scripts → shims, `harness.env` → pure schema'd config, machinery removal with backups under `.har/migrate/backup/`).
- **`har env maintain` drives the migration** on a pre-1.0 harness: files classified via manifest checksums — stock replaced silently, adapted lifted into config/stages/hooks/local-plugin. Machinery still sourced by a surviving script (e.g. `agent-slot.sh` from an adapted `browser-e2e.sh`) is retained with a residue item until the script is rewritten against the 1.0 stage surface.
- **MIGRATE-PROMPT.md** generated for the non-mechanical residue (same pattern as ADAPT-PROMPT.md), ending in doctor + full verify + `maintain --finalize`.
- **Eject offered** during migration for heavily-customized harnesses.
- **Compat window**: pre-1.0 vendored scripts keep working against the 1.0 CLI with loud deprecation warnings pointing at `har env maintain`.
- `adaptation-prompt-maintain.md`'s hand-maintained "platform upgrades checklist" prose replaced by the migration registry.
- Fixes surfaced by the gate: port lanes skipped for services not in `HARNESS_INFRA_SERVICES`; `NODE_ENV=production` pinned on the node build-smoke fallback.

## Gate

M4 fixture-e2e asserts (migrate car-app fixture → doctor green → residue lift → launch → full verify incl. Playwright) — **green**, batch `017fd5b6` verified by run `3b5595de`. 898/898 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)