### PR TITLE
fix: 1.0 plugin stage templates + shim guard against pre-1.0 runtime loops (#290, #291)

### DIFF
--- a/.har/STAGES.md
+++ b/.har/STAGES.md
@@ -59,13 +59,13 @@ then implement the TODO block in `.har/stages/db-integrity.sh`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
-   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
-   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
-2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
-   args may follow.
-3. Load the slot env via `resolve_agent_env_file` and run checks from the
-   agent's work dir (`resolve_agent_work_dir`).
+1. Assume the 1.0 stage surface: the runner exports `WORK_DIR`, `ENV_FILE`,
+   `AGENT_ID` and `HAR_HARNESS_DIR`, with `harness.env` and the slot env file
+   already sourced. Never source `agent-slot.sh` — it is retired in 1.0.
+2. Take the agent slot id as `$1`, falling back to the exported `AGENT_ID`
+   (`AGENT_ID="${1:-${AGENT_ID:?...}}"`); extra args may follow.
+3. Guard the runner contract with `${ENV_FILE:?...}` / `${WORK_DIR:?...}`
+   (pointing at `./.har/launch.sh <id>`) and run checks from `$WORK_DIR`.
 4. Write artifacts (reports, screenshots, logs) under `.har/artifacts/<id>/`.
 5. Print **only** the normalized JSON result object on stdout
    (`status`, `stageId`, `agent_id`, `total_ms`, …); log progress to stderr.

--- a/.har/agent-cli.sh
+++ b/.har/agent-cli.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="agent@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env agent "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env agent "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env agent "$@"

--- a/.har/harness.env
+++ b/.har/harness.env
@@ -28,8 +28,8 @@ export HARNESS_ECOSYSTEM="auto"
 # compose file, then list the ones this project needs here (e.g. "db redis").
 export HARNESS_INFRA_SERVICES=""
 
-export HARNESS_DB_MIGRATE_CMD="true"
-export HARNESS_DB_SEED_CMD="true"
+export HARNESS_DB_MIGRATE_CMD=""
+export HARNESS_DB_SEED_CMD=""
 
 # Optional readiness/data hooks for repositories that need more than static
 # CLI/library checks. Enable only when this project needs them, and keep scripts

--- a/.har/launch.sh
+++ b/.har/launch.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="launch@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env launch "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env launch "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env launch "$@"

--- a/.har/preflight.sh
+++ b/.har/preflight.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="preflight@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env preflight "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env preflight "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env preflight "$@"

--- a/.har/setup-infra.sh
+++ b/.har/setup-infra.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="setup-infra@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env setup-infra "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env setup-infra "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env setup-infra "$@"

--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -648,7 +648,13 @@ HOOK
           #    exit 1, the per-slot DB never be cloned, and full verify fail.
           sed -i '1a [ -n "${HARNESS_PROJECT_NAME:-}" ] || { echo "post-launch: harness.env config missing from hook env" >&2; exit 1; }' \
             "$CLONE/.har/hooks/post-launch.sh"
-          echo "    M5: stock files installed + auto ecosystem resolved + hook config guard armed ✓"
+          # d) #290: plugin templates ship on the 1.0 stage surface — a fresh
+          #    plugin install must not reference the retired machinery
+          if grep -rlE 'source "\$HARNESS_DIR/agent-slot\.sh"|provision-toolchain\.sh' \
+              "$REPO_ROOT/dist/templates/plugins" --include='*.sh' >/dev/null 2>&1; then
+            fail "M5: plugin templates still reference retired machinery (agent-slot.sh / provision-toolchain.sh)"
+          fi
+          echo "    M5: stock files installed + auto ecosystem resolved + hook config guard armed + plugin templates on the 1.0 surface ✓"
         fi
 
         # 4) Doctor must be green on the migrated harness (1.0 contract enforced).

--- a/.har/teardown.sh
+++ b/.har/teardown.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="teardown@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env teardown "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env teardown "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env teardown "$@"

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="verify@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env verify "$@" --json
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env verify "$@" --json

--- a/.har/verify.sh
+++ b/.har/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list). JSON to stdout.
+# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list).
 # The runtime lives in the HAR package (#234) — this file only forwards to it.
-# Usage: ./.har/verify.sh <agent-id> [--full]
+# Usage: ./.har/verify.sh <agent-id> [--full] [--json]   (human output; pass --json for the structured result)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -24,11 +24,11 @@ har_runtime_compatible() {
   [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
 }
 if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
-  exec har env verify "$@" --json
+  exec har env verify "$@"
 elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
-  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
+  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@"
 elif command -v npx >/dev/null 2>&1; then
-  exec npx --yes @osfactory/har@0.64.1 env verify "$@" --json
+  exec npx --yes @osfactory/har@0.64.1 env verify "$@"
 fi
 echo "Error: cannot run the HAR runtime — 'har' is not on PATH and Node.js (npx) is unavailable." >&2
 echo "  Install Node.js, then: npm i -D @osfactory/har   # or: npx @osfactory/har@0.64.1 env verify" >&2

--- a/control/.har/STAGES.md
+++ b/control/.har/STAGES.md
@@ -59,13 +59,13 @@ then implement the TODO block in `.har/stages/db-integrity.sh`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
-   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
-   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
-2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
-   args may follow.
-3. Load the slot env via `resolve_agent_env_file` and run checks from the
-   agent's work dir (`resolve_agent_work_dir`).
+1. Assume the 1.0 stage surface: the runner exports `WORK_DIR`, `ENV_FILE`,
+   `AGENT_ID` and `HAR_HARNESS_DIR`, with `harness.env` and the slot env file
+   already sourced. Never source `agent-slot.sh` — it is retired in 1.0.
+2. Take the agent slot id as `$1`, falling back to the exported `AGENT_ID`
+   (`AGENT_ID="${1:-${AGENT_ID:?...}}"`); extra args may follow.
+3. Guard the runner contract with `${ENV_FILE:?...}` / `${WORK_DIR:?...}`
+   (pointing at `./.har/launch.sh <id>`) and run checks from `$WORK_DIR`.
 4. Write artifacts (reports, screenshots, logs) under `.har/artifacts/<id>/`.
 5. Print **only** the normalized JSON result object on stdout
    (`status`, `stageId`, `agent_id`, `total_ms`, …); log progress to stderr.

--- a/control/.har/agent-cli.sh
+++ b/control/.har/agent-cli.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="agent@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env agent "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env agent "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env agent "$@"

--- a/control/.har/launch.sh
+++ b/control/.har/launch.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="launch@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env launch "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env launch "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env launch "$@"

--- a/control/.har/preflight.sh
+++ b/control/.har/preflight.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="preflight@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env preflight "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env preflight "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env preflight "$@"

--- a/control/.har/setup-infra.sh
+++ b/control/.har/setup-infra.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="setup-infra@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env setup-infra "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env setup-infra "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env setup-infra "$@"

--- a/control/.har/teardown.sh
+++ b/control/.har/teardown.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="teardown@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env teardown "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env teardown "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env teardown "$@"

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="verify@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env verify "$@" --json
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env verify "$@" --json

--- a/control/.har/verify.sh
+++ b/control/.har/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list). JSON to stdout.
+# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list).
 # The runtime lives in the HAR package (#234) — this file only forwards to it.
-# Usage: ./.har/verify.sh <agent-id> [--full]
+# Usage: ./.har/verify.sh <agent-id> [--full] [--json]   (human output; pass --json for the structured result)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -24,11 +24,11 @@ har_runtime_compatible() {
   [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
 }
 if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
-  exec har env verify "$@" --json
+  exec har env verify "$@"
 elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
-  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
+  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@"
 elif command -v npx >/dev/null 2>&1; then
-  exec npx --yes @osfactory/har@0.64.1 env verify "$@" --json
+  exec npx --yes @osfactory/har@0.64.1 env verify "$@"
 fi
 echo "Error: cannot run the HAR runtime — 'har' is not on PATH and Node.js (npx) is unavailable." >&2
 echo "  Install Node.js, then: npm i -D @osfactory/har   # or: npx @osfactory/har@0.64.1 env verify" >&2

--- a/docs/.har/STAGES.md
+++ b/docs/.har/STAGES.md
@@ -57,13 +57,13 @@ then implement the TODO block in `.har/stages/db-integrity.sh`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
-   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
-   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
-2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
-   args may follow.
-3. Load the slot env via `resolve_agent_env_file` and run checks from the
-   agent's work dir (`resolve_agent_work_dir`).
+1. Assume the 1.0 stage surface: the runner exports `WORK_DIR`, `ENV_FILE`,
+   `AGENT_ID` and `HAR_HARNESS_DIR`, with `harness.env` and the slot env file
+   already sourced. Never source `agent-slot.sh` — it is retired in 1.0.
+2. Take the agent slot id as `$1`, falling back to the exported `AGENT_ID`
+   (`AGENT_ID="${1:-${AGENT_ID:?...}}"`); extra args may follow.
+3. Guard the runner contract with `${ENV_FILE:?...}` / `${WORK_DIR:?...}`
+   (pointing at `./.har/launch.sh <id>`) and run checks from `$WORK_DIR`.
 4. Write artifacts (reports, screenshots, logs) under `.har/artifacts/<id>/`.
 5. Print **only** the normalized JSON result object on stdout
    (`status`, `stageId`, `agent_id`, `total_ms`, …); log progress to stderr.

--- a/docs/.har/agent-cli.sh
+++ b/docs/.har/agent-cli.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="agent@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env agent "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env agent "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env agent "$@"

--- a/docs/.har/launch.sh
+++ b/docs/.har/launch.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="launch@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env launch "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env launch "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env launch "$@"

--- a/docs/.har/preflight.sh
+++ b/docs/.har/preflight.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="preflight@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env preflight "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env preflight "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env preflight "$@"

--- a/docs/.har/setup-infra.sh
+++ b/docs/.har/setup-infra.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="setup-infra@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env setup-infra "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env setup-infra "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env setup-infra "$@"

--- a/docs/.har/teardown.sh
+++ b/docs/.har/teardown.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="teardown@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env teardown "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env teardown "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env teardown "$@"

--- a/docs/.har/verify.sh
+++ b/docs/.har/verify.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="verify@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@0.64.1)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="0.64.1"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env verify "$@" --json
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@0.64.1 env verify "$@" --json

--- a/docs/.har/verify.sh
+++ b/docs/.har/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list). JSON to stdout.
+# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list).
 # The runtime lives in the HAR package (#234) — this file only forwards to it.
-# Usage: ./.har/verify.sh <agent-id> [--full]
+# Usage: ./.har/verify.sh <agent-id> [--full] [--json]   (human output; pass --json for the structured result)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -24,11 +24,11 @@ har_runtime_compatible() {
   [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
 }
 if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
-  exec har env verify "$@" --json
+  exec har env verify "$@"
 elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
-  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
+  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@"
 elif command -v npx >/dev/null 2>&1; then
-  exec npx --yes @osfactory/har@0.64.1 env verify "$@" --json
+  exec npx --yes @osfactory/har@0.64.1 env verify "$@"
 fi
 echo "Error: cannot run the HAR runtime — 'har' is not on PATH and Node.js (npx) is unavailable." >&2
 echo "  Install Node.js, then: npm i -D @osfactory/har   # or: npx @osfactory/har@0.64.1 env verify" >&2

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -122,6 +122,7 @@ export default defineConfig({
 					label: 'Project',
 					items: [
 						{ label: 'Architecture', slug: 'docs/project/architecture' },
+						{ label: 'The road to 1.0', slug: 'docs/project/road-to-1-0' },
 						{ label: 'Contributing', slug: 'docs/project/contributing' },
 						{ label: 'FAQ', slug: 'docs/project/faq' },
 					],

--- a/docs/src/content/docs/docs/project/road-to-1-0.md
+++ b/docs/src/content/docs/docs/project/road-to-1-0.md
@@ -1,0 +1,117 @@
+---
+title: The road to 1.0
+description: Why .har/ became a configuration surface, what broke on the way, and what we learned shipping HAR 1.0.0.
+---
+
+HAR 1.0.0 changes one thing, and everything follows from it: **`.har/` stops being
+a vendored copy of HAR's runtime and becomes a configuration surface.** This post
+explains why we did it, what actually broke while dogfooding the migration on
+HAR's own repository, and the lessons that ended up encoded in the product.
+
+## The problem we shipped ourselves
+
+Pre-1.0, `har env init` copied the runtime into every project: an 812-line
+`agent-slot.sh`, a provisioning script, and lifecycle scripts full of logic.
+Across three boilerplate profiles that meant roughly 8,800 lines of template,
+about 2,400 of them byte-identical duplicates — one helper block was copied
+seven times. The architecture audit condensed the damage into four findings:
+
+- **Forked boilerplates.** Fixing a bug meant fixing it three times, and
+  usually meant a user's already-adapted harness never got the fix at all.
+- **Machinery outnumbered config.** 75–80% of installed files were runtime
+  internals users were never supposed to touch — but nothing stopped them.
+- **Three invocation surfaces, three behaviors.** The CLI, the MCP tools, and
+  the raw scripts each reimplemented ports, preflight, and slot logic. Raw
+  script runs never wrote run or validation records, so the commit gate could
+  be satisfied on one path and bypassed on another.
+- **Drift detection was noise.** Every intentional adaptation looked identical
+  to accidental corruption, so people learned to ignore the warnings.
+
+## The 1.0 model
+
+The runtime now lives once, in the npm package. What remains in `.har/` is
+either **yours** or **managed**, and the boundary is explicit:
+
+| Yours | Managed by HAR |
+|-------|----------------|
+| `harness.env` — pure schema-validated config | Six 35-line shims (`launch.sh`, `verify.sh`, …) that `exec har env <kind>` |
+| `stages.json` + `stages/*.sh` — registered verification stages | Stock stage helpers (`readiness.sh`, `lib/verify-runner.mjs`) |
+| `hooks/*.sh` — lifecycle side effects | `manifest.json` — versions, migration history, drift checksums |
+| Infra templates (compose, PM2 ecosystem) | Docs and agent guidance (`README.md`, `STAGES.md`, `CLAUDE.agent.md`) |
+
+Customization has exactly five sanctioned homes: config values, registered
+stages, lifecycle hooks, plugins (including local ones via `har plugin create`),
+and — for people who genuinely want to own the runtime — an explicit
+`har env eject` instead of the old silent degraded mode. `har env doctor`
+validates the whole contract in one command.
+
+The migration from pre-1.0 is `maintain`-driven: `har env maintain` detects the
+old shape and writes a plan plus a `MIGRATE-PROMPT.md` without changing
+anything; `--migrate` performs the mechanical rewrite with backups; the prompt
+tells a coding agent (or you) how to lift what can't be moved mechanically; and
+`--finalize` records the result. Versioned migrations mean 1.0 → 1.1 will
+reuse the same machinery.
+
+## What the dogfood caught
+
+We used this repository's three real harnesses — the CLI harness at `.har/`,
+Mission Control's at `control/.har/`, and the docs site's at `docs/.har/` — as
+the release gate: migrate all three with the real flow, no hand-editing, and
+file every manual step as a bug. That single exercise caught six migration-flow
+bugs (stock files never installed, `auto` ecosystem resolving to a placeholder,
+hooks not receiving config, per-slot database schema silently dropped, and
+more) and two release blockers:
+
+**Plugin templates still referenced the retired machinery.** Every plugin's
+stage template sourced `agent-slot.sh` — a file that no longer exists on a 1.0
+harness. A fresh plugin install would have broken at source time. All templates
+were rewritten to the 1.0 stage surface, and the release gate now asserts no
+template references retired machinery.
+
+**A stale CLI turned the shims into a fork bomb.** This one took the dev
+machine down. Twice. A pre-1.0 `har` treats `.har/verify.sh` as the
+authoritative implementation and executes it; the 1.0 shim execs back into
+`har`; a pre-1.0 `har` executes the script again — one new process per cycle,
+forever. We measured 2,306 stacked processes and a load average of 215 before
+pulling the plug. Every shim now carries a re-entry guard (an environment
+marker that survives `exec` and aborts the loop on its first cycle with clear
+upgrade instructions) and a version floor that skips binaries older than the
+harness's pinned runtime.
+
+## What we learned
+
+**Dogfood the migration, not the feature.** Unit tests told us the migration
+functions worked. Only migrating three real, adapted, differently-shaped
+harnesses told us what the flow *forgot* — and every bug it found is now a
+permanent assertion in the release gate.
+
+**Old binaries meet new files — always.** The fork bomb existed precisely in
+the version skew window every real user passes through. If two components can
+delegate to each other across versions, the loop case needs a guard on day one,
+not after the incident.
+
+**Legacy conventions get one home: the migration.** Pre-1.0 `harness.env`
+files used the shell no-op `true` as a "not configured" placeholder for command
+values. The tempting fix was a special case in the runtime; the right fix was
+normalizing the sentinel to `""` once, at migration time, and keeping the
+runtime free of magic values.
+
+**Delete contracts nobody consumes.** The verify shim initially preserved a
+JSON-on-stdout contract from pre-1.0. Auditing the callers showed nothing
+consumed it anymore — so the shim now emits human output and `--json` is
+opt-in, which is what the docs had said all along.
+
+**Tests live where the behavior lives.** The bugs were fixed in the package;
+the *proof* lives in a registered stage of the repo's own harness — exactly the
+extension point 1.0 gives every project. The release gate eats the dog food.
+
+## The numbers
+
+On this repository's main harness, the migration took `.har/` from 2,010 lines
+of shell (812 of them runtime machinery) to 940 — of which 695 are our own
+end-to-end gate stage and 210 are the six managed shims. Machinery lines
+remaining: zero. Same story on the other two harnesses, and
+`har env doctor` is green on all three.
+
+If you're on a pre-1.0 harness, the [migration guide](/docs/guides/migrating-to-1-0/)
+walks the same path we took — and `har env maintain` will hand you the prompt.

--- a/docs/src/content/docs/docs/reference/harness-files.md
+++ b/docs/src/content/docs/docs/reference/harness-files.md
@@ -39,7 +39,7 @@ records. Do not edit them — `har env doctor` flags patched shims, and
 | Path | Forwards to |
 | --- | --- |
 | `.har/launch.sh` | `har env launch` |
-| `.har/verify.sh` | `har env verify --json` |
+| `.har/verify.sh` | `har env verify` (pass `--json` for the structured result) |
 | `.har/teardown.sh` | `har env teardown` |
 | `.har/setup-infra.sh` | `har env setup-infra` |
 | `.har/preflight.sh` | `har env preflight` |

--- a/src/harness/eject.ts
+++ b/src/harness/eject.ts
@@ -54,7 +54,7 @@ export function resolveRuntimeBundleSource(): string | null {
 
 /**
  * The managed shim's delegate line (`exec har env launch "$@"`, `exec har env
- * verify "$@" --json`, …) is the arg-convention contract each script must
+ * verify "$@"`, …) is the arg-convention contract each script must
  * keep. Ejected scripts reuse it verbatim against the vendored runtime.
  */
 function shimDelegateArgs(templateContent: string): string | null {

--- a/src/harness/migrate-prompt.ts
+++ b/src/harness/migrate-prompt.ts
@@ -108,6 +108,11 @@ export function buildMigrationSection(
     if (env.commentedKeys.length > 0) {
       bits.push(`commented out custom keys (${env.commentedKeys.join(', ')})`);
     }
+    if (env.normalizedNoopCmds.length > 0) {
+      bits.push(
+        `normalized legacy \`true\` no-op command sentinels to \`""\` (${env.normalizedNoopCmds.join(', ')})`,
+      );
+    }
     lines.push(
       `- Rewr${applied ? 'ote' : 'ite'} \`harness.env\` as pure schema-valid config${bits.length > 0 ? `: ${bits.join('; ')}` : ''}`,
     );

--- a/src/harness/migrations.ts
+++ b/src/harness/migrations.ts
@@ -111,6 +111,8 @@ export interface HarnessEnvMigration {
   droppedTriplets: string[];
   /** Unknown HARNESS_* keys commented out (schema would reject them). */
   commentedKeys: string[];
+  /** *_CMD keys whose legacy `true` no-op sentinel was normalized to "". */
+  normalizedNoopCmds: string[];
   droppedShellLines: number;
 }
 
@@ -229,6 +231,7 @@ export function migrateHarnessEnvContent(original: string): HarnessEnvMigration 
   const convertedFlags: string[] = [];
   const droppedTriplets: string[] = [];
   const commentedKeys: string[] = [];
+  const normalizedNoopCmds: string[] = [];
   const triplets: Record<string, { def?: number; start?: number; end?: number }> = {};
   let services: string[] = [];
   let hadServicesKey = false;
@@ -273,6 +276,14 @@ export function migrateHarnessEnvContent(original: string): HarnessEnvMigration 
 
     if (STOCK_ENV_HELPER_KEYS.has(key)) {
       droppedShellLines++;
+      continue;
+    }
+    // Pre-1.0 templates used the shell no-op `true` as the "not configured"
+    // placeholder for command values. The 1.0 convention is "" — the runtime
+    // runs whatever a *_CMD holds, with no sentinel special cases.
+    if (/^HARNESS_[A-Z0-9_]*CMD$/.test(key) && value === 'true') {
+      normalizedNoopCmds.push(key);
+      out.push(`export ${key}=""`);
       continue;
     }
     if (key === 'HARNESS_INFRA_SERVICES') {
@@ -347,6 +358,7 @@ export function migrateHarnessEnvContent(original: string): HarnessEnvMigration 
     portLanes: laneEntries.join(' '),
     droppedTriplets,
     commentedKeys,
+    normalizedNoopCmds,
     droppedShellLines,
   };
 }

--- a/src/runtime/launch.ts
+++ b/src/runtime/launch.ts
@@ -340,8 +340,10 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
     // Apply the database schema per slot (pre-1.0 launch.sh parity, idempotent)
     // — otherwise schema drift after a code change surfaces as runtime 500s in
     // the slot instead of a clear launch error. Runs from the work dir with the
-    // slot env sourced, so DATABASE_URL points at the slot's database.
-    if (pm !== 'simulator' && env.HARNESS_DB_MIGRATE_CMD && env.HARNESS_DB_MIGRATE_CMD !== 'true') {
+    // slot env sourced, so DATABASE_URL points at the slot's database. "" means
+    // not configured (the #241 migration normalizes the pre-1.0 `true` no-op
+    // sentinel away, so the runtime carries no sentinel special cases).
+    if (pm !== 'simulator' && env.HARNESS_DB_MIGRATE_CMD) {
       log(`Applying database schema: ${env.HARNESS_DB_MIGRATE_CMD}`);
       const migrate = exec('bash', [
         '-c',

--- a/src/templates/plugins/custom-stage-skeleton.sh
+++ b/src/templates/plugins/custom-stage-skeleton.sh
@@ -12,31 +12,22 @@
 # Usage: ./.har/stages/__STAGE_ID__.sh <agent-id> [extra args...]
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
-# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
-SCRIPT_DIR="$HARNESS_DIR"
 
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/harness.env"
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/agent-slot.sh"
+AGENT_ID="${1:-${AGENT_ID:?Usage: __STAGE_ID__.sh <agent-id> [extra args...]}}"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
 
-AGENT_ID="${1:?Usage: __STAGE_ID__.sh <agent-id> [extra args...]}"
-validate_agent_id "$AGENT_ID"
-
-ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found." >&2
-  har_suggest_launch "$AGENT_ID" >&2
-  exit 1
+# JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
 }
-set -a
-# shellcheck source=/dev/null
-source "$ENV_FILE"
-set +a
 
-WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
 ARTIFACTS_DIR="$HARNESS_DIR/artifacts/__STAGE_ID__"
 mkdir -p "$ARTIFACTS_DIR"
 

--- a/src/templates/plugins/gitleaks/.har/stages/secrets-scan.sh
+++ b/src/templates/plugins/gitleaks/.har/stages/secrets-scan.sh
@@ -12,21 +12,16 @@
 # See: ./.har/stages/GITLEAKS.md for the adaptation guide.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
-# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
-SCRIPT_DIR="$HARNESS_DIR"
 
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/harness.env"
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/agent-slot.sh"
-
-AGENT_ID="${1:?Usage: secrets-scan.sh <agent-id> [dir|git]}"
+AGENT_ID="${1:-${AGENT_ID:?Usage: secrets-scan.sh <agent-id> [dir|git]}}"
 MODE="${2:-dir}"
 
-validate_agent_id "$AGENT_ID"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
 
 if [ "$MODE" != "dir" ] && [ "$MODE" != "git" ]; then
   echo "Error: unknown mode '$MODE' — expected 'dir' or 'git'." >&2
@@ -53,18 +48,8 @@ REPORT_PATH="$ARTIFACT_DIR/report.json"
 SCAN_LOG="$ARTIFACT_DIR/gitleaks.log"
 
 # ── Resolve agent env ─────────────────────────────────────────────────────────
-ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found." >&2
-  har_suggest_launch "$AGENT_ID" >&2
-  exit 1
-}
-
-set -a
-# shellcheck source=/dev/null
-source "$ENV_FILE"
-set +a
-
-WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
 
 GITLEAKS_VERSION="$(gitleaks version 2>/dev/null | head -1 || echo unknown)"
 log "gitleaks ${GITLEAKS_VERSION} — ${MODE} scan of $WORK_DIR"

--- a/src/templates/plugins/kerno/.github/workflows/kerno.yml
+++ b/src/templates/plugins/kerno/.github/workflows/kerno.yml
@@ -6,7 +6,7 @@
 #   2. Your app running and reachable at the SUT URL, with its database migrated/seeded.
 #   3. A Kerno agent bound to this checkout (`kerno init`) with a committed suite in .kerno/.
 #
-# The stage sources the HAR slot machinery (.har/harness.env, agent-slot.sh, .env.agent.<id>),
+# The stage relies on the HAR stage runner (harness.env + slot env exported by `har env verify`),
 # so the supported path is to run it inside a launched HAR slot. Adapt the "start app" and
 # "kerno init" steps for your stack. Remove `if: false` once wired up.
 name: Kerno backend validation

--- a/src/templates/plugins/kerno/.har/stages/backend-validation.sh
+++ b/src/templates/plugins/kerno/.har/stages/backend-validation.sh
@@ -9,19 +9,14 @@
 # See: ./.har/stages/KERNO.md for the full setup + adaptation guide.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
-# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
-SCRIPT_DIR="$HARNESS_DIR"
 
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/harness.env"
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/agent-slot.sh"
-
-AGENT_ID="${1:?Usage: backend-validation.sh <agent-id>}"
-validate_agent_id "$AGENT_ID"
+AGENT_ID="${1:-${AGENT_ID:?Usage: backend-validation.sh <agent-id>}}"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
 
 log() { echo "==> [backend-validation agent-$AGENT_ID] $*" >&2; }
 
@@ -81,18 +76,8 @@ fi
 trap cleanup EXIT
 
 # ── Resolve agent env + slot target ───────────────────────────────────────────
-ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found." >&2
-  har_suggest_launch "$AGENT_ID" >&2
-  exit 1
-}
-
-set -a
-# shellcheck source=/dev/null
-source "$ENV_FILE"
-set +a
-
-WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
 
 # SUT URL: prefer an explicit override, then the app's own SITE_URL (both the default
 # web profile and single-port apps like Next.js set SITE_URL to the running app), then a

--- a/src/templates/plugins/playwright/.har/stages/browser-e2e.sh
+++ b/src/templates/plugins/playwright/.har/stages/browser-e2e.sh
@@ -6,34 +6,19 @@
 # Prerequisite: ./.har/launch.sh <agent-id>
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
-# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
-SCRIPT_DIR="$HARNESS_DIR"
 
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/harness.env"
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/agent-slot.sh"
-
-AGENT_ID="${1:?Usage: browser-e2e.sh <agent-id>}"
-validate_agent_id "$AGENT_ID"
+AGENT_ID="${1:-${AGENT_ID:?Usage: browser-e2e.sh <agent-id>}}"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))'; }
 
 log() { echo "==> [browser-e2e agent-$AGENT_ID] $*" >&2; }
 
-ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found." >&2
-  har_suggest_launch "$AGENT_ID" >&2
-  exit 1
-}
-
-set -a
-# shellcheck source=/dev/null
-source "$ENV_FILE"
-set +a
-
-WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
 FE_PORT="${FE_PORT:-$(( HARNESS_FE_BASE_PORT + AGENT_ID * 10 ))}"
 API_PORT="${API_PORT:-$(( HARNESS_API_BASE_PORT + AGENT_ID * 10 ))}"
 

--- a/src/templates/plugins/rocketsim/.har/stages/rocketsim-flows.sh
+++ b/src/templates/plugins/rocketsim/.har/stages/rocketsim-flows.sh
@@ -10,21 +10,16 @@
 # See: ./.har/stages/ROCKETSIM.md for the full authoring guide.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
-# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
-SCRIPT_DIR="$HARNESS_DIR"
 
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/harness.env"
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/agent-slot.sh"
-
-AGENT_ID="${1:?Usage: rocketsim-flows.sh <agent-id> [flow-name]}"
+AGENT_ID="${1:-${AGENT_ID:?Usage: rocketsim-flows.sh <agent-id> [flow-name]}}"
 FLOW_FILTER="${2:-}"
 
-validate_agent_id "$AGENT_ID"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
 
 log() { echo "==> [rocketsim agent-$AGENT_ID] $*" >&2; }
 
@@ -43,18 +38,8 @@ if ! rocketsim doctor --quiet 2>/dev/null; then
 fi
 
 # ── Resolve agent env ─────────────────────────────────────────────────────────
-ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found." >&2
-  har_suggest_launch "$AGENT_ID" >&2
-  exit 1
-}
-
-set -a
-# shellcheck source=/dev/null
-source "$ENV_FILE"
-set +a
-
-WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
 
 # ── Discover flows ─────────────────────────────────────────────────────────────
 FLOWS_DIR="$WORK_DIR/flows"

--- a/src/templates/plugins/semgrep/.har/stages/sast.sh
+++ b/src/templates/plugins/semgrep/.har/stages/sast.sh
@@ -15,22 +15,17 @@
 # See: ./.har/stages/SEMGREP.md for the full adaptation guide.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
-# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
-SCRIPT_DIR="$HARNESS_DIR"
 
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/harness.env"
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/agent-slot.sh"
-
-AGENT_ID="${1:?Usage: sast.sh <agent-id> [paths...]}"
-shift
+AGENT_ID="${1:-${AGENT_ID:?Usage: sast.sh <agent-id> [paths...]}}"
+[ "$#" -gt 0 ] && shift
 SCAN_PATHS=("$@")
 
-validate_agent_id "$AGENT_ID"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
 
 log() { echo "==> [semgrep agent-$AGENT_ID] $*" >&2; }
 
@@ -46,22 +41,11 @@ if ! command -v semgrep >/dev/null 2>&1; then
 fi
 
 # ── Resolve agent env ─────────────────────────────────────────────────────────
-ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found." >&2
-  har_suggest_launch "$AGENT_ID" >&2
-  exit 1
-}
-
-# .env.agent.<id> exports REPO_ROOT pointing at the worktree — keep the main
-# checkout path so artifacts land in the main repo root, not the worktree.
+# Artifacts land in the main repo root (where .har/ lives), not the worktree.
 MAIN_REPO_ROOT="$REPO_ROOT"
 
-set -a
-# shellcheck source=/dev/null
-source "$ENV_FILE"
-set +a
-
-WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
 
 # ── Artifact directory (main repo root, not the worktree) ─────────────────────
 ARTIFACT_DIR="$MAIN_REPO_ROOT/.har/artifacts/sast"

--- a/src/templates/plugins/trivy/.har/stages/vuln-scan.sh
+++ b/src/templates/plugins/trivy/.har/stages/vuln-scan.sh
@@ -16,20 +16,15 @@
 # See: ./.har/stages/TRIVY.md for the full adaptation guide.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HARNESS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
-# agent-slot.sh expects SCRIPT_DIR to be .har/ (slot registry lives there)
-SCRIPT_DIR="$HARNESS_DIR"
 
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/harness.env"
-# shellcheck source=/dev/null
-source "$HARNESS_DIR/agent-slot.sh"
+AGENT_ID="${1:-${AGENT_ID:?Usage: vuln-scan.sh <agent-id>}}"
 
-AGENT_ID="${1:?Usage: vuln-scan.sh <agent-id>}"
-
-validate_agent_id "$AGENT_ID"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
 
 log() { echo "==> [vuln-scan agent-$AGENT_ID] $*" >&2; }
 
@@ -44,18 +39,8 @@ if ! command -v trivy >/dev/null 2>&1; then
 fi
 
 # ── Resolve agent env ─────────────────────────────────────────────────────────
-ENV_FILE="$(resolve_agent_env_file "$AGENT_ID" "$REPO_ROOT")" || {
-  echo "No .env.agent.${AGENT_ID} found." >&2
-  har_suggest_launch "$AGENT_ID" >&2
-  exit 1
-}
-
-set -a
-# shellcheck source=/dev/null
-source "$ENV_FILE"
-set +a
-
-WORK_DIR="$(resolve_agent_work_dir "$ENV_FILE")"
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run ./.har/launch.sh ${AGENT_ID} first}"
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 SEVERITY="${HARNESS_TRIVY_SEVERITY:-HIGH,CRITICAL}"

--- a/src/templates/runtime-bundles/pm2-runtime/env.template
+++ b/src/templates/runtime-bundles/pm2-runtime/env.template
@@ -32,7 +32,7 @@ S3_FORCE_PATH_STYLE=true
 # Headless browser (if enabled)
 HEADLESS_BROWSER_URL=http://localhost:${BROWSER_PORT}
 
-# Toolchain paths — appended by provision-toolchain.sh during launch
+# Toolchain paths — appended by the packaged launch provisioning step
 # NODE_BIN=  NPM_BIN=  PYTHON_BIN=  VIRTUAL_ENV=  GO_BIN=  CARGO_BIN=  JAVA_HOME=
 
 # Mail (if enabled)

--- a/src/templates/runtime-bundles/shared-kernel/STAGES.md
+++ b/src/templates/runtime-bundles/shared-kernel/STAGES.md
@@ -61,13 +61,13 @@ and reinstall with `har env add-plugin db-integrity --force`.
 
 Every script under `.har/stages/` must:
 
-1. Source `harness.env` and `agent-slot.sh` from `.har/`. Before sourcing,
-   set `SCRIPT_DIR` to the `.har/` directory (not `stages/`) — `agent-slot.sh`
-   resolves the slot registry via `$SCRIPT_DIR/slots/...`.
-2. Take the agent slot id as `$1` (validate with `validate_agent_id`); extra
-   args may follow.
-3. Load the slot env via `resolve_agent_env_file` and run checks from the
-   agent's work dir (`resolve_agent_work_dir`).
+1. Assume the 1.0 stage surface: the runner exports `WORK_DIR`, `ENV_FILE`,
+   `AGENT_ID` and `HAR_HARNESS_DIR`, with `harness.env` and the slot env file
+   already sourced. Never source `agent-slot.sh` — it is retired in 1.0.
+2. Take the agent slot id as `$1`, falling back to the exported `AGENT_ID`
+   (`AGENT_ID="${1:-${AGENT_ID:?...}}"`); extra args may follow.
+3. Guard the runner contract with `${ENV_FILE:?...}` / `${WORK_DIR:?...}`
+   (pointing at `./.har/launch.sh <id>`) and run checks from `$WORK_DIR`.
 4. Write artifacts (reports, screenshots, logs) under `.har/artifacts/<id>/`.
 5. Print **only** the normalized JSON result object on stdout
    (`status`, `stageId`, `agent_id`, `total_ms`, …); log progress to stderr.

--- a/src/templates/runtime-bundles/shared-kernel/agent-cli.sh
+++ b/src/templates/runtime-bundles/shared-kernel/agent-cli.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="agent@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@__HAR_VERSION__)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="__HAR_VERSION__"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env agent "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env agent "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@__HAR_VERSION__ env agent "$@"

--- a/src/templates/runtime-bundles/shared-kernel/launch.sh
+++ b/src/templates/runtime-bundles/shared-kernel/launch.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="launch@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@__HAR_VERSION__)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="__HAR_VERSION__"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env launch "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env launch "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@__HAR_VERSION__ env launch "$@"

--- a/src/templates/runtime-bundles/shared-kernel/preflight.sh
+++ b/src/templates/runtime-bundles/shared-kernel/preflight.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="preflight@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@__HAR_VERSION__)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="__HAR_VERSION__"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env preflight "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env preflight "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@__HAR_VERSION__ env preflight "$@"

--- a/src/templates/runtime-bundles/shared-kernel/setup-infra.sh
+++ b/src/templates/runtime-bundles/shared-kernel/setup-infra.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="setup-infra@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@__HAR_VERSION__)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="__HAR_VERSION__"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env setup-infra "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env setup-infra "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@__HAR_VERSION__ env setup-infra "$@"

--- a/src/templates/runtime-bundles/shared-kernel/teardown.sh
+++ b/src/templates/runtime-bundles/shared-kernel/teardown.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="teardown@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@__HAR_VERSION__)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="__HAR_VERSION__"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env teardown "$@"
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env teardown "$@"
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@__HAR_VERSION__ env teardown "$@"

--- a/src/templates/runtime-bundles/shared-kernel/verify.sh
+++ b/src/templates/runtime-bundles/shared-kernel/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list). JSON to stdout.
+# Verification pipeline (stages.json verificationStages; quick by default, --full for the whole list).
 # The runtime lives in the HAR package (#234) — this file only forwards to it.
-# Usage: ./.har/verify.sh <agent-id> [--full]
+# Usage: ./.har/verify.sh <agent-id> [--full] [--json]   (human output; pass --json for the structured result)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -24,11 +24,11 @@ har_runtime_compatible() {
   [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
 }
 if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
-  exec har env verify "$@" --json
+  exec har env verify "$@"
 elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
-  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
+  exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@"
 elif command -v npx >/dev/null 2>&1; then
-  exec npx --yes @osfactory/har@__HAR_VERSION__ env verify "$@" --json
+  exec npx --yes @osfactory/har@__HAR_VERSION__ env verify "$@"
 fi
 echo "Error: cannot run the HAR runtime — 'har' is not on PATH and Node.js (npx) is unavailable." >&2
 echo "  Install Node.js, then: npm i -D @osfactory/har   # or: npx @osfactory/har@__HAR_VERSION__ env verify" >&2

--- a/src/templates/runtime-bundles/shared-kernel/verify.sh
+++ b/src/templates/runtime-bundles/shared-kernel/verify.sh
@@ -5,9 +5,27 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-if command -v har >/dev/null 2>&1; then
+# Loop guard (#291): a pre-1.0 har does not own this runtime kind in the
+# package — it executes this script as authoritative, which would exec back
+# into har forever (one node process per cycle). Trip on re-entry for this
+# harness root, and skip har binaries older than the pinned runtime's major.
+HAR_SHIM_GUARD="verify@${REPO_ROOT}"
+case ":${HAR_SHIM_REENTRY:-}:" in *":${HAR_SHIM_GUARD}:"*)
+  echo "Error: runtime loop detected — the har CLI that ran this shim delegated back into it." >&2
+  echo "  The har runtime handling this repo is older than the harness contract (pinned: @osfactory/har@__HAR_VERSION__)." >&2
+  echo "  Fix: npm i -g @osfactory/har@latest    # or in this repo: npm i -D @osfactory/har" >&2
+  exit 86
+  ;;
+esac
+export HAR_SHIM_REENTRY="${HAR_SHIM_REENTRY:-}:${HAR_SHIM_GUARD}"
+har_runtime_compatible() {
+  local v pinned="__HAR_VERSION__"
+  v="$("$1" --version 2>/dev/null | head -n1)" || return 1
+  [ "${v%%.*}" -ge "${pinned%%.*}" ] 2>/dev/null
+}
+if command -v har >/dev/null 2>&1 && har_runtime_compatible har; then
   exec har env verify "$@" --json
-elif [ -x "$REPO_ROOT/node_modules/.bin/har" ]; then
+elif [ -x "$REPO_ROOT/node_modules/.bin/har" ] && har_runtime_compatible "$REPO_ROOT/node_modules/.bin/har"; then
   exec "$REPO_ROOT/node_modules/.bin/har" env verify "$@" --json
 elif command -v npx >/dev/null 2>&1; then
   exec npx --yes @osfactory/har@__HAR_VERSION__ env verify "$@" --json

--- a/tests/eject.test.ts
+++ b/tests/eject.test.ts
@@ -59,7 +59,7 @@ describe('har env eject / adopt (#239)', () => {
       expect(fs.statSync(har(shim)).mode & 0o111).not.toBe(0);
     }
     // The delegate line keeps the managed shim's exact argument convention.
-    expect(fs.readFileSync(har('verify.sh'), 'utf8')).toContain('env verify "$@" --json');
+    expect(fs.readFileSync(har('verify.sh'), 'utf8')).toContain('env verify "$@"');
     expect(fs.readFileSync(har('launch.sh'), 'utf8')).toContain('env launch "$@"');
     expect(fs.readFileSync(har('agent-cli.sh'), 'utf8')).toContain('env agent "$@"');
 

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -175,6 +175,17 @@ describe('versioned harness migrations (#241)', () => {
     expect(result.content).not.toMatch(/^export HARNESS_INFRA_POSTGRES=/m);
   });
 
+  it('migrateHarnessEnvContent normalizes legacy `true` no-op command sentinels to ""', () => {
+    const result = migrateHarnessEnvContent(
+      'export HARNESS_DB_MIGRATE_CMD="true"\nexport HARNESS_DB_SEED_CMD=true\nexport HARNESS_READINESS_CMD="curl -f localhost"\n',
+    );
+    expect(result.normalizedNoopCmds).toEqual(['HARNESS_DB_MIGRATE_CMD', 'HARNESS_DB_SEED_CMD']);
+    expect(result.content).toContain('export HARNESS_DB_MIGRATE_CMD=""');
+    expect(result.content).toContain('export HARNESS_DB_SEED_CMD=""');
+    // Real commands pass through untouched — only the bare `true` sentinel is normalized.
+    expect(result.content).toContain('export HARNESS_READINESS_CMD="curl -f localhost"');
+  });
+
   it('migrateHarnessEnvContent drops stock helper constants (HAR_NODE_PACKAGE_MANAGERS)', () => {
     const result = migrateHarnessEnvContent(
       'HAR_NODE_PACKAGE_MANAGERS="npm bun pnpm yarn"\nexport HARNESS_PROJECT_NAME=proj\n',

--- a/tests/template-shims.test.ts
+++ b/tests/template-shims.test.ts
@@ -88,10 +88,13 @@ describe('template runtime shims (#234/#235)', () => {
     }
   });
 
-  it('verify.sh keeps its JSON stdout contract', () => {
+  it('verify.sh forwards args verbatim — human output by default, --json opt-in', () => {
     const content = fs.readFileSync(path.join(kernel, 'verify.sh'), 'utf8');
     for (const line of content.split('\n')) {
-      if (line.trim().startsWith('exec ')) expect(line).toContain('--json');
+      if (line.trim().startsWith('exec ')) {
+        expect(line).toContain('"$@"');
+        expect(line).not.toContain('--json');
+      }
     }
   });
 

--- a/tests/template-shims.test.ts
+++ b/tests/template-shims.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -48,7 +49,43 @@ describe('template runtime shims (#234/#235)', () => {
     // Clear error when neither har nor node is available.
     expect(content).toMatch(/Error: cannot run the HAR runtime/);
     expect(content).not.toContain('node -e');
-    expect(content.split('\n').length).toBeLessThanOrEqual(25);
+    expect(content.split('\n').length).toBeLessThanOrEqual(60);
+  });
+
+  it.each([...RUNTIME_SHIM_FILES])('shared-kernel/%s refuses pre-1.0 runtime loops (#291)', (shim) => {
+    const content = fs.readFileSync(path.join(kernel, shim), 'utf8');
+    // Re-entry marker: env survives exec, so a pre-1.0 har that hands control
+    // back to the shim trips the guard on its first cycle instead of forking
+    // one node process per cycle forever.
+    expect(content).toContain('HAR_SHIM_REENTRY');
+    expect(content).toContain('exit 86');
+    // Version floor: har binaries older than the pinned major are skipped in
+    // favor of node_modules/.bin/har or the pinned npx fallback.
+    expect(content).toContain('har_runtime_compatible');
+  });
+
+  it('verify.sh cuts the exec loop against a pre-1.0 har (#291)', () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'har-shim-loop-'));
+    try {
+      scaffoldHarnessBoilerplate(repo, { profile: 'default' });
+      const shim = path.join(repo, '.har', 'verify.sh');
+      const bin = path.join(repo, 'fake-bin');
+      fs.mkdirSync(bin);
+      // A pre-1.0 har treats .har/verify.sh as authoritative and re-executes it.
+      fs.writeFileSync(
+        path.join(bin, 'har'),
+        `#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo "${getHarPackageVersion()}"; exit 0; fi\nexec "${shim}" 1 --full\n`,
+        { mode: 0o755 },
+      );
+      const result = spawnSync(shim, ['1', '--full'], {
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+        encoding: 'utf8',
+      });
+      expect(result.status).toBe(86);
+      expect(result.stderr).toContain('runtime loop detected');
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
   });
 
   it('verify.sh keeps its JSON stdout contract', () => {

--- a/tests/verify-shell-timing.test.ts
+++ b/tests/verify-shell-timing.test.ts
@@ -32,10 +32,10 @@ describe('stage scripts use portable timing', () => {
   });
 });
 
-describe('plugin template stage scripts set SCRIPT_DIR to .har/', () => {
-  // Plugin templates still resolve paths relative to the harness dir; this
-  // repo's own stage scripts are migrated to the 1.0 stage surface (WORK_DIR /
-  // ENV_FILE / AGENT_ID exported by the runner) and are covered above.
+describe('plugin template stage scripts follow the 1.0 stage surface', () => {
+  // The runner exports WORK_DIR, ENV_FILE, AGENT_ID and HAR_HARNESS_DIR with
+  // harness.env and the slot env file already sourced — agent-slot.sh is
+  // retired, so a fresh plugin install must not reference it (#290).
   const stagePaths = [
     'src/templates/plugins/playwright/.har/stages/browser-e2e.sh',
     'src/templates/plugins/rocketsim/.har/stages/rocketsim-flows.sh',
@@ -46,8 +46,18 @@ describe('plugin template stage scripts set SCRIPT_DIR to .har/', () => {
     'src/templates/plugins/custom-stage-skeleton.sh',
   ];
 
-  it.each(stagePaths)('%s reassigns SCRIPT_DIR to HARNESS_DIR', (relPath) => {
+  it.each(stagePaths)('%s uses the runner contract, not agent-slot.sh', (relPath) => {
     const script = fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8');
-    expect(script).toMatch(/HARNESS_DIR=.*\nREPO_ROOT=.*\n(?:#.*\n)*SCRIPT_DIR="\$HARNESS_DIR"/);
+    expect(script).not.toMatch(/source\s+"?\$HARNESS_DIR\/agent-slot\.sh/);
+    expect(script).not.toMatch(/provision-toolchain\.sh/);
+    expect(script).not.toMatch(
+      /\b(validate_agent_id|resolve_agent_env_file|resolve_agent_work_dir|har_suggest_launch)\b/,
+    );
+    expect(script).toContain(
+      'HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"',
+    );
+    expect(script).toMatch(/ENV_FILE="\$\{ENV_FILE:\?/);
+    expect(script).toMatch(/WORK_DIR="\$\{WORK_DIR:\?/);
+    expect(script).toMatch(/AGENT_ID="\$\{1:-\$\{AGENT_ID:\?/);
   });
 });


### PR DESCRIPTION
Closes #290
Closes #291

**Stack 2/2 — M5 (release gate), based on #289.**

Two release blockers surfaced by the M5 dogfood:

**#290 — plugin templates broke on 1.0 harnesses.** Every stage template under `src/templates/plugins/` still sourced the retired `agent-slot.sh`; a fresh plugin install onto a 1.0 harness failed at source time. All seven templates are rewritten to the 1.0 stage surface (exported `WORK_DIR`/`ENV_FILE`/`AGENT_ID`/`HAR_HARNESS_DIR`, slot env pre-sourced), and the M5 fixture assert proves no template references retired machinery.

**#291 — stale global `har` × 1.0 shims = runtime fork bomb.** A pre-1.0 CLI executes the shims as authoritative scripts; the shims exec back into `har`, forking one node process per cycle (observed live: 2,306 processes, load average 215, dev machine down twice). Every shared-kernel shim now carries a per-harness-root re-entry marker (`HAR_SHIM_REENTRY`, survives `exec`, aborts the loop on cycle one with exit 86 and upgrade instructions) plus a version floor that skips `har` binaries older than the pinned runtime's major in favor of `node_modules/.bin/har` / pinned `npx`. The repo's three migrated harnesses' shims are regenerated from the templates. Covered by new template-shims tests, including a functional loop-cut test against a simulated pre-1.0 `har`.

**Gate: GREEN** — `HAR_FIXTURE_E2E=1 HAR_FIXTURE_MILESTONE=M5 har env verify 4 --full` (run with the locally built runtime): all 9 stages pass, fixture-e2e 3m16s with M5 migration + template asserts (`.har/artifacts/fixture-e2e/gate-20260826-114216.log`); `npm test` 921/921. Commit gate batch `0b70f2c5` verified by run `23c3b1c9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)