### PR TITLE
docs: factory-line contract and this-repo instances (#303)

### DIFF
--- a/.claude/skills/factory-line/LINE.schema.md
+++ b/.claude/skills/factory-line/LINE.schema.md
@@ -1,0 +1,147 @@
+# Line template contract (Phase 1)
+
+A **line template** is data an agent (or a human) fills in to mint a factory
+line. It is not wired into the CLI yet — Phase 2 (#304) should be able to lift
+this file almost as-is into `.har/line.json`. Until then, the
+[`factory-line` skill](./SKILL.md) reads it as the program.
+
+`contractVersion: 1`. Additive fields are fine; renaming a field is a new
+version.
+
+## Design constraints (do not violate)
+
+- A line **composes** things HAR 1.0 already has: work units, slots, stages,
+  plugins, skills, MCP. It is not a fourth marketplace and not a second runner.
+- A **station** is a named step. GitHub/Linear/none is a `work.source` on the
+  station, not the type of the station.
+- The **ratchet** is "every gate stage tagged ≤ current station still runs."
+  The bash `case` in `.har/stages/fixture-e2e.sh` is a **prototype**, not this
+  contract: later milestone arms there add questions but do not always re-enter
+  earlier arms. Productize the *intent* (grow-only, never drop a station's
+  stages), not the `case`.
+- HAR does not install or copy third-party skill packs. `skills[]` are
+  declarations + install hints. MCP entries are server names + why, never new
+  core tools named after a tracker or a framework.
+- Stacked PRs, a long-lived integration branch, `M0..M5` names, and a specific
+  fixture repo are **instance data**. Put them on the line file, not in the
+  skill.
+
+## Document shape
+
+JSON object. Comments in this markdown are normative; JSON files are the
+instances.
+
+```json
+{
+  "contractVersion": 1,
+  "id": "kebab-id",
+  "title": "Human title",
+  "description": "What program this is, in one paragraph.",
+  "skills": [
+    {
+      "id": "factory-line",
+      "role": "orchestrator",
+      "install": "repo:.claude/skills/factory-line"
+    }
+  ],
+  "mcp": [
+    {
+      "name": "github",
+      "why": "issue tracker and pull requests",
+      "required": false
+    }
+  ],
+  "plugins": ["playwright"],
+  "stations": [
+    {
+      "id": "S1",
+      "title": "First station",
+      "description": "What this station produces.",
+      "work": {
+        "source": "github",
+        "ids": ["123"],
+        "optional": false
+      },
+      "waves": [
+        [{ "workId": "123", "title": "optional override" }]
+      ],
+      "skills": ["optional-station-skill"],
+      "mcp": ["github"]
+    }
+  ],
+  "gate": {
+    "cumulative": true,
+    "optInEnv": null,
+    "stages": [
+      {
+        "id": "browser-e2e",
+        "fromStation": "S1",
+        "tier": "full"
+      }
+    ]
+  },
+  "extraStages": [
+    {
+      "id": "example-gate",
+      "kind": "test",
+      "tier": "full",
+      "description": "Line-owned check; Phase 2 installs this as a registered stage."
+    }
+  ],
+  "handoff": {
+    "autonomousShip": false,
+    "waitFor": "human review before merge or release"
+  },
+  "traveler": {
+    "kind": "github-issue-comment",
+    "ref": "optional-stable-id",
+    "note": "Where durable notes live given this repo's merge policy."
+  },
+  "prototypeNotes": [
+    "Tactics this instance uses that are NOT part of the primitive."
+  ]
+}
+```
+
+## Field notes
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | yes | Stable kebab id. Becomes the line id in Phase 2. |
+| `stations[].id` | yes | Stable id. Order in the array is station order. |
+| `stations[].work` | no | Binding to a tracker. `source` is `github`, `linear`, `none`, or a free string. `ids` are work-unit ids to pass to `har env launch --work-id`. |
+| `stations[].waves` | no | Each inner array is one **wave** (groups in a wave run in parallel). Each group is one agent / one HAR slot. If omitted, the station is a single sequential cell. |
+| `skills` (root) | no | Skills the **line** expects. `role` is `orchestrator` or `station`. `install` is a hint (`repo:…`, `upstream:url`, `agent-managed`). |
+| `mcp` | no | MCP **servers** the line expects. Declare, do not vendor. `required: false` means skip tracker steps if absent. |
+| `plugins` | no | Plugin ids the gate needs (`har env add-plugin`). |
+| `gate.cumulative` | yes | Must be `true` for a factory line. A QA station is never removed. |
+| `gate.stages[].fromStation` | yes | This stage becomes required at this station **and every later station**. |
+| `gate.optInEnv` | no | If set (e.g. `HAR_FIXTURE_E2E`), the gate is skipped unless that env is `1`, so routine verifies stay fast. |
+| `extraStages` | no | Testing/verify/custom stages this line adds beyond the profile defaults. Phase 1: documentation only. Phase 2: registered stages. |
+| `handoff.autonomousShip` | yes | Must be `false`. Agents hand off; they do not merge or release. |
+| `traveler` | no | Durable record that survives the repo's actual merge policy (squash drops `BREAKING CHANGE:` footers). |
+| `prototypeNotes` | no | Instance tactics that must not leak into the primitive. |
+
+## Growing the ratchet
+
+Adding a station **must not** drop earlier `gate.stages`. To ask a new
+question the previous gate forgot (prose vs scripts, CI vs local CLI version,
+docs drift):
+
+1. Add a stage (or a `doctor` check) that asks that question.
+2. Tag it `fromStation` of the station that made the question askable.
+3. Leave every earlier tag in place.
+
+That is how #291 / #297 / #298 / #299 become permanent questions instead of
+one-off review comments.
+
+## Open decisions (Phase 2 — do not freeze here)
+
+See epic #302. This contract is written so either answer still maps:
+
+1. Per-repo `.har/line.json` vs tracker-as-source-of-truth — this file can live
+   in-repo either way; tracker URLs stay on `work`.
+2. Tagged stages vs a new `kind` — `gate.stages[].fromStation` *is* the tag.
+3. Line vs plugin — this document **references** plugins; it is not one.
+4. How MCP/skills are checked — Phase 1: agent preflight. Phase 2: `doctor` /
+   `har line` preflight.

--- a/.claude/skills/factory-line/SKILL.md
+++ b/.claude/skills/factory-line/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: factory-line
+description: Factory line for executing one station of a declared multi-station program — load a line template, plan parallel work into isolated HAR slots, run the cumulative gate, and hand off for human review. Use when asked to "run a factory line", "run the next station", "execute a milestone program", or when a repo has a line template (*.line.json) and you need to advance it. Not limited to the HAR v1.0.0 migration.
+---
+
+# Factory line
+
+Execute **one station** of a declared program end-to-end:
+
+sync → wave plan → parallel slots → cumulative gate → human handoff.
+
+The program lives in a **line template** (`*.line.json`), not in this skill.
+This skill is the orchestrator. Station-specific how-to lives in other skills
+the template lists.
+
+**HAR already has the primitives.** Work units, isolated slots, stages with
+quick/full tiers, validation records, the commit gate, plugins, Mission Control.
+A line is composition plus a manifest. Do not invent a second runner, a
+stack-specific MCP tool, or GitHub-shaped stations.
+
+Contract: [LINE.schema.md](./LINE.schema.md).
+Instances: [examples/](./examples/).
+
+## Inputs
+
+Resolve these before doing anything (ask only if not inferable):
+
+1. **Line file** — path to a `*.line.json`. Examples in this folder:
+   `examples/v1-milestone.line.json`, `examples/new-plugin.line.json`,
+   `examples/docs-milestone.line.json`.
+2. **Station id** — default: the first station whose bound work is not all
+   closed / whose gate has not passed. Must be an id in `stations[]`.
+3. **Slot budget** — how many concurrent HAR slots you may occupy (check
+   `har env status` first). One slot per concurrent agent. Occupied slots
+   always block — that is a feature.
+
+If the user says "run the next v1 milestone", load `examples/v1-milestone.line.json`
+and prefer the existing [`v1-milestone`](../v1-milestone/SKILL.md) playbook for
+station tactics (it remains the executable instance until 1.0 ships). This
+skill still owns the loop.
+
+## What this skill must not bake in
+
+These showed up on the HAR 1.0.0 line. They are **instance tactics**. If the
+template does not declare them, do not do them:
+
+- GitHub issues as the unit of a station (use `stations[].work`)
+- Stacked PRs / a long-lived integration branch
+- A named fixture repo (car-app) or `HAR_FIXTURE_MILESTONE=M0..M5`
+- "One issue = one PR = one slot"
+- Assuming the product of the line is a HAR migration
+
+## Phase 0 — Load and preflight
+
+1. Read the line file. Confirm `contractVersion`, `gate.cumulative === true`,
+   `handoff.autonomousShip === false`.
+2. **Skills.** For each root `skills[]` entry, confirm the skill is present
+   (repo path or the agent's skill list). HAR does not install third-party
+   packs — if `install` is an upstream URL, tell the user how to install it.
+   Missing optional skills: skip those station steps and say so.
+3. **MCP.** For each `mcp[]` entry with `required: true`, confirm the server
+   is available. If a required server is missing, stop. If `required: false`,
+   skip tracker-dependent steps (issue comments, PRs) and keep the rest.
+4. **Plugins / extra stages.** Note what the gate needs. Do not `add-plugin`
+   unless the user asked and the template lists it.
+5. Pick the station. Print: line id, station id, waves, slot plan, gate stages
+   that will run (every `gate.stages[]` whose `fromStation` is this station
+   **or an earlier one**).
+
+## Phase 1 — Wave plan
+
+Print the wave plan from `stations[].waves` (or a single cell if `waves` is
+omitted). For each group: work id, suggested branch, HAR slot, stack notes
+**only if the template's `prototypeNotes` say this line stacks PRs**.
+
+Adjust for work already done. Never share a slot between two concurrent groups.
+
+## Phase 2 — Execute waves
+
+For each wave, spawn **one subagent per group, in parallel**. Each subagent:
+
+1. Checks the slot is free (`har env status`). Occupied → complete/teardown
+   that slot first, or pick a free slot in budget. Never share.
+2. Launches from the intended base:
+   `har env launch <slot> --work-id <workId> --work-source <work.source> --work-url <url> --work-title <title>`
+   when work is bound. Skip tracker flags when `work.source` is `none`.
+3. Edits **only** in the returned work dir.
+4. Follows station skills listed on the station / line.
+5. Runs full verify in-slot until green. If this station made a new gate
+   question askable, extend the **cumulative** gate (add a stage / assert
+   tagged from this station). Never remove an earlier station's stages.
+6. Reports back: branch, commits, verify result, deviations. Subagents never
+   push, PR, complete, or teardown on their own.
+
+The orchestrator reviews, resolves cross-branch conflicts, and only then
+starts the next wave.
+
+## Phase 3 — Gate
+
+From a slot launched off the integrated result of this station:
+
+Run every gate stage whose `fromStation` ≤ current station, at the listed
+`tier`. If `gate.optInEnv` is set, export it as `1` for this run so the
+opt-in gate actually executes.
+
+Red gate → fix in-station, re-run. Never hand off a red gate. Never bypass
+(`HAR_SKIP_GATE`, `--no-verify`).
+
+The prototype of a real-product gate (not mocks) is this repo's
+`.har/stages/fixture-e2e.sh`: freshly built CLI, clone of a real repo, two
+modes (adapted harness + fresh `env init`), opt-in so routine verifies stay
+fast. Copy the *properties* when a line needs a jig; do not copy car-app
+paths or the `milestone_asserts` `case`.
+
+## Phase 4 — Traveler and handoff
+
+Update the `traveler` the template names (issue comment, ledger file, PR
+body). The traveler has to survive this repo's merge policy — squash-merge
+drops per-commit `BREAKING CHANGE:` footers.
+
+Then **stop and wait**. Do not merge, push to the default branch, complete a
+slot, or release. Present a session handoff (summary, session branch, preview
+URLs, gate evidence).
+
+## Growing the ratchet
+
+A gate only tests the questions you thought to ask. After six green
+milestones, HAR 1.0 still missed #291 (shim × stale CLI fork bomb),
+#297/#299 (scripts migrated, prose and `attach.sh` did not), and #298 (CI
+tested the published pre-1.0 package). When a review finds a new class of
+defect, add a stage or `doctor` question and tag it onto the line — that is
+how the ratchet earns the next station.
+
+See [LINE.schema.md](./LINE.schema.md) "Growing the ratchet."

--- a/.claude/skills/factory-line/examples/docs-milestone.line.json
+++ b/.claude/skills/factory-line/examples/docs-milestone.line.json
@@ -1,0 +1,72 @@
+{
+  "contractVersion": 1,
+  "id": "docs-milestone",
+  "title": "Docs-only milestone (minimal example)",
+  "description": "Ship a documentation or marketing-site change with a screenshot gate. Stresses an empty tracker, no stacked PRs, and a gate that is just tagged existing stages. Not a real program this repo runs — a filled template so the contract is not migration-shaped.",
+  "skills": [
+    {
+      "id": "factory-line",
+      "role": "orchestrator",
+      "install": "repo:.claude/skills/factory-line"
+    }
+  ],
+  "mcp": [],
+  "plugins": ["playwright"],
+  "stations": [
+    {
+      "id": "draft",
+      "title": "Draft the change",
+      "description": "Agree scope. No tracker required.",
+      "work": {
+        "source": "none",
+        "ids": [],
+        "optional": true
+      }
+    },
+    {
+      "id": "implement",
+      "title": "Implement in a docs harness slot",
+      "description": "Launch docs/.har, edit only in the session work dir, keep copy and routes consistent."
+    },
+    {
+      "id": "proof",
+      "title": "Screenshot and a11y proof",
+      "description": "Full verify includes browser-e2e. After screenshots live in the session work dir."
+    }
+  ],
+  "gate": {
+    "cumulative": true,
+    "optInEnv": null,
+    "stages": [
+      {
+        "id": "docs-check",
+        "fromStation": "implement",
+        "tier": "quick"
+      },
+      {
+        "id": "docs-build",
+        "fromStation": "implement",
+        "tier": "quick"
+      },
+      {
+        "id": "browser-e2e",
+        "fromStation": "proof",
+        "tier": "full"
+      }
+    ]
+  },
+  "extraStages": [],
+  "handoff": {
+    "autonomousShip": false,
+    "waitFor": "Human review of preview URL plus after-screenshots. Commit title docs: … so this does not cut a release."
+  },
+  "traveler": {
+    "kind": "pull-request-body",
+    "note": "No epic. The PR (or the session handoff if there is no PR yet) is the traveler."
+  },
+  "prototypeNotes": [
+    "No GitHub issues, no stacked PRs, no car-app, no M0..M5.",
+    "The docs harness already has browser-e2e — this line only tags it.",
+    "Use this as a check: if a new field is required to express this line, the contract is still biased toward v1."
+  ]
+}

--- a/.claude/skills/factory-line/examples/new-plugin.line.json
+++ b/.claude/skills/factory-line/examples/new-plugin.line.json
@@ -1,0 +1,113 @@
+{
+  "contractVersion": 1,
+  "id": "new-plugin",
+  "title": "New HAR verification plugin",
+  "description": "Ship a verification plugin for any framework: research docs, build the template, register it everywhere, validate on a real repository, open a PR. Second instance of the factory-line template — proves the contract is not the v1 migration in disguise.",
+  "skills": [
+    {
+      "id": "factory-line",
+      "role": "orchestrator",
+      "install": "repo:.claude/skills/factory-line"
+    },
+    {
+      "id": "new-plugin",
+      "role": "station",
+      "install": "repo:.claude/skills/new-plugin"
+    }
+  ],
+  "mcp": [
+    {
+      "name": "github",
+      "why": "Open the plugin PR after handoff approval. Not required to research or build.",
+      "required": false
+    }
+  ],
+  "plugins": [],
+  "stations": [
+    {
+      "id": "inputs",
+      "title": "Establish inputs",
+      "description": "Plugin id, framework, stage id (what it does, not the brand), validation repo."
+    },
+    {
+      "id": "research",
+      "title": "Research the framework",
+      "description": "Headless CLI, config, artifacts, install, CI recipe, exit codes. Read both existing plugins first.",
+      "skills": ["new-plugin"]
+    },
+    {
+      "id": "launch",
+      "title": "Launch a HAR session",
+      "description": "This repo dogfoods HAR. Launch the cli-profile slot before editing.",
+      "work": {
+        "source": "github",
+        "ids": [],
+        "optional": true
+      }
+    },
+    {
+      "id": "template",
+      "title": "Build the template",
+      "description": "src/templates/plugins/<id>/ with template.manifest.json, stage script, docs, optional package fragment and CI workflow."
+    },
+    {
+      "id": "register",
+      "title": "Register everywhere",
+      "description": "Tests, docs, landing card, plugins.ts catalog, adaptation prompt, boilerplate STAGES.md. No PLUGIN_IDS enum — discovery is from disk after build."
+    },
+    {
+      "id": "validate",
+      "title": "Validate locally, then on a real repository",
+      "description": "Scratch fixture for add-plugin, then a repo that genuinely uses the framework. Stage must pass and write artifacts."
+    },
+    {
+      "id": "handoff",
+      "title": "Full verify and hand off",
+      "description": "har env verify --full, then wait. PR only after approval."
+    }
+  ],
+  "gate": {
+    "cumulative": true,
+    "optInEnv": null,
+    "stages": [
+      {
+        "id": "typecheck",
+        "fromStation": "template",
+        "tier": "quick"
+      },
+      {
+        "id": "unit-tests",
+        "fromStation": "register",
+        "tier": "full",
+        "note": "Must include applies <id> plugin, onboarding ids, verify-shell-timing."
+      },
+      {
+        "id": "lint",
+        "fromStation": "handoff",
+        "tier": "full"
+      }
+    ]
+  },
+  "extraStages": [
+    {
+      "id": "<stage-id>",
+      "kind": "test",
+      "tier": "full",
+      "description": "The plugin's own stage, installed into the target repo by add-plugin. Validated on a real repository in the validate station — not mocked."
+    }
+  ],
+  "handoff": {
+    "autonomousShip": false,
+    "waitFor": "Session handoff, then approval before push/PR/complete. Commit title feat: add <framework> plugin (this is an intended minor)."
+  },
+  "traveler": {
+    "kind": "pull-request-body",
+    "note": "PR body carries what the plugin installs, the registration checklist, and validation evidence (real repo, artifacts, anything not executable here)."
+  },
+  "prototypeNotes": [
+    "Stations here are sequential phases, not GitHub issues and not stacked PRs.",
+    "The product of this line is a plugin template, not a HAR runtime migration.",
+    "Never add stack-specific MCP tools or core stages — plugins install generic stage kinds.",
+    "Real-repo validation is this line's jig. It is not car-app and not fixture-e2e."
+  ]
+}

--- a/.claude/skills/factory-line/examples/v1-milestone.line.json
+++ b/.claude/skills/factory-line/examples/v1-milestone.line.json
@@ -1,0 +1,161 @@
+{
+  "contractVersion": 1,
+  "id": "v1-milestone",
+  "title": "HAR v1.0.0 milestone line",
+  "description": "Execute one milestone of the HAR 1.0.0 refactor: wave of parallel subagents, one issue per isolated slot, stacked PRs onto v1, fixture-e2e gate, human handoff. Instance of the factory-line template — not the primitive.",
+  "skills": [
+    {
+      "id": "factory-line",
+      "role": "orchestrator",
+      "install": "repo:.claude/skills/factory-line"
+    },
+    {
+      "id": "v1-milestone",
+      "role": "station",
+      "install": "repo:.claude/skills/v1-milestone"
+    }
+  ],
+  "mcp": [
+    {
+      "name": "github",
+      "why": "Epic #225 and sub-issues are the traveler; PRs are how stations land on v1.",
+      "required": true
+    }
+  ],
+  "plugins": ["playwright"],
+  "stations": [
+    {
+      "id": "M0",
+      "title": "Foundations + 0.x patches",
+      "description": "Bundle composition, double-truths, surface bugs, single-source helpers. Plus triaged 0.x bugs.",
+      "work": {
+        "source": "github",
+        "ids": ["226", "227", "228", "229", "196", "197", "198", "195"],
+        "optional": false
+      },
+      "waves": [
+        [
+          { "workId": "228" },
+          { "workId": "196" },
+          { "workId": "197" },
+          { "workId": "198" },
+          { "workId": "195" }
+        ],
+        [{ "workId": "226" }],
+        [{ "workId": "227" }, { "workId": "229" }]
+      ]
+    },
+    {
+      "id": "M1",
+      "title": "Contract",
+      "description": "Schema'd harness.env, verification-as-data, doctor, CLI/MCP parity.",
+      "work": {
+        "source": "github",
+        "ids": ["230", "231", "232", "233"],
+        "optional": false
+      },
+      "waves": [
+        [{ "workId": "230" }, { "workId": "233" }],
+        [{ "workId": "231" }],
+        [{ "workId": "232" }]
+      ]
+    },
+    {
+      "id": "M2",
+      "title": "Runtime into the package",
+      "description": "TS runtime, shims, profiles as data. #234 splits into module forks plus one integration fork.",
+      "work": {
+        "source": "github",
+        "ids": ["234", "235", "236"],
+        "optional": false
+      },
+      "waves": [
+        [
+          { "workId": "234", "title": "ports/preflight fork" },
+          { "workId": "234", "title": "worktree+launch fork" },
+          { "workId": "234", "title": "provisioning fork" },
+          { "workId": "234", "title": "infra fork" },
+          { "workId": "234", "title": "slot-registry fork" },
+          { "workId": "234", "title": "integration fork" }
+        ],
+        [{ "workId": "235" }, { "workId": "236" }]
+      ]
+    },
+    {
+      "id": "M3",
+      "title": "Adaptation & extensibility",
+      "description": "Two-signal drift, hooks, eject, local plugins.",
+      "work": {
+        "source": "github",
+        "ids": ["237", "238", "239", "240"],
+        "optional": false
+      },
+      "waves": [
+        [
+          { "workId": "237" },
+          { "workId": "238" },
+          { "workId": "239" },
+          { "workId": "240" }
+        ],
+        [{ "workId": "237", "title": "integration pass" }]
+      ]
+    },
+    {
+      "id": "M4",
+      "title": "Migration & docs",
+      "description": "Versioned migrations + docs rewrite.",
+      "work": {
+        "source": "github",
+        "ids": ["241", "243"],
+        "optional": false
+      },
+      "waves": [[{ "workId": "241" }, { "workId": "243" }]]
+    },
+    {
+      "id": "M5",
+      "title": "Release gate",
+      "description": "Dogfood the three harnesses, then the v1 → main release PR. Sequential; ends in handoff for the 1.0.0 decision.",
+      "work": {
+        "source": "github",
+        "ids": ["242"],
+        "optional": false
+      }
+    }
+  ],
+  "gate": {
+    "cumulative": true,
+    "optInEnv": "HAR_FIXTURE_E2E",
+    "stages": [
+      {
+        "id": "fixture-e2e",
+        "fromStation": "M0",
+        "tier": "full",
+        "note": "Prototype lives in .har/stages/fixture-e2e.sh. Product intent: every later station still runs earlier asserts. The bash case is a per-milestone arm approximation — Phase 2 should tag stages, not copy the case. Two modes: adapted car-app harness + fresh env init. Fixture source is never modified; remotes scrubbed."
+      }
+    ]
+  },
+  "extraStages": [
+    {
+      "id": "fixture-e2e",
+      "kind": "test",
+      "tier": "full",
+      "description": "Built CLI vs a clone of a real default-profile repo (Playwright). Opt-in via HAR_FIXTURE_E2E=1."
+    }
+  ],
+  "handoff": {
+    "autonomousShip": false,
+    "waitFor": "Antoine's review. 1.0.0 is cut only by the M5 v1 → main PR he approves — merge commit, not squash, so semantic-release reads feat!:/feat:/fix: commits."
+  },
+  "traveler": {
+    "kind": "github-issue-comment",
+    "ref": "225",
+    "note": "This repo squash-merges, which drops per-commit BREAKING CHANGE: footers. The ledger comment on #225 is the durable record. Report progress as issue comments and epic checkboxes — do not duplicate the plan into files."
+  },
+  "prototypeNotes": [
+    "GitHub issues are this line's work source, not the definition of a station.",
+    "Stacked PRs onto a long-lived v1 branch are how this repo resolved file conflicts. Other lines may not PR at all.",
+    "car-app as the fixture and HAR_FIXTURE_MILESTONE=M0..M5 are this gate's jig, not a required fixture.",
+    "One issue ≈ one PR ≈ one slot was a good default for #225; do not treat it as a law.",
+    "The bash milestone_asserts case is the working prototype of the ratchet, not the product schema."
+  ]
+}

--- a/.claude/skills/new-plugin/SKILL.md
+++ b/.claude/skills/new-plugin/SKILL.md
@@ -5,6 +5,12 @@ description: Factory line for adding a new HAR verification plugin (like playwri
 
 # New HAR plugin factory line
 
+> **Instance of the [factory-line](../factory-line/SKILL.md) template.**
+> Program data: [`new-plugin.line.json`](../factory-line/examples/new-plugin.line.json).
+> Stations here are sequential phases, not GitHub issues. The product is a
+> plugin, not a runtime migration — that is why this line exists as a second
+> instance.
+
 Ship a new verification plugin `<id>` for framework `<framework>` end-to-end:
 research → template → registration → local validation → real-repo validation → PR.
 

--- a/.claude/skills/v1-milestone/SKILL.md
+++ b/.claude/skills/v1-milestone/SKILL.md
@@ -5,6 +5,12 @@ description: Factory line for executing one milestone of the HAR v1.0.0 refactor
 
 # HAR v1.0.0 milestone factory line
 
+> **Instance of the [factory-line](../factory-line/SKILL.md) template.**
+> Program data: [`v1-milestone.line.json`](../factory-line/examples/v1-milestone.line.json).
+> This skill stays the executable playbook for the 1.0.0 run. Stacked PRs,
+> GitHub-issue stations, and the car-app jig are *this line's* tactics — not
+> the primitive. To run a different program, copy a line file, not this skill.
+
 Execute one milestone of the v1.0.0 refactor end-to-end:
 sync → wave plan → parallel implementation → stacked PRs → gate → handoff.
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -101,6 +101,7 @@ export default defineConfig({
 						{ label: 'Local plugins', slug: 'docs/guides/local-plugins' },
 						{ label: 'Agent integrations', slug: 'docs/guides/agent-integrations' },
 						{ label: 'Skill-pack compatibility', slug: 'docs/guides/skill-pack-compatibility' },
+						{ label: 'Factory lines', slug: 'docs/guides/factory-lines' },
 						{ label: 'Verification & commit gate', slug: 'docs/guides/verification' },
 						{ label: 'Mission Control', slug: 'docs/guides/mission-control' },
 						{ label: 'Eject', slug: 'docs/guides/eject' },

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -129,3 +129,9 @@ har env teardown 2
 
 Branch deletion is a separate, explicit operation. Prefer `complete` when the
 task succeeded and you want a validation record.
+
+## Factory lines
+
+For a multi-station program (parallel slots, cumulative gate, human handoff)
+declare a line template instead of forking a skill. See
+[Factory lines](/docs/guides/factory-lines/).

--- a/docs/src/content/docs/docs/guides/factory-lines.md
+++ b/docs/src/content/docs/docs/guides/factory-lines.md
@@ -1,0 +1,118 @@
+---
+title: Factory lines
+description: Declare a repeatable multi-station program — skills, MCP, and cumulative gate stages — without forking a playbook.
+---
+
+A **factory line** is a declared program: an ordered set of stations, each
+runnable by one or more agents in isolated HAR slots, with a **cumulative**
+gate and a handoff a human owns.
+
+HAR 1.0 already has the primitives — work units, slots, stages, plugins,
+validation records, the commit gate. A line is **composition plus a
+manifest**, not a new runner. This guide is Phase 1 of
+[epic #302](https://github.com/os-factory/har/issues/302): the skill and the
+template contract, with no CLI yet. `.har/line.json` and `har line` are Phase 2.
+
+Two skills in this repository already described themselves as a factory line
+before the name was a product:
+
+- `v1-milestone` — one milestone of the 1.0.0 refactor
+- `new-plugin` — research, template, register, validate on a real repo, PR
+
+Those are **instances**. The orchestrator is the `factory-line` skill at
+`.claude/skills/factory-line/` in this repository. Do not copy `v1-milestone`
+and edit issue numbers.
+
+## The unit of work is a station
+
+A station is a named step with optional work-unit binding, a slot policy, and
+a gate. How work is tracked (GitHub, Linear, nothing) is data on the station,
+not the type of the station.
+
+Identical isolated slots are the workstation. One slot per concurrent agent;
+**occupied slots always block** — that is what makes N parallel agents safe.
+
+## Author a line
+
+1. Copy the contract in `.claude/skills/factory-line/LINE.schema.md` and a
+   close instance from `.claude/skills/factory-line/examples/`.
+2. Fill `id`, `stations[]`, `skills[]`, `mcp[]`, `gate`, `handoff`, `traveler`.
+3. Keep `gate.cumulative` true and `handoff.autonomousShip` false.
+4. Put instance tactics (stacked PRs, a specific fixture, tracker-only
+   stations) in `prototypeNotes` — not in the orchestrator skill.
+
+Then run the `factory-line` skill with the path to your file and a station id.
+
+### Attach a skill
+
+Root `skills[]` are what the line expects. Station `skills[]` are extra
+playbooks for that step. HAR does **not** install or copy third-party skill
+packs ([skill-pack compatibility](/docs/guides/skill-pack-compatibility/)).
+`install` is a hint (`repo:…`, an upstream URL). The agent or a human installs;
+Phase 2 can have `doctor` check presence.
+
+### Declare MCP
+
+List MCP **servers** the line needs (`github`, `linear`, a product MCP) and
+why. Lines declare MCP; they do not add stack-specific tools to HAR core.
+*Plugins install stages; agents only talk to the stage registry.* If a server
+is `required: false`, skip tracker steps when it is missing.
+
+### Add a testing / gate stage
+
+`gate.stages[]` tags **existing** registered stages (`stages.json`) with
+`fromStation`. From that station on, the stage stays in the gate. That is the
+**ratchet**: a QA station is never removed.
+
+`extraStages[]` is for checks the profile does not already have (a
+fixture-e2e analogue, a docs-drift rule, a `doctor` question). Phase 1
+documents them; Phase 2 registers them. Prefer tagging a stage that already
+exists.
+
+Routine verifies should stay fast. If the jig is expensive, set
+`gate.optInEnv` (this repo uses `HAR_FIXTURE_E2E=1`).
+
+### Grow the ratchet
+
+A gate only tests the questions you thought to ask. After six green
+milestones, the 1.0 line still missed a shim × stale-CLI fork bomb (#291),
+scripts-vs-prose drift (#297, #299), and CI testing the published pre-1.0
+package (#298). When that happens:
+
+1. Add a stage or a `doctor` check that asks the new question.
+2. Tag `fromStation` on the station that made it askable.
+3. Leave every earlier tag in place.
+
+The bash `case` in `.har/stages/fixture-e2e.sh` is the **prototype** of this
+pattern, not the product. Later milestone arms there add questions; they do
+not always re-enter earlier arms. Phase 2 should make "run every stage tagged
+≤ current station" data on the stage registry.
+
+## Instances
+
+| Line file | What it proves |
+|---|---|
+| `examples/v1-milestone.line.json` | The contract can express the 1.0.0 run (waves, GitHub work, opt-in real-repo gate, traveler on an epic). |
+| `examples/new-plugin.line.json` | Same contract, sequential phases, optional MCP, a real-repo jig that is not car-app. |
+| `examples/docs-milestone.line.json` | Empty tracker, no stacked PRs, gate is tagged existing stages only. |
+
+If a field is required to express `docs-milestone` that only exists because of
+the v1 migration, the contract is still biased — delete it.
+
+## What a line is not
+
+| Not this | Because |
+|---|---|
+| A new plugin kind | Plugins already install stages. A line *references* plugins. |
+| A new MCP surface | No `har_run_playwright`. No tracker-named core tools. |
+| Identical units out the door | The line repeats the *process*. Every program is bespoke. |
+| Rework as a defect | Iteration is the expected mode. |
+
+Agents hand off. They do not ship. That is the andon cord.
+
+## Next
+
+Phase 2 will lift the template into `.har/line.json` and `har line status`,
+with the ratchet as tagged stages. Until then this guide and the skill are
+the whole feature — cheap on purpose, so the shape gets used before anyone
+invents CLI surface.


### PR DESCRIPTION
## Summary
- **This repository only.** Line-template contract (`LINE.schema.md`) plus instances (`v1-milestone`, `new-plugin`, `docs-milestone`) and the authoring guide at `/docs/guides/factory-lines/`.
- `v1-milestone` / `new-plugin` stay executable playbooks with a pointer at the template. Zero CLI/runtime change.

Closes #303. Parent: #302.

The orchestrator that ships to every HAR repo (Claude + Cursor + Codex) is **#319**, not this PR. Do not treat `.claude/skills/factory-line/` as the product — it is dogfood so we could lock the shape.

**Post-1.0.0.** `docs:` will not cut a release.

## Test plan
- [x] Root harness `har env verify 1 --full`
- [ ] Open `/docs/guides/factory-lines/` after merge
- [ ] Confirm `v1-milestone` / `new-plugin` still read as executable playbooks