### PR TITLE
fix: derive usage seen timestamps from the transcript, not the sync clock

### DIFF
--- a/control/src/server/usage.test.ts
+++ b/control/src/server/usage.test.ts
@@ -167,6 +167,45 @@ describe('upsertSessionUsage', () => {
     });
   });
 
+  it('replaces a seen window the superseded row stamped with sync time', async () => {
+    findUnique.mockResolvedValue(
+      storedRow({
+        firstSeenAt: new Date('2026-01-01T00:00:00.000Z'),
+        lastSeenAt: new Date('2026-06-01T00:00:00.000Z'),
+      }),
+    );
+    await upsertSessionUsage(
+      'repo-1',
+      harvestInput({
+        firstSeenAt: '2026-01-02T09:00:00.000Z',
+        lastSeenAt: '2026-01-02T10:00:00.000Z',
+      }),
+    );
+    const fields = writtenFields();
+    expect(fields.firstSeenAt.toISOString()).toBe('2026-01-02T09:00:00.000Z');
+    expect(fields.lastSeenAt.toISOString()).toBe('2026-01-02T10:00:00.000Z');
+  });
+
+  it('widens the seen window on a same-version merge', async () => {
+    findUnique.mockResolvedValue(
+      storedRow({
+        harvestVersion: 1,
+        firstSeenAt: new Date('2026-01-01T00:00:00.000Z'),
+        lastSeenAt: new Date('2026-01-01T12:00:00.000Z'),
+      }),
+    );
+    await upsertSessionUsage(
+      'repo-1',
+      harvestInput({
+        firstSeenAt: '2025-12-31T00:00:00.000Z',
+        lastSeenAt: '2026-01-03T00:00:00.000Z',
+      }),
+    );
+    const fields = writtenFields();
+    expect(fields.firstSeenAt.toISOString()).toBe('2025-12-31T00:00:00.000Z');
+    expect(fields.lastSeenAt.toISOString()).toBe('2026-01-03T00:00:00.000Z');
+  });
+
   it('stamps the incoming version on a session it has never seen', async () => {
     findUnique.mockResolvedValue(null);
     await upsertSessionUsage('repo-1', harvestInput());

--- a/control/src/server/usage.ts
+++ b/control/src/server/usage.ts
@@ -127,14 +127,17 @@ export async function upsertSessionUsage(repositoryId: string, input: UsageUpser
   const harvestVersion = supersedes
     ? usageHarvestVersion(input)
     : mergedHarvestVersion(existingAuthority, input);
-  const firstSeenAt = existing
-    ? new Date(
-        Math.min(existing.firstSeenAt.getTime(), new Date(input.firstSeenAt).getTime()),
-      )
-    : new Date(input.firstSeenAt);
-  const lastSeenAt = existing
-    ? new Date(Math.max(existing.lastSeenAt.getTime(), new Date(input.lastSeenAt).getTime()))
-    : new Date(input.lastSeenAt);
+  // A superseding harvest recomputes the window, so it may also lower it.
+  const firstSeenAt =
+    existing && !supersedes
+      ? new Date(
+          Math.min(existing.firstSeenAt.getTime(), new Date(input.firstSeenAt).getTime()),
+        )
+      : new Date(input.firstSeenAt);
+  const lastSeenAt =
+    existing && !supersedes
+      ? new Date(Math.max(existing.lastSeenAt.getTime(), new Date(input.lastSeenAt).getTime()))
+      : new Date(input.lastSeenAt);
 
   const mergedModelBreakdown = supersedes
     ? mergeModelBreakdown(null, input.modelBreakdown)

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -733,7 +733,7 @@ export type AgentTrajectoryRecordV1 = z.infer<typeof AgentTrajectoryRecordV1Sche
 export type AgentTrajectoryRecord = AgentTrajectoryRecordV1;
 
 /** Generation of the usage-harvest algorithm; a newer one supersedes an older. */
-export const USAGE_HARVEST_VERSION = 1;
+export const USAGE_HARVEST_VERSION = 2;
 
 /** Harvested before the algorithm was versioned, so the totals read high. */
 export const PRE_DEDUPE_HARVEST_VERSION = 0;

--- a/src/core/usage-harvest/claude.ts
+++ b/src/core/usage-harvest/claude.ts
@@ -6,6 +6,7 @@ import type { AgentSessionEvent, AgentSessionUsage } from '../../harness/schema'
 import { getTelemetrySignals } from '../telemetry-config';
 import { buildSessionKey } from '../telemetry-env';
 import { workspaceMatchesTarget } from '../workspace-path-match';
+import { recordTimeRange } from './record-time-range';
 
 export interface HarvestSlotContext {
   agentId: number;
@@ -266,7 +267,8 @@ export function harvestClaudeUsage(slot: HarvestSlotContext): AgentSessionUsage 
   // own, so the fallback tier is never summed with the primary one.
   const own = matches.filter((match) => match.primary);
   const usable = own.length > 0 ? own : matches;
-  const usage = extractClaudeUsageFromRecords(usable.flatMap((match) => match.records));
+  const records = usable.flatMap((match) => match.records);
+  const usage = extractClaudeUsageFromRecords(records);
   if (
     usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead === 0 &&
     (usage.costUsd == null || usage.costUsd === 0)
@@ -275,6 +277,7 @@ export function harvestClaudeUsage(slot: HarvestSlotContext): AgentSessionUsage 
   }
 
   const now = new Date().toISOString();
+  const seen = recordTimeRange(records);
   const tokensTotal =
     usage.tokensInput + usage.tokensOutput + usage.tokensCacheRead + usage.tokensCacheCreation;
 
@@ -296,8 +299,8 @@ export function harvestClaudeUsage(slot: HarvestSlotContext): AgentSessionUsage 
       : {}),
     sources: ['harvest'],
     harvestVersion: USAGE_HARVEST_VERSION,
-    firstSeenAt: slot.sessionCreatedAt ?? now,
-    lastSeenAt: now,
+    firstSeenAt: seen?.firstAt ?? slot.sessionCreatedAt ?? now,
+    lastSeenAt: seen?.lastAt ?? now,
   };
 }
 

--- a/src/core/usage-harvest/codex.ts
+++ b/src/core/usage-harvest/codex.ts
@@ -6,6 +6,7 @@ import type { AgentSessionUsage } from '../../harness/schema';
 import { buildSessionKey } from '../telemetry-env';
 import type { HarvestSlotContext } from './claude';
 import { workspaceMatchesTarget } from '../workspace-path-match';
+import { recordTimeRange, type RecordTimeRange } from './record-time-range';
 
 function codexSessionsRoot(): string {
   return process.env.HAR_CODEX_SESSIONS_DIR
@@ -43,6 +44,7 @@ function extractCodexTokens(records: unknown[]): {
   tokensOutput: number;
   tokensCacheRead: number;
   cwd?: string;
+  seen: RecordTimeRange | null;
 } {
   let tokensInput = 0;
   let tokensOutput = 0;
@@ -86,7 +88,7 @@ function extractCodexTokens(records: unknown[]): {
     }
   }
 
-  return { tokensInput, tokensOutput, tokensCacheRead, cwd };
+  return { tokensInput, tokensOutput, tokensCacheRead, cwd, seen: recordTimeRange(records) };
 }
 
 export function harvestCodexUsage(slot: HarvestSlotContext): AgentSessionUsage | null {
@@ -108,7 +110,12 @@ export function harvestCodexUsage(slot: HarvestSlotContext): AgentSessionUsage |
     createdAt: slot.sessionCreatedAt,
   });
 
-  type CodexTokens = { tokensInput: number; tokensOutput: number; tokensCacheRead: number };
+  type CodexTokens = {
+    tokensInput: number;
+    tokensOutput: number;
+    tokensCacheRead: number;
+    seen: RecordTimeRange | null;
+  };
   let bestPrimary: CodexTokens | null = null;
   let bestPrimaryMtime = 0;
   let bestFallback: CodexTokens | null = null;
@@ -153,7 +160,7 @@ export function harvestCodexUsage(slot: HarvestSlotContext): AgentSessionUsage |
     costUsd: null,
     sources: ['harvest'],
     harvestVersion: USAGE_HARVEST_VERSION,
-    firstSeenAt: slot.sessionCreatedAt ?? now,
-    lastSeenAt: now,
+    firstSeenAt: best.seen?.firstAt ?? slot.sessionCreatedAt ?? now,
+    lastSeenAt: best.seen?.lastAt ?? now,
   };
 }

--- a/src/core/usage-harvest/record-time-range.ts
+++ b/src/core/usage-harvest/record-time-range.ts
@@ -12,7 +12,7 @@ function recordTimestamp(record: unknown): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
-/** Metadata records carry no timestamp, so scan for the extremes. */
+/** Metadata records carry no timestamp, so scan for the extremes */
 export function recordTimeRange(records: unknown[]): RecordTimeRange | null {
   let first: number | null = null;
   let last: number | null = null;

--- a/src/core/usage-harvest/record-time-range.ts
+++ b/src/core/usage-harvest/record-time-range.ts
@@ -1,0 +1,27 @@
+export interface RecordTimeRange {
+  firstAt: string;
+  lastAt: string;
+}
+
+function recordTimestamp(record: unknown): number | null {
+  if (!record || typeof record !== 'object') return null;
+  const payload = record as { timestamp?: unknown; ts?: unknown };
+  const raw = typeof payload.timestamp === 'string' ? payload.timestamp : payload.ts;
+  if (typeof raw !== 'string') return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** Metadata records carry no timestamp, so scan for the extremes. */
+export function recordTimeRange(records: unknown[]): RecordTimeRange | null {
+  let first: number | null = null;
+  let last: number | null = null;
+  for (const record of records) {
+    const ms = recordTimestamp(record);
+    if (ms === null) continue;
+    if (first === null || ms < first) first = ms;
+    if (last === null || ms > last) last = ms;
+  }
+  if (first === null || last === null) return null;
+  return { firstAt: new Date(first).toISOString(), lastAt: new Date(last).toISOString() };
+}

--- a/tests/usage-harvest.test.ts
+++ b/tests/usage-harvest.test.ts
@@ -381,6 +381,117 @@ describe('usage harvest claude', () => {
 
     expect(usage!.tokensOutput).toBe(7);
   });
+  it('takes the seen window from the transcript records, not the harvest time', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-4-tt11';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(
+      path.join(project, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'summary', leafUuid: 'abc' }),
+        JSON.stringify({ type: 'user', cwd: workDir, timestamp: '2026-02-01T09:30:00.000Z' }),
+        JSON.stringify({
+          type: 'assistant',
+          timestamp: '2026-02-01T11:45:00.000Z',
+          message: { role: 'assistant', model: 'claude-opus-5', usage: { output_tokens: 20 } },
+        }),
+        JSON.stringify({ type: 'mode', mode: 'default' }),
+        JSON.stringify({
+          type: 'result',
+          timestamp: '2026-02-01T10:00:00.000Z',
+          usage: { input_tokens: 40, output_tokens: 20 },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const usage = harvestClaudeUsage({
+      agentId: 4,
+      workDir,
+      branch: 'main-abcd-har-agent-4-tt11',
+      suffix: 'tt11',
+      sessionCreatedAt: '2026-01-15T00:00:00.000Z',
+      repoPath: '/home/user/repo',
+    });
+
+    expect(usage!.firstSeenAt).toBe('2026-02-01T09:30:00.000Z');
+    expect(usage!.lastSeenAt).toBe('2026-02-01T11:45:00.000Z');
+  });
+
+  it('reports the same window on a re-harvest of an unchanged transcript', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-5-rr22';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(
+      path.join(project, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: workDir, timestamp: '2026-02-01T09:30:00.000Z' }),
+        JSON.stringify({
+          type: 'result',
+          timestamp: '2026-02-01T10:00:00.000Z',
+          usage: { input_tokens: 40, output_tokens: 20 },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const slot = {
+      agentId: 5,
+      workDir,
+      branch: 'main-abcd-har-agent-5-rr22',
+      suffix: 'rr22',
+      repoPath: '/home/user/repo',
+    };
+
+    expect(harvestClaudeUsage(slot)).toEqual(harvestClaudeUsage(slot));
+  });
+
+  it('spans the window across every transcript the slot owns', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-6-ss33';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    const transcript = (at: string) =>
+      [
+        JSON.stringify({ type: 'user', cwd: workDir, timestamp: at }),
+        JSON.stringify({ type: 'result', timestamp: at, usage: { output_tokens: 5 } }),
+      ].join('\n') + '\n';
+    fs.writeFileSync(path.join(project, 'a.jsonl'), transcript('2026-03-02T08:00:00.000Z'));
+    fs.writeFileSync(path.join(project, 'b.jsonl'), transcript('2026-03-01T08:00:00.000Z'));
+
+    const usage = harvestClaudeUsage({
+      agentId: 6,
+      workDir,
+      branch: 'main-abcd-har-agent-6-ss33',
+      suffix: 'ss33',
+      repoPath: '/home/user/repo',
+    });
+
+    expect(usage!.firstSeenAt).toBe('2026-03-01T08:00:00.000Z');
+    expect(usage!.lastSeenAt).toBe('2026-03-02T08:00:00.000Z');
+  });
+
+  it('falls back to the slot creation time when no record is timestamped', () => {
+    const workDir = '/home/user/worktrees/main-abcd-har-agent-7-uu44';
+    const project = path.join(tmp, encodeClaudeProjectDir(workDir));
+    fs.mkdirSync(project, { recursive: true });
+    fs.writeFileSync(
+      path.join(project, 'session.jsonl'),
+      [
+        JSON.stringify({ type: 'user', cwd: workDir }),
+        JSON.stringify({ type: 'result', usage: { input_tokens: 10, output_tokens: 5 } }),
+      ].join('\n') + '\n',
+    );
+
+    const usage = harvestClaudeUsage({
+      agentId: 7,
+      workDir,
+      branch: 'main-abcd-har-agent-7-uu44',
+      suffix: 'uu44',
+      sessionCreatedAt: '2026-01-15T00:00:00.000Z',
+      repoPath: '/home/user/repo',
+    });
+
+    expect(usage!.firstSeenAt).toBe('2026-01-15T00:00:00.000Z');
+    expect(Date.parse(usage!.lastSeenAt)).toBeGreaterThan(Date.parse('2026-01-15T00:00:00.000Z'));
+  });
 });
 
 describe('workspace path match', () => {
@@ -460,6 +571,33 @@ describe('usage harvest codex', () => {
         repoPath: '/home/alice/project',
       }),
     ).toBeNull();
+  });
+  it('takes the seen window from the rollout records', () => {
+    const workDir = '/tmp/wt-codex-window';
+    const sessionDir = path.join(tmp, '2026');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, 's.jsonl'),
+      [
+        JSON.stringify({ cwd: workDir, timestamp: '2026-04-01T07:00:00.000Z' }),
+        JSON.stringify({
+          timestamp: '2026-04-01T07:40:00.000Z',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }),
+      ].join('\n') + '\n',
+    );
+
+    const usage = harvestCodexUsage({
+      agentId: 2,
+      workDir,
+      branch: 'main-xxxx-har-agent-2-abcd',
+      suffix: 'abcd',
+      sessionCreatedAt: '2026-03-01T00:00:00.000Z',
+      repoPath: '/repo',
+    });
+
+    expect(usage!.firstSeenAt).toBe('2026-04-01T07:00:00.000Z');
+    expect(usage!.lastSeenAt).toBe('2026-04-01T07:40:00.000Z');
   });
 });
 


### PR DESCRIPTION
## Problem

`harvestClaudeUsage` stamped `firstSeenAt` with the slot's creation time and `lastSeenAt` with the moment the harvest ran. Because the harvest re-reports a session's whole history on every sync, `lastSeenAt` ratcheted forward for every session that ever existed — Mission Control keeps `max(lastSeenAt)`, so it converged on "the last time anyone synced".

Anything reading those timestamps was really reading sync time: a session's last-active, session duration derived from usage rows, and any period-over-period trend whose window filter is applied to them. `harvestCodexUsage` had the same two lines.

## Change

- **`record-time-range.ts` (new)** — scan records for a parseable `timestamp`/`ts` and return the min/max. Metadata records (`mode`, `file-history-snapshot`, `ai-title`) carry no timestamp, so it scans for the extremes rather than reading the first and last line.
- **`claude.ts` / `codex.ts`** — take the window from the same records the totals come from; the old `sessionCreatedAt ?? now` / `now` becomes the fallback for a transcript with no timestamps.
- **`USAGE_HARVEST_VERSION` 1 → 2** and **`upsertSessionUsage`** — a superseding harvest now *replaces* the seen window instead of min/max-merging it. Without this a window already ratcheted to sync time could never come back down. Blended harvest+OTLP rows are untouched: `harvestSupersedes` short-circuits whenever `otel` is on either side, since those accumulate one batch at a time rather than being recomputed.

## Before / after

| Situation | Before | After |
|---|---|---|
| `firstSeenAt` on a harvested row | Slot creation time (`slot.sessionCreatedAt`), or harvest time if the slot had none | Earliest timestamp in the transcript records |
| `lastSeenAt` on a harvested row | Harvest time (`now`) — always | Latest timestamp in the transcript records |
| Transcript with no timestamped record at all | Same as above | Unchanged — falls back to `sessionCreatedAt ?? now` / `now` |
| Re-sync, no new agent activity | `lastSeenAt` jumps forward to the new sync time | Both stay byte-identical |
| Slot owning several transcripts | Single fabricated pair | Window spans min across all / max across all |
| Mission Control merge, same harvest generation | `min(first)` / `max(last)` | Unchanged — still widens |
| Mission Control merge, newer generation supersedes | `min`/`max` — a window already ratcheted to sync time could never come back down | Replaced outright, so it heals |
| Row with any `otel` source | `min`/`max` | Unchanged — `harvestSupersedes` short-circuits on otel |

Per file:

| File | Before | After |
|---|---|---|
| `src/core/usage-harvest/record-time-range.ts` | — | New: scans records for `timestamp`/`ts`, returns min/max ISO or `null` |
| `src/core/usage-harvest/claude.ts` | `slot.sessionCreatedAt ?? now` / `now` | `seen?.firstAt ?? slot.sessionCreatedAt ?? now` / `seen?.lastAt ?? now` |
| `src/core/usage-harvest/codex.ts` | Same two lines | Same fix, range threaded through `extractCodexTokens` |
| `packages/schemas/src/schema.ts` | `USAGE_HARVEST_VERSION = 1` | `= 2` |
| `control/src/server/usage.ts` | `existing ? min/max : input` | `existing && !supersedes ? min/max : input` |
| `tests/usage-harvest.test.ts` | 14 tests | 19 (+4 claude, +1 codex) |
| `control/src/server/usage.test.ts` | 9 tests | 11 (+supersede replaces, +same-version widens) |

## Tests

Five in `tests/usage-harvest.test.ts` — window from the records (out-of-order, with untimestamped metadata mixed in), a re-harvest of an unchanged transcript returning an identical row, the window spanning every transcript a slot owns, the no-timestamp fallback, and the codex equivalent. Two in `control/src/server/usage.test.ts` — a superseding harvest replacing a window stamped with sync time, and a same-version merge still widening it.

## Checked against a real transcript

A dormant session last touched two days earlier:

| | `firstSeenAt` | `lastSeenAt` |
|---|---|---|
| Before | `2026-01-01…` (the slot creation time passed in) | `2026-08-26T15:28` (now) |
| After | `2026-08-24T11:41:48.200Z` | `2026-08-24T11:43:14.353Z` |

An 86-second window matching the transcript's own min/max exactly, where the previous code reported `lastSeenAt = now`. A deliberately bogus `sessionCreatedAt` passed alongside it is correctly ignored.

`typecheck`, `lint` and `jest` are clean in both the CLI and `control/`, apart from four suites (`hooks`, `slot-registry`, `provision-toolchain`, `control-repo-path`, plus `control`'s `git-repo-path`) that fail identically on an unmodified `main` — macOS `/private` symlink and nested-worktree issues unrelated to this change.

## Not in this PR

`control/src/server/otel-ingest.ts` also stamps `firstSeenAt`/`lastSeenAt` with `now` for an OTLP batch. That is materially less wrong — each batch stamps its own ingest time, close to export time, so min/max still yields a real window — and it is a separate path from the harvest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
