### PR TITLE
feat: post-add-plugin adaptation prompt with clipboard offer (#195)

### DIFF
--- a/.har/stages/fixture-e2e.sh
+++ b/.har/stages/fixture-e2e.sh
@@ -677,6 +677,19 @@ HOOK
         [ ! -d "$CLONE/.har/migrate" ] || fail "M4: finalize left .har/migrate/ behind"
         [ ! -f "$CLONE/.har/MIGRATE-PROMPT.md" ] || fail "M4: finalize left MIGRATE-PROMPT.md behind"
         echo "    finalize clears migration artifacts ✓"
+
+        if [ "$MILESTONE" = "M5" ]; then
+          # e) #195: add-plugin leaves a structured adaptation prompt for the
+          #    coding agent. Runs after the lifecycle asserts so the extra
+          #    stage never joins the verified pipeline above.
+          har "$CLONE" env add-plugin gitleaks --force >/dev/null 2>&1 \
+            || fail "M5: add-plugin gitleaks failed on the migrated harness"
+          [ -f "$CLONE/.har/ADAPT-PROMPT-gitleaks.md" ] \
+            || fail "M5: add-plugin wrote no adaptation prompt (#195)"
+          grep -q 'Prove it green' "$CLONE/.har/ADAPT-PROMPT-gitleaks.md" \
+            || fail "M5: plugin adaptation prompt missing its verify section"
+          echo "    M5: add-plugin writes the agent adaptation prompt (#195) ✓"
+        fi
       fi
       ;;
     generic)

--- a/docs/src/content/docs/docs/guides/local-plugins.md
+++ b/docs/src/content/docs/docs/guides/local-plugins.md
@@ -11,6 +11,7 @@ that lives in your repository under `.har/plugins/<id>/`.
 ```bash
 har plugin create db-integrity   # scaffold .har/plugins/db-integrity/
 har env add-plugin db-integrity  # install its stages into stages.json
+                                 # → writes .har/ADAPT-PROMPT-db-integrity.md for your agent
 ```
 
 ## What the scaffold contains

--- a/docs/src/content/docs/docs/guides/plugins.md
+++ b/docs/src/content/docs/docs/guides/plugins.md
@@ -48,6 +48,13 @@ Resolution order: path → git → bundled id → npm. The target must expose
 stage ids, timestamp). `har env maintain` uses the ledger when present, otherwise
 falls back to matching stage ids in `stages.json`.
 
+Every successful install also writes `.har/ADAPT-PROMPT-<id>.md` — a structured
+adaptation prompt for your coding agent (install dependencies with the repo's
+real package manager, adapt the scaffolded files, prove the stage green via full
+verify) — and offers to copy it to the clipboard, like `har env init` does.
+A `package.json` merge declares dependencies but does **not** install them; the
+prompt leads with the install command.
+
 ## Multi-stage plugins
 
 A plugin manifest may declare `stages: [...]` (preferred) or the legacy single

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import type { Argv } from 'yargs';
 import { finishCommand } from '../finish-command';
@@ -930,6 +931,10 @@ export async function handleAddPlugin(argv: {
     console.error('');
     console.error(`  Docs: ${result.docsPath}`);
     console.error('');
+    // #195: hand the structured prompt to the coding agent, like init does.
+    info(`Adaptation prompt saved to ${result.adaptPromptPath}`);
+    const promptContent = fs.readFileSync(path.join(repoPath, result.adaptPromptPath), 'utf8');
+    await offerAdaptationPromptClipboard(promptContent, { fileLabel: result.adaptPromptPath });
   } catch (err: unknown) {
     error((err as Error).message);
     return finishCommand(1);

--- a/src/harness/adaptation-prompt.ts
+++ b/src/harness/adaptation-prompt.ts
@@ -95,6 +95,8 @@ function askYesNo(question: string): Promise<boolean> {
 export interface OfferClipboardCopyOptions {
   /** When true, copy without prompting (still requires a TTY for OSC 52 fallback). */
   autoYes?: boolean;
+  /** Where the prompt was saved, for the skip/fallback messages. */
+  fileLabel?: string;
 }
 
 /**
@@ -105,9 +107,10 @@ export async function offerAdaptationPromptClipboard(
   content: string,
   options: OfferClipboardCopyOptions = {},
 ): Promise<boolean> {
+  const fileLabel = options.fileLabel ?? `.har/${ADAPTATION_PROMPT_FILE}`;
   const interactive = Boolean(process.stdin.isTTY && process.stderr.isTTY);
   if (!interactive && !options.autoYes) {
-    info('Prompt also saved to .har/ADAPT-PROMPT.md (open or copy from there)');
+    info(`Prompt also saved to ${fileLabel} (open or copy from there)`);
     return false;
   }
 
@@ -116,7 +119,7 @@ export async function offerAdaptationPromptClipboard(
     shouldCopy = await askYesNo('Copy adaptation prompt to clipboard for your coding agent? [Y/n]');
   }
   if (!shouldCopy) {
-    info('Skipped clipboard copy — prompt is in .har/ADAPT-PROMPT.md');
+    info(`Skipped clipboard copy — prompt is in ${fileLabel}`);
     return false;
   }
 
@@ -131,6 +134,6 @@ export async function offerAdaptationPromptClipboard(
   }
 
   warn(`Could not copy to clipboard: ${result.detail}`);
-  info('Open .har/ADAPT-PROMPT.md and paste that into your coding agent instead');
+  info(`Open ${fileLabel} and paste that into your coding agent instead`);
   return false;
 }

--- a/src/harness/plugin-create.ts
+++ b/src/harness/plugin-create.ts
@@ -148,6 +148,7 @@ export function createLocalPlugin(
     nextSteps: [
       `Edit ${pluginDirRel}/stages/${id}.sh — replace the TODO block with the real check`,
       `Install it: har env add-plugin ${id}   (re-run with --force after changes)`,
+      `Installing writes .har/ADAPT-PROMPT-${id}.md — a ready adaptation prompt for your coding agent`,
       `Document what it checks in ${pluginDirRel}/README.md`,
       'Publishing later (npm/git) needs zero format changes — see the README',
     ],

--- a/src/harness/plugin-prompt.ts
+++ b/src/harness/plugin-prompt.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveTemplateFile } from '../utils/paths';
+import { writeFileSafe } from '../utils/file-ops';
+import { nodePackageManager } from '../runtime/node-pm';
+import { getHarnessDir } from './manifest';
+import { readHarnessEnv } from './env';
+import type { ApplyPluginResult } from './plugins';
+
+/** Per-plugin adaptation prompt, sibling of ADAPT-PROMPT.md / MIGRATE-PROMPT.md. */
+export function pluginAdaptationPromptFile(pluginId: string): string {
+  return `ADAPT-PROMPT-${pluginId}.md`;
+}
+
+function loadTemplate(): string {
+  const filePath = resolveTemplateFile('adaptation-prompt-plugin.md');
+  if (!filePath) {
+    throw new Error(
+      'Plugin adaptation prompt template not found: adaptation-prompt-plugin.md. Run npm run build.',
+    );
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+/**
+ * The install command this repo actually uses: an explicit HARNESS_INSTALL_CMD
+ * wins, then the detected package manager (packageManager field / lockfile /
+ * what is installed). Never hardcodes npm.
+ */
+export function resolveInstallCommand(repoPath: string): string {
+  const env = readHarnessEnv(repoPath);
+  if (env.HARNESS_INSTALL_CMD) return env.HARNESS_INSTALL_CMD;
+  return `${nodePackageManager(repoPath, env)} install`;
+}
+
+/** A bare package-manager install line ("npm install", "pnpm install", …). */
+const BARE_INSTALL_RE = /^(npm|pnpm|yarn|bun)\s+install$/;
+
+/**
+ * Build the post-install adaptation prompt for a plugin from its apply result.
+ * package.json merge ≠ installed dependencies — when the plugin merged a
+ * fragment, the prompt opens with the repo's real install command and the
+ * manifest's own bare "<pm> install" next step is dropped as redundant.
+ */
+export function buildPluginAdaptationPrompt(
+  repoPath: string,
+  result: ApplyPluginResult,
+): string {
+  const mergedPackageJson = result.filesWritten.includes('package.json');
+  const installCmd = resolveInstallCommand(repoPath);
+
+  const packageMergeNote = mergedPackageJson
+    ? [
+        '## Dependencies: merged is NOT installed',
+        '',
+        'The plugin merged new `devDependencies` into `package.json` — it did **not**',
+        'install them. Install first or every later step fails:',
+        '',
+        '```bash',
+        installCmd,
+        '```',
+      ].join('\n')
+    : '## Dependencies\n\nThis plugin merged no package.json fragment — no dependency install is required.';
+
+  const setupSteps = result.nextSteps
+    .filter((step) => !(mergedPackageJson && BARE_INSTALL_RE.test(step.trim())))
+    .map((step, i) => `${i + 1}. \`${step}\``)
+    .join('\n');
+
+  const filesWritten = result.filesWritten
+    .filter((f) => f !== 'package.json')
+    .map((f) => `   - \`${f}\``)
+    .join('\n');
+
+  return loadTemplate()
+    .replace(/\{\{PLUGIN_ID\}\}/g, result.pluginId)
+    .replace(/\{\{STAGE_IDS\}\}/g, result.stageIds.map((id) => `\`${id}\``).join(', '))
+    .replace(/\{\{DOCS_PATH\}\}/g, result.docsPath)
+    .replace('{{PACKAGE_MERGE_NOTE}}', packageMergeNote)
+    .replace('{{PLUGIN_SETUP_STEPS}}', setupSteps || '_No plugin-specific setup steps declared._')
+    .replace('{{FILES_WRITTEN}}', filesWritten || '   - _(no scaffolded files)_');
+}
+
+/** Write the prompt to .har/ADAPT-PROMPT-<plugin>.md; returns the absolute path. */
+export function writePluginAdaptationPrompt(
+  repoPath: string,
+  pluginId: string,
+  content: string,
+): string {
+  const filePath = path.join(getHarnessDir(repoPath), pluginAdaptationPromptFile(pluginId));
+  writeFileSafe(filePath, content);
+  return filePath;
+}

--- a/src/harness/plugins.ts
+++ b/src/harness/plugins.ts
@@ -11,6 +11,7 @@ import {
   type PluginSourceKind,
 } from './plugin-resolve';
 import { upsertPluginLedgerEntry } from './plugin-ledger';
+import { buildPluginAdaptationPrompt, writePluginAdaptationPrompt } from './plugin-prompt';
 import { HarnessStageRegistry, HarnessStageSchema } from './schema';
 import { readStageRegistry, writeStageRegistry } from './stages';
 
@@ -108,6 +109,8 @@ export interface ApplyPluginResult {
   nextSteps: string[];
   docsPath: string;
   source: PluginSourceKind;
+  /** Repo-relative path of the generated adaptation prompt (#195). */
+  adaptPromptPath: string;
 }
 
 /** @deprecated Use ApplyPluginResult — `templateId` mirrors `pluginId` */
@@ -361,16 +364,10 @@ function applyPluginFromDir(
   });
 
   const primary = primaryStageId(manifest);
-  success(`Applied plugin: ${manifest.id}`);
-  info(`Registered stage(s): ${stageIds.join(', ')}`);
-  for (const file of filesWritten) {
-    info(`  + ${file}`);
-  }
-  for (const warning of warnings) {
-    warn(`  ⚠ ${warning}`);
-  }
 
-  return {
+  // #195: the install is scaffolding only — leave the agent a structured
+  // adaptation prompt (sibling of ADAPT-PROMPT.md), written only on success.
+  const partialResult = {
     pluginId: manifest.id,
     stageId: primary,
     stageIds,
@@ -380,6 +377,24 @@ function applyPluginFromDir(
     docsPath: manifest.docsPath,
     source: meta.source,
   };
+  const promptContent = buildPluginAdaptationPrompt(resolved, {
+    ...partialResult,
+    adaptPromptPath: '',
+  });
+  const promptAbsPath = writePluginAdaptationPrompt(resolved, manifest.id, promptContent);
+  const adaptPromptPath = path.relative(resolved, promptAbsPath);
+
+  success(`Applied plugin: ${manifest.id}`);
+  info(`Registered stage(s): ${stageIds.join(', ')}`);
+  for (const file of filesWritten) {
+    info(`  + ${file}`);
+  }
+  info(`  + ${adaptPromptPath} (adaptation prompt for your coding agent)`);
+  for (const warning of warnings) {
+    warn(`  ⚠ ${warning}`);
+  }
+
+  return { ...partialResult, adaptPromptPath };
 }
 
 /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -398,6 +398,7 @@ export async function handleMcpToolCall(
         nextSteps: result.nextSteps,
         docsPath: result.docsPath,
         source: result.source,
+        adaptPromptPath: result.adaptPromptPath,
       });
     }
 

--- a/src/templates/adaptation-prompt-plugin.md
+++ b/src/templates/adaptation-prompt-plugin.md
@@ -1,0 +1,40 @@
+Adapt the freshly installed `{{PLUGIN_ID}}` plugin so its verification stage(s) run green in this repository.
+
+## Your mission
+
+`har env add-plugin {{PLUGIN_ID}}` scaffolded files and registered stage(s) {{STAGE_IDS}} in `.har/stages.json` — **scaffolding only**. Nothing was installed or adapted to this app yet, and full verify will fail on the new stage(s) until you finish the steps below.
+
+`.har/` is a **configuration surface** — the runtime machinery lives in the HAR
+package behind the `./.har/*.sh` shims. Adapt the plugin through its sanctioned
+homes only: the scaffolded specs/config files, `harness.env` values, and the
+stage entries in `.har/stages.json`. Never edit the shims.
+
+{{PACKAGE_MERGE_NOTE}}
+
+## Plugin setup steps
+
+{{PLUGIN_SETUP_STEPS}}
+
+## Adapt to this repository
+
+1. Read the plugin docs: `{{DOCS_PATH}}`.
+2. Open every scaffolded file listed below and adapt it to this app — selectors,
+   routes, API paths, project-specific commands. Scaffolds describe a generic
+   app; they are wrong until proven right here.
+
+{{FILES_WRITTEN}}
+
+3. Align `harness.env` with the app where the plugin depends on it (for example
+   `HARNESS_HEALTH_CHECK_PATH`, ports/preview URL layout). `har env doctor`
+   validates the config.
+
+## Prove it green
+
+```bash
+har env launch 1                # or ./.har/launch.sh 1
+har env verify 1 --full         # must pass INCLUDING {{STAGE_IDS}}
+```
+
+Iterate on the scaffolded files until full verify passes. Artifacts land under
+`.har/artifacts/` if the stage declares them. Do not remove the stage from
+`verificationStages` to get green — adapt it.

--- a/tests/plugin-prompt.test.ts
+++ b/tests/plugin-prompt.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { scaffoldHarnessBoilerplate } from '../src/harness/generator';
+import { applyPlugin } from '../src/harness/plugins';
+import {
+  buildPluginAdaptationPrompt,
+  pluginAdaptationPromptFile,
+  resolveInstallCommand,
+} from '../src/harness/plugin-prompt';
+
+function makeTempRepo(name: string): string {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+  fs.writeFileSync(
+    path.join(repoPath, 'package.json'),
+    JSON.stringify({ name: 'test-app', version: '1.0.0' }, null, 2) + '\n',
+  );
+  scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'cli' });
+  return repoPath;
+}
+
+describe('post-add-plugin adaptation prompt (#195)', () => {
+  it('add-plugin writes .har/ADAPT-PROMPT-<id>.md and reports its path', () => {
+    const repoPath = makeTempRepo('har-plugin-prompt');
+    const result = applyPlugin(repoPath, 'playwright', { skipCi: true });
+
+    expect(result.adaptPromptPath).toBe(path.join('.har', 'ADAPT-PROMPT-playwright.md'));
+    const promptPath = path.join(repoPath, result.adaptPromptPath);
+    expect(fs.existsSync(promptPath)).toBe(true);
+
+    const content = fs.readFileSync(promptPath, 'utf8');
+    // Tokens substituted, none leaked.
+    expect(content).not.toMatch(/\{\{[A-Z_]+\}\}/);
+    expect(content).toContain('`playwright`');
+    expect(content).toContain('`browser-e2e`');
+    expect(content).toContain('.har/stages/PLAYWRIGHT.md');
+    // Manifest nextSteps folded in (minus the bare install line, covered below).
+    expect(content).toContain('npx playwright install');
+    // merged ≠ installed is explicit, with the repo's real install command.
+    expect(content).toContain('merged is NOT installed');
+    expect(content).toContain(resolveInstallCommand(repoPath));
+  });
+
+  it('drops the manifest\'s bare "<pm> install" step when the merge note already leads with it', () => {
+    const repoPath = makeTempRepo('har-plugin-prompt-dedup');
+    const result = applyPlugin(repoPath, 'playwright', { skipCi: true });
+    const content = fs.readFileSync(path.join(repoPath, result.adaptPromptPath), 'utf8');
+    const setupSection = content.split('## Plugin setup steps')[1].split('## Adapt')[0];
+    expect(setupSection).not.toMatch(/^\d+\. `npm install`$/m);
+  });
+
+  it('honors HARNESS_INSTALL_CMD over the detected package manager', () => {
+    const repoPath = makeTempRepo('har-plugin-prompt-install-cmd');
+    fs.appendFileSync(
+      path.join(repoPath, '.har', 'harness.env'),
+      '\nexport HARNESS_INSTALL_CMD="pnpm install --frozen-lockfile"\n',
+    );
+    expect(resolveInstallCommand(repoPath)).toBe('pnpm install --frozen-lockfile');
+    const result = applyPlugin(repoPath, 'playwright', { skipCi: true, force: true });
+    const content = fs.readFileSync(path.join(repoPath, result.adaptPromptPath), 'utf8');
+    expect(content).toContain('pnpm install --frozen-lockfile');
+  });
+
+  it('skips the dependency-install framing for plugins without a package fragment', () => {
+    const repoPath = makeTempRepo('har-plugin-prompt-nomerge');
+    const result = applyPlugin(repoPath, 'gitleaks', { skipCi: true });
+    const content = fs.readFileSync(path.join(repoPath, result.adaptPromptPath), 'utf8');
+    expect(content).toContain('no dependency install is required');
+    expect(content).not.toContain('merged is NOT installed');
+  });
+
+  it('does not write a prompt when the plugin install fails', () => {
+    const repoPath = makeTempRepo('har-plugin-prompt-fail');
+    // Pre-existing stage script → applyPlugin throws before completion.
+    const stagePath = path.join(repoPath, '.har', 'stages', 'browser-e2e.sh');
+    fs.mkdirSync(path.dirname(stagePath), { recursive: true });
+    fs.writeFileSync(stagePath, '#!/usr/bin/env bash\n');
+
+    expect(() => applyPlugin(repoPath, 'playwright', { skipCi: true })).toThrow(/already exists/);
+    expect(
+      fs.existsSync(path.join(repoPath, '.har', pluginAdaptationPromptFile('playwright'))),
+    ).toBe(false);
+  });
+
+  it('buildPluginAdaptationPrompt lists scaffolded files but not package.json', () => {
+    const repoPath = makeTempRepo('har-plugin-prompt-files');
+    const result = applyPlugin(repoPath, 'playwright', { skipCi: true });
+    const content = buildPluginAdaptationPrompt(repoPath, result);
+    expect(content).toContain('`playwright.config.js`');
+    expect(content).not.toMatch(/^ {3}- `package\.json`$/m);
+  });
+});


### PR DESCRIPTION
Closes #195

Completes the second half of #195 (the `--skip-ci` → default-true half shipped in M0; verified still in place).

`har env add-plugin <id>` now leaves the coding agent a structured prompt at `.har/ADAPT-PROMPT-<plugin>.md` — sibling of `ADAPT-PROMPT.md` / `MIGRATE-PROMPT.md`, written only when the install succeeds:

- **Merged ≠ installed**: when a `package.json` fragment was merged, the prompt leads with the repo's real install command (`HARNESS_INSTALL_CMD`, else the detected package manager — never hardcoded npm), deduplicating the manifest's bare install next-step.
- Plugin setup steps folded in from the manifest's `nextSteps` (`npx playwright install` etc. come from the plugin, not hardcoded), scaffolded files listed for adaptation, `harness.env` keys called out, and a prove-it-green full-verify section.
- CLI prints the path and offers clipboard copy like `har env init`; MCP `har_add_plugin` returns `adaptPromptPath` (CLI/MCP parity).
- `har plugin create` points its next steps at the prompt the eventual install will write (create-time is an unedited skeleton; the natural flow is create → edit → add-plugin → prompt).
- Docs: `plugins` and `local-plugins` guides mention the generated prompt.

**Gate: GREEN** — `HAR_FIXTURE_E2E=1 HAR_FIXTURE_MILESTONE=M5 har env verify 5 --full`: 9/9 stages, fixture-e2e 3m13s with a new M5 assert (add-plugin on the migrated fixture harness writes the prompt); `npm test` 954/954 (6 new tests in `tests/plugin-prompt.test.ts`). Commit-gate batch `0bd2836a` / run `48bb8df0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)