### PR TITLE
docs: factory-line blog — the ratchet and what the gate missed (#306)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The public site is an [Astro](https://astro.build/) project deployed to GitHub
 Pages at <https://harproject.dev/>:
 
 - `/` — marketing landing page with interactive workflow hero
-- `/blog` — journal index and articles
+- `/blog/` — journal index; articles under `/blog/<slug>/` (currently `/blog/the-factory-line/`)
 - `/docs` — Starlight documentation (same content as before, new theme)
 
 ## Agent harness
@@ -61,7 +61,8 @@ Documentation content is licensed under the
 ## Source layout
 
 - `src/pages/index.astro` — landing page
-- `src/pages/blog/` — journal pages
+- `src/pages/blog/` — journal index and article routes
+- `src/content/blog/` — journal markdown
 - `src/content/docs/docs/` — documentation (served under `/docs`)
 - `src/styles/global.css` — landing/blog theme
 - `src/styles/custom.css` — Starlight theme overrides

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -30,7 +30,7 @@ const { minimal = false } = Astro.props;
         </div>
       </div>
       <div class="footer-col"><strong>Product</strong><a href="/#why">What HAR gives you</a><a href="/#workflow">How HAR works</a><a href="/#control">Mission Control</a><a href="/teams/">Teams</a></div>
-      <div class="footer-col"><strong>Resources</strong><a href="/docs">Documentation</a><a href="/docs/getting-started/quick-start/">Quick start</a><a href="https://www.npmjs.com/package/@osfactory/har">npm</a></div>
+      <div class="footer-col"><strong>Resources</strong><a href="/docs">Documentation</a><a href="/blog/">Blog</a><a href="/docs/getting-started/quick-start/">Quick start</a><a href="https://www.npmjs.com/package/@osfactory/har">npm</a></div>
       <div class="footer-col"><strong>Project</strong><a href="https://github.com/os-factory/har">GitHub</a><a href="https://github.com/os-factory/har/blob/main/CONTRIBUTING.md">Contributing</a><a href="https://github.com/os-factory/har/blob/main/LICENSE">Apache-2.0</a></div>
     </div>
   )}

--- a/docs/src/components/Header.astro
+++ b/docs/src/components/Header.astro
@@ -2,12 +2,11 @@
 import ThemeToggle from './ThemeToggle.astro';
 
 interface Props {
-  active?: 'home' | 'plugins' | 'teams';
+  active?: 'home' | 'blog' | 'plugins' | 'teams';
   solid?: boolean;
 }
 
 const { active = 'home', solid = false } = Astro.props;
-const homePrefix = active === 'home' ? '' : '/';
 ---
 <header class:list={['site-header', { 'site-header-solid': solid }]} data-header>
   <div class="container nav-shell">
@@ -17,6 +16,7 @@ const homePrefix = active === 'home' ? '' : '/';
     <div class="nav-right">
       <nav class="desktop-nav" aria-label="Primary navigation">
         <a href="/docs">Docs</a>
+        <a href="/blog/" class:list={{ active: active === 'blog' }} aria-current={active === 'blog' ? 'page' : undefined}>Blog</a>
         <a href="/plugins/" class:list={{ active: active === 'plugins' }} aria-current={active === 'plugins' ? 'page' : undefined}>Plugins</a>
         <a href="/teams/" class:list={{ active: active === 'teams' }} aria-current={active === 'teams' ? 'page' : undefined}>Teams</a>
       </nav>
@@ -38,6 +38,7 @@ const homePrefix = active === 'home' ? '' : '/';
   </div>
   <div class="mobile-menu" id="mobile-menu" data-mobile-menu>
     <a href="/docs">Documentation</a>
+    <a href="/blog/">Blog</a>
     <a href="/plugins/">Plugins</a>
     <a href="/teams/">Teams</a>
     <a href="https://github.com/os-factory/har">Star on GitHub</a>

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,7 +1,19 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
+const blog = defineCollection({
+	loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+	schema: z.object({
+		title: z.string(),
+		description: z.string(),
+		date: z.coerce.date(),
+		kicker: z.string().optional(),
+	}),
+});
+
 export const collections = {
 	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+	blog,
 };

--- a/docs/src/content/blog/the-factory-line.md
+++ b/docs/src/content/blog/the-factory-line.md
@@ -1,0 +1,85 @@
+---
+title: The factory line
+description: How we ran HAR 1.0.0 as a software factory — stations, a ratchet, and the questions the gate never asked.
+date: 2026-08-27
+kicker: Method
+---
+
+A harness is a manufacturing word. It is a jig: something that holds a unit in a known state so you can measure it. HAR already named that. Shipping 1.0.0 was the rest of the factory — stations in sequence, identical workstations, a QA gate on a real unit, a traveler that survives the merge policy, and a human on the andon cord.
+
+Two skills in this repository already call themselves a factory line: `v1-milestone`, which ran the 1.0.0 refactor, and `new-plugin`, which ships a verification plugin from research to a pull request. Those are unrelated jobs. They converged on the same shape. That is evidence the metaphor is load-bearing, not a slide.
+
+The [road to 1.0](/docs/project/road-to-1-0/) is the configuration-surface story — why `.har/` stopped being a vendored copy of the runtime. This piece is the method we used to get there.
+
+## Where the analogy holds — and where it breaks
+
+An analogy that admits its limits reads as thinking.
+
+| Holds | Breaks |
+| --- | --- |
+| Stations in sequence; identical HAR slots as workstations; parallel cells; a QA gate; poka-yoke; jidoka; a traveler; an andon cord | **Identical units out the door** — the line repeats the *process*, never the product. Every program is bespoke. |
+| | **Rework = waste** — iteration is the expected mode, not a defect. |
+
+M0 through M5 were stations. A HAR slot is the strongest fit in the table: an identical workstation, isolated, reusable. Occupied slots block, the commit gate refuses an unproven tree, and `doctor` refuses a broken contract — poka-yoke. The gate can stop the line (jidoka; later, exit 86). Nothing merges without a go-ahead.
+
+What the analogy will not do is pretend the output was interchangeable parts. The line repeats a process. The product of each station was a different slice of a refactor. And rework was not waste: iteration was how the stations ran.
+
+## The unit of work is a station, not a task
+
+Epic [#225](https://github.com/os-factory/har/issues/225) started from a number, not a vibe. Pre-1.0, `har env init` copied the runtime into every project. Across three boilerplate profiles that was roughly 8,800 lines of template, about 2,400 of them byte-identical duplicates. One node-PM helper block was copied seven times. Twenty files landed in an installed harness; the target was about seven.
+
+"Let an agent refactor this" fails without a line for the same reason a factory does not hand a whole plant to one person with a punch list. The work has file conflicts, ordered dependencies, and a quality bar that has to hold after every station, not only at the end. An agent given the epic as a task will either serialize everything — and stall — or parallelize without isolation — and collide. A station is a named step with a workstation, a gate, and a handoff. A task is a sentence.
+
+## The workstation
+
+HAR already had the workstation: an isolated slot — its own worktree, ports, and environment. "Occupied slots always block" is the feature that makes N parallel agents safe. Sharing a slot across unrelated chats is how you get two writers on one tree. The line treated that as poka-yoke, not ceremony. Each concurrent station got its own slot; an occupied slot meant complete or teardown first, then launch.
+
+Identical workstations are why a wave of subagents could run without inventing a new isolation story per issue.
+
+## The jig
+
+The gate was not a mock. `fixture-e2e` cloned a real repository — car-app, Next.js and SQLite, default profile, Playwright plugin — and ran the freshly built CLI against it in two modes: (1) an already-adapted harness through maintain → launch → full verify → complete, and (2) a fresh `env init` and a full slot lifecycle. The source repo was never touched.
+
+It is opt-in (`HAR_FIXTURE_E2E=1`) so routine verifies stay fast. A jig you run on every keystroke stops being a jig; it becomes the bottleneck. The line ran it when a station claimed to have moved the contract.
+
+## The ratchet
+
+This is the piece most refactor write-ups do not have.
+
+`HAR_FIXTURE_MILESTONE=M0..M5` does not swap assertions. It **adds** them. M1 still runs M0. M5 still runs M0. A QA station, once installed, is never removed.
+
+That sounds small. It is the difference between a checklist you edit down as you get tired and a line that only ever tightens. Most milestone gates replace the old questions with the new ones, which is how you ship a later station that silently regresses an earlier one. The ratchet makes that a fail: the new work still has to pass the old stations.
+
+The implementation in this repository is a `case` in `.har/stages/fixture-e2e.sh`. That is a prototype, not the product. The invariant is the cumulative gate.
+
+## The traveler
+
+The epic was the traveler — the card that rides with the unit. On it we kept a breaking-changes ledger, as a comment, because squash-merge drops per-commit `BREAKING CHANGE:` footers. Semantic-release never sees them. The ledger comment is the only durable record of what actually broke.
+
+A line has to survive the merge policy the repository actually has, not the one the process diagram wished for.
+
+## The andon cord
+
+Agents hand off. They do not ship. Every merge waited on a human go-ahead. That is the andon cord: anyone can stop the line; nobody on the line pulls the release.
+
+The session contract in this repository says the same thing in tooling language — present a handoff, then wait. Complete, push, and open a pull request are approval steps, not agent steps. A factory that lets the station ship the unit is not a factory. It is an unsupervised pipeline.
+
+## What the line caught, and what it missed
+
+The line caught a lot. Dogfooding the migration on this repository's three real harnesses found six flow bugs and two release blockers before users would have. The [road to 1.0](/docs/project/road-to-1-0/) covers that catch. This section is about the misses — defects that showed up in a pre-release review after six green milestones.
+
+**[#291](https://github.com/os-factory/har/issues/291) — a stale global `har` and the 1.0 shims.** Pre-1.0 `har` treats `.har/verify.sh` as the implementation and executes it. The 1.0 shim `exec`s back into `har`. A pre-1.0 binary executes the script again. One new process per cycle, forever. We measured 2,306 node processes and a load average of 215. It took the machine down twice. The fix is a re-entry guard (exit 86) and a version floor that skips binaries older than the harness's pinned runtime. The gate never asked "what if the `har` on `PATH` is from last month?"
+
+**[#297](https://github.com/os-factory/har/issues/297) / [#299](https://github.com/os-factory/har/issues/299) — scripts, not prose.** The line migrated scripts, `harness.env`, and stages. It did not migrate the words agents read. `attach.sh` still sourced `agent-slot.sh`, a file the same migration deleted. The dogfood READMEs still indexed retired machinery. `doctor` reported PASS. Drift treated the READMEs as user-adapted, so it would not revert them. The gate never asked whether the prose still described the files on disk. `doctor` now does.
+
+**[#298](https://github.com/os-factory/har/issues/298) — CI against the published package.** The Mission Control job invoked the new shims without putting this repository's freshly built CLI on `PATH`. The shims fell through to `npx @osfactory/har@0.64.1` — the last published release, which predates the 1.0 runtime. The job was testing the new harness surface against the old package. The re-entry guard did its job (exit 86). The question "does CI run the code under test?" had not been on the ratchet.
+
+The honest lesson: **a gate only tests the questions you thought to ask.** A ratchet that cannot grow is just a freeze. The misses are now questions. That is the point of a line you keep.
+
+## Making it a product
+
+None of this requires a rewrite. Isolated slots, stages with tiers, validation records, the commit gate, hooks, plugins, work-unit binding, skills, MCP — HAR 1.0 already has the primitives. A factory line is composition: an ordered set of stations, each runnable by one or more agents in isolated slots, with a cumulative gate, and a handoff a human owns.
+
+That work lives in [#302](https://github.com/os-factory/har/issues/302). It is post-1.0.0 on purpose. 1.0 ships the primitives; the line composes them. What comes next is a parameterized skill and a template contract — not a new orchestrator, and not a promise about Mission Control boards or a `har line` command. This post does not wait on those.
+
+The method already ran. The product is whether the next program — a plugin line, a migration line, something that is not HAR itself — can declare the same shape without forking `v1-milestone`.

--- a/docs/src/content/docs/docs/project/road-to-1-0.md
+++ b/docs/src/content/docs/docs/project/road-to-1-0.md
@@ -6,7 +6,9 @@ description: Why .har/ became a configuration surface, what broke on the way, an
 HAR 1.0.0 changes one thing, and everything follows from it: **`.har/` stops being
 a vendored copy of HAR's runtime and becomes a configuration surface.** This post
 explains why we did it, what actually broke while dogfooding the migration on
-HAR's own repository, and the lessons that ended up encoded in the product.
+HAR's own repository, and the lessons that ended up encoded in the product. How
+we ran the work itself — stations, a ratchet, a gate on a real clone — is a
+separate piece: [The factory line](/blog/the-factory-line/).
 
 ## The problem we shipped ourselves
 
@@ -115,3 +117,7 @@ remaining: zero. Same story on the other two harnesses, and
 
 If you're on a pre-1.0 harness, the [migration guide](/docs/guides/migrating-to-1-0/)
 walks the same path we took — and `har env maintain` will hand you the prompt.
+
+The configuration surface is this page. [The factory line](/blog/the-factory-line/)
+is the method: why the unit of work is a station, how the gate only ever adds
+assertions, and what it missed because nobody thought to ask.

--- a/docs/src/layouts/BlogLayout.astro
+++ b/docs/src/layouts/BlogLayout.astro
@@ -1,0 +1,25 @@
+---
+import '@fontsource/instrument-serif/400.css';
+import '@fontsource/instrument-serif/400-italic.css';
+import BaseLayout from './BaseLayout.astro';
+import Header from '../components/Header.astro';
+
+interface Props {
+  title: string;
+  description: string;
+  canonicalPath: string;
+}
+
+const { title, description, canonicalPath } = Astro.props;
+---
+<BaseLayout
+  title={title}
+  description={description}
+  bodyClass="home-page blog-page"
+  canonicalPath={canonicalPath}
+>
+  <Header active="blog" />
+  <main>
+    <slot />
+  </main>
+</BaseLayout>

--- a/docs/src/pages/blog/[slug].astro
+++ b/docs/src/pages/blog/[slug].astro
@@ -1,0 +1,51 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+import Footer from '../../components/Footer.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+
+const dateFormat = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+---
+<BlogLayout
+  title={`${post.data.title} — HAR`}
+  description={post.data.description}
+  canonicalPath={`/blog/${post.id}/`}
+>
+<section class="hero blueprint-surface blog-hero blog-hero-article">
+<div class="container">
+<header class="blog-article-head reveal">
+<a class="blog-back" href="/blog/">← Journal</a>
+<div class="eyebrow"><span class="eyebrow-dot"></span> {post.data.kicker ?? 'Journal'}</div>
+<h1>{post.data.title}</h1>
+<p class="hero-lede">{post.data.description}</p>
+<p class="blog-article-date">
+<time datetime={post.data.date.toISOString()}>{dateFormat.format(post.data.date)}</time>
+</p>
+</header>
+</div>
+</section>
+<div class="page-frame">
+<section class="section blog-article-section">
+<div class="container">
+<article class="blog-prose reveal">
+<Content />
+</article>
+</div>
+</section>
+<Footer />
+</div>
+</BlogLayout>

--- a/docs/src/pages/blog/index.astro
+++ b/docs/src/pages/blog/index.astro
@@ -1,0 +1,52 @@
+---
+import BlogLayout from '../../layouts/BlogLayout.astro';
+import Footer from '../../components/Footer.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog')).sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+
+const dateFormat = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+});
+---
+<BlogLayout
+  title="HAR journal"
+  description="Writing on the harness, the factory line, and what the gates actually catch."
+  canonicalPath="/blog/"
+>
+<section class="hero blueprint-surface blog-hero">
+<div class="container">
+<div class="hero-copy reveal">
+<div class="eyebrow"><span class="eyebrow-dot"></span> Journal</div>
+<h1>Notes from the line.</h1>
+<p class="hero-lede">How HAR actually runs work — stations, gates, and the questions we forgot to ask — not a changelog.</p>
+</div>
+</div>
+</section>
+<div class="page-frame">
+<section class="section blog-index-section">
+<div class="container">
+<ul class="blog-index-list reveal">
+{posts.map((post) => (
+<li>
+<a class="blog-post-card" href={`/blog/${post.id}/`}>
+<span class="blog-post-meta">
+<time datetime={post.data.date.toISOString()}>{dateFormat.format(post.data.date)}</time>
+{post.data.kicker && <span>{post.data.kicker}</span>}
+</span>
+<h2>{post.data.title}</h2>
+<p>{post.data.description}</p>
+<span class="blog-post-read">Read <span aria-hidden="true">→</span></span>
+</a>
+</li>
+))}
+</ul>
+</div>
+</section>
+<Footer />
+</div>
+</BlogLayout>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -497,3 +497,51 @@ body { transition: background-color .25s ease, color .25s ease; }
 
 /* Dark-stroke logos (e.g. Gitleaks) need inverting on the dark theme. */
 :root[data-theme="dark"] .logo-invert-dark { filter: invert(1); }
+
+/* Journal — long-form on the marketing tokens (serif body, mono chrome). */
+.blog-hero { padding: 130px 0 64px; }
+.blog-hero .hero-copy,
+.blog-article-head { max-width: 720px; }
+.blog-hero h1 { font-family: var(--serif); font-weight: 400; letter-spacing: -.02em; max-width: none; }
+.blog-back { display: inline-block; margin-bottom: 18px; font-size: 13.5px; color: var(--muted); }
+.blog-back:hover { color: var(--text); }
+.blog-article-date { margin: 22px 0 0; font-family: var(--mono); font-size: 12px; letter-spacing: .04em; color: var(--muted); }
+.blog-index-section { padding: 48px 0 80px; }
+.blog-article-section { padding: 0; }
+.blog-index-list { list-style: none; margin: 0; padding: 0; max-width: 720px; }
+.blog-post-card { display: grid; gap: 12px; padding: 36px 0; }
+.blog-index-list li + li { border-top: 1px solid var(--theme-border); }
+.blog-post-meta { display: flex; flex-wrap: wrap; gap: 10px 16px; font-family: var(--mono); font-size: 12px; letter-spacing: .04em; color: var(--muted); text-transform: uppercase; }
+.blog-post-card h2 { margin: 0; font-family: var(--serif); font-size: clamp(28px, 3.2vw, 36px); font-weight: 400; letter-spacing: -.02em; line-height: 1.2; }
+.blog-post-card p { margin: 0; max-width: 640px; color: var(--muted); font-size: 16px; line-height: 1.65; }
+.blog-post-read { font-family: var(--mono); font-size: 13px; color: var(--text); }
+.blog-post-card:hover h2 { color: var(--accent); }
+:root[data-theme="dark"] .blog-post-card:hover h2 { color: var(--accent-bright); }
+
+.blog-prose { max-width: 720px; padding: 56px 0 80px; font-family: var(--serif); font-size: 19px; line-height: 1.75; color: var(--text); }
+.blog-prose > *:first-child { margin-top: 0; }
+.blog-prose h2 { margin: 2.4em 0 0.7em; font-family: var(--sans); font-size: 22px; font-weight: 650; letter-spacing: -.02em; line-height: 1.25; }
+.blog-prose h3 { margin: 1.8em 0 0.55em; font-family: var(--sans); font-size: 18px; font-weight: 650; letter-spacing: -.01em; }
+.blog-prose p { margin: 0 0 1.15em; }
+.blog-prose a { color: var(--text); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 3px; }
+.blog-prose a:hover { color: var(--accent); }
+:root[data-theme="dark"] .blog-prose a:hover { color: var(--accent-bright); }
+.blog-prose code { font-family: var(--mono); font-size: .78em; padding: 2px 5px; border-radius: 4px; background: color-mix(in srgb, var(--muted) 15%, transparent); -webkit-box-decoration-break: clone; box-decoration-break: clone; }
+.blog-prose pre { padding: 16px 18px; overflow-x: auto; border: 1px solid var(--theme-border); border-radius: 5px; background: var(--theme-surface-raised); font-size: 14px; line-height: 1.6; }
+.blog-prose pre code { padding: 0; background: none; font-size: inherit; }
+.blog-prose ul, .blog-prose ol { margin: 0 0 1.15em; padding-left: 1.25em; }
+.blog-prose li { margin: 0.35em 0; }
+.blog-prose li::marker { color: var(--muted); }
+.blog-prose strong { font-weight: 600; }
+.blog-prose em { font-style: italic; }
+.blog-prose blockquote { margin: 1.4em 0; padding: 0 0 0 1em; border-left: 2px solid var(--theme-border); color: var(--muted); }
+.blog-prose table { width: 100%; margin: 1.4em 0 1.8em; border-collapse: collapse; font-family: var(--sans); font-size: 14.5px; line-height: 1.55; }
+.blog-prose th, .blog-prose td { padding: 12px 14px; text-align: left; vertical-align: top; border: 1px solid var(--theme-border); }
+.blog-prose th { font-family: var(--mono); font-size: 11px; font-weight: 650; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); background: var(--theme-surface-raised); }
+.blog-prose td:first-child { width: 52%; }
+@media (max-width: 760px) {
+  .blog-hero { padding: 120px 0 48px; }
+  .blog-prose { font-size: 17.5px; padding: 36px 0 64px; }
+  .blog-prose table { display: block; overflow-x: auto; }
+  .blog-post-card { padding: 36px 0; }
+}

--- a/docs/tests/frontend/blog.spec.cjs
+++ b/docs/tests/frontend/blog.spec.cjs
@@ -1,0 +1,50 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Blog', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(
+      /(?:posthog|googletagmanager|google-analytics|youtube|youtu\.be|web3forms|doubleclick)/i,
+      (route) => route.abort(),
+    );
+  });
+
+  test('index lists the factory-line post and marks Blog active', async ({ page }) => {
+    await page.goto('/blog/');
+    await expect(page.locator('h1')).toContainText('Notes from the line.');
+    await expect(page.getByRole('navigation', { name: 'Primary navigation' }).getByRole('link', { name: 'Blog' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    const article = page.getByRole('link', { name: /The factory line/ });
+    await expect(article).toBeVisible();
+    await expect(article).toHaveAttribute('href', '/blog/the-factory-line/');
+    await expect(page.locator('.site-footer').getByRole('link', { name: 'Blog' })).toBeVisible();
+  });
+
+  test('factory-line article covers the ratchet and the gate misses', async ({ page }) => {
+    await page.goto('/blog/the-factory-line/');
+    await expect(page.locator('h1')).toContainText('The factory line');
+    await expect(page.locator('h2', { hasText: 'The ratchet' })).toBeVisible();
+    await expect(page.locator('.blog-prose')).toContainText(
+      'does not swap assertions. It adds them',
+    );
+    await expect(page.locator('.blog-prose')).toContainText(
+      'Identical units out the door',
+    );
+    await expect(page.locator('.blog-prose')).toContainText(
+      'Rework = waste',
+    );
+    await expect(page.locator('.blog-prose')).toContainText('2,306 node processes');
+    await expect(page.locator('.blog-prose')).toContainText(
+      'a gate only tests the questions you thought to ask',
+    );
+    await expect(page.getByRole('link', { name: 'road to 1.0' }).first()).toHaveAttribute(
+      'href',
+      '/docs/project/road-to-1-0/',
+    );
+    await expect(page.getByRole('link', { name: '#302' })).toHaveAttribute(
+      'href',
+      'https://github.com/os-factory/har/issues/302',
+    );
+  });
+});

--- a/docs/tests/frontend/visual-proof.spec.cjs
+++ b/docs/tests/frontend/visual-proof.spec.cjs
@@ -74,4 +74,24 @@ test.describe('Visual proof screenshots', () => {
     const file = await capturePageScreenshot(page, testInfo, 'teams');
     expect(file).toBeTruthy();
   });
+
+  test('blog index full-page shot', async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    await page.goto('/blog/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('h1')).toContainText('Notes from the line.');
+    await page.locator('.blog-index-list').waitFor({ state: 'visible' });
+    await page.waitForTimeout(800);
+    const file = await capturePageScreenshot(page, testInfo, 'blog-index');
+    expect(file).toBeTruthy();
+  });
+
+  test('factory-line article full-page shot', async ({ page }, testInfo) => {
+    test.setTimeout(90_000);
+    await page.goto('/blog/the-factory-line/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('h1')).toContainText('The factory line');
+    await page.locator('.blog-prose').waitFor({ state: 'visible' });
+    await page.waitForTimeout(800);
+    const file = await capturePageScreenshot(page, testInfo, 'blog-the-factory-line');
+    expect(file).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- Scaffolds `/blog` on the marketing site (index + article collection) and adds the factory-line journal post: stations, workstation, jig, ratchet, traveler, andon, and what the gate missed (#291, #297/#299, #298).
- Cross-links `/docs/project/road-to-1-0/` (does not duplicate that migration write-up). Blog nav in header and footer.
- Playwright smoke + visual-proof screenshots for the index and article.

Closes #306. Parent: #302.

**Post-1.0.0:** do not include this in the 1.0.0 release merge. Base is `v1` because the post assumes 1.0 shipped. After 1.0 is on `main`, retarget there (`docs:` will not cut a release).

## Test plan
- [x] Docs harness `har env verify 1 --full` (check, drift, build, links, browser-e2e)
- [ ] http://localhost:4321/blog/ and http://localhost:4321/blog/the-factory-line/
- [ ] Confirm both analogy breaks are named; credibility section is present; road-to-1-0 is not duplicated
- [ ] Header/footer Blog link; visual-proof shots for index and article

Made with [Cursor](https://cursor.com)