### PR TITLE
fix: count a result record's cache reads once and stop summing it with nested usage

### DIFF
--- a/packages/schemas/src/usage-pricing.ts
+++ b/packages/schemas/src/usage-pricing.ts
@@ -33,7 +33,7 @@ function providerHint(agentTool: AgentTool): string | undefined {
 /**
  * Map HAR token buckets to genai-prices semantics.
  * genai-prices treats `input_tokens` as the inclusive parent; cache read/write are subsets.
- * Claude harvest reports disjoint buckets (uncached input vs cache creation).
+ * Every modelBreakdown producer reports disjoint buckets (uncached input vs cache).
  */
 export function toGenaiPricesUsage(totals: ModelUsageTotals): {
   input_tokens: number;
@@ -44,10 +44,8 @@ export function toGenaiPricesUsage(totals: ModelUsageTotals): {
   const rawInput = num(totals.tokensInput);
   const cacheRead = num(totals.tokensCacheRead);
   const cacheWrite = num(totals.tokensCacheCreation);
-  const uncached = rawInput >= cacheRead ? rawInput - cacheRead : rawInput;
-  const inclusiveInput = uncached + cacheRead + cacheWrite;
   return {
-    input_tokens: inclusiveInput,
+    input_tokens: rawInput + cacheRead + cacheWrite,
     output_tokens: num(totals.tokensOutput),
     cache_read_tokens: cacheRead,
     cache_write_tokens: cacheWrite,

--- a/src/core/usage-harvest/claude.ts
+++ b/src/core/usage-harvest/claude.ts
@@ -70,8 +70,13 @@ function extractClaudeUsageFromRecords(records: unknown[]): {
   let tokensOutput = 0;
   let tokensCacheRead = 0;
   let tokensCacheCreation = 0;
-  let costUsd: number | null = null;
   const modelBreakdown: Record<string, ModelUsageTotals> = {};
+
+  let resultInput = 0;
+  let resultOutput = 0;
+  let resultCacheRead = 0;
+  let resultCacheCreation = 0;
+  let resultCostUsd: number | null = null;
 
   // Claude Code repeats one message's `usage` on every record it splits that
   // message across.
@@ -83,12 +88,13 @@ function extractClaudeUsageFromRecords(records: unknown[]): {
     const payload = record as Record<string, unknown>;
     if (payload.type === 'result') {
       const usage = (payload.usage ?? {}) as Record<string, unknown>;
-      tokensInput =
-        Number(usage.input_tokens ?? 0) + Number(usage.cache_read_input_tokens ?? 0);
-      tokensOutput = Number(usage.output_tokens ?? 0);
-      tokensCacheRead = Number(usage.cache_read_input_tokens ?? 0);
-      tokensCacheCreation = Number(usage.cache_creation_input_tokens ?? 0);
-      if (payload.total_cost_usd != null) costUsd = Number(payload.total_cost_usd);
+      resultInput += Number(usage.input_tokens ?? 0);
+      resultOutput += Number(usage.output_tokens ?? 0);
+      resultCacheRead += Number(usage.cache_read_input_tokens ?? 0);
+      resultCacheCreation += Number(usage.cache_creation_input_tokens ?? 0);
+      if (payload.total_cost_usd != null) {
+        resultCostUsd = (resultCostUsd ?? 0) + Number(payload.total_cost_usd);
+      }
     }
     // Some transcripts nest usage on message/assistant events — collect when present.
     const message = payload.message as
@@ -130,7 +136,21 @@ function extractClaudeUsageFromRecords(records: unknown[]): {
     }
   }
 
-  return { tokensInput, tokensOutput, tokensCacheRead, tokensCacheCreation, costUsd, modelBreakdown };
+  const resultTotal = resultInput + resultOutput + resultCacheRead + resultCacheCreation;
+  if (resultTotal > 0) {
+    tokensInput = resultInput;
+    tokensOutput = resultOutput;
+    tokensCacheRead = resultCacheRead;
+    tokensCacheCreation = resultCacheCreation;
+  }
+  return {
+    tokensInput,
+    tokensOutput,
+    tokensCacheRead,
+    tokensCacheCreation,
+    costUsd: resultCostUsd,
+    modelBreakdown,
+  };
 }
 
 interface TranscriptMatch {

--- a/tests/usage-harvest.test.ts
+++ b/tests/usage-harvest.test.ts
@@ -56,7 +56,11 @@ describe('usage harvest claude', () => {
 
     expect(usage).not.toBeNull();
     expect(usage!.agentTool).toBe('claude_code');
+    expect(usage!.tokensInput).toBe(100);
     expect(usage!.tokensOutput).toBe(50);
+    expect(usage!.tokensCacheRead).toBe(20);
+    expect(usage!.tokensCacheCreation).toBe(5);
+    expect(usage!.tokensTotal).toBe(175);
     expect(usage!.costUsd).toBe(0.42);
     expect(usage!.sources).toEqual(['harvest']);
     expect(usage!.harvestVersion).toBe(USAGE_HARVEST_VERSION);
@@ -98,6 +102,10 @@ describe('usage harvest claude', () => {
     });
 
     expect(usage).not.toBeNull();
+    expect(usage!.tokensInput).toBe(30);
+    expect(usage!.tokensOutput).toBe(10);
+    expect(usage!.tokensCacheRead).toBe(4);
+    expect(usage!.tokensTotal).toBe(44);
     expect(usage!.modelBreakdown).toEqual({
       'claude-opus-4-8': {
         tokensInput: 30,
@@ -107,6 +115,77 @@ describe('usage harvest claude', () => {
         tokensTotal: 44,
       },
     });
+  });
+
+  it('sums repeated result records instead of overwriting them', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-5-ff66';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    const result = (input: number, output: number, cost: number) =>
+      JSON.stringify({
+        type: 'result',
+        usage: { input_tokens: input, output_tokens: output, cache_read_input_tokens: 1 },
+        total_cost_usd: cost,
+      });
+    fs.writeFileSync(
+      path.join(project, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: workDir }),
+        result(10, 5, 0.1),
+        result(20, 7, 0.2),
+      ].join('\n') + '\n',
+    );
+
+    const usage = harvestClaudeUsage({
+      agentId: 5,
+      workDir,
+      branch: 'main-abcd-har-agent-5-ff66',
+      suffix: 'ff66',
+      repoPath: '/home/user/repo',
+    });
+
+    expect(usage).not.toBeNull();
+    expect(usage!.tokensInput).toBe(30);
+    expect(usage!.tokensOutput).toBe(12);
+    expect(usage!.tokensCacheRead).toBe(2);
+    expect(usage!.tokensTotal).toBe(44);
+    expect(usage!.costUsd).toBeCloseTo(0.3);
+  });
+
+  it('falls back to nested usage when the result record carries no tokens', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-6-gg77';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(
+      path.join(project, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: workDir }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            id: 'msg_1',
+            role: 'assistant',
+            model: 'claude-opus-5',
+            usage: { input_tokens: 8, output_tokens: 3, cache_read_input_tokens: 40 },
+          },
+        }),
+        JSON.stringify({ type: 'result', subtype: 'error_during_execution', usage: {} }),
+      ].join('\n') + '\n',
+    );
+
+    const usage = harvestClaudeUsage({
+      agentId: 6,
+      workDir,
+      branch: 'main-abcd-har-agent-6-gg77',
+      suffix: 'gg77',
+      repoPath: '/home/user/repo',
+    });
+
+    expect(usage).not.toBeNull();
+    expect(usage!.tokensInput).toBe(8);
+    expect(usage!.tokensOutput).toBe(3);
+    expect(usage!.tokensCacheRead).toBe(40);
+    expect(usage!.tokensTotal).toBe(51);
   });
 
   it('bills a repeated assistant message id once', () => {

--- a/tests/usage-pricing.test.ts
+++ b/tests/usage-pricing.test.ts
@@ -52,7 +52,7 @@ describe('toGenaiPricesUsage', () => {
     });
   });
 
-  it('does not double-count cache read when input already includes it', () => {
+  it('sums disjoint buckets into the inclusive input parent', () => {
     expect(
       toGenaiPricesUsage({
         tokensInput: 1200,
@@ -60,10 +60,24 @@ describe('toGenaiPricesUsage', () => {
         tokensCacheCreation: 50,
       }),
     ).toEqual({
-      input_tokens: 1250,
+      input_tokens: 2250,
       output_tokens: 0,
       cache_read_tokens: 1000,
       cache_write_tokens: 50,
+    });
+  });
+
+  it('keeps uncached input whole when it exceeds cache reads', () => {
+    expect(
+      toGenaiPricesUsage({
+        tokensInput: 5000,
+        tokensCacheRead: 100,
+      }),
+    ).toEqual({
+      input_tokens: 5100,
+      output_tokens: 0,
+      cache_read_tokens: 100,
+      cache_write_tokens: 0,
     });
   });
 });

--- a/tests/usage-pricing.test.ts
+++ b/tests/usage-pricing.test.ts
@@ -67,7 +67,7 @@ describe('toGenaiPricesUsage', () => {
     });
   });
 
-  it('keeps uncached input whole when it exceeds cache reads', () => {
+  it('keeps uncached input tokens whole when it exceeds cache reads', () => {
     expect(
       toGenaiPricesUsage({
         tokensInput: 5000,


### PR DESCRIPTION
## What

`extractClaudeUsageFromRecords` handled a `type: result` record with two odd behaviours:

```ts
tokensInput = Number(usage.input_tokens ?? 0) + Number(usage.cache_read_input_tokens ?? 0);
tokensCacheRead = Number(usage.cache_read_input_tokens ?? 0);
```

1. **Cache reads landed in the total twice** — once folded into `tokensInput`, once in `tokensCacheRead`, and `tokensTotal` adds all four buckets.
2. **It assigned rather than accumulated**, so the values were order-dependent: the nested-usage loop that runs afterwards added its own totals on top of the assignment, and a second result record overwrote the first.

The knock-on effect was that `tokensInput` meant "uncached input" on the nested path and "input including cache reads" on the result path.

## Approach

A result record is the authoritative summary of one `claude -p` invocation, so result records now accumulate into their own totals and **replace** the nested sums when they carry tokens, instead of being added to them. `modelBreakdown` still comes from nested usage only — that is the only place per-model ids exist.

A result record with empty usage (an `error_during_execution` close) falls through to the nested totals rather than zeroing the row.

With `tokensInput` meaning uncached input on both paths, the `rawInput >= cacheRead ? rawInput - cacheRead : rawInput` subtraction in `toGenaiPricesUsage` is gone.

### That guard was under-billing

Worth a closer look in review: it wasn't merely redundant. `toGenaiPricesUsage` is reachable only via `enrichUsageWithPricing` → `modelBreakdown`, and all three breakdown producers emit **disjoint** buckets:

- `src/core/usage-harvest/claude.ts` (nested path)
- `control/src/server/otel-ingest.ts`
- `control/src/server/trajectory-projections.ts`

So subtracting cache reads from an already-uncached number silently discarded billable input whenever a model row's summed uncached input exceeded its summed cache reads. Codex is the one harvester with inclusive OpenAI-style `input_tokens`, and it never builds a `modelBreakdown` — so nothing depended on the guard. The docblock now records that constraint.

## Scope

Only the `claude -p --output-format json` shape carries result records, so the transcript files `findMatchingClaudeTranscripts` reads for real Claude Code sessions are unaffected. This is a latent-defect fix, which is why it was kept out of #279.

`benchmarks/har-vs-raw/scripts/run_task.py` has the same `input + cache_read` line, but there `tokens_total = input + output` with no separate cache bucket — it counts cache reads exactly once, so it is left alone.

## Before / after

Measured by running identical fixtures through both versions.

| Transcript | Field | Before | After | Why |
|---|---|---|---|---|
| **A** — one `result` record only<br>`in 100, out 50, cr 20, cc 5` | `tokensInput`<br>`tokensTotal` | `120`<br>`195` | **`100`**<br>**`175`** | Cache reads were folded into input *and* reported separately; `tokensTotal` added both |
| **B** — assistant message `30/10/4` **plus** a `result` summarising it | `tokensInput`<br>`tokensOutput`<br>`tokensCacheRead`<br>`tokensTotal` | `64`<br>`20`<br>`8`<br>`92` | **`30`**<br>**`10`**<br>**`4`**<br>**`44`** | Result assigned, then the nested loop added on top, so every bucket doubled. `modelBreakdown.tokensTotal` said `44` throughout |
| **C** — two `result` records, `10/5/1` then `20/7/1` | `tokensInput`<br>`tokensOutput`<br>`tokensTotal`<br>`costUsd` | `21`<br>`7`<br>`29`<br>`0.20` | **`30`**<br>**`12`**<br>**`44`**<br>**`0.30`** | The second record overwrote the first, losing that invocation's tokens and cost |
| **D** — assistant message `8/3/40` + empty-usage `result` | `tokensTotal` | `51` | `51` | Unchanged — a regression guard for the new fallback, not a bug being fixed |

Fixture **B** is the one worth a close look: it is an existing test in this repo, and it was already producing the doubled `92` against its own breakdown's `44`. The test simply never asserted session totals.

### Pricing — `toGenaiPricesUsage` → `input_tokens`

| Input | Before | After | |
|---|---|---|---|
| `in 2, cr 0, cc 26207` (the common real shape) | `26209` | `26209` | unchanged; no cache reads to subtract |
| `in 1200, cr 1000, cc 50` | `1250` | **`2250`** | the guard's intended case, subtracting reads from an already-uncached number |
| `in 5000, cr 100` | `5000` | **`5100`** | the under-billing: 100 billable tokens silently dropped |

That last row is the live defect — whenever a model row's summed uncached input exceeded its summed cache reads, the guard discarded the difference.

### Code

| File | Before | After |
|---|---|---|
| `claude.ts` result branch | `tokensInput = input + cache_read`<br>`tokensOutput = output`<br>`tokensCacheRead = cache_read`<br>`costUsd = total_cost_usd` | `resultInput += input`<br>`resultOutput += output`<br>`resultCacheRead += cache_read`<br>`resultCostUsd = (resultCostUsd ?? 0) + total_cost_usd` |
| `claude.ts` return | the nested loop had already added into the same four locals | `if (resultTotal > 0)` the result totals **replace** the nested sums; `costUsd: resultCostUsd` |
| `usage-pricing.ts` | `uncached = rawInput >= cacheRead ? rawInput - cacheRead : rawInput`<br>`inclusiveInput = uncached + cacheRead + cacheWrite` | `input_tokens: rawInput + cacheRead + cacheWrite` |
| `costUsd` local in `claude.ts` | declared, only ever written by the result branch | removed; returned directly |

## Tests

Each row above is covered by a test:

- **A** — strengthened the existing result-record test to assert all four buckets and `tokensTotal`.
- **B** — strengthened the existing breakdown fixture to assert session totals, not just `modelBreakdown`.
- **C** — new: repeated result records sum rather than overwrite.
- **D** — new: a zero-usage result record falls back to nested totals.
- Pricing — replaced the test that asserted the subtraction with disjoint-summation cases.

`typecheck` and `lint` clean. Full `jest`: 680 passed; the 12 remaining reds are pre-existing `/private/var` symlink failures that also fail on `main` — no new failures. Stashing just the two source files reds 5 of the new assertions, so they aren't vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

