### PR TITLE
fix(ci): honor the `!` breaking marker — semantic-release preset was dropping every breaking change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,11 +247,11 @@ HAR session branches are derived from whatever base you launch from (`docs-…-h
 |---------------|---------|
 | `fix:` | Patch |
 | `feat:` | Minor |
-| `feat!:` or `BREAKING CHANGE:` footer | Major |
+| `feat!:` / `fix!:` (`!` on any type) or a `BREAKING CHANGE:` footer | Major |
 | `chore:`, `docs:`, `test:`, `refactor:`, `ci:` | No release |
 | `feat(benchmark):`, `*(ci):`, `docs(*):` | No release ([release.config.cjs](./release.config.cjs) rules) |
 
-Explicit analyzer rules in [release.config.cjs](./release.config.cjs): type `ci`, type `docs`, scope `ci`, and scope `benchmark` all set `release: false`. Prefer type `ci:` / `docs:` for those-only PRs — not `feat(docs):` or `fix(docs):` (type `feat`/`fix` still releases unless the scope is `ci` or `benchmark`). Squash-merge PR titles must follow the same format.
+Explicit analyzer rules in [release.config.cjs](./release.config.cjs): type `ci`, type `docs`, scope `ci`, and scope `benchmark` all set `release: false`. The analyzer uses the `conventionalcommits` preset so `!` alone marks a breaking change (#311) — put it in the **squash-merge title**, since a squash drops `BREAKING CHANGE:` footers written in commit bodies. Prefer type `ci:` / `docs:` for those-only PRs — not `feat(docs):` or `fix(docs):` (type `feat`/`fix` still releases unless the scope is `ci` or `benchmark`). Squash-merge PR titles must follow the same format.
 
 ### What actually skips CI jobs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,7 +406,7 @@ Releases are cut automatically when PRs merge to `main`. [semantic-release](http
 |---------------|---------|
 | `fix:` | Patch |
 | `feat:` | Minor |
-| `feat!:` or `BREAKING CHANGE:` footer | Major |
+| `feat!:` / `fix!:` (`!` on any type) or a `BREAKING CHANGE:` footer | Major |
 | `chore:`, `docs:`, `test:`, `refactor:`, `ci:` | No release |
 | `feat(benchmark):`, `*(ci):`, `docs(*):` | No release (type/scope rules in [release.config.cjs](release.config.cjs): types `ci` + `docs`, scopes `ci` + `benchmark`) |
 
@@ -421,5 +421,13 @@ BREAKING CHANGE: run records now require runId v2 fields
 ```
 
 Use scopes when helpful (`feat(cli):`, `fix(control):`). Squash-merge PR titles should follow the same format — they become the commit on `main`.
+
+> **Put `!` in the title, not only a footer.** The repo squash-merges, and a
+> squash keeps the PR title but discards the individual commit bodies — so a
+> `BREAKING CHANGE:` footer written in a commit body does not survive to `main`.
+> Seven `feat!:` commits reached `v1` with their footers stripped this way
+> (#311). The `!` in the squash-merge title always survives, and since the
+> analyzer uses the `conventionalcommits` preset it is sufficient on its own.
+
 
 Maintainer release mechanics (npm, Docker Hub, secrets, version coupling): [RELEASING.md](./RELEASING.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^8.62.0",
         "@typescript-eslint/parser": "^8.62.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "esbuild": "^0.23.0",
         "eslint": "^8.57.1",
         "jest": "^29.7.0",
@@ -4489,6 +4490,19 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
       "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.62.0",
     "@typescript-eslint/parser": "^8.62.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "esbuild": "^0.23.0",
     "eslint": "^8.57.1",
     "jest": "^29.7.0",

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -5,6 +5,12 @@ module.exports = {
     [
       '@semantic-release/commit-analyzer',
       {
+        // conventionalcommits, not the default angular preset (#311): angular
+        // does not understand the `!` breaking marker — `feat!: x` analyzed to
+        // `null` there, so it bumped nothing AND never reached the changelog.
+        // AGENTS.md / CONTRIBUTING.md document `feat!:` as a major; this is
+        // what makes that true.
+        preset: 'conventionalcommits',
         releaseRules: [
           { scope: 'benchmark', release: false },
           { scope: 'ci', release: false },
@@ -14,7 +20,12 @@ module.exports = {
         ],
       },
     ],
-    '@semantic-release/release-notes-generator',
+    [
+      '@semantic-release/release-notes-generator',
+      // Must match the analyzer's preset, or breaking commits are versioned
+      // correctly but still omitted from the notes (#311).
+      { preset: 'conventionalcommits' },
+    ],
     [
       '@semantic-release/changelog',
       {

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+
+/**
+ * #311 acceptance: the release contract documented in AGENTS.md and
+ * CONTRIBUTING.md must be what semantic-release actually does.
+ *
+ * The default angular preset silently ignored the Conventional Commits `!`
+ * marker: `feat!: x` analyzed to `null`, so seven breaking changes on the v1
+ * branch bumped nothing and never reached the changelog. Nothing failed — a
+ * release still happened, with the wrong number and incomplete notes. That is
+ * exactly the kind of regression a test has to hold down.
+ *
+ * The analyzer is ESM and pulls in the preset at runtime, so this drives it in
+ * a child process rather than fighting ts-jest/ESM interop.
+ */
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function releaseTypeFor(messages: string[]): (string | null)[] {
+  const script = `
+    const { createRequire } = await import('module');
+    const require = createRequire(${JSON.stringify(REPO_ROOT + '/')});
+    const analyzer = await import(${JSON.stringify(REPO_ROOT + '/node_modules/@semantic-release/commit-analyzer/index.js')});
+    const cfg = require(${JSON.stringify(REPO_ROOT + '/release.config.cjs')});
+    const aCfg = cfg.plugins.find((p) => Array.isArray(p) && p[0] === '@semantic-release/commit-analyzer')[1];
+    const out = [];
+    for (const m of ${JSON.stringify(messages)}) {
+      out.push(await analyzer.analyzeCommits(aCfg, {
+        commits: [{ hash: 'x', subject: m.split('\\n')[0], body: m.split('\\n').slice(2).join('\\n'), message: m }],
+        logger: { log() {} },
+        cwd: ${JSON.stringify(REPO_ROOT)},
+        options: {},
+      }));
+    }
+    process.stdout.write(JSON.stringify(out));
+  `;
+  const stdout = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 32,
+  });
+  return JSON.parse(stdout);
+}
+
+describe('release contract (#311)', () => {
+  // The whole point of the fix: `!` means breaking, with or without a footer.
+  it.each([
+    ['feat!: x', 'major'],
+    ['fix!: x', 'major'],
+    ['feat(scope)!: x', 'major'],
+    ['feat: x\n\nBREAKING CHANGE: y', 'major'],
+    ['feat: x', 'minor'],
+    ['fix: x', 'patch'],
+  ])('%s => %s', (message, expected) => {
+    expect(releaseTypeFor([message])[0]).toBe(expected);
+  });
+
+  // The no-release rules AGENTS.md promises must survive the preset change.
+  it.each([
+    'docs: x',
+    'ci: x',
+    'chore: x',
+    'refactor: x',
+    'test: x',
+    'feat(ci): x',
+    'feat(docs): x',
+    'feat(benchmark): x',
+    'fix(ci): x',
+  ])('%s does not release', (message) => {
+    expect(releaseTypeFor([message])[0]).toBeNull();
+  });
+
+  it('the analyzer and the notes generator agree on the preset', () => {
+    // Versioning correctly while rendering notes with a different preset is the
+    // half-fixed state that drops breaking changes from the changelog.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const cfg = require(path.join(REPO_ROOT, 'release.config.cjs'));
+    const pluginOpts = (name: string) => {
+      const entry = cfg.plugins.find((p: unknown) => Array.isArray(p) && p[0] === name);
+      return entry ? entry[1] : undefined;
+    };
+    const analyzer = pluginOpts('@semantic-release/commit-analyzer');
+    const notes = pluginOpts('@semantic-release/release-notes-generator');
+    expect(analyzer?.preset).toBe('conventionalcommits');
+    expect(notes?.preset).toBe('conventionalcommits');
+  });
+});


### PR DESCRIPTION
Closes #311. Targets `v1`, so the fix lands on `main` with the merge that cuts the release.

**Without this, merging `v1` publishes 0.65.0 with a changelog missing every breaking change.**

## The bug

`release.config.cjs` used `@semantic-release/commit-analyzer` with its default **angular** preset, which does not understand the Conventional Commits `!` marker — while `AGENTS.md` and `CONTRIBUTING.md` both document `feat!:` as a major.

Probing the repo's own config:

| Commit | Before | After |
|---|---|---|
| `feat!: x` | **`null`** | `major` |
| `fix!: x` | `null` | `major` |
| `feat(scope)!: x` | `null` | `major` |
| `feat: x` + `BREAKING CHANGE:` footer | `major` | `major` |
| `feat: x` | `minor` | `minor` |
| `fix: x` | `patch` | `patch` |

`feat!:` returned **`null`** — not "no major", but unrecognized. The `!` breaks the angular preset's type match, so the commit counted as neither a feature nor a breaking change and never reached the changelog.

## Why it bites right now

`v1` carries **7 `feat!:` commits and zero `BREAKING CHANGE:` footers**. The footers were stripped by squash-merging — verified on `ae1f961`, whose body is only a co-author trailer. Analyzed over the real 28 commits in `origin/main..origin/v1`:

| | Release type | Changelog |
|---|---|---|
| before | **`minor`** → 0.65.0 | 12 entries, **no** breaking changes listed |
| after | **`major`** → 1.0.0 | 26 entries + `### ⚠ BREAKING CHANGES` |

All seven now appear:

```
### ⚠ BREAKING CHANGES

* collapse the agent instruction surface onto AGENTS.md (#307)
* har plugin create — local plugins in .har/plugins/, retire add-stage --custom (#240)
* two-signal drift — user-edited vs upstream-updated (#237)
* profiles become capability manifests (#236)
* move the harness runtime into the package (#234)
* verification as data — one stage namespace with quick/full tiers (#231)
* harness.env becomes pure schema-validated config (#230)
```

## Two things worth calling out

**Both plugins move, not just the analyzer.** Setting the preset on `commit-analyzer` alone versions correctly but still renders notes with the old preset — the half-fixed state that keeps dropping breaking changes from the changelog.

**The preset is pinned to `^9`, not `^10`.** v10 requires `conventional-changelog-writer@9+`, and `@semantic-release/release-notes-generator@14` depends on `^8`. I installed v10 first and it threw `Missing helper: conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer` at render time — the analyzer was happy, only actually generating the notes exposed it.

## Formatting delta

Entry count 12 → 26 (the 7 breaking commits now appear under both Features and BREAKING CHANGES), a new BREAKING CHANGES section, and the version heading going `#` → `##`. Nothing else changed.

## Regression test

`tests/release-config.test.ts` (16 cases) locks the contract: `!` on any type is major, footers still work, `feat:`/`fix:` unchanged, every documented no-release rule (`docs:`, `ci:`, `chore:`, `refactor:`, `test:`, `feat(ci):`, `feat(docs):`, `feat(benchmark):`, `fix(ci):`) still returns null, and the two plugins agree on the preset.

This failure mode is silent — a release still happens, with the wrong number and incomplete notes — so it needs a test, not a convention.

## Docs

`AGENTS.md` / `CONTRIBUTING.md` tables are now true, and gain the operational half: **put `!` in the squash-merge title**, because a squash discards commit bodies and takes any `BREAKING CHANGE:` footer with them. That is precisely how `v1` lost all seven.

## Verification

Full verify green — 9/9 stages, **991** unit tests (commit gate: batch `145bd388` / run `4243a41b`).

## After this merges

Merge #293 normally. The `!` markers already on `v1` now do the work, so the merge commit no longer needs a hand-written `BREAKING CHANGE:` footer. Worth a `workflow_dispatch` run of Release with `dry_run: true` on `main` first to see `1.0.0` confirmed before the real cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
