### PR TITLE
feat: har line — install factory lines as bundles that never widen verify (#304, #322)

### DIFF
--- a/.claude/skills/factory-line/LINE.schema.md
+++ b/.claude/skills/factory-line/LINE.schema.md
@@ -1,24 +1,37 @@
-# Line template contract (Phase 1)
+# Line program contract
 
-A **line template** is data an agent (or a human) fills in to mint a factory
-line. It is not wired into the CLI yet — Phase 2 (#304) should be able to lift
-this file almost as-is into `.har/line.json`. Until then, the
-[`factory-line` skill](./SKILL.md) reads it as the program.
+A **line program** is the data that defines a factory line. It is the
+`line.json` inside an installable line bundle; installing that bundle
+(`har line add <spec>`) puts it at `.har/lines/<id>/line.json`, which is what
+the [`factory-line` skill](./SKILL.md) reads.
+
+The `*.line.json` files under [`examples/`](./examples/) are **authoring
+templates** — seeds for `har line create <id>` or for a fork of
+[`os-factory/har-line`](https://github.com/os-factory/har-line) — not installed
+programs.
 
 `contractVersion: 1`. Additive fields are fine; renaming a field is a new
 version.
 
 ## Design constraints (do not violate)
 
-- A line **composes** things HAR 1.0 already has: work units, slots, stages,
-  plugins, skills, MCP. It is not a fourth marketplace and not a second runner.
+- A line **composes** things HAR already has: work units, slots, stages,
+  plugins, skills, MCP. It is not a fourth marketplace and not a second runner:
+  it reuses the plugin install channels (path → git → bundled id → npm) and the
+  ordinary stage runner.
+- A line is a **plugin-style bundle with a different apply path**. Installing
+  one registers stages but **never** adds them to `verificationStages`. That is
+  the whole reason the kinds are separate — a check that must gate every verify
+  belongs in a verification plugin
+  ([os-factory/har-plugin](https://github.com/os-factory/har-plugin)), not a
+  line.
 - A **station** is a named step. GitHub/Linear/none is a `work.source` on the
   station, not the type of the station.
 - The **ratchet** is "every gate stage tagged ≤ current station still runs."
-  The bash `case` in `.har/stages/fixture-e2e.sh` is a **prototype**, not this
+  `har line gate <station>` implements exactly that from this data. The bash
+  `case` in `.har/stages/fixture-e2e.sh` was the **prototype**, not this
   contract: later milestone arms there add questions but do not always re-enter
-  earlier arms. Productize the *intent* (grow-only, never drop a station's
-  stages), not the `case`.
+  earlier arms.
 - HAR does not install or copy third-party skill packs. `skills[]` are
   declarations + install hints. MCP entries are server names + why, never new
   core tools named after a tracker or a framework.
@@ -117,7 +130,7 @@ instances.
 | `gate.cumulative` | yes | Must be `true` for a factory line. A QA station is never removed. |
 | `gate.stages[].fromStation` | yes | This stage becomes required at this station **and every later station**. |
 | `gate.optInEnv` | no | If set (e.g. `HAR_FIXTURE_E2E`), the gate is skipped unless that env is `1`, so routine verifies stay fast. |
-| `extraStages` | no | Testing/verify/custom stages this line adds beyond the profile defaults. Phase 1: documentation only. Phase 2: registered stages. |
+| `extraStages` | no | Testing/verify/custom stages this line adds beyond the profile defaults. The bundle's `line.manifest.json` `stages[]` registers them at install — registered and runnable, never in `verificationStages`. |
 | `handoff.autonomousShip` | yes | Must be `false`. Agents hand off; they do not merge or release. |
 | `traveler` | no | Durable record that survives the repo's actual merge policy (squash drops `BREAKING CHANGE:` footers). |
 | `prototypeNotes` | no | Instance tactics that must not leak into the primitive. |
@@ -135,13 +148,19 @@ docs drift):
 That is how #291 / #297 / #298 / #299 become permanent questions instead of
 one-off review comments.
 
-## Open decisions (Phase 2 — do not freeze here)
+## Closed decisions
 
-See epic #302. This contract is written so either answer still maps:
+Settled in epic #302 / #304. Do not reopen without updating them:
 
-1. Per-repo `.har/line.json` vs tracker-as-source-of-truth — this file can live
-   in-repo either way; tracker URLs stay on `work`.
-2. Tagged stages vs a new `kind` — `gate.stages[].fromStation` *is* the tag.
-3. Line vs plugin — this document **references** plugins; it is not one.
-4. How MCP/skills are checked — Phase 1: agent preflight. Phase 2: `doctor` /
-   `har line` preflight.
+1. **Per-repo installed bundle.** The program lives at
+   `.har/lines/<id>/line.json`, with the install recorded in
+   `.har/lines.json`. Tracker URLs stay on `stations[].work`.
+2. **Tagged stages, not a new kind.** `gate.stages[].fromStation` *is* the tag.
+   Tiers stay independent.
+3. **Plugin-style bundle, separate apply.** A line installs through the plugin
+   resolver but with its own apply path, which cannot patch
+   `verificationStages`. `har env add-plugin` refuses a line bundle and
+   `har line add` refuses a plugin manifest.
+4. **Preflight.** `har line status` reports gate progress and any stage that
+   leaked onto the verify plan; `har env doctor` fails on such a leak. Skill and
+   MCP presence stay an agent preflight — HAR declares, it does not vendor.

--- a/.claude/skills/factory-line/SKILL.md
+++ b/.claude/skills/factory-line/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: factory-line
-description: Factory line for executing one station of a declared multi-station program — load a line template, plan parallel work into isolated HAR slots, run the cumulative gate, and hand off for human review. Use when asked to "run a factory line", "run the next station", "execute a milestone program", or when a repo has a line template (*.line.json) and you need to advance it. Not limited to the HAR v1.0.0 migration.
+description: Factory line for executing one station of a declared multi-station program — read the installed line bundle (har line status), plan parallel work into isolated HAR slots, run the cumulative gate with har line gate, and hand off for human review. Use when asked to "run a factory line", "run the next station", "execute a milestone program", or when a repo has an installed line and you need to advance it. Not limited to the HAR v1.0.0 migration.
 ---
 
 # Factory line
@@ -9,9 +9,15 @@ Execute **one station** of a declared program end-to-end:
 
 sync → wave plan → parallel slots → cumulative gate → human handoff.
 
-The program lives in a **line template** (`*.line.json`), not in this skill.
-This skill is the orchestrator. Station-specific how-to lives in other skills
-the template lists.
+The program lives in an **installed line bundle**, not in this skill. Find it
+with `har line status`: installed lines live at `.har/lines/<id>/line.json` and
+are recorded in `.har/lines.json`. This skill is the orchestrator;
+station-specific how-to lives in other skills the program lists.
+
+`*.line.json` files under `examples/` are **authoring templates**, not the
+installed program. Read one to learn the shape or to seed a new bundle
+(`har line create <id>`); do not run a station off a loose file when a line is
+installed.
 
 **HAR already has the primitives.** Work units, isolated slots, stages with
 quick/full tiers, validation records, the commit gate, plugins, Mission Control.
@@ -25,9 +31,12 @@ Instances: [examples/](./examples/).
 
 Resolve these before doing anything (ask only if not inferable):
 
-1. **Line file** — path to a `*.line.json`. Examples in this folder:
-   `examples/v1-milestone.line.json`, `examples/new-plugin.line.json`,
-   `examples/docs-milestone.line.json`.
+1. **Line** — run `har line status` (or MCP `har_line_status`). One installed
+   line: use it. Several: ask which. **None installed**: stop and offer
+   `har line create <id>` (scaffold) or `har line add <spec>` (install a
+   published bundle, e.g. `github:os-factory/har-line`). Authoring templates
+   live in `examples/`: `v1-milestone.line.json`, `new-plugin.line.json`,
+   `docs-milestone.line.json` — seeds, not installed programs.
 2. **Station id** — default: the first station whose bound work is not all
    closed / whose gate has not passed. Must be an id in `stations[]`.
 3. **Slot budget** — how many concurrent HAR slots you may occupy (check
@@ -52,8 +61,10 @@ template does not declare them, do not do them:
 
 ## Phase 0 — Load and preflight
 
-1. Read the line file. Confirm `contractVersion`, `gate.cumulative === true`,
-   `handoff.autonomousShip === false`.
+1. `har line status [id]` and read the program it names
+   (`.har/lines/<id>/line.json`). Confirm `contractVersion`,
+   `gate.cumulative === true`, `handoff.autonomousShip === false`. The status
+   output already reports which stations are green and which is next.
 2. **Skills.** For each root `skills[]` entry, confirm the skill is present
    (repo path or the agent's skill list). HAR does not install third-party
    packs — if `install` is an upstream URL, tell the user how to install it.
@@ -99,9 +110,18 @@ starts the next wave.
 
 From a slot launched off the integrated result of this station:
 
-Run every gate stage whose `fromStation` ≤ current station, at the listed
-`tier`. If `gate.optInEnv` is set, export it as `1` for this run so the
-opt-in gate actually executes.
+```bash
+har line gate <station> --line <id> --agent <slot>
+```
+
+That runs every gate stage whose `fromStation` ≤ current station — the
+cumulative set, from data, through the normal stage runner. Pass `--force`
+when the program sets `gate.optInEnv` and you want the opt-in jig to run
+anyway.
+
+Line gate stages are deliberately **not** part of `har env verify --full`.
+Run both: full verify for the harness contract, `har line gate` for the
+station.
 
 Red gate → fix in-station, re-run. Never hand off a red gate. Never bypass
 (`HAR_SKIP_GATE`, `--no-verify`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ These are non-negotiable. Do not introduce imports that violate them.
 | MCP tool handler or JSON Schema | `src/mcp/server.ts`, `schemas.ts` |
 | Files copied into target `.har/` | `src/templates/har-boilerplate/` |
 | Optional verification plugins | `src/templates/plugins/` (applied via `har env add-plugin`) |
+| Factory line schemas (program + bundle manifest) | `packages/schemas/src/line.ts` |
+| Line apply / scaffold / ledger | `src/harness/lines.ts`, `line-create.ts`, `line-ledger.ts` |
+| Line status + cumulative gate orchestration | `src/core/lines.ts` |
+| Bundle install channels shared by plugins and lines | `src/harness/bundle-resolve.ts` |
+| Bundled example line (seed for `os-factory/har-line`) | `src/templates/lines/example-line/` |
 | Generic shell/path/logging helper | `src/utils/` |
 
 When unsure: put domain logic in `harness/` or `core/`, never in an adapter.
@@ -169,6 +174,7 @@ naming plugins ≠ shipping a marketplace.
 
 - **`StageExecutor`** (`src/core/types.ts`) — swap local vs cloud execution by injecting a different executor into `RunService`. `local-executor.ts` is the current implementation.
 - **Project-owned stages** — runtime behavior lives in the target repo's `.har/` scripts and `stages.json`, not as hardcoded tool APIs in core.
+- **Factory lines** — installable *programs* (`har line add <id|path|npm|git>`), resolved through the same channels as plugins (`bundle-resolve.ts`) but with an apply path that registers stages and **never** touches `verificationStages`. `har line gate <station>` runs the cumulative set through `RunService`; there is no second stage runner. Poka-yoke both ways: `add-plugin` refuses `kind: line`, `line add` refuses a plugin manifest, and `doctor` fails if a line stage reaches the verify plan.
 - **Plugins** — optional bundles applied with `har env add-plugin <id|path|npm|git>` (e.g. `playwright` → `browser-e2e` stage + test scaffold). Discovered from `src/templates/plugins/*/template.manifest.json` (no closed enum). Installs are recorded in `.har/plugins.json`. They compile down to generic stage kinds (`setup`, `launch`, `verify`, `test`, `custom`, etc.). Do not add stack-specific MCP tools like `run_playwright`. Philosophy: *plugins install stages; agents only talk to the stage registry.*
 - **Profiles** — ordered runtime bundles (`src/templates/profiles/<id>/profile.manifest.json`), not forked logic in core. Stack capabilities (PM2, Simulator, ports) are detected via `src/harness/capabilities.ts` marker files.
 
@@ -193,6 +199,7 @@ First-run scaffold: humans use `har onboard`; agents use `har_init_harness`.
 | doctor | `har env doctor` (also auto-runs in `maintain` and before `launch`) | `har_doctor` |
 | complete / teardown | `har env complete`, `teardown` | `har_complete_environment`, `har_teardown_environment` |
 | runs / work links | `har env runs list\|get`, `work-link` | `har_list_runs`, `har_get_run`, `har_add_work_unit_link` |
+| factory lines | `har line create\|add\|status\|gate\|list` | `har_line_create`, `har_add_line`, `har_line_status`, `har_run_line_gate` |
 | Mission Control | `har control up` | `har_control_up` |
 
 Intentional holes (human-only, no MCP tool):
@@ -212,6 +219,8 @@ Intentional holes (human-only, no MCP tool):
 
 - Orchestration logic in `mcp/server.ts` or `cli/commands/` — adapters delegate to `core/`
 - Stack-specific stages or MCP tools in core (Playwright, Cypress, migrations, etc.)
+- Implementing line apply by calling `applyPlugin` / `patchStageRegistry` — those exist to widen `verificationStages`; a line must never
+- Adding a line's gate stages to `verificationStages` (that is a verification plugin, not a line)
 - `harness/` importing from `core/` — keeps the contract layer independent
 - Domain types or HAR concepts in `utils/`
 - Deep barrel re-exports inside `src/` — prefer explicit imports; public surface is `run-service.ts` / `run.ts`

--- a/docs/src/content/docs/docs/guides/factory-lines.md
+++ b/docs/src/content/docs/docs/guides/factory-lines.md
@@ -7,11 +7,37 @@ A **factory line** is a declared program: an ordered set of stations, each
 runnable by one or more agents in isolated HAR slots, with a **cumulative**
 gate and a handoff a human owns.
 
-HAR 1.0 already has the primitives — work units, slots, stages, plugins,
+HAR already has the primitives — work units, slots, stages, plugins,
 validation records, the commit gate. A line is **composition plus a
-manifest**, not a new runner. This guide is Phase 1 of
-[epic #302](https://github.com/os-factory/har/issues/302): the skill and the
-template contract, with no CLI yet. `.har/line.json` and `har line` are Phase 2.
+manifest**, not a new runner.
+
+A line ships as an **installable bundle**, the same way a verification plugin
+does: `line.manifest.json` at the package root, installed from a path, git
+repo, npm package, or a bundled id. The difference is the apply path.
+
+> **Installing a line never widens verify.** `har line add` registers the
+> line's stages in `.har/stages.json` but does **not** add them to
+> `verificationStages`. Default `har env verify --full` takes exactly as long
+> as it did before. If a check should gate *every* verify, ship it as a
+> [verification plugin](/docs/guides/plugins/) instead.
+
+## Install one
+
+```bash
+har line add github:os-factory/har-line   # git
+har line add ./my-line                    # local path
+har line add @acme/onboarding-line        # npm
+har line status                           # stations and gate progress
+har line gate S2 --line my-line           # run the cumulative gate
+```
+
+`har line create <id>` scaffolds a publishable bundle at `.har/lines/<id>/`
+(manifest, program, an off-verify gate stage, README). Installs are recorded
+in `.har/lines.json`.
+
+[`os-factory/har-line`](https://github.com/os-factory/har-line) is the GitHub
+template for authoring one — the line equivalent of
+[`os-factory/har-plugin`](https://github.com/os-factory/har-plugin).
 
 Two skills in this repository already described themselves as a factory line
 before the name was a product:
@@ -34,14 +60,17 @@ Identical isolated slots are the workstation. One slot per concurrent agent;
 
 ## Author a line
 
-1. Copy the contract in `.claude/skills/factory-line/LINE.schema.md` and a
-   close instance from `.claude/skills/factory-line/examples/`.
-2. Fill `id`, `stations[]`, `skills[]`, `mcp[]`, `gate`, `handoff`, `traveler`.
+1. `har line create <id>`, or "Use this template" on
+   [`os-factory/har-line`](https://github.com/os-factory/har-line).
+2. Fill `id`, `stations[]`, `skills[]`, `mcp[]`, `gate`, `handoff`, `traveler`
+   in `line.json`. The contract is in
+   `.claude/skills/factory-line/LINE.schema.md`; close instances are under
+   `.claude/skills/factory-line/examples/`.
 3. Keep `gate.cumulative` true and `handoff.autonomousShip` false.
 4. Put instance tactics (stacked PRs, a specific fixture, tracker-only
    stations) in `prototypeNotes` — not in the orchestrator skill.
-
-Then run the `factory-line` skill with the path to your file and a station id.
+5. `har line add <id>` to install it, then run the `factory-line` skill with a
+   station id.
 
 ### Attach a skill
 
@@ -65,9 +94,9 @@ is `required: false`, skip tracker steps when it is missing.
 **ratchet**: a QA station is never removed.
 
 `extraStages[]` is for checks the profile does not already have (a
-fixture-e2e analogue, a docs-drift rule, a `doctor` question). Phase 1
-documents them; Phase 2 registers them. Prefer tagging a stage that already
-exists.
+fixture-e2e analogue, a docs-drift rule, a `doctor` question). The bundle's
+`stages[]` register them at install time — registered and runnable, and still
+absent from `verificationStages`. Prefer tagging a stage that already exists.
 
 Routine verifies should stay fast. If the jig is expensive, set
 `gate.optInEnv` (this repo uses `HAR_FIXTURE_E2E=1`).
@@ -83,10 +112,11 @@ package (#298). When that happens:
 2. Tag `fromStation` on the station that made it askable.
 3. Leave every earlier tag in place.
 
-The bash `case` in `.har/stages/fixture-e2e.sh` is the **prototype** of this
-pattern, not the product. Later milestone arms there add questions; they do
-not always re-enter earlier arms. Phase 2 should make "run every stage tagged
-≤ current station" data on the stage registry.
+The bash `case` in `.har/stages/fixture-e2e.sh` was the **prototype** of this
+pattern, not the product: later milestone arms there add questions but do not
+always re-enter earlier arms. `har line gate <station>` is the productized
+version — it runs every stage tagged at that station or earlier, from data, so
+the set can only grow.
 
 ## Instances
 
@@ -103,16 +133,28 @@ the v1 migration, the contract is still biased — delete it.
 
 | Not this | Because |
 |---|---|
-| A new plugin kind | Plugins already install stages. A line *references* plugins. |
+| A verification plugin | Plugin stages join `verificationStages` and gate every verify. Line stages never do. A line also *references* plugins by id. |
+| A fourth marketplace | Lines reuse the plugin install channels (path, git, npm) and the plugin resolver. |
+| A second stage runner | `har line gate` runs stages through the same runner and writes the same `.har/runs/` records. |
 | A new MCP surface | No `har_run_playwright`. No tracker-named core tools. |
 | Identical units out the door | The line repeats the *process*. Every program is bespoke. |
 | Rework as a defect | Iteration is the expected mode. |
 
 Agents hand off. They do not ship. That is the andon cord.
 
+## Poka-yoke
+
+The two bundle kinds are deliberately not interchangeable:
+
+- `har env add-plugin` on a line bundle fails and points at `har line add`.
+- `har line add` on a plugin manifest fails and points at `har env add-plugin`.
+- A line manifest that declares `verificationStages` is a schema error.
+- `har line add` re-reads the verify plan after applying and refuses to write
+  if it moved.
+- `har env doctor` fails when a line stage appears in `verificationStages` —
+  so a hand edit is caught before the next launch.
+
 ## Next
 
-Phase 2 will lift the template into `.har/line.json` and `har line status`,
-with the ratchet as tagged stages. Until then this guide and the skill are
-the whole feature — cheap on purpose, so the shape gets used before anyone
-invents CLI surface.
+Mission Control gets a line board over `.har/lines.json` and `har line status`
+([#305](https://github.com/os-factory/har/issues/305)).

--- a/docs/src/content/docs/docs/guides/plugins.md
+++ b/docs/src/content/docs/docs/guides/plugins.md
@@ -9,7 +9,8 @@ description: Install framework-specific verification bundles that register stage
 |---|---|---|
 | **Profile** | Ordered runtime bundles composing a stack scaffold (`default`, `cli`, `ios`) | `har onboard --profile …` |
 | **Stage** | Runtime operation in `.har/stages.json` | `har_run_stage`, `har env verify` |
-| **Plugin** | Installable bundle that *registers* one or more stages | `har env add-plugin …` |
+| **Plugin** | Installable bundle that *registers* one or more stages **and adds them to `verificationStages`** | `har env add-plugin …` |
+| **Factory line** | Installable *program* — stations plus a cumulative gate. Registers stages but **never** joins `verificationStages` | `har line add …` |
 
 Profiles are defined in `templates/profiles/<id>/profile.manifest.json` as an ordered
 list of runtime bundles (shared kernel, PM2, Xcode, profile overlay). Core detects
@@ -22,6 +23,14 @@ registry — never with stack-specific MCP tools like `run_playwright`.
 Profiles and plugins share one ledger file (`.har/plugins.json`): init records
 `profile` + `bundles`; each `add-plugin` appends to `plugins[]`. They are still
 different layers — profiles scaffold the environment; plugins add verification stages.
+Factory lines keep their own ledger (`.har/lines.json`) for the same reason they
+have their own command: installing one must not widen verification.
+
+**Which one do I want?** Ask whether the check should run on every
+`har env verify --full`. Yes → a plugin (this guide). No, it gates a *station*
+of a program → a [factory line](/docs/guides/factory-lines/), installed with
+`har line add`. Programs install with `har line add`, not `add-plugin` —
+`add-plugin` refuses a line bundle and points you at the right command.
 
 ## Discovery and install
 

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -123,6 +123,10 @@ in 1.0 — one-liner checks are plain command stages in `.har/stages.json`. See
 `.har/STAGES.md` in every generated harness and the [Plugins](/docs/guides/plugins/)
 guide.
 
+A **factory line** is the other bundle kind: it registers stages but never adds
+them to `verificationStages`. `add-plugin` refuses a line bundle and points at
+`har line add` — see [`har line`](#har-line).
+
 ### Launch and recovery
 
 ```bash
@@ -240,6 +244,48 @@ run records. `run-stage` executes any stage registered in `.har/stages.json`
 classifies active slots and orphan directories under `~/worktrees`, and runs
 full harness teardown for approved rows. Use `--dry-run` to preview the plan;
 pin live sessions with `--keep har-portal:4` or a worktree path.
+
+## `har line`
+
+```bash
+har line create <id> [--stations S1,S2,S3] [--title <text>]
+                     [--description <text>] [--opt-in-env <VAR>]
+                     [--no-gate-stage] [--force]
+har line add <id|./path|@org/pkg|github:org/repo> [--force]
+har line status [id] [--json]
+har line gate <station> [--line <id>] [--agent <slot>] [--force] [--json]
+har line list
+```
+
+A **factory line** is a program: an ordered set of stations plus a cumulative
+gate. It composes what HAR already has — work units, slots, stages, plugins,
+skills, MCP — and is installed through the same channels as a plugin (path →
+git → bundled id → npm).
+
+The difference is the apply path. Installing a line registers its stages in
+`.har/stages.json` and records the install in `.har/lines.json`, but **never**
+touches `verificationStages`. Default `har env verify --full` takes exactly as
+long as it did before. Line gate stages run on demand:
+
+```bash
+har line gate S2 --line my-line
+```
+
+`gate.stages[].fromStation` is the ratchet: a stage tagged at a station is
+required at that station **and every later one**, so growing a line can never
+drop an earlier station's checks.
+
+`har line create` scaffolds a publishable bundle at `.har/lines/<id>/`
+(`line.manifest.json`, `line.json`, an off-verify gate stage, README);
+`har line add <id>` installs it. Publishing to git or npm later needs no format
+change.
+
+Poka-yoke runs both ways: `har env add-plugin` refuses a line bundle, and
+`har line add` refuses a verification-plugin manifest. If a check should gate
+*every* verify, it is a plugin, not a line. `har env doctor` fails if a line
+stage ever appears in `verificationStages`.
+
+See the [Factory lines](/docs/guides/factory-lines/) guide.
 
 ## `har agents`
 

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -60,6 +60,24 @@ Stage kinds are `setup`, `launch`, `verify`, `test`, `inspect`, `reset`,
 | `har_list_runs` | optional `stageId`, `limit` | Persisted run records |
 | `har_get_run` | `runId` | One normalized run record |
 
+## Factory lines
+
+A **factory line** is a multi-station program with a cumulative gate. Line
+stages are registered in `.har/stages.json` but are **never** added to
+`verificationStages` — `har_run_verification` is unaffected by installing one.
+Verification plugins (which *do* join verify) use `har_add_plugin` instead.
+
+| Tool | Inputs | Result |
+| --- | --- | --- |
+| `har_line_create` | `id`, optional `title`, `description`, `stations`, `gateStage`, `optInEnv`, `force` | Scaffolds `.har/lines/<id>/` (manifest, program, gate stage, README) and returns files written and next steps |
+| `har_add_line` | `line` (local id, path, npm package, or git URL), optional `force` | Installed line id, stations, registered stage ids, files written, program path, adaptation prompt path, and `verificationStagesUnchanged: true` |
+| `har_line_status` | optional `line` | Stations with cumulative gate progress from run records, slots in flight, and any stage that leaked onto the verify plan. A pure read — writes no run records |
+| `har_run_line_gate` | `station`, optional `line`, `agentId`, `force` | Per-stage results for every gate stage tagged at that station or earlier |
+
+`har_add_line` refuses a verification-plugin bundle, and `har_add_plugin`
+refuses a line bundle — the two apply paths are deliberately not
+interchangeable.
+
 ## Mission Control
 
 | Tool | Inputs | Result |

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -2,3 +2,4 @@ export * from './schema';
 export * from './harness-env';
 export * from './usage-authority';
 export * from './usage-pricing';
+export * from './line';

--- a/packages/schemas/src/line.ts
+++ b/packages/schemas/src/line.ts
@@ -1,0 +1,196 @@
+import { z } from 'zod';
+import { HarnessStageKindSchema, HarnessStageSchema } from './schema';
+
+/**
+ * Factory line schemas (#302 Phase 2 / #304).
+ *
+ * A *line* is a program: an ordered set of stations plus a cumulative gate.
+ * It is installed like a plugin (path → git → bundled → npm) but its apply
+ * path may NEVER touch `verificationStages` — line gate stages are opt-in and
+ * are run by `har line gate`, never by `har env verify --full`.
+ */
+
+/** Program contract version — see .claude/skills/factory-line/LINE.schema.md. */
+export const LINE_CONTRACT_VERSION = 1;
+
+/** Discriminator that separates a line bundle from a verification plugin. */
+export const LINE_BUNDLE_KIND = 'line';
+
+/** Manifest file names a line bundle may use, in resolution order. */
+export const LINE_MANIFEST_FILES = ['line.manifest.json', 'template.manifest.json'] as const;
+
+export const LineIdSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/, 'Line id must be a lowercase slug (letters, digits, ._-)');
+
+export const StationIdSchema = z
+  .string()
+  .min(1)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, 'Station id must be stable and shell-friendly');
+
+export const LineSkillSchema = z.object({
+  id: z.string().min(1),
+  role: z.enum(['orchestrator', 'station']).default('station'),
+  /** Install hint only — HAR never vendors third-party skill packs. */
+  install: z.string().min(1).optional(),
+});
+
+export const LineMcpSchema = z.object({
+  name: z.string().min(1),
+  why: z.string().min(1).optional(),
+  required: z.boolean().default(false),
+});
+
+export const LineWorkSchema = z.object({
+  /** `github`, `linear`, `none`, or a free string. */
+  source: z.string().min(1).default('none'),
+  ids: z.array(z.string().min(1)).default([]),
+  url: z.string().min(1).optional(),
+  optional: z.boolean().default(false),
+});
+
+export const LineWaveCellSchema = z.object({
+  workId: z.string().min(1).optional(),
+  title: z.string().min(1).optional(),
+});
+
+export const LineStationSchema = z.object({
+  id: StationIdSchema,
+  title: z.string().min(1),
+  description: z.string().min(1).optional(),
+  work: LineWorkSchema.optional(),
+  /** Each inner array is one wave; cells inside a wave run in parallel slots. */
+  waves: z.array(z.array(LineWaveCellSchema)).optional(),
+  skills: z.array(z.string().min(1)).optional(),
+  mcp: z.array(z.string().min(1)).optional(),
+});
+
+export const LineGateStageSchema = z.object({
+  id: z.string().min(1),
+  /** Required from this station onward — this is the ratchet tag. */
+  fromStation: StationIdSchema,
+  tier: z.enum(['quick', 'full']).default('full'),
+});
+
+export const LineGateSchema = z.object({
+  /** Must be true: a factory line never drops an earlier station's stages. */
+  cumulative: z.literal(true),
+  /** When set, the gate is skipped unless this env var is "1". */
+  optInEnv: z.string().min(1).nullable().default(null),
+  stages: z.array(LineGateStageSchema).default([]),
+});
+
+export const LineExtraStageSchema = z.object({
+  id: z.string().min(1),
+  kind: HarnessStageKindSchema.default('test'),
+  tier: z.enum(['quick', 'full']).default('full'),
+  description: z.string().min(1).optional(),
+});
+
+export const LineHandoffSchema = z.object({
+  /** Must be false: agents hand off, they do not merge or release. */
+  autonomousShip: z.literal(false),
+  waitFor: z.string().min(1).optional(),
+});
+
+export const LineTravelerSchema = z.object({
+  kind: z.string().min(1),
+  ref: z.string().min(1).optional(),
+  note: z.string().min(1).optional(),
+});
+
+/** The program itself — `.har/lines/<id>/line.json`. */
+export const LineProgramSchema = z
+  .object({
+    contractVersion: z.literal(LINE_CONTRACT_VERSION),
+    id: LineIdSchema,
+    title: z.string().min(1),
+    description: z.string().min(1).optional(),
+    skills: z.array(LineSkillSchema).default([]),
+    mcp: z.array(LineMcpSchema).default([]),
+    plugins: z.array(z.string().min(1)).default([]),
+    stations: z.array(LineStationSchema).min(1),
+    gate: LineGateSchema,
+    extraStages: z.array(LineExtraStageSchema).default([]),
+    handoff: LineHandoffSchema,
+    traveler: LineTravelerSchema.optional(),
+    prototypeNotes: z.array(z.string().min(1)).default([]),
+  })
+  .superRefine((data, ctx) => {
+    const stationIds = new Set(data.stations.map((s) => s.id));
+    if (stationIds.size !== data.stations.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'station ids must be unique' });
+    }
+    for (const stage of data.gate.stages) {
+      if (!stationIds.has(stage.fromStation)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `gate.stages[].fromStation "${stage.fromStation}" is not a station id`,
+        });
+      }
+    }
+  });
+
+export type LineProgram = z.infer<typeof LineProgramSchema>;
+export type LineStation = z.infer<typeof LineStationSchema>;
+export type LineGateStage = z.infer<typeof LineGateStageSchema>;
+
+const LineManifestFileSchema = z.object({
+  src: z.string().min(1),
+  dest: z.string().min(1),
+  executable: z.boolean().optional(),
+});
+
+/**
+ * Manifest for an installable line bundle — `line.manifest.json`.
+ *
+ * `verificationStages` is rejected outright rather than allowed-if-empty: the
+ * whole point of a separate bundle kind is that apply cannot widen verify.
+ */
+export const LineManifestSchema = z
+  .object({
+    kind: z.literal(LINE_BUNDLE_KIND),
+    id: LineIdSchema,
+    title: z.string().min(1).optional(),
+    /** Bundle-relative path to the program JSON. */
+    program: z.string().min(1).default('line.json'),
+    files: z.array(LineManifestFileSchema).default([]),
+    /** Stages to REGISTER in .har/stages.json — never added to verificationStages. */
+    stages: z.array(HarnessStageSchema).default([]),
+    nextSteps: z.array(z.string().min(1)).default([]),
+    docsPath: z.string().min(1).optional(),
+  })
+  .passthrough()
+  .superRefine((data, ctx) => {
+    const raw = data as Record<string, unknown>;
+    if (raw.verificationStages !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Line manifests must not declare verificationStages — line gate stages are opt-in and run via `har line gate`.',
+      });
+    }
+  });
+
+export type LineManifest = z.infer<typeof LineManifestSchema>;
+
+export const LineLedgerEntrySchema = z.object({
+  id: LineIdSchema,
+  source: z.enum(['bundled', 'local', 'path', 'npm', 'git']),
+  spec: z.string().min(1),
+  version: z.string().optional(),
+  /** Stages this line registered (registered only — not on verify). */
+  stageIds: z.array(z.string().min(1)).default([]),
+  programPath: z.string().min(1),
+  installedAt: z.string(),
+});
+
+export type LineLedgerEntry = z.infer<typeof LineLedgerEntrySchema>;
+
+export const LineLedgerSchema = z.object({
+  version: z.literal('1'),
+  lines: z.array(LineLedgerEntrySchema).default([]),
+});
+
+export type LineLedger = z.infer<typeof LineLedgerSchema>;

--- a/src/cli/commands/line.ts
+++ b/src/cli/commands/line.ts
@@ -1,0 +1,360 @@
+import * as path from 'path';
+import type { Argv } from 'yargs';
+import { finishCommand } from '../finish-command';
+import {
+  addLine,
+  createLineBundle,
+  getAllLineStatuses,
+  getLineStatus,
+  listInstalledLineIds,
+  runLineGate,
+  type LineStatus,
+} from '../../core/lines';
+import { listBundledLineIds, listLocalLineIds } from '../../harness/line-resolve';
+import { divider, error, header, info, success, warn } from '../../utils/logging';
+
+function handleLineCreate(argv: {
+  id?: string;
+  repo: string;
+  title?: string;
+  description?: string;
+  stations?: string[];
+  gateStage: boolean;
+  optInEnv?: string;
+  force: boolean;
+}): Promise<void> | void {
+  if (!argv.id) {
+    error('Missing line id. Usage: har line create <id> [--stations S1,S2] [--title "..."]');
+    return finishCommand(1);
+  }
+
+  const repoPath = path.resolve(argv.repo);
+  header('har line create');
+  info(`Repository: ${repoPath}`);
+  info(`Line: ${argv.id}`);
+
+  try {
+    const result = createLineBundle(repoPath, {
+      id: argv.id,
+      title: argv.title,
+      description: argv.description,
+      stations: argv.stations,
+      gateStage: argv.gateStage,
+      optInEnv: argv.optInEnv,
+      force: argv.force,
+    });
+
+    divider();
+    success(`Factory line scaffolded: .har/lines/${result.lineId}/`);
+    for (const file of result.filesWritten) {
+      info(`  + ${file}`);
+    }
+    console.error('');
+    console.error('  Next steps:');
+    for (const step of result.nextSteps) {
+      console.error(`    ${step}`);
+    }
+    console.error('');
+    console.error(`  Docs: .har/lines/${result.lineId}/README.md`);
+    console.error('');
+  } catch (err: unknown) {
+    error((err as Error).message);
+    return finishCommand(1);
+  }
+}
+
+function handleLineAdd(argv: {
+  spec?: string;
+  repo: string;
+  force: boolean;
+}): Promise<void> | void {
+  if (!argv.spec) {
+    error('Missing line spec. Usage: har line add <id|path|npm|git>');
+    return finishCommand(1);
+  }
+
+  const repoPath = path.resolve(argv.repo);
+  header('har line add');
+  info(`Repository: ${repoPath}`);
+  info(`Line: ${argv.spec}`);
+
+  try {
+    const result = addLine(repoPath, argv.spec, { force: argv.force, spec: argv.spec });
+    divider();
+    console.error('');
+    console.error('  verificationStages unchanged — line gate stages are opt-in.');
+    console.error(`  Run the gate with: har line gate ${result.stationIds[0]} --line ${result.lineId}`);
+    console.error('');
+    console.error('  Next steps:');
+    for (const step of result.nextSteps) {
+      console.error(`    ${step}`);
+    }
+    console.error('');
+  } catch (err: unknown) {
+    error((err as Error).message);
+    return finishCommand(1);
+  }
+}
+
+function renderStatus(status: LineStatus): void {
+  header(`Line: ${status.lineId} — ${status.title}`);
+  info(`Program: ${status.programPath}${status.source ? ` (source: ${status.source})` : ''}`);
+  info(
+    status.optInEnv
+      ? `Gate: opt-in via ${status.optInEnv}=1`
+      : 'Gate: on demand (har line gate <station>)',
+  );
+  info(
+    status.registeredStageIds.length > 0
+      ? `Registered stages (off verify): ${status.registeredStageIds.join(', ')}`
+      : 'Registered stages (off verify): none',
+  );
+  console.error('');
+
+  for (const station of status.stations) {
+    const marker = station.green ? '✓' : station.id === status.nextStationId ? '▶' : '·';
+    const required =
+      station.requiredStageIds.length > 0
+        ? `${station.passedStageIds.length}/${station.requiredStageIds.length} gate stages green`
+        : 'no gate stages';
+    console.error(`  ${marker} ${station.id}  ${station.title}  — ${required}`);
+    if (station.missingStageIds.length > 0) {
+      console.error(`      missing (not registered): ${station.missingStageIds.join(', ')}`);
+    }
+    const pending = station.requiredStageIds.filter((id) => !station.passedStageIds.includes(id));
+    if (pending.length > 0 && station.missingStageIds.length === 0) {
+      console.error(`      pending: ${pending.join(', ')}`);
+    }
+  }
+  console.error('');
+
+  if (status.slotsInFlight.length > 0) {
+    console.error('  Slots in flight:');
+    for (const slot of status.slotsInFlight) {
+      const work = slot.workUnitId ? ` work=${slot.workUnitId}` : '';
+      console.error(`    agent ${slot.agentId}: ${slot.branch ?? slot.workDir}${work}`);
+    }
+    console.error('');
+  }
+
+  for (const warning of status.warnings) {
+    warn(`  ⚠ ${warning}`);
+  }
+
+  console.error(
+    status.nextStationId
+      ? `  Next station: ${status.nextStationId}`
+      : '  All stations green — hand off for human review (autonomousShip: false).',
+  );
+  console.error('');
+}
+
+function handleLineStatus(argv: { id?: string; repo: string; json: boolean }): Promise<void> | void {
+  const repoPath = path.resolve(argv.repo);
+  try {
+    const statuses = argv.id ? [getLineStatus(repoPath, argv.id)] : getAllLineStatuses(repoPath);
+    if (argv.json) {
+      console.log(JSON.stringify(argv.id ? statuses[0] : statuses, null, 2));
+      return;
+    }
+    if (statuses.length === 0) {
+      info('No factory line installed.');
+      info('Scaffold one: har line create <id>   •   Install one: har line add <spec>');
+      return;
+    }
+    for (const status of statuses) {
+      renderStatus(status);
+    }
+  } catch (err: unknown) {
+    error((err as Error).message);
+    return finishCommand(1);
+  }
+}
+
+async function handleLineGate(argv: {
+  station?: string;
+  repo: string;
+  line?: string;
+  agent?: number;
+  force: boolean;
+  json: boolean;
+}): Promise<void> {
+  if (!argv.station) {
+    error('Missing station. Usage: har line gate <station> [--line <id>] [--agent <slot>]');
+    return finishCommand(1);
+  }
+
+  const repoPath = path.resolve(argv.repo);
+  try {
+    const result = await runLineGate({
+      repoPath,
+      lineId: argv.line,
+      station: argv.station,
+      agentId: argv.agent,
+      force: argv.force,
+    });
+
+    if (argv.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return finishCommand(result.pass ? 0 : 1);
+    }
+
+    header(`har line gate ${result.station} (${result.lineId})`);
+    if (result.skipped) {
+      info(result.skipReason ?? 'Gate skipped.');
+      for (const stage of result.stages) {
+        info(`  · ${stage.stageId} (from ${stage.fromStation}) — skipped`);
+      }
+      return;
+    }
+
+    for (const stage of result.stages) {
+      const mark = stage.status === 'pass' ? '✓' : stage.status === 'skipped' ? '·' : '✗';
+      const detail = stage.reason ? ` — ${stage.reason}` : '';
+      const ms = stage.durationMs !== undefined ? ` (${Math.round(stage.durationMs / 100) / 10}s)` : '';
+      console.error(`  ${mark} ${stage.stageId}  from ${stage.fromStation}  ${stage.status}${ms}${detail}`);
+    }
+    divider();
+    if (result.pass) {
+      success(`Gate passed for station ${result.station}`);
+    } else {
+      error(`Gate failed for station ${result.station}`);
+    }
+    return finishCommand(result.pass ? 0 : 1);
+  } catch (err: unknown) {
+    error((err as Error).message);
+    return finishCommand(1);
+  }
+}
+
+function handleLineList(argv: { repo: string }): void {
+  const repoPath = path.resolve(argv.repo);
+  const installed = new Set(listInstalledLineIds(repoPath));
+  for (const id of listBundledLineIds()) {
+    console.log(`${id}\t(bundled)`);
+  }
+  for (const id of listLocalLineIds(repoPath)) {
+    console.log(`${id}\t(local: .har/lines/${id})${installed.has(id) ? ' [installed]' : ''}`);
+  }
+}
+
+function parseStations(value: unknown): string[] | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined;
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export const lineCommand = {
+  command: 'line <subcommand>',
+  describe:
+    'Factory lines: multi-station programs with a cumulative gate that never joins verificationStages',
+  builder: (yargs: Argv) =>
+    yargs
+      .command(
+        'create [id]',
+        'Scaffold a project-owned line at .har/lines/<id>/ (manifest, program, gate stage, README)',
+        (y: Argv) =>
+          y
+            .positional('id', { type: 'string', describe: 'Line id (lowercase slug, e.g. onboarding-line)' })
+            .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+            .option('title', { type: 'string', describe: 'Human-readable line title' })
+            .option('description', { type: 'string', describe: 'One-paragraph description of the program' })
+            .option('stations', {
+              type: 'string',
+              describe: 'Comma-separated station ids in order (default: S1,S2)',
+            })
+            .option('gate-stage', {
+              type: 'boolean',
+              default: true,
+              describe: 'Scaffold one registered-but-off-verify gate stage',
+            })
+            .option('opt-in-env', {
+              type: 'string',
+              describe: 'Env var that must be "1" for the gate to run (e.g. HAR_FIXTURE_E2E)',
+            })
+            .option('force', { type: 'boolean', default: false, describe: 'Overwrite an existing line' }),
+        (argv) =>
+          handleLineCreate({
+            id: argv.id as string | undefined,
+            repo: argv.repo as string,
+            title: argv.title as string | undefined,
+            description: argv.description as string | undefined,
+            stations: parseStations(argv.stations),
+            gateStage: argv['gate-stage'] as boolean,
+            optInEnv: argv['opt-in-env'] as string | undefined,
+            force: argv.force as boolean,
+          }),
+      )
+      .command(
+        'add [spec]',
+        'Install a line bundle (local id, path, npm package, or git URL) — never touches verificationStages',
+        (y: Argv) =>
+          y
+            .positional('spec', {
+              type: 'string',
+              describe: 'Line id, path (./line), npm package (@org/pkg), or git URL (github:org/repo)',
+            })
+            .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+            .option('force', {
+              type: 'boolean',
+              default: false,
+              describe: 'Overwrite existing line files and stage entries',
+            }),
+        (argv) =>
+          handleLineAdd({
+            spec: argv.spec as string | undefined,
+            repo: argv.repo as string,
+            force: argv.force as boolean,
+          }),
+      )
+      .command(
+        'status [id]',
+        'Show stations, cumulative gate progress from run records, and slots in flight',
+        (y: Argv) =>
+          y
+            .positional('id', { type: 'string', describe: 'Line id (default: all installed lines)' })
+            .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+            .option('json', { type: 'boolean', default: false, describe: 'Emit structured JSON' }),
+        (argv) =>
+          handleLineStatus({
+            id: argv.id as string | undefined,
+            repo: argv.repo as string,
+            json: argv.json as boolean,
+          }),
+      )
+      .command(
+        'gate [station]',
+        'Run the cumulative gate for a station (does NOT run verify and does not widen it)',
+        (y: Argv) =>
+          y
+            .positional('station', { type: 'string', describe: 'Station id (e.g. S1)' })
+            .option('repo', { type: 'string', default: '.', describe: 'Path to the repository' })
+            .option('line', { type: 'string', describe: 'Line id when more than one is installed' })
+            .option('agent', { type: 'number', describe: 'Agent slot to run the stages in' })
+            .option('force', {
+              type: 'boolean',
+              default: false,
+              describe: 'Run even when the program declares an opt-in env var that is not set',
+            })
+            .option('json', { type: 'boolean', default: false, describe: 'Emit structured JSON' }),
+        (argv) =>
+          handleLineGate({
+            station: argv.station as string | undefined,
+            repo: argv.repo as string,
+            line: argv.line as string | undefined,
+            agent: argv.agent as number | undefined,
+            force: argv.force as boolean,
+            json: argv.json as boolean,
+          }),
+      )
+      .command(
+        'list',
+        'List lines available to this repository (bundled and local)',
+        (y: Argv) => y.option('repo', { type: 'string', default: '.', describe: 'Path to the repository' }),
+        (argv) => handleLineList({ repo: argv.repo as string }),
+      )
+      .demandCommand(1, 'Please specify a subcommand: create, add, status, gate, list'),
+  handler: () => {},
+};

--- a/src/cli/commands/line.ts
+++ b/src/cli/commands/line.ts
@@ -83,7 +83,9 @@ function handleLineAdd(argv: {
     divider();
     console.error('');
     console.error('  verificationStages unchanged — line gate stages are opt-in.');
-    console.error(`  Run the gate with: har line gate ${result.stationIds[0]} --line ${result.lineId}`);
+    console.error(
+      `  Run the gate with: har line gate ${result.firstGatedStationId} --line ${result.lineId}`,
+    );
     console.error('');
     console.error('  Next steps:');
     for (const step of result.nextSteps) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { hqCommand } from './commands/hq';
 import { hooksCommand } from './commands/hooks';
 import { mcpCommand } from './commands/mcp';
 import { onboardCommand } from './commands/onboard';
+import { lineCommand } from './commands/line';
 import { pluginCommand } from './commands/plugin';
 import { preferencesCommand } from './commands/preferences';
 import { telemetryCommand } from './commands/telemetry';
@@ -28,6 +29,7 @@ export async function runCli(): Promise<void> {
     .command(hooksCommand)
     .command(mcpCommand)
     .command(pluginCommand)
+    .command(lineCommand)
     .command(preferencesCommand)
     .command(telemetryCommand)
     .demandCommand(1, 'Please specify a command. Try: har onboard   or   har env --help')

--- a/src/core/lines.ts
+++ b/src/core/lines.ts
@@ -1,0 +1,319 @@
+import * as path from 'path';
+import { applyLine, readInstalledLineProgram, type ApplyLineOptions, type ApplyLineResult } from '../harness/lines';
+import { createLine, type CreateLineOptions, type CreateLineResult } from '../harness/line-create';
+import { readLineLedger } from '../harness/line-ledger';
+import { listLocalLineIds } from '../harness/line-resolve';
+import { readStageRegistry } from '../harness/stages';
+import type { LineGateStage, LineProgram, LineStation } from '../harness/schema';
+import { listSlotRegistryEntries } from './slot-registry';
+import { listRuns } from './runs';
+import { runStage } from './run-service';
+import type { StageResult } from '../harness/schema';
+
+/**
+ * Factory-line orchestration (#304).
+ *
+ * Core owns the logic; `cli/commands/line.ts` and `mcp/server.ts` are thin
+ * adapters over these functions. Gate execution goes through the existing
+ * `RunService.runStage` — there is deliberately no second stage runner.
+ */
+
+export interface LineStationStatus {
+  id: string;
+  title: string;
+  index: number;
+  /** Cumulative: every gate stage tagged at this station or an earlier one. */
+  requiredStageIds: string[];
+  /** Gate stages that have a passing run record. */
+  passedStageIds: string[];
+  /** Required stages with no run record at all. */
+  neverRunStageIds: string[];
+  /** Required stages that are not registered in .har/stages.json. */
+  missingStageIds: string[];
+  /** All required stages green. */
+  green: boolean;
+  work?: LineStation['work'];
+}
+
+export interface LineSlotInFlight {
+  agentId: number;
+  branch?: string;
+  workUnitId?: string;
+  workDir: string;
+}
+
+export interface LineStatus {
+  lineId: string;
+  title: string;
+  programPath: string;
+  installed: boolean;
+  source?: string;
+  stations: LineStationStatus[];
+  /** Last station whose required stages are all green. */
+  currentStationId?: string;
+  /** First station that is not green — where the line is working now. */
+  nextStationId?: string;
+  optInEnv: string | null;
+  /** Registered line stages that are (correctly) absent from verificationStages. */
+  registeredStageIds: string[];
+  /** Set when a line stage has leaked onto the verify plan. */
+  verifyLeaks: string[];
+  slotsInFlight: LineSlotInFlight[];
+  handoffAutonomousShip: false;
+  warnings: string[];
+}
+
+/** Ids of every line installed in this repo (ledger first, then on-disk). */
+export function listInstalledLineIds(repoPath: string): string[] {
+  const ledger = readLineLedger(repoPath);
+  const fromLedger = ledger?.lines.map((l) => l.id) ?? [];
+  const onDisk = listLocalLineIds(repoPath).filter(
+    (id) => readInstalledLineProgram(repoPath, id) !== null,
+  );
+  return [...new Set([...fromLedger, ...onDisk])].sort();
+}
+
+/**
+ * The ratchet, as data: a stage tagged `fromStation: X` is required at X and
+ * at every later station. Order comes from `stations[]`, so growing the line
+ * can never drop an earlier station's stages.
+ */
+export function cumulativeGateStages(program: LineProgram, stationId: string): LineGateStage[] {
+  const stationIndex = program.stations.findIndex((s) => s.id === stationId);
+  if (stationIndex < 0) {
+    throw new Error(
+      `Unknown station "${stationId}". Stations: ${program.stations.map((s) => s.id).join(', ')}`,
+    );
+  }
+  const indexOf = new Map(program.stations.map((s, i) => [s.id, i]));
+  return program.gate.stages.filter((stage) => {
+    const from = indexOf.get(stage.fromStation);
+    return from !== undefined && from <= stationIndex;
+  });
+}
+
+function latestRunStatusByStage(repoPath: string, stageIds: string[]): Map<string, string> {
+  const statuses = new Map<string, string>();
+  for (const stageId of stageIds) {
+    const [latest] = listRuns(repoPath, { stageId, limit: 1 });
+    if (latest) statuses.set(stageId, latest.status);
+  }
+  return statuses;
+}
+
+export function getLineStatus(repoPath: string, lineId: string): LineStatus {
+  const resolved = path.resolve(repoPath);
+  const program = readInstalledLineProgram(resolved, lineId);
+  if (!program) {
+    throw new Error(
+      `Line not installed: ${lineId}. Install one with "har line add <spec>" or scaffold with "har line create <id>".`,
+    );
+  }
+
+  const ledger = readLineLedger(resolved);
+  const entry = ledger?.lines.find((l) => l.id === lineId);
+  const registry = readStageRegistry(resolved);
+  const registeredIds = new Set(registry.stages.map((s) => s.id));
+  const verificationStages = registry.verificationStages ?? [];
+
+  const allGateStageIds = [...new Set(program.gate.stages.map((s) => s.id))];
+  const runStatuses = latestRunStatusByStage(resolved, allGateStageIds);
+
+  const stations: LineStationStatus[] = program.stations.map((station, index) => {
+    const required = cumulativeGateStages(program, station.id);
+    const requiredStageIds = [...new Set(required.map((s) => s.id))];
+    const missingStageIds = requiredStageIds.filter((id) => !registeredIds.has(id));
+    const passedStageIds = requiredStageIds.filter((id) => runStatuses.get(id) === 'pass');
+    const neverRunStageIds = requiredStageIds.filter((id) => !runStatuses.has(id));
+    return {
+      id: station.id,
+      title: station.title,
+      index,
+      requiredStageIds,
+      passedStageIds,
+      neverRunStageIds,
+      missingStageIds,
+      green: missingStageIds.length === 0 && passedStageIds.length === requiredStageIds.length,
+      work: station.work,
+    };
+  });
+
+  let currentStationId: string | undefined;
+  for (const station of stations) {
+    if (station.green) currentStationId = station.id;
+    else break;
+  }
+  const nextStationId = stations.find((s) => !s.green)?.id;
+
+  const lineStageIds = entry?.stageIds ?? [];
+  const verifyLeaks = lineStageIds.filter((id) => verificationStages.includes(id));
+
+  const warnings: string[] = [];
+  if (verifyLeaks.length > 0) {
+    warnings.push(
+      `Line stage(s) ${verifyLeaks.join(', ')} are listed in verificationStages — ` +
+        'line gate stages must stay off `har env verify --full`. Remove them from .har/stages.json.',
+    );
+  }
+  for (const station of stations) {
+    for (const missing of station.missingStageIds) {
+      warnings.push(`Gate stage "${missing}" (station ${station.id}) is not registered in .har/stages.json`);
+    }
+  }
+
+  const slotsInFlight: LineSlotInFlight[] = listSlotRegistryEntries(resolved).map((slot) => ({
+    agentId: slot.agentId,
+    branch: slot.branch,
+    workUnitId: slot.workUnitId,
+    workDir: slot.workDir,
+  }));
+
+  return {
+    lineId,
+    title: program.title,
+    programPath: entry?.programPath ?? `.har/lines/${lineId}/line.json`,
+    installed: true,
+    source: entry?.source,
+    stations,
+    currentStationId,
+    nextStationId,
+    optInEnv: program.gate.optInEnv,
+    registeredStageIds: lineStageIds,
+    verifyLeaks,
+    slotsInFlight,
+    handoffAutonomousShip: false,
+    warnings: [...new Set(warnings)],
+  };
+}
+
+/** Status for every installed line. */
+export function getAllLineStatuses(repoPath: string): LineStatus[] {
+  return listInstalledLineIds(repoPath).map((id) => getLineStatus(repoPath, id));
+}
+
+export interface RunLineGateOptions {
+  repoPath: string;
+  lineId?: string;
+  station: string;
+  agentId?: number;
+  /** Run even when the program declares an opt-in env var that is not set. */
+  force?: boolean;
+}
+
+export interface LineGateStageResult {
+  stageId: string;
+  fromStation: string;
+  status: StageResult['status'] | 'skipped';
+  durationMs?: number;
+  reason?: string;
+}
+
+export interface RunLineGateResult {
+  lineId: string;
+  station: string;
+  /** Cumulative set actually considered, in station order. */
+  stages: LineGateStageResult[];
+  pass: boolean;
+  skipped: boolean;
+  skipReason?: string;
+}
+
+function resolveLineId(repoPath: string, lineId?: string): string {
+  if (lineId) return lineId;
+  const ids = listInstalledLineIds(repoPath);
+  if (ids.length === 0) {
+    throw new Error('No factory line installed. Run "har line create <id>" or "har line add <spec>".');
+  }
+  if (ids.length > 1) {
+    throw new Error(`Multiple lines installed (${ids.join(', ')}). Pass --line <id>.`);
+  }
+  return ids[0];
+}
+
+/**
+ * Run the cumulative gate for one station.
+ *
+ * Runs the tagged stages through `RunService.runStage` — the same executor and
+ * the same `.har/runs/` records as any other stage. It never calls verify and
+ * never adds these stages to the verify plan.
+ */
+export async function runLineGate(options: RunLineGateOptions): Promise<RunLineGateResult> {
+  const repoPath = path.resolve(options.repoPath);
+  const lineId = resolveLineId(repoPath, options.lineId);
+  const program = readInstalledLineProgram(repoPath, lineId);
+  if (!program) {
+    throw new Error(`Line not installed: ${lineId}`);
+  }
+
+  const required = cumulativeGateStages(program, options.station);
+
+  if (program.gate.optInEnv && !options.force && process.env[program.gate.optInEnv] !== '1') {
+    return {
+      lineId,
+      station: options.station,
+      stages: required.map((stage) => ({
+        stageId: stage.id,
+        fromStation: stage.fromStation,
+        status: 'skipped' as const,
+        reason: `${program.gate.optInEnv} is not "1"`,
+      })),
+      pass: true,
+      skipped: true,
+      skipReason: `Gate is opt-in: set ${program.gate.optInEnv}=1 (or pass --force) to run it.`,
+    };
+  }
+
+  const registry = readStageRegistry(repoPath);
+  const registeredIds = new Set(registry.stages.map((s) => s.id));
+
+  const results: LineGateStageResult[] = [];
+  let pass = true;
+
+  for (const stage of required) {
+    if (!registeredIds.has(stage.id)) {
+      results.push({
+        stageId: stage.id,
+        fromStation: stage.fromStation,
+        status: 'skipped',
+        reason: 'stage is not registered in .har/stages.json',
+      });
+      pass = false;
+      continue;
+    }
+
+    const result = await runStage({
+      repoPath,
+      stageId: stage.id,
+      agentId: options.agentId,
+      trigger: 'cli',
+    });
+    results.push({
+      stageId: stage.id,
+      fromStation: stage.fromStation,
+      status: result.status,
+      durationMs: result.durationMs,
+    });
+    if (result.status !== 'pass') {
+      pass = false;
+    }
+  }
+
+  return { lineId, station: options.station, stages: results, pass, skipped: false };
+}
+
+/** Scaffold a project-owned line at `.har/lines/<id>/`. */
+export function createLineBundle(
+  repoPath: string,
+  options: CreateLineOptions,
+): CreateLineResult {
+  return createLine(repoPath, options);
+}
+
+/** Install a line bundle (path → git → bundled id → npm). */
+export function addLine(
+  repoPath: string,
+  spec: string,
+  options: ApplyLineOptions = {},
+): ApplyLineResult {
+  return applyLine(repoPath, spec, options);
+}

--- a/src/harness/bundle-resolve.ts
+++ b/src/harness/bundle-resolve.ts
@@ -1,0 +1,353 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveTemplatesDir } from '../utils/paths';
+
+/**
+ * Generic resolver for installable HAR bundles (verification plugins and
+ * factory lines). Both kinds share the same install channels — path → git →
+ * bundled id → npm — and differ only in manifest file name, template
+ * subdirectory, and in-repo home. Keeping one resolver is the point: a line is
+ * plugin-style plumbing with a different apply path, not a fourth marketplace.
+ */
+
+export type BundleSourceKind = 'bundled' | 'local' | 'path' | 'npm' | 'git';
+
+export interface BundleResolveConfig {
+  /** Manifest file names accepted at a bundle root, in priority order. */
+  manifestFiles: readonly string[];
+  /** Subdirectory of the packaged templates dir holding bundled ids. */
+  templatesSubdir: string;
+  /** Repo-relative home for project-owned bundles (e.g. `.har/plugins`). */
+  localDir: string;
+  /** Subdirectory a git repo may nest bundles under (e.g. `plugins`). */
+  gitNestedDir: string;
+  /** Human label used in errors ("plugin", "line"). */
+  label: string;
+  /** Extra hint appended to "unknown bundle" errors. */
+  unknownHint?: (repoPath: string) => string;
+}
+
+export interface ResolvedBundleSource {
+  id: string;
+  kind: BundleSourceKind;
+  /** Absolute directory containing the manifest. */
+  dir: string;
+  /** Original user/spec string. */
+  spec: string;
+  /** Optional package version read from package.json. */
+  version?: string;
+  /** Temp dirs that should be cleaned up after apply. */
+  cleanupDirs: string[];
+}
+
+export function findManifestPath(dir: string, config: BundleResolveConfig): string | null {
+  for (const name of config.manifestFiles) {
+    const candidate = path.join(dir, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function hasManifest(dir: string, config: BundleResolveConfig): boolean {
+  return findManifestPath(dir, config) !== null;
+}
+
+function readPackageVersion(dir: string): string | undefined {
+  const pkgPath = path.join(dir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return undefined;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return typeof pkg.version === 'string' ? pkg.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readManifestId(dir: string, config: BundleResolveConfig): string | undefined {
+  const manifestPath = findManifestPath(dir, config);
+  if (!manifestPath) return undefined;
+  try {
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { id?: string };
+    return typeof raw.id === 'string' ? raw.id : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function looksLikePath(spec: string): boolean {
+  return (
+    spec.startsWith('.') || spec.startsWith('/') || spec.startsWith('~') || spec.startsWith('file:')
+  );
+}
+
+export function looksLikeGit(spec: string): boolean {
+  return (
+    spec.startsWith('git+') ||
+    spec.startsWith('github:') ||
+    spec.startsWith('gitlab:') ||
+    spec.startsWith('bitbucket:') ||
+    /^https?:\/\/.+\.git$/i.test(spec) ||
+    /^git@/.test(spec)
+  );
+}
+
+export function looksLikeNpm(spec: string): boolean {
+  if (looksLikePath(spec) || looksLikeGit(spec)) return false;
+  if (spec.includes('/') && !spec.startsWith('@')) return false;
+  return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(@.+)?$/i.test(spec);
+}
+
+function expandHome(p: string): string {
+  if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
+  if (p === '~') return os.homedir();
+  return p;
+}
+
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function manifestNames(config: BundleResolveConfig): string {
+  return config.manifestFiles.join(' or ');
+}
+
+function resolveTemplatesBundleDir(id: string, config: BundleResolveConfig): string | null {
+  const dir = path.join(resolveTemplatesDir(), config.templatesSubdir, id);
+  return hasManifest(dir, config) ? dir : null;
+}
+
+function resolveLocalDir(id: string, repoPath: string, config: BundleResolveConfig): string | null {
+  const dir = path.resolve(repoPath, config.localDir, id);
+  return hasManifest(dir, config) ? dir : null;
+}
+
+function isLocalBundleDir(dir: string, repoPath: string, config: BundleResolveConfig): boolean {
+  return path.dirname(dir) === path.resolve(repoPath, config.localDir);
+}
+
+function resolvePathSpec(
+  spec: string,
+  repoPath: string,
+  config: BundleResolveConfig,
+): ResolvedBundleSource {
+  const raw = spec.startsWith('file:') ? spec.slice('file:'.length) : spec;
+  const dir = path.resolve(expandHome(raw));
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    throw new Error(`${config.label} path not found: ${spec}`);
+  }
+  if (!hasManifest(dir, config)) {
+    throw new Error(`No ${manifestNames(config)} in ${dir}`);
+  }
+  return {
+    id: readManifestId(dir, config) ?? path.basename(dir),
+    kind: isLocalBundleDir(dir, repoPath, config) ? 'local' : 'path',
+    dir,
+    spec,
+    version: readPackageVersion(dir),
+    cleanupDirs: [],
+  };
+}
+
+function resolveNpmSpec(spec: string, config: BundleResolveConfig): ResolvedBundleSource {
+  const tmp = makeTempDir(`har-${config.label}-npm-`);
+  const cleanupDirs = [tmp];
+  try {
+    execFileSync('npm', ['pack', spec, '--pack-destination', tmp], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    });
+    const tarballs = fs.readdirSync(tmp).filter((f) => f.endsWith('.tgz'));
+    if (tarballs.length === 0) {
+      throw new Error(`npm pack produced no tarball for ${spec}`);
+    }
+    const extractDir = path.join(tmp, 'extract');
+    fs.mkdirSync(extractDir);
+    execFileSync('tar', ['-xzf', path.join(tmp, tarballs[0]), '-C', extractDir], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let dir = path.join(extractDir, 'package');
+    if (!hasManifest(dir, config)) {
+      const nested = fs
+        .readdirSync(extractDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => path.join(extractDir, e.name))
+        .find((d) => hasManifest(d, config));
+      if (!nested) {
+        throw new Error(
+          `npm package ${spec} has no ${manifestNames(config)} (not a HAR ${config.label} bundle)`,
+        );
+      }
+      dir = nested;
+    }
+    return {
+      id: readManifestId(dir, config) ?? spec.replace(/^@/, '').replace(/[/:].*/g, ''),
+      kind: 'npm',
+      dir,
+      spec,
+      version: readPackageVersion(dir),
+      cleanupDirs,
+    };
+  } catch (err) {
+    for (const d of cleanupDirs) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to install ${config.label} from npm (${spec}): ${message}`);
+  }
+}
+
+function resolveGitSpec(spec: string, config: BundleResolveConfig): ResolvedBundleSource {
+  const tmp = makeTempDir(`har-${config.label}-git-`);
+  const cleanupDirs = [tmp];
+  const cloneDir = path.join(tmp, 'repo');
+  try {
+    let url = spec;
+    if (spec.startsWith('github:')) {
+      url = `https://github.com/${spec.slice('github:'.length)}.git`;
+    } else if (spec.startsWith('gitlab:')) {
+      url = `https://gitlab.com/${spec.slice('gitlab:'.length)}.git`;
+    } else if (spec.startsWith('bitbucket:')) {
+      url = `https://bitbucket.org/${spec.slice('bitbucket:'.length)}.git`;
+    } else if (spec.startsWith('git+')) {
+      url = spec.slice('git+'.length);
+    }
+
+    execFileSync('git', ['clone', '--depth', '1', url, cloneDir], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 180_000,
+    });
+
+    let dir = cloneDir;
+    if (!hasManifest(dir, config)) {
+      const nestedRoot = path.join(cloneDir, config.gitNestedDir);
+      if (fs.existsSync(nestedRoot)) {
+        const child = fs
+          .readdirSync(nestedRoot, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((e) => path.join(nestedRoot, e.name))
+          .find((d) => hasManifest(d, config));
+        if (child) dir = child;
+      }
+    }
+    if (!hasManifest(dir, config)) {
+      throw new Error(
+        `Git repo ${spec} has no ${manifestNames(config)} (not a HAR ${config.label} bundle)`,
+      );
+    }
+
+    return {
+      id: readManifestId(dir, config) ?? path.basename(url.replace(/\.git$/, '')),
+      kind: 'git',
+      dir,
+      spec,
+      version: readPackageVersion(dir),
+      cleanupDirs,
+    };
+  } catch (err) {
+    for (const d of cleanupDirs) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to install ${config.label} from git (${spec}): ${message}`);
+  }
+}
+
+/** Resolve an install spec to a directory containing the bundle manifest. */
+export function resolveBundleSource(
+  spec: string,
+  repoPath: string,
+  config: BundleResolveConfig,
+): ResolvedBundleSource {
+  const trimmed = spec.trim();
+  if (!trimmed) {
+    throw new Error(`${config.label} spec is empty`);
+  }
+
+  if (looksLikePath(trimmed)) {
+    return resolvePathSpec(trimmed, repoPath, config);
+  }
+
+  if (looksLikeGit(trimmed)) {
+    return resolveGitSpec(trimmed, config);
+  }
+
+  const bundled = resolveTemplatesBundleDir(trimmed, config);
+  if (bundled) {
+    return {
+      id: trimmed,
+      kind: 'bundled',
+      dir: bundled,
+      spec: trimmed,
+      version: readPackageVersion(bundled),
+      cleanupDirs: [],
+    };
+  }
+
+  const local = resolveLocalDir(trimmed, repoPath, config);
+  if (local) {
+    return {
+      id: readManifestId(local, config) ?? trimmed,
+      kind: 'local',
+      dir: local,
+      spec: trimmed,
+      version: readPackageVersion(local),
+      cleanupDirs: [],
+    };
+  }
+
+  const hint = config.unknownHint?.(repoPath) ?? '';
+
+  if (looksLikeNpm(trimmed)) {
+    try {
+      return resolveNpmSpec(trimmed, config);
+    } catch (npmErr) {
+      if (trimmed.includes('@') || trimmed.includes('/')) throw npmErr;
+      const npmMessage = npmErr instanceof Error ? npmErr.message : String(npmErr);
+      throw new Error(
+        `Unknown ${config.label}: ${trimmed}. ${hint} ` +
+          `Or pass a path, npm package, or git URL. (${npmMessage})`,
+      );
+    }
+  }
+
+  throw new Error(
+    `Unknown ${config.label}: ${trimmed}. ${hint} ` +
+      `Or pass a path (./bundle), npm package (@org/pkg), or git URL (github:org/repo).`,
+  );
+}
+
+/** List bundle ids under `<templates>/<subdir>/<id>/<manifest>`. */
+export function listTemplateBundleIds(config: BundleResolveConfig): string[] {
+  const root = path.join(resolveTemplatesDir(), config.templatesSubdir);
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => hasManifest(path.join(root, name), config))
+    .sort();
+}
+
+/** List project-owned bundle ids under `<repo>/<localDir>/<id>/<manifest>`. */
+export function listLocalBundleIds(repoPath: string, config: BundleResolveConfig): string[] {
+  const root = path.resolve(repoPath, config.localDir);
+  if (!fs.existsSync(root)) return [];
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => hasManifest(path.join(root, name), config))
+    .sort();
+}
+
+export function cleanupResolvedBundle(source: ResolvedBundleSource): void {
+  for (const dir of source.cleanupDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/src/harness/doctor.ts
+++ b/src/harness/doctor.ts
@@ -6,6 +6,8 @@ import { readValidatedHarnessEnv } from './env';
 import { getHarnessDir, readManifest } from './manifest';
 import { PACKAGE_RUNTIME_KINDS, stagePointsAtLifecycleShim } from './lifecycle-shims';
 import { HarnessStage, HarnessStageRegistry, PortLane } from './schema';
+import { readLineLedger } from './line-ledger';
+import { readInstalledLineProgram } from './lines';
 import { readStageRegistry } from './stages';
 import { findPhantomVerificationStageIds } from './verification';
 import { LIFECYCLE_HOOKS } from '../runtime/hooks';
@@ -29,7 +31,8 @@ export type DoctorCheckId =
   | 'slot-registry'
   | 'hooks'
   | 'retired-machinery'
-  | 'ejected-runtime';
+  | 'ejected-runtime'
+  | 'factory-lines';
 
 export type DoctorContract = '1.0' | 'pre-1.0' | 'none';
 
@@ -98,6 +101,7 @@ const CHECK_LABELS: Record<DoctorCheckId, string> = {
   hooks: 'lifecycle hooks (.har/hooks)',
   'retired-machinery': 'no references to retired runtime machinery',
   'ejected-runtime': 'ejected runtime (user-owned)',
+  'factory-lines': 'factory lines stay off verify',
 };
 
 /** Legacy helper functions whose presence marks a pre-1.0 harness.env. */
@@ -428,6 +432,56 @@ export function runDoctor(repoPath: string): DoctorReport {
           'Rewrite the script against the 1.0 stage surface (WORK_DIR, ENV_FILE, AGENT_ID and the slot env file are already exported), or run `har env maintain --migrate`',
       });
       break; // one finding per script is enough to act on
+    }
+  }
+
+  // Factory lines (#304): a line registers stages but must never put them on
+  // the verify plan. A hand edit (or a bad bundle) that leaks one there turns
+  // an opt-in station gate into a tax on every `verify --full` — the exact
+  // failure mode the separate bundle kind exists to prevent.
+  const lineLedger = readLineLedger(repoPath);
+  if (lineLedger) {
+    const verificationStages = registry?.verificationStages ?? [];
+    const registeredIds = new Set((registry?.stages ?? []).map((stage) => stage.id));
+
+    for (const line of lineLedger.lines) {
+      for (const stageId of line.stageIds) {
+        if (verificationStages.includes(stageId)) {
+          findings.push({
+            check: 'factory-lines',
+            severity: 'error',
+            file: 'stages.json',
+            message: `line "${line.id}" stage "${stageId}" is listed in verificationStages`,
+            remedy:
+              'Remove it from verificationStages — line gate stages run via `har line gate <station>`. If it must gate every verify, ship it as a verification plugin instead.',
+          });
+        }
+      }
+
+      const program = readInstalledLineProgram(repoPath, line.id);
+      if (!program) {
+        findings.push({
+          check: 'factory-lines',
+          severity: 'warning',
+          file: line.programPath,
+          message: `line "${line.id}" is in .har/lines.json but its program is missing or invalid`,
+          remedy: `Reinstall it (\`har line add ${line.id}\`) or drop the entry from .har/lines.json`,
+        });
+        continue;
+      }
+
+      for (const gateStage of program.gate.stages) {
+        if (!registeredIds.has(gateStage.id)) {
+          findings.push({
+            check: 'factory-lines',
+            severity: 'warning',
+            file: line.programPath,
+            message: `line "${line.id}" gate stage "${gateStage.id}" (from ${gateStage.fromStation}) is not registered in stages.json`,
+            remedy:
+              'Install the plugin that provides it, add it to the line bundle, or drop the gate tag',
+          });
+        }
+      }
     }
   }
 

--- a/src/harness/line-create.ts
+++ b/src/harness/line-create.ts
@@ -1,0 +1,248 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { resolveTemplatesDir } from '../utils/paths';
+import { harnessExists } from './parser';
+import { LOCAL_LINES_DIR } from './line-resolve';
+import {
+  LINE_BUNDLE_KIND,
+  LINE_CONTRACT_VERSION,
+  LineManifestSchema,
+  LineProgramSchema,
+  type LineManifest,
+  type LineProgram,
+} from './schema';
+
+export interface CreateLineOptions {
+  id: string;
+  title?: string;
+  description?: string;
+  /** Station ids in order (default: S1, S2). */
+  stations?: string[];
+  /** Scaffold one registered-but-not-on-verify gate stage (default: true). */
+  gateStage?: boolean;
+  /** Env var that must be "1" for the gate to run (default: none). */
+  optInEnv?: string;
+  force?: boolean;
+}
+
+export interface CreateLineResult {
+  lineId: string;
+  lineDir: string;
+  filesWritten: string[];
+  nextSteps: string[];
+}
+
+const LINE_ID_PATTERN = /^[a-z0-9][a-z0-9._-]*$/;
+
+function renderSkeleton(templatePath: string, tokens: Record<string, string>): string {
+  let content = fs.readFileSync(templatePath, 'utf8');
+  for (const [token, value] of Object.entries(tokens)) {
+    content = content.replace(new RegExp(token, 'g'), value);
+  }
+  return content;
+}
+
+/**
+ * Scaffold a project-owned factory line at `.har/lines/<id>/`.
+ *
+ * The output is a complete, publishable bundle — the same shape
+ * `os-factory/har-line` ships (#322) — so `har line add <id>` installs it
+ * unchanged and publishing it to npm/git later needs no format change.
+ */
+export function createLine(repoPath: string, options: CreateLineOptions): CreateLineResult {
+  const resolved = path.resolve(repoPath);
+  if (!harnessExists(resolved)) {
+    throw new Error('No .har/ harness found. Run "har onboard" first.');
+  }
+
+  const id = options.id.trim();
+  if (!LINE_ID_PATTERN.test(id)) {
+    throw new Error(
+      `Invalid line id "${id}". Use lowercase letters, digits, dots, dashes (e.g. "onboarding-line").`,
+    );
+  }
+
+  const lineDir = path.join(resolved, LOCAL_LINES_DIR, id);
+  const lineDirRel = `${LOCAL_LINES_DIR}/${id}`;
+  if (fs.existsSync(lineDir) && !options.force) {
+    throw new Error(`Line already exists: ${lineDirRel}/. Use --force to overwrite.`);
+  }
+
+  const stationIds = options.stations?.length ? options.stations : ['S1', 'S2'];
+  const title = options.title ?? `${id} factory line`;
+  const gateStageId = `${id}-gate`;
+  const withGateStage = options.gateStage ?? true;
+
+  const program: LineProgram = LineProgramSchema.parse({
+    contractVersion: LINE_CONTRACT_VERSION,
+    id,
+    title,
+    description:
+      options.description ??
+      'Describe the program: what it produces, and what "done" means at the last station.',
+    skills: [{ id: 'factory-line', role: 'orchestrator', install: 'repo:.claude/skills/factory-line' }],
+    mcp: [],
+    plugins: [],
+    stations: stationIds.map((stationId, i) => ({
+      id: stationId,
+      title: `Station ${i + 1}`,
+      description: 'What this station produces.',
+      work: { source: 'none', ids: [], optional: true },
+    })),
+    gate: {
+      cumulative: true,
+      optInEnv: options.optInEnv ?? null,
+      stages: withGateStage
+        ? [{ id: gateStageId, fromStation: stationIds[0], tier: 'full' }]
+        : [],
+    },
+    extraStages: withGateStage
+      ? [
+          {
+            id: gateStageId,
+            kind: 'test',
+            tier: 'full',
+            description: `Line-owned gate for ${id} — registered, never on verify`,
+          },
+        ]
+      : [],
+    handoff: {
+      autonomousShip: false,
+      waitFor: 'human review before merge or release',
+    },
+    prototypeNotes: [],
+  });
+
+  const manifest: LineManifest = LineManifestSchema.parse({
+    kind: LINE_BUNDLE_KIND,
+    id,
+    title,
+    program: 'line.json',
+    files: withGateStage
+      ? [{ src: `stages/${gateStageId}.sh`, dest: `.har/stages/${gateStageId}.sh`, executable: true }]
+      : [],
+    stages: withGateStage
+      ? [
+          {
+            id: gateStageId,
+            kind: 'test',
+            description: `Line-owned gate for ${id} — registered, never on verify`,
+            script: `stages/${gateStageId}.sh`,
+            requiresAgentId: true,
+            artifacts: [
+              {
+                path: `.har/artifacts/${gateStageId}`,
+                kind: 'directory',
+                description: `Artifacts for the ${gateStageId} stage`,
+              },
+            ],
+            tier: 'full',
+          },
+        ]
+      : [],
+    nextSteps: [
+      `Edit ${lineDirRel}/line.json — name the stations and bind tracker work`,
+      ...(withGateStage
+        ? [`Edit ${lineDirRel}/stages/${gateStageId}.sh — replace the TODO with the real gate`]
+        : []),
+      `har line status ${id}`,
+      `har line gate ${stationIds[0]} --line ${id}`,
+    ],
+    docsPath: `${lineDirRel}/README.md`,
+  });
+
+  const filesWritten: string[] = [];
+  const write = (rel: string, content: string, executable = false): void => {
+    const abs = path.join(lineDir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content);
+    if (executable) fs.chmodSync(abs, 0o755);
+    filesWritten.push(`${lineDirRel}/${rel}`);
+  };
+
+  write('line.manifest.json', `${JSON.stringify(manifest, null, 2)}\n`);
+  write('line.json', `${JSON.stringify(program, null, 2)}\n`);
+
+  if (withGateStage) {
+    const stageScript = renderSkeleton(
+      path.join(resolveTemplatesDir(), 'plugins', 'custom-stage-skeleton.sh'),
+      {
+        __STAGE_ID__: gateStageId,
+        __STAGE_KIND__: 'test',
+        __STAGE_DESCRIPTION__: `Line-owned gate for ${id} (not on verify)`,
+      },
+    );
+    write(`stages/${gateStageId}.sh`, stageScript, true);
+  }
+
+  write('README.md', renderLineReadme(id, title, stationIds, gateStageId, withGateStage));
+
+  return {
+    lineId: id,
+    lineDir,
+    filesWritten,
+    nextSteps: [
+      `Edit ${lineDirRel}/line.json — stations, work binding, gate tags`,
+      ...(withGateStage
+        ? [`Edit ${lineDirRel}/stages/${gateStageId}.sh — replace the TODO with the real gate`]
+        : []),
+      `Install it: har line add ${id}   (re-run with --force after changes)`,
+      `Installing writes .har/ADAPT-PROMPT-line-${id}.md — a ready adaptation prompt for your coding agent`,
+      'Publishing later (npm/git) needs zero format changes — see the README',
+    ],
+  };
+}
+
+function renderLineReadme(
+  id: string,
+  title: string,
+  stationIds: string[],
+  gateStageId: string,
+  withGateStage: boolean,
+): string {
+  return `# ${title}
+
+A HAR **factory line**: an ordered program of stations plus a cumulative gate.
+
+A line is not a verification plugin. Installing it registers stages but never
+adds them to \`verificationStages\` — default \`har env verify --full\` stays
+exactly as fast as it was. Line gate stages run on demand:
+
+\`\`\`bash
+har line gate ${stationIds[0]} --line ${id}
+\`\`\`
+
+If a check should gate *every* verify, it belongs in a verification plugin
+(\`har plugin create\` / \`har env add-plugin\`), not here.
+
+## Layout
+
+\`\`\`text
+${id}/
+├── line.manifest.json   # kind: line — what \`har line add\` applies
+├── line.json            # the program: stations, gate, handoff
+${withGateStage ? `├── stages/${gateStageId}.sh   # extra gate stage — registered, NOT on verify\n` : ''}└── README.md
+\`\`\`
+
+## Stations
+
+${stationIds.map((s, i) => `${i + 1}. \`${s}\``).join('\n')}
+
+## The ratchet
+
+\`gate.stages[].fromStation\` tags a stage as required at that station **and
+every later one**. Adding a station must never drop an earlier station's
+stages — that is what \`gate.cumulative: true\` means, and it is contract.
+
+## Install channels
+
+\`\`\`bash
+har line add ${id}                        # this repo (.har/lines/${id})
+har line add ./${id}                      # local path
+har line add github:acme/${id}            # git
+har line add @acme/${id}                  # npm
+\`\`\`
+
+Publishing needs no format change: add a \`package.json\` and push.
+`;
+}

--- a/src/harness/line-ledger.ts
+++ b/src/harness/line-ledger.ts
@@ -1,0 +1,51 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { writeFileSafe } from '../utils/file-ops';
+import { DEFAULT_HAR_DIR } from './manifest';
+import { LineLedger, LineLedgerEntry, LineLedgerSchema } from './schema';
+
+/** Installed-line ledger — `.har/lines.json`, sibling of `.har/plugins.json`. */
+export function getLineLedgerPath(repoPath: string): string {
+  return path.join(path.resolve(repoPath), DEFAULT_HAR_DIR, 'lines.json');
+}
+
+export function readLineLedger(repoPath: string): LineLedger | null {
+  const ledgerPath = getLineLedgerPath(repoPath);
+  if (!fs.existsSync(ledgerPath)) return null;
+  try {
+    const parsed = LineLedgerSchema.safeParse(JSON.parse(fs.readFileSync(ledgerPath, 'utf8')));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLineLedger(repoPath: string, ledger: LineLedger): void {
+  const ledgerPath = getLineLedgerPath(repoPath);
+  const harnessDir = path.dirname(ledgerPath);
+  if (!fs.existsSync(harnessDir)) {
+    fs.mkdirSync(harnessDir, { recursive: true });
+  }
+  writeFileSafe(ledgerPath, `${JSON.stringify(ledger, null, 2)}\n`);
+}
+
+export function upsertLineLedgerEntry(repoPath: string, entry: LineLedgerEntry): LineLedger {
+  const existing = readLineLedger(repoPath) ?? { version: '1' as const, lines: [] };
+  const lines = existing.lines.filter((l) => l.id !== entry.id);
+  lines.push(entry);
+  lines.sort((a, b) => a.id.localeCompare(b.id));
+
+  const ledger: LineLedger = { version: '1', lines };
+  writeLineLedger(repoPath, ledger);
+  return ledger;
+}
+
+export function removeLineLedgerEntry(repoPath: string, lineId: string): LineLedger {
+  const existing = readLineLedger(repoPath) ?? { version: '1' as const, lines: [] };
+  const ledger: LineLedger = {
+    version: '1',
+    lines: existing.lines.filter((l) => l.id !== lineId),
+  };
+  writeLineLedger(repoPath, ledger);
+  return ledger;
+}

--- a/src/harness/line-prompt.ts
+++ b/src/harness/line-prompt.ts
@@ -1,0 +1,137 @@
+import * as path from 'path';
+import { writeFileSafe } from '../utils/file-ops';
+import { getHarnessDir } from './manifest';
+import type { LineProgram } from './schema';
+import type { ApplyLineResult } from './lines';
+
+/** Per-line adaptation prompt, sibling of ADAPT-PROMPT-<plugin>.md. */
+export function lineAdaptationPromptFile(lineId: string): string {
+  return `ADAPT-PROMPT-line-${lineId}.md`;
+}
+
+/**
+ * Post-install prompt for the coding agent.
+ *
+ * Deliberately does NOT tell the agent to "get full verify green on the new
+ * stages": the stages this line registered are off `verify --full` by design
+ * and are exercised by `har line gate`. Telling an agent otherwise is how a
+ * line quietly becomes a plugin.
+ */
+export function buildLineAdaptationPrompt(
+  repoPath: string,
+  program: LineProgram,
+  result: ApplyLineResult,
+): string {
+  const stations = program.stations
+    .map((s, i) => `${i + 1}. \`${s.id}\` — ${s.title}${s.work?.ids?.length ? ` (work: ${s.work.ids.join(', ')})` : ''}`)
+    .join('\n');
+
+  const gateRows = program.gate.stages
+    .map((s) => `| \`${s.id}\` | \`${s.fromStation}\` | ${s.tier} |`)
+    .join('\n');
+
+  const registered =
+    result.stageIds.length > 0
+      ? result.stageIds.map((id) => `- \`${id}\` — registered, **not** in \`verificationStages\``).join('\n')
+      : '- _(this line registered no extra stages)_';
+
+  const declaredSkills =
+    program.skills.length > 0
+      ? program.skills.map((s) => `- \`${s.id}\` (${s.role})${s.install ? ` — install: \`${s.install}\`` : ''}`).join('\n')
+      : '- _(none declared)_';
+
+  const declaredMcp =
+    program.mcp.length > 0
+      ? program.mcp
+          .map((m) => `- \`${m.name}\`${m.required ? ' (required)' : ' (optional)'}${m.why ? ` — ${m.why}` : ''}`)
+          .join('\n')
+      : '- _(none declared)_';
+
+  const warnings =
+    result.warnings.length > 0
+      ? result.warnings.map((w) => `- ⚠ ${w}`).join('\n')
+      : '- _(none)_';
+
+  const optIn = program.gate.optInEnv
+    ? `This line's gate is opt-in: stages run only when \`${program.gate.optInEnv}=1\`.`
+    : 'This line has no opt-in env var — `har line gate` runs its stages on demand.';
+
+  return `# Adapt the factory line: ${result.lineId}
+
+Installed from \`${result.source}\` into \`${path.basename(path.resolve(repoPath))}\`.
+Program: \`${result.programPath}\`
+
+## What just happened
+
+A **factory line** was installed. A line is a *program* — an ordered set of
+stations plus a cumulative gate. It is not a verification plugin:
+
+${registered}
+
+\`verificationStages\` was **not** modified. Default \`har env verify --full\`
+takes exactly as long as it did before this install. ${optIn}
+
+## Stations
+
+${stations}
+
+## Cumulative gate (the ratchet)
+
+A gate stage tagged \`fromStation: X\` is required at X **and every later
+station**. Adding a station must never drop an earlier station's stages.
+
+| Stage | From station | Tier |
+|---|---|---|
+${gateRows || '| _(none)_ | | |'}
+
+Run it with:
+
+\`\`\`bash
+har line gate <station> --line ${result.lineId}
+\`\`\`
+
+Never with \`har env verify --full\` — that is the whole point of the split.
+
+## Declared dependencies (declarations, not installs)
+
+Skills:
+
+${declaredSkills}
+
+MCP servers:
+
+${declaredMcp}
+
+HAR does not vendor skill packs or MCP servers. Check they are present, install
+them the way your agent normally does, and skip tracker steps for any MCP marked
+optional that is missing.
+
+## Warnings from install
+
+${warnings}
+
+## Your job now
+
+1. Read \`${result.programPath}\` and make the stations describe *this* repo's
+   work — station titles, \`work.source\`/\`work.ids\`, waves.
+2. Make each registered stage script real (replace TODO blocks). They live under
+   \`.har/stages/\`.
+3. Leave \`gate.cumulative: true\` and \`handoff.autonomousShip: false\` alone —
+   both are contract, not preference.
+4. Do **not** add line stages to \`verificationStages\`. If a check should gate
+   every verify, it belongs in a verification plugin instead
+   (\`har env add-plugin\`), not on this line.
+5. Verify the harness still passes as before: \`har env verify <slot> --full\`.
+`;
+}
+
+/** Write the prompt to .har/ADAPT-PROMPT-line-<id>.md; returns the absolute path. */
+export function writeLineAdaptationPrompt(
+  repoPath: string,
+  lineId: string,
+  content: string,
+): string {
+  const filePath = path.join(getHarnessDir(repoPath), lineAdaptationPromptFile(lineId));
+  writeFileSafe(filePath, content);
+  return filePath;
+}

--- a/src/harness/line-resolve.ts
+++ b/src/harness/line-resolve.ts
@@ -1,0 +1,59 @@
+import {
+  cleanupResolvedBundle,
+  listLocalBundleIds,
+  listTemplateBundleIds,
+  resolveBundleSource,
+  type BundleResolveConfig,
+  type BundleSourceKind,
+  type ResolvedBundleSource,
+} from './bundle-resolve';
+import { LINE_MANIFEST_FILES } from './schema';
+
+export type LineSourceKind = BundleSourceKind;
+export type ResolvedLineSource = ResolvedBundleSource;
+
+/** Conventional in-repo home for factory lines (authored and installed). */
+export const LOCAL_LINES_DIR = '.har/lines';
+
+export const LINE_BUNDLE_CONFIG: BundleResolveConfig = {
+  manifestFiles: LINE_MANIFEST_FILES,
+  templatesSubdir: 'lines',
+  localDir: LOCAL_LINES_DIR,
+  gitNestedDir: 'lines',
+  label: 'line',
+  unknownHint: (repoPath: string) => knownLinesHint(repoPath),
+};
+
+/**
+ * Resolve a line install spec to a directory with line.manifest.json.
+ * Same channels as plugins (path → git → bundled → npm), different apply.
+ */
+export function resolveLineSource(spec: string, repoPath = '.'): ResolvedLineSource {
+  return resolveBundleSource(spec, repoPath, LINE_BUNDLE_CONFIG);
+}
+
+function knownLinesHint(repoPath: string): string {
+  const bundled = listBundledLineIds();
+  const local = listLocalLineIds(repoPath);
+  const parts = [`Bundled: ${bundled.join(', ') || '(none)'}.`];
+  if (local.length > 0) {
+    parts.push(`Local (${LOCAL_LINES_DIR}/): ${local.join(', ')}.`);
+  } else {
+    parts.push('Scaffold a project-owned one with: har line create <id>.');
+  }
+  return parts.join(' ');
+}
+
+/** List line ids under <repo>/.har/lines/<id>/line.manifest.json */
+export function listLocalLineIds(repoPath = '.'): string[] {
+  return listLocalBundleIds(repoPath, LINE_BUNDLE_CONFIG);
+}
+
+/** List line ids discovered under templates/lines/<id>/line.manifest.json */
+export function listBundledLineIds(): string[] {
+  return listTemplateBundleIds(LINE_BUNDLE_CONFIG);
+}
+
+export function cleanupResolvedLine(source: ResolvedLineSource): void {
+  cleanupResolvedBundle(source);
+}

--- a/src/harness/lines.ts
+++ b/src/harness/lines.ts
@@ -38,6 +38,8 @@ export interface ApplyLineResult {
   adaptPromptPath: string;
   /** Station ids in order, for the handoff summary. */
   stationIds: string[];
+  /** First station whose cumulative gate is non-empty — what to run next. */
+  firstGatedStationId: string;
 }
 
 /** Repo-relative home of an installed line. */
@@ -267,12 +269,19 @@ function applyLineFromDir(
     installedAt: new Date().toISOString(),
   });
 
+  // Point at the first station that actually has gate stages — suggesting the
+  // first station runs an empty gate and reads like the install did nothing.
+  const firstGatedStation =
+    program.stations.find((station) =>
+      program.gate.stages.some((stage) => stage.fromStation === station.id),
+    )?.id ?? program.stations[0].id;
+
   const nextSteps =
     manifest.nextSteps.length > 0
       ? manifest.nextSteps
       : [
           `har line status ${manifest.id}`,
-          `har line gate ${program.stations[0].id} --line ${manifest.id}`,
+          `har line gate ${firstGatedStation} --line ${manifest.id}`,
           `Adapt the program: ${lineProgramPathRel(manifest.id)}`,
         ];
 
@@ -287,6 +296,7 @@ function applyLineFromDir(
     docsPath: manifest.docsPath,
     source: meta.source,
     stationIds: program.stations.map((s) => s.id),
+    firstGatedStationId: firstGatedStation,
   };
 
   const promptAbsPath = writeLineAdaptationPrompt(

--- a/src/harness/lines.ts
+++ b/src/harness/lines.ts
@@ -1,0 +1,334 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { info, success, warn } from '../utils/logging';
+import { harnessExists } from './parser';
+import { upsertLineLedgerEntry } from './line-ledger';
+import { buildLineAdaptationPrompt, writeLineAdaptationPrompt } from './line-prompt';
+import {
+  cleanupResolvedLine,
+  LOCAL_LINES_DIR,
+  resolveLineSource,
+  type LineSourceKind,
+} from './line-resolve';
+import { findManifestPath } from './bundle-resolve';
+import { LINE_BUNDLE_KIND, LINE_MANIFEST_FILES } from './schema';
+import type { HarnessStage, LineManifest, LineProgram } from './schema';
+import { LineManifestSchema, LineProgramSchema } from './schema';
+import { readStageRegistry, writeStageRegistry } from './stages';
+import { LINE_BUNDLE_CONFIG } from './line-resolve';
+
+export interface ApplyLineOptions {
+  force?: boolean;
+  /** Install spec when different from the resolved line id. */
+  spec?: string;
+}
+
+export interface ApplyLineResult {
+  lineId: string;
+  title: string;
+  /** Stages registered in .har/stages.json — registered only, never on verify. */
+  stageIds: string[];
+  filesWritten: string[];
+  warnings: string[];
+  nextSteps: string[];
+  /** Repo-relative path of the installed program. */
+  programPath: string;
+  docsPath?: string;
+  source: LineSourceKind;
+  adaptPromptPath: string;
+  /** Station ids in order, for the handoff summary. */
+  stationIds: string[];
+}
+
+/** Repo-relative home of an installed line. */
+export function lineDirRel(lineId: string): string {
+  return `${LOCAL_LINES_DIR}/${lineId}`;
+}
+
+export function lineProgramPathRel(lineId: string): string {
+  return `${lineDirRel(lineId)}/line.json`;
+}
+
+/**
+ * Read a line manifest from a bundle directory.
+ *
+ * Poka-yoke (#304 decision 4): a verification-plugin manifest resolved here is
+ * rejected with a pointer at `har env add-plugin`, and vice versa in
+ * `plugins.ts`. The two apply paths are deliberately not interchangeable —
+ * `add-plugin` appends to `verificationStages`, `line add` must never do that.
+ */
+export function readLineManifestFromDir(bundleDir: string, expectedId?: string): LineManifest {
+  const manifestPath = findManifestPath(bundleDir, LINE_BUNDLE_CONFIG);
+  if (!manifestPath) {
+    throw new Error(`No ${LINE_MANIFEST_FILES.join(' or ')} in ${bundleDir}`);
+  }
+
+  const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+  if (raw.kind !== LINE_BUNDLE_KIND) {
+    throw new Error(
+      `${path.basename(manifestPath)} is not a factory line bundle (missing "kind": "line"). ` +
+        'Verification plugins install with: har env add-plugin <spec>',
+    );
+  }
+
+  const parsed = LineManifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid line manifest: ${parsed.error.message}`);
+  }
+  if (expectedId && parsed.data.id !== expectedId) {
+    throw new Error(`Line manifest id mismatch: expected ${expectedId}, got ${parsed.data.id}`);
+  }
+  return parsed.data;
+}
+
+export function readLineProgramFromDir(bundleDir: string, manifest: LineManifest): LineProgram {
+  const programPath = path.join(bundleDir, manifest.program);
+  if (!fs.existsSync(programPath)) {
+    throw new Error(`Line program missing: ${manifest.program} (referenced by line.manifest.json)`);
+  }
+  const parsed = LineProgramSchema.safeParse(JSON.parse(fs.readFileSync(programPath, 'utf8')));
+  if (!parsed.success) {
+    throw new Error(`Invalid line program (${manifest.program}): ${parsed.error.message}`);
+  }
+  if (parsed.data.id !== manifest.id) {
+    throw new Error(
+      `Line program id "${parsed.data.id}" does not match manifest id "${manifest.id}"`,
+    );
+  }
+  return parsed.data;
+}
+
+/** Read the installed program for a line id, or null when not installed. */
+export function readInstalledLineProgram(repoPath: string, lineId: string): LineProgram | null {
+  const programPath = path.join(path.resolve(repoPath), lineProgramPathRel(lineId));
+  if (!fs.existsSync(programPath)) return null;
+  const parsed = LineProgramSchema.safeParse(JSON.parse(fs.readFileSync(programPath, 'utf8')));
+  return parsed.success ? parsed.data : null;
+}
+
+function ensureParentDir(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function copyBundleFile(
+  bundleDir: string,
+  file: { src: string; dest: string; executable?: boolean },
+  repoPath: string,
+  force: boolean,
+): string {
+  const srcPath = path.join(bundleDir, file.src);
+  const destPath = path.join(repoPath, file.dest);
+
+  if (!fs.existsSync(srcPath)) {
+    throw new Error(`Line file missing: ${file.src}`);
+  }
+  if (path.resolve(srcPath) === path.resolve(destPath)) {
+    // Authoring in place (.har/lines/<id>/ installed onto itself) — nothing to copy.
+    return file.dest;
+  }
+  if (fs.existsSync(destPath) && !force) {
+    throw new Error(
+      `File already exists: ${file.dest}. Use --force to overwrite or remove it first.`,
+    );
+  }
+
+  ensureParentDir(destPath);
+  fs.copyFileSync(srcPath, destPath);
+  if (file.executable) {
+    fs.chmodSync(destPath, 0o755);
+  }
+  return file.dest;
+}
+
+/**
+ * Register stages WITHOUT touching `verificationStages`.
+ *
+ * Deliberately not `patchStageRegistry` from plugins.ts: that function's whole
+ * job is appending to `verificationStages`. Calling it with an empty array and
+ * hoping is the anti-pattern #304 calls out, so line apply has its own writer
+ * plus an assertion that the verify plan is byte-identical afterwards.
+ */
+function registerStagesOnly(repoPath: string, stages: HarnessStage[], force: boolean): void {
+  if (stages.length === 0) return;
+
+  const registry = readStageRegistry(repoPath);
+  const before = JSON.stringify(registry.verificationStages ?? null);
+
+  let nextStages = [...registry.stages];
+  for (const stage of stages) {
+    const existing = nextStages.find((s) => s.id === stage.id);
+    if (existing && !force) {
+      throw new Error(
+        `Stage "${stage.id}" already registered in .har/stages.json. Use --force to replace.`,
+      );
+    }
+    nextStages = existing
+      ? nextStages.map((s) => (s.id === stage.id ? stage : s))
+      : [...nextStages, stage];
+  }
+
+  const updated = { ...registry, stages: nextStages };
+  const after = JSON.stringify(updated.verificationStages ?? null);
+  if (before !== after) {
+    throw new Error(
+      'Refusing to write: applying a line changed verificationStages. ' +
+        'Line gate stages are opt-in and run via `har line gate`.',
+    );
+  }
+
+  writeStageRegistry(repoPath, updated);
+}
+
+function assertGateStagesResolvable(program: LineProgram, registeredIds: string[], repoPath: string): string[] {
+  const warnings: string[] = [];
+  const registry = readStageRegistry(repoPath);
+  const known = new Set([...registry.stages.map((s) => s.id), ...registeredIds]);
+  for (const stage of program.gate.stages) {
+    if (!known.has(stage.id)) {
+      warnings.push(
+        `gate stage "${stage.id}" (from ${stage.fromStation}) is not registered in .har/stages.json — ` +
+          'install the plugin that provides it, or add it to the line bundle.',
+      );
+    }
+  }
+  return warnings;
+}
+
+function applyLineFromDir(
+  repoPath: string,
+  bundleDir: string,
+  options: ApplyLineOptions,
+  meta: { source: LineSourceKind; spec: string; version?: string },
+): ApplyLineResult {
+  const resolved = path.resolve(repoPath);
+  const force = options.force ?? false;
+  const warnings: string[] = [];
+  const filesWritten: string[] = [];
+
+  if (!harnessExists(resolved)) {
+    throw new Error('No .har/ harness found. Run "har onboard" first.');
+  }
+
+  const manifest = readLineManifestFromDir(bundleDir);
+  const program = readLineProgramFromDir(bundleDir, manifest);
+  const stages = manifest.stages;
+  const stageIds = stages.map((s) => s.id);
+
+  // Snapshot the verify plan across the whole apply, not just the registry write.
+  const verificationBefore = JSON.stringify(readStageRegistry(resolved).verificationStages ?? null);
+
+  for (const file of manifest.files) {
+    filesWritten.push(copyBundleFile(bundleDir, file, resolved, force));
+  }
+
+  // The program always lands at .har/lines/<id>/line.json, whatever the bundle
+  // called it, so `har line status` has one place to look.
+  const programDest = path.join(resolved, lineProgramPathRel(manifest.id));
+  const programSrc = path.join(bundleDir, manifest.program);
+  if (path.resolve(programSrc) !== path.resolve(programDest)) {
+    if (fs.existsSync(programDest) && !force) {
+      throw new Error(
+        `Line already installed: ${lineProgramPathRel(manifest.id)}. Use --force to replace.`,
+      );
+    }
+    ensureParentDir(programDest);
+    fs.copyFileSync(programSrc, programDest);
+  }
+  filesWritten.push(lineProgramPathRel(manifest.id));
+
+  // Keep the manifest next to the program so a bare id re-resolves locally.
+  const manifestDest = path.join(resolved, lineDirRel(manifest.id), 'line.manifest.json');
+  const manifestSrc = findManifestPath(bundleDir, LINE_BUNDLE_CONFIG) as string;
+  if (path.resolve(manifestSrc) !== path.resolve(manifestDest)) {
+    ensureParentDir(manifestDest);
+    fs.copyFileSync(manifestSrc, manifestDest);
+    filesWritten.push(`${lineDirRel(manifest.id)}/line.manifest.json`);
+  }
+
+  registerStagesOnly(resolved, stages, force);
+
+  const verificationAfter = JSON.stringify(readStageRegistry(resolved).verificationStages ?? null);
+  if (verificationBefore !== verificationAfter) {
+    throw new Error(
+      'Line apply changed verificationStages — this is a bug. ' +
+        'Line gate stages must stay off `har env verify --full`.',
+    );
+  }
+
+  warnings.push(...assertGateStagesResolvable(program, stageIds, resolved));
+
+  upsertLineLedgerEntry(resolved, {
+    id: manifest.id,
+    source: meta.source,
+    spec: meta.spec,
+    version: meta.version,
+    stageIds,
+    programPath: lineProgramPathRel(manifest.id),
+    installedAt: new Date().toISOString(),
+  });
+
+  const nextSteps =
+    manifest.nextSteps.length > 0
+      ? manifest.nextSteps
+      : [
+          `har line status ${manifest.id}`,
+          `har line gate ${program.stations[0].id} --line ${manifest.id}`,
+          `Adapt the program: ${lineProgramPathRel(manifest.id)}`,
+        ];
+
+  const partial = {
+    lineId: manifest.id,
+    title: manifest.title ?? program.title,
+    stageIds,
+    filesWritten,
+    warnings,
+    nextSteps,
+    programPath: lineProgramPathRel(manifest.id),
+    docsPath: manifest.docsPath,
+    source: meta.source,
+    stationIds: program.stations.map((s) => s.id),
+  };
+
+  const promptAbsPath = writeLineAdaptationPrompt(
+    resolved,
+    manifest.id,
+    buildLineAdaptationPrompt(resolved, program, { ...partial, adaptPromptPath: '' }),
+  );
+  const adaptPromptPath = path.relative(resolved, promptAbsPath);
+
+  success(`Applied line: ${manifest.id}`);
+  info(`Stations: ${partial.stationIds.join(' → ')}`);
+  info(
+    stageIds.length > 0
+      ? `Registered stage(s) (NOT on verify): ${stageIds.join(', ')}`
+      : 'No extra stages registered',
+  );
+  for (const file of filesWritten) {
+    info(`  + ${file}`);
+  }
+  info(`  + ${adaptPromptPath} (adaptation prompt for your coding agent)`);
+  for (const warning of warnings) {
+    warn(`  ⚠ ${warning}`);
+  }
+
+  return { ...partial, adaptPromptPath };
+}
+
+/** Install a factory line by bundled id, local id, path, npm package, or git URL. */
+export function applyLine(
+  repoPath: string,
+  lineSpec: string,
+  options: ApplyLineOptions = {},
+): ApplyLineResult {
+  const spec = options.spec ?? lineSpec;
+  const source = resolveLineSource(spec, repoPath);
+  try {
+    return applyLineFromDir(repoPath, source.dir, options, {
+      source: source.kind,
+      spec: source.spec,
+      version: source.version,
+    });
+  } finally {
+    cleanupResolvedLine(source);
+  }
+}

--- a/src/harness/plugin-resolve.ts
+++ b/src/harness/plugin-resolve.ts
@@ -1,235 +1,31 @@
-import { execFileSync } from 'child_process';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { resolveTemplatesDir } from '../utils/paths';
+import {
+  cleanupResolvedBundle,
+  listLocalBundleIds,
+  listTemplateBundleIds,
+  resolveBundleSource,
+  type BundleResolveConfig,
+  type BundleSourceKind,
+  type ResolvedBundleSource,
+} from './bundle-resolve';
 
-export type PluginSourceKind = 'bundled' | 'local' | 'path' | 'npm' | 'git';
+export type PluginSourceKind = BundleSourceKind;
 
 /** Conventional in-repo home for project-owned plugins. */
 export const LOCAL_PLUGINS_DIR = '.har/plugins';
 
-export interface ResolvedPluginSource {
-  id: string;
-  kind: PluginSourceKind;
-  /** Absolute directory containing template.manifest.json */
-  dir: string;
-  /** Original user/spec string */
-  spec: string;
-  /** Optional package version read from package.json */
-  version?: string;
-  /** Temp dirs that should be cleaned up after apply */
-  cleanupDirs: string[];
-}
+export type ResolvedPluginSource = ResolvedBundleSource;
 
-function hasManifest(dir: string): boolean {
-  return fs.existsSync(path.join(dir, 'template.manifest.json'));
-}
-
-function readPackageVersion(dir: string): string | undefined {
-  const pkgPath = path.join(dir, 'package.json');
-  if (!fs.existsSync(pkgPath)) return undefined;
-  try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { version?: string };
-    return typeof pkg.version === 'string' ? pkg.version : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function readManifestId(dir: string): string | undefined {
-  const manifestPath = path.join(dir, 'template.manifest.json');
-  if (!fs.existsSync(manifestPath)) return undefined;
-  try {
-    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { id?: string };
-    return typeof raw.id === 'string' ? raw.id : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function looksLikePath(spec: string): boolean {
-  return (
-    spec.startsWith('.') ||
-    spec.startsWith('/') ||
-    spec.startsWith('~') ||
-    spec.startsWith('file:')
-  );
-}
-
-function looksLikeGit(spec: string): boolean {
-  return (
-    spec.startsWith('git+') ||
-    spec.startsWith('github:') ||
-    spec.startsWith('gitlab:') ||
-    spec.startsWith('bitbucket:') ||
-    /^https?:\/\/.+\.git$/i.test(spec) ||
-    /^git@/.test(spec)
-  );
-}
-
-function looksLikeNpm(spec: string): boolean {
-  // @scope/name, @scope/name@version, name@version, or plain package name with /
-  if (looksLikePath(spec) || looksLikeGit(spec)) return false;
-  if (spec.includes('/') && !spec.startsWith('@')) return false; // avoid treating relative as npm
-  return /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(@.+)?$/i.test(spec);
-}
-
-function resolveBundledDir(pluginId: string): string | null {
-  const dir = path.join(resolveTemplatesDir(), 'plugins', pluginId);
-  return hasManifest(dir) ? dir : null;
-}
-
-function expandHome(p: string): string {
-  if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
-  if (p === '~') return os.homedir();
-  return p;
-}
-
-/** Whether `dir` lives inside the repo's `.har/plugins/` home. */
-function isLocalPluginDir(dir: string, repoPath: string): boolean {
-  const localRoot = path.resolve(repoPath, LOCAL_PLUGINS_DIR);
-  return path.dirname(dir) === localRoot;
-}
-
-function resolvePathSpec(spec: string, repoPath: string): ResolvedPluginSource {
-  const raw = spec.startsWith('file:') ? spec.slice('file:'.length) : spec;
-  const dir = path.resolve(expandHome(raw));
-  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
-    throw new Error(`Plugin path not found: ${spec}`);
-  }
-  if (!hasManifest(dir)) {
-    throw new Error(`No template.manifest.json in ${dir}`);
-  }
-  const id = readManifestId(dir) ?? path.basename(dir);
-  return {
-    id,
-    kind: isLocalPluginDir(dir, repoPath) ? 'local' : 'path',
-    dir,
-    spec,
-    version: readPackageVersion(dir),
-    cleanupDirs: [],
-  };
-}
-
-function resolveLocalDir(pluginId: string, repoPath: string): string | null {
-  const dir = path.resolve(repoPath, LOCAL_PLUGINS_DIR, pluginId);
-  return hasManifest(dir) ? dir : null;
-}
-
-function makeTempDir(prefix: string): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-}
-
-function resolveNpmSpec(spec: string): ResolvedPluginSource {
-  const tmp = makeTempDir('har-plugin-npm-');
-  const cleanupDirs = [tmp];
-  try {
-    execFileSync('npm', ['pack', spec, '--pack-destination', tmp], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 120_000,
-    });
-    const tarballs = fs.readdirSync(tmp).filter((f) => f.endsWith('.tgz'));
-    if (tarballs.length === 0) {
-      throw new Error(`npm pack produced no tarball for ${spec}`);
-    }
-    const extractDir = path.join(tmp, 'extract');
-    fs.mkdirSync(extractDir);
-    execFileSync('tar', ['-xzf', path.join(tmp, tarballs[0]), '-C', extractDir], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const packageDir = path.join(extractDir, 'package');
-    // Some packs nest the manifest; prefer package/, else search one level
-    let dir = packageDir;
-    if (!hasManifest(dir)) {
-      const nested = fs
-        .readdirSync(extractDir, { withFileTypes: true })
-        .filter((e) => e.isDirectory())
-        .map((e) => path.join(extractDir, e.name))
-        .find((d) => hasManifest(d));
-      if (!nested) {
-        throw new Error(
-          `npm package ${spec} has no template.manifest.json (not a HAR plugin bundle)`,
-        );
-      }
-      dir = nested;
-    }
-    const id = readManifestId(dir) ?? spec.replace(/^@/, '').replace(/[/:].*/g, '');
-    return {
-      id,
-      kind: 'npm',
-      dir,
-      spec,
-      version: readPackageVersion(dir),
-      cleanupDirs,
-    };
-  } catch (err) {
-    for (const d of cleanupDirs) {
-      fs.rmSync(d, { recursive: true, force: true });
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to install plugin from npm (${spec}): ${message}`);
-  }
-}
-
-function resolveGitSpec(spec: string): ResolvedPluginSource {
-  const tmp = makeTempDir('har-plugin-git-');
-  const cleanupDirs = [tmp];
-  const cloneDir = path.join(tmp, 'repo');
-  try {
-    let url = spec;
-    if (spec.startsWith('github:')) {
-      url = `https://github.com/${spec.slice('github:'.length)}.git`;
-    } else if (spec.startsWith('gitlab:')) {
-      url = `https://gitlab.com/${spec.slice('gitlab:'.length)}.git`;
-    } else if (spec.startsWith('bitbucket:')) {
-      url = `https://bitbucket.org/${spec.slice('bitbucket:'.length)}.git`;
-    } else if (spec.startsWith('git+')) {
-      url = spec.slice('git+'.length);
-    }
-
-    execFileSync('git', ['clone', '--depth', '1', url, cloneDir], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 180_000,
-    });
-
-    // Manifest at root, or under a single plugins/<id> dir
-    let dir = cloneDir;
-    if (!hasManifest(dir)) {
-      const pluginsRoot = path.join(cloneDir, 'plugins');
-      if (fs.existsSync(pluginsRoot)) {
-        const child = fs
-          .readdirSync(pluginsRoot, { withFileTypes: true })
-          .filter((e) => e.isDirectory())
-          .map((e) => path.join(pluginsRoot, e.name))
-          .find((d) => hasManifest(d));
-        if (child) dir = child;
-      }
-    }
-    if (!hasManifest(dir)) {
-      throw new Error(`Git repo ${spec} has no template.manifest.json (not a HAR plugin bundle)`);
-    }
-
-    const id = readManifestId(dir) ?? path.basename(url.replace(/\.git$/, ''));
-    return {
-      id,
-      kind: 'git',
-      dir,
-      spec,
-      version: readPackageVersion(dir),
-      cleanupDirs,
-    };
-  } catch (err) {
-    for (const d of cleanupDirs) {
-      fs.rmSync(d, { recursive: true, force: true });
-    }
-    const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Failed to install plugin from git (${spec}): ${message}`);
-  }
-}
+export const PLUGIN_BUNDLE_CONFIG: BundleResolveConfig = {
+  // `line.manifest.json` is accepted here on purpose: resolving a line bundle
+  // lets `readPluginManifestFromDir` refuse it with a pointer at `har line add`
+  // instead of a bare "not a HAR plugin bundle".
+  manifestFiles: ['template.manifest.json', 'line.manifest.json'],
+  templatesSubdir: 'plugins',
+  localDir: LOCAL_PLUGINS_DIR,
+  gitNestedDir: 'plugins',
+  label: 'plugin',
+  unknownHint: (repoPath: string) => knownPluginsHint(repoPath),
+};
 
 /**
  * Resolve a plugin install spec to a directory with template.manifest.json.
@@ -242,67 +38,7 @@ function resolveGitSpec(spec: string): ResolvedPluginSource {
  * - git: `github:org/repo`, `git+https://…`, `https://….git`
  */
 export function resolvePluginSource(spec: string, repoPath = '.'): ResolvedPluginSource {
-  const trimmed = spec.trim();
-  if (!trimmed) {
-    throw new Error('Plugin spec is empty');
-  }
-
-  if (looksLikePath(trimmed)) {
-    return resolvePathSpec(trimmed, repoPath);
-  }
-
-  if (looksLikeGit(trimmed)) {
-    return resolveGitSpec(trimmed);
-  }
-
-  // Prefer bundled when the id matches a shipped plugin (even if it also looks like npm)
-  const bundled = resolveBundledDir(trimmed);
-  if (bundled) {
-    return {
-      id: trimmed,
-      kind: 'bundled',
-      dir: bundled,
-      spec: trimmed,
-      version: readPackageVersion(bundled),
-      cleanupDirs: [],
-    };
-  }
-
-  // Bare id matching a project-owned plugin under .har/plugins/<id>
-  const local = resolveLocalDir(trimmed, repoPath);
-  if (local) {
-    return {
-      id: readManifestId(local) ?? trimmed,
-      kind: 'local',
-      dir: local,
-      spec: trimmed,
-      version: readPackageVersion(local),
-      cleanupDirs: [],
-    };
-  }
-
-  // Bare id that isn't bundled — if it looks like an npm package name, try npm
-  if (looksLikeNpm(trimmed) && (trimmed.includes('@') || trimmed.includes('/'))) {
-    return resolveNpmSpec(trimmed);
-  }
-
-  if (looksLikeNpm(trimmed)) {
-    // Could be a typo for a bundled plugin, or an npm package without scope
-    try {
-      return resolveNpmSpec(trimmed);
-    } catch (npmErr) {
-      const npmMessage = npmErr instanceof Error ? npmErr.message : String(npmErr);
-      throw new Error(
-        `Unknown plugin: ${trimmed}. ${knownPluginsHint(repoPath)} ` +
-          `Or pass a path, npm package, or git URL. (${npmMessage})`,
-      );
-    }
-  }
-
-  throw new Error(
-    `Unknown plugin: ${trimmed}. ${knownPluginsHint(repoPath)} ` +
-      `Or pass a path (./plugin), npm package (@org/pkg), or git URL (github:org/repo).`,
-  );
+  return resolveBundleSource(spec, repoPath, PLUGIN_BUNDLE_CONFIG);
 }
 
 function knownPluginsHint(repoPath: string): string {
@@ -319,32 +55,14 @@ function knownPluginsHint(repoPath: string): string {
 
 /** List project-owned plugin ids under <repo>/.har/plugins/<id>/template.manifest.json */
 export function listLocalPluginIds(repoPath = '.'): string[] {
-  const root = path.resolve(repoPath, LOCAL_PLUGINS_DIR);
-  if (!fs.existsSync(root)) return [];
-
-  return fs
-    .readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((name) => hasManifest(path.join(root, name)))
-    .sort();
+  return listLocalBundleIds(repoPath, PLUGIN_BUNDLE_CONFIG);
 }
 
 /** List plugin ids discovered under templates/plugins/<id>/template.manifest.json */
 export function listBundledPluginIds(): string[] {
-  const root = path.join(resolveTemplatesDir(), 'plugins');
-  if (!fs.existsSync(root)) return [];
-
-  return fs
-    .readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((name) => hasManifest(path.join(root, name)))
-    .sort();
+  return listTemplateBundleIds(PLUGIN_BUNDLE_CONFIG);
 }
 
 export function cleanupResolvedPlugin(source: ResolvedPluginSource): void {
-  for (const dir of source.cleanupDirs) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  cleanupResolvedBundle(source);
 }

--- a/src/harness/plugins.ts
+++ b/src/harness/plugins.ts
@@ -4,15 +4,17 @@ import { z } from 'zod';
 import { info, success, warn } from '../utils/logging';
 import { resolveTemplatesDir } from '../utils/paths';
 import { harnessExists } from './parser';
+import { findManifestPath } from './bundle-resolve';
 import {
   cleanupResolvedPlugin,
   listBundledPluginIds,
+  PLUGIN_BUNDLE_CONFIG,
   resolvePluginSource,
   type PluginSourceKind,
 } from './plugin-resolve';
 import { upsertPluginLedgerEntry } from './plugin-ledger';
 import { buildPluginAdaptationPrompt, writePluginAdaptationPrompt } from './plugin-prompt';
-import { HarnessStageRegistry, HarnessStageSchema } from './schema';
+import { HarnessStageRegistry, HarnessStageSchema, LINE_BUNDLE_KIND } from './schema';
 import { readStageRegistry, writeStageRegistry } from './stages';
 
 /** Plugin id is a free-form slug discovered from manifests (no closed enum). */
@@ -147,13 +149,22 @@ function resolveBundledPluginDir(pluginId: PluginId): string {
 }
 
 export function readPluginManifestFromDir(pluginDir: string, expectedId?: string): PluginManifest {
-  const manifestPath = path.join(pluginDir, 'template.manifest.json');
-  if (!fs.existsSync(manifestPath)) {
+  const manifestPath = findManifestPath(pluginDir, PLUGIN_BUNDLE_CONFIG);
+  if (!manifestPath) {
     throw new Error(`No template.manifest.json in ${pluginDir}`);
   }
-  const parsed = PluginManifestSchema.safeParse(
-    JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
-  );
+  const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+
+  // Poka-yoke (#304): add-plugin always appends to verificationStages, so a
+  // factory line must never travel this path — its stages are opt-in.
+  if (raw.kind === LINE_BUNDLE_KIND || path.basename(manifestPath) === 'line.manifest.json') {
+    throw new Error(
+      `${path.basename(manifestPath)} declares "kind": "line" — this is a factory line bundle, ` +
+        'not a verification plugin. Install it with: har line add <spec>',
+    );
+  }
+
+  const parsed = PluginManifestSchema.safeParse(raw);
   if (!parsed.success) {
     throw new Error(`Invalid plugin manifest: ${parsed.error.message}`);
   }

--- a/src/harness/schema.ts
+++ b/src/harness/schema.ts
@@ -3,3 +3,4 @@ export * from '../../packages/schemas/src/schema';
 export * from '../../packages/schemas/src/harness-env';
 export * from '../../packages/schemas/src/usage-authority';
 export * from '../../packages/schemas/src/usage-pricing';
+export * from '../../packages/schemas/src/line';

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -258,3 +258,47 @@ export const ControlUpOutputSchema = z.object({
 });
 
 export { StageResultSchema };
+
+/** Factory lines (#304) — same core as `har line …`, mirrored on MCP. */
+export const CreateLineInputSchema = z.object({
+  repo: z.string().default('.'),
+  id: z.string().min(1).describe('Line id (lowercase slug, e.g. onboarding-line)'),
+  title: z.string().min(1).optional().describe('Human-readable line title'),
+  description: z.string().min(1).max(2000).optional(),
+  stations: z.array(z.string().min(1)).optional().describe('Station ids in order (default: S1, S2)'),
+  gateStage: z
+    .boolean()
+    .default(true)
+    .describe('Scaffold one registered-but-off-verify gate stage'),
+  optInEnv: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Env var that must be "1" for the gate to run (e.g. HAR_FIXTURE_E2E)'),
+  force: z.boolean().default(false),
+});
+
+export const AddLineInputSchema = z.object({
+  repo: z.string().default('.'),
+  line: z
+    .string()
+    .min(1)
+    .describe('Line id, local path (./line), npm package (@org/pkg), or git URL (github:org/repo)'),
+  force: z.boolean().default(false).describe('Overwrite existing line files and stage entries'),
+});
+
+export const LineStatusInputSchema = z.object({
+  repo: z.string().default('.'),
+  line: z.string().min(1).optional().describe('Line id (default: every installed line)'),
+});
+
+export const RunLineGateInputSchema = z.object({
+  repo: z.string().default('.'),
+  station: z.string().min(1).describe('Station id whose cumulative gate should run'),
+  line: z.string().min(1).optional().describe('Line id when more than one is installed'),
+  agentId: z.number().int().optional().describe('Agent slot to run the stages in'),
+  force: z
+    .boolean()
+    .default(false)
+    .describe('Run even when the program declares an opt-in env var that is not set'),
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -745,6 +745,7 @@ export async function handleMcpToolCall(
         lineId: result.lineId,
         title: result.title,
         stationIds: result.stationIds,
+        firstGatedStationId: result.firstGatedStationId,
         stageIds: result.stageIds,
         filesWritten: result.filesWritten,
         warnings: result.warnings,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,6 +23,13 @@ import {
   teardownEnvironment,
 } from '../core/run-service';
 import { getRun, listRuns } from '../core/runs';
+import {
+  addLine,
+  createLineBundle,
+  getAllLineStatuses,
+  getLineStatus,
+  runLineGate,
+} from '../core/lines';
 import { addWorkUnitLinks } from '../core/work-units';
 import { resolveHarnessRoot } from '../harness/manifest';
 import { runDoctor } from '../harness/doctor';
@@ -58,6 +65,10 @@ import {
   GetStatusOutputSchema,
   MaintainHarnessInputSchema,
   AddPluginInputSchema,
+  AddLineInputSchema,
+  CreateLineInputSchema,
+  LineStatusInputSchema,
+  RunLineGateInputSchema,
   RunStageInputSchema,
   RunVerificationInputSchema,
   RunVerificationOutputSchema,
@@ -325,6 +336,77 @@ export const HAR_MCP_TOOLS: Tool[] = [
       repo: repoJsonProperty,
       detach: { type: 'boolean', description: 'Run the container in detached mode (default true)' },
     }),
+  },
+  {
+    name: 'har_line_create',
+    description:
+      'Scaffold a project-owned factory line at .har/lines/<id>/ (manifest, program, optional gate stage, README). A line is a multi-station program, not a verification plugin.',
+    inputSchema: objectJsonSchema(
+      {
+        repo: repoJsonProperty,
+        id: { type: 'string', description: 'Line id (lowercase slug, e.g. onboarding-line)' },
+        title: { type: 'string', description: 'Human-readable line title' },
+        description: { type: 'string', description: 'One-paragraph description of the program' },
+        stations: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Station ids in order (default: S1, S2)',
+        },
+        gateStage: {
+          type: 'boolean',
+          description: 'Scaffold one registered-but-off-verify gate stage (default true)',
+        },
+        optInEnv: {
+          type: 'string',
+          description: 'Env var that must be "1" for the gate to run (e.g. HAR_FIXTURE_E2E)',
+        },
+        force: { type: 'boolean', description: 'Overwrite an existing line' },
+      },
+      ['id'],
+    ),
+  },
+  {
+    name: 'har_add_line',
+    description:
+      'Install a factory line bundle (local id, path, npm package, or git URL). Registers the line\'s stages but NEVER adds them to verificationStages — default verify stays unchanged. Verification plugins use har_add_plugin instead.',
+    inputSchema: objectJsonSchema(
+      {
+        repo: repoJsonProperty,
+        line: {
+          type: 'string',
+          description: 'Line id, local path (./line), npm package (@org/pkg), or git URL',
+        },
+        force: { type: 'boolean', description: 'Overwrite existing line files and stage entries' },
+      },
+      ['line'],
+    ),
+  },
+  {
+    name: 'har_line_status',
+    description:
+      'Stations, cumulative gate progress derived from .har/runs/ records, and slots in flight for installed factory lines. Pure read — writes no run records.',
+    inputSchema: objectJsonSchema({
+      repo: repoJsonProperty,
+      line: { type: 'string', description: 'Line id (default: every installed line)' },
+    }),
+  },
+  {
+    name: 'har_run_line_gate',
+    description:
+      'Run one station\'s cumulative gate: every gate stage tagged at that station or earlier. Runs through the normal stage runner and writes run records; does not call verify and does not widen the verify plan.',
+    inputSchema: objectJsonSchema(
+      {
+        repo: repoJsonProperty,
+        station: { type: 'string', description: 'Station id whose cumulative gate should run' },
+        line: { type: 'string', description: 'Line id when more than one is installed' },
+        agentId: agentIdJsonProperty,
+        force: {
+          type: 'boolean',
+          description: 'Run even when the program declares an opt-in env var that is not set',
+        },
+      },
+      ['station'],
+    ),
   },
 ];
 
@@ -636,6 +718,62 @@ export async function handleMcpToolCall(
           apiReady: result.apiReady,
         }),
       );
+    }
+
+    case 'har_line_create': {
+      const input = CreateLineInputSchema.parse({ ...args, repo });
+      const result = createLineBundle(repo, {
+        id: input.id,
+        title: input.title,
+        description: input.description,
+        stations: input.stations,
+        gateStage: input.gateStage,
+        optInEnv: input.optInEnv,
+        force: input.force,
+      });
+      return jsonContent({
+        lineId: result.lineId,
+        filesWritten: result.filesWritten,
+        nextSteps: result.nextSteps,
+      });
+    }
+
+    case 'har_add_line': {
+      const input = AddLineInputSchema.parse({ ...args, repo });
+      const result = addLine(repo, input.line, { force: input.force, spec: input.line });
+      return jsonContent({
+        lineId: result.lineId,
+        title: result.title,
+        stationIds: result.stationIds,
+        stageIds: result.stageIds,
+        filesWritten: result.filesWritten,
+        warnings: result.warnings,
+        nextSteps: result.nextSteps,
+        programPath: result.programPath,
+        docsPath: result.docsPath,
+        source: result.source,
+        adaptPromptPath: result.adaptPromptPath,
+        verificationStagesUnchanged: true,
+      });
+    }
+
+    case 'har_line_status': {
+      const input = LineStatusInputSchema.parse({ ...args, repo });
+      const statuses = input.line ? [getLineStatus(repo, input.line)] : getAllLineStatuses(repo);
+      return jsonContent(input.line ? statuses[0] : { lines: statuses });
+    }
+
+    case 'har_run_line_gate': {
+      const input = RunLineGateInputSchema.parse({ ...args, repo });
+      const agentId = input.agentId === undefined ? undefined : validateAgentId(input.agentId, repo);
+      const result = await runLineGate({
+        repoPath: repo,
+        lineId: input.line,
+        station: input.station,
+        agentId,
+        force: input.force,
+      });
+      return jsonContent(result);
     }
 
     default:

--- a/src/templates/agent-skills/factory-line.md
+++ b/src/templates/agent-skills/factory-line.md
@@ -4,9 +4,10 @@ Execute **one station** of a declared multi-station program:
 
 sync → wave plan → parallel HAR slots → cumulative gate → human handoff.
 
-The program lives in a **line template** (a `*.line.json` the user points at,
-or `.har/line.json` when that file exists). This workflow is the orchestrator.
-Station-specific how-to lives in other skills the template lists.
+The program lives in an **installed line bundle**, not in this workflow. Find
+it with `har line status` — installed lines live at `.har/lines/<id>/line.json`
+and are recorded in `.har/lines.json`. This workflow is the orchestrator;
+station-specific how-to lives in other skills the program lists.
 
 HAR already has the primitives — work units, isolated slots, stages, plugins,
 validation records. A line is composition plus a manifest. Do not invent a
@@ -19,9 +20,10 @@ This workflow is the same on Claude Code (`/factory-line`), Cursor
 
 Resolve these before doing anything (ask only if not inferable):
 
-1. **Line file** — path to a `*.line.json`. If the repo has no line file and
-   the user did not name one, stop and say so. Do not invent GitHub issue
-   numbers or a fixture repo.
+1. **Line** — run `har line status` (or MCP `har_line_status`). One installed
+   line: use it. Several: ask which. **None installed**: stop and offer
+   `har line create <id>` or `har line add <spec>` — do not invent GitHub
+   issue numbers, a fixture repo, or a program of your own.
 2. **Station id** — default: the first station whose bound work is not all
    done / whose gate has not passed.
 3. **Slot budget** — `har env status` first. One slot per concurrent agent.
@@ -29,7 +31,7 @@ Resolve these before doing anything (ask only if not inferable):
 
 ## Contract (minimum)
 
-A line file is JSON with `contractVersion: 1`. Required:
+A line program is JSON with `contractVersion: 1`. Required:
 
 - `id`, `stations[]` (ordered; each has `id` + `title`)
 - `gate.cumulative` must be `true`
@@ -56,7 +58,9 @@ does not declare them, do not do them.
 
 ## 0. Load and preflight
 
-1. Read the line file. Confirm `gate.cumulative` and `handoff.autonomousShip`.
+1. `har line status [id]` — read the program it names. Confirm
+   `gate.cumulative` and `handoff.autonomousShip`. `har line status` already
+   reports which stations are green and which is next.
 2. Skills and MCP: confirm required ones are present. Missing optional:
    skip those steps and say so. Do not install third-party packs yourself.
 3. Print: line id, station id, waves, slot plan, and every gate stage whose
@@ -83,8 +87,16 @@ For each wave, one subagent per group, in parallel. Each:
 
 ## 3. Gate
 
-Run every gate stage whose `fromStation` ≤ current station. If
-`gate.optInEnv` is set, export it as `1` so the opt-in jig actually runs.
+```bash
+har line gate <station> --line <id> --agent <slot>
+```
+
+That runs every gate stage whose `fromStation` ≤ this station — the cumulative
+set, from data. Add `--force` when the program sets `gate.optInEnv` and you
+want the opt-in jig to run anyway.
+
+Line gate stages are **not** part of `har env verify --full`, by design. Run
+both: full verify for the harness contract, `har line gate` for the station.
 
 Red gate → fix, re-run. Never hand off a red gate. Never bypass
 (`HAR_SKIP_GATE`, `--no-verify`).

--- a/src/templates/agent-skills/skills.manifest.json
+++ b/src/templates/agent-skills/skills.manifest.json
@@ -13,8 +13,12 @@
           "allowed-tools": "Bash(har *) Bash(npm *) Bash(git *) Bash(docker *) Read Grep Glob Edit Write"
         }
       },
-      "cursor": { "command": true },
-      "codex": { "promptName": "har-setup" }
+      "cursor": {
+        "command": true
+      },
+      "codex": {
+        "promptName": "har-setup"
+      }
     },
     {
       "id": "har-wt",
@@ -26,8 +30,12 @@
           "description": "Use BEFORE making any code change in this repository. Launches a har harness slot, which creates an isolated git session worktree — all edits must happen there, never in the main checkout — and verifies the work through the harness when done."
         }
       },
-      "cursor": { "command": true },
-      "codex": { "promptName": "har-wt" }
+      "cursor": {
+        "command": true
+      },
+      "codex": {
+        "promptName": "har-wt"
+      }
     },
     {
       "id": "har-maintain",
@@ -41,8 +49,12 @@
           "allowed-tools": "Bash(har *) Bash(git *) Read Grep Glob Edit Write"
         }
       },
-      "cursor": { "command": true },
-      "codex": { "promptName": "har-maintain" }
+      "cursor": {
+        "command": true
+      },
+      "codex": {
+        "promptName": "har-maintain"
+      }
     },
     {
       "id": "factory-line",
@@ -51,11 +63,15 @@
       "claude": {
         "frontmatter": {
           "name": "factory-line",
-          "description": "Execute one station of a declared multi-station program (*.line.json): parallel HAR slots, cumulative gate, human handoff. Use when asked to run a factory line, the next station, or a milestone program."
+          "description": "Execute one station of an installed factory line (har line status / .har/lines/<id>/line.json): parallel HAR slots, cumulative gate via har line gate, human handoff. Use when asked to run a factory line, the next station, or a milestone program."
         }
       },
-      "cursor": { "command": true },
-      "codex": { "promptName": "har-factory-line" }
+      "cursor": {
+        "command": true
+      },
+      "codex": {
+        "promptName": "har-factory-line"
+      }
     }
   ]
 }

--- a/src/templates/lines/example-line/.github/workflows/check-manifest.yml
+++ b/src/templates/lines/example-line/.github/workflows/check-manifest.yml
@@ -1,0 +1,24 @@
+name: Check line bundle
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Validate line manifest and program
+        run: node scripts/check-manifest.mjs
+      - name: Stage scripts are executable
+        run: |
+          set -euo pipefail
+          for script in stages/*.sh; do
+            [ -x "$script" ] || { echo "not executable: $script" >&2; exit 1; }
+            bash -n "$script"
+          done

--- a/src/templates/lines/example-line/AGENTS.md
+++ b/src/templates/lines/example-line/AGENTS.md
@@ -1,0 +1,48 @@
+# Authoring guide for coding agents
+
+This repository is a **HAR factory line bundle**. Read this before changing it.
+
+## Is this a line or a verification plugin?
+
+Ask one question: **should this run on every `har env verify --full`?**
+
+| Answer | Bundle kind | Template | Install |
+|---|---|---|---|
+| Yes — it must gate every change | Verification plugin | [har-plugin](https://github.com/os-factory/har-plugin) | `har env add-plugin <spec>` |
+| No — it gates a *station* of a program | Factory line | this repo | `har line add <spec>` |
+
+Typical lines: a migration executed in waves, an onboarding program, a
+heavy proof jig (Docker lab, fixture end-to-end, device farm) that must exist
+and be runnable but must not be on the hot path of every verify.
+
+If you find yourself wanting to add a line stage to `verificationStages`, stop:
+you wanted a plugin.
+
+## Hard rules
+
+- `line.manifest.json` declares `"kind": "line"` and **must not** declare
+  `verificationStages`. The schema rejects it.
+- `gate.cumulative` is `true`. A stage tagged `fromStation: X` is required at X
+  **and every later station**. Adding a station may never drop an earlier
+  station's stages.
+- `handoff.autonomousShip` is `false`. Agents hand off; humans merge and
+  release.
+- `skills[]` and `mcp[]` are **declarations with install hints**. HAR does not
+  vendor skill packs or MCP servers, and a line never introduces a core tool
+  named after a tracker or a framework.
+- Station names, tracker ids, branch strategy, and fixture repos are *instance
+  data*. They belong in `line.json`, never in the tooling.
+
+## Validate
+
+```bash
+node scripts/check-manifest.mjs
+```
+
+Then prove the invariant on a scratch harness:
+
+```bash
+har line add ./           # from a repo with a .har/ harness
+har line status <id>
+git diff -- .har/stages.json   # verificationStages must be untouched
+```

--- a/src/templates/lines/example-line/README.md
+++ b/src/templates/lines/example-line/README.md
@@ -1,0 +1,72 @@
+# har-line
+
+A GitHub template for authoring **HAR factory lines**.
+
+A *factory line* is a program: an ordered set of **stations** plus a
+**cumulative gate**. It composes what HAR 1.0 already has — work units, slots,
+stages, plugins, skills, MCP. It is not a fourth marketplace and not a second
+stage runner.
+
+> **A line is not a verification plugin.** Installing a line registers its
+> stages but **never** adds them to `verificationStages`. Default
+> `har env verify --full` takes exactly as long as it did before. That is the
+> entire reason the two bundle kinds are separate.
+>
+> If your check should gate *every* verify, use
+> [os-factory/har-plugin](https://github.com/os-factory/har-plugin) instead.
+
+## Quick start
+
+1. **Use this template** → name your repo (e.g. `onboarding-line`).
+2. Rename the example: `line.manifest.json` `id`, `line.json` `id`/`title`, and
+   the stage script under `stages/`.
+3. Describe your stations in `line.json`.
+4. Install it into a product repo:
+
+```bash
+har line add github:your-org/onboarding-line
+har line status onboarding-line
+har line gate S2 --line onboarding-line
+```
+
+## Package layout
+
+```text
+har-line/
+├── line.manifest.json     # kind: line — what `har line add` applies
+├── line.json              # the program: stations, gate, handoff
+├── stages/
+│   └── example-gate.sh    # extra stage — registered, NOT on verify
+├── docs/AUTHORING.md      # how to write a line
+├── scripts/check-manifest.mjs
+└── AGENTS.md              # line vs verification plugin, for coding agents
+```
+
+## Install channels
+
+| Spec | Example |
+|---|---|
+| Local path | `har line add ./har-line` |
+| Git | `har line add github:acme/onboarding-line` |
+| npm | `har line add @acme/onboarding-line` |
+
+Add a `package.json` (name, version, `files`) only if you want the npm channel —
+git and path installs need nothing else.
+
+Resolution order is path → git → bundled id → npm, the same resolver plugins
+use. The package root must contain `line.manifest.json`.
+
+`har env add-plugin` **refuses** a line bundle and points at `har line add`.
+
+## The invariant
+
+After `har line add`, `.har/stages.json` `verificationStages` is unchanged —
+no new ids, same default verify duration. `scripts/check-manifest.mjs` asserts
+the manifest side of that; the CLI asserts the applied side and refuses to
+write if the verify plan moved.
+
+## Related
+
+- [os-factory/har](https://github.com/os-factory/har) — the CLI and MCP control plane
+- [os-factory/har-plugin](https://github.com/os-factory/har-plugin) — template for **verification plugins** (these *do* join verify)
+- [Factory lines guide](https://har.osfactory.dev/docs/guides/factory-lines/)

--- a/src/templates/lines/example-line/docs/AUTHORING.md
+++ b/src/templates/lines/example-line/docs/AUTHORING.md
@@ -1,0 +1,79 @@
+# Authoring a factory line
+
+## 1. The program (`line.json`)
+
+`contractVersion: 1`. Additive fields are fine; renaming a field is a new
+version.
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | yes | Stable kebab id. Must match `line.manifest.json`. |
+| `title` | yes | Human title. |
+| `stations[]` | yes | Ordered. Array order *is* station order. |
+| `stations[].id` | yes | Stable, shell-friendly. |
+| `stations[].work` | no | Tracker binding: `source` (`github`, `linear`, `none`, …), `ids[]` passed to `har env launch --work-id`. |
+| `stations[].waves` | no | Each inner array is one wave; cells in a wave run in parallel slots. |
+| `skills[]` | no | Skills the line expects. `role` is `orchestrator` or `station`; `install` is a hint (`repo:…`, `upstream:url`, `agent-managed`). |
+| `mcp[]` | no | MCP **servers** the line expects. `required: false` means skip those steps when absent. |
+| `plugins[]` | no | Verification plugin ids the gate assumes (`har env add-plugin`). |
+| `gate.cumulative` | yes | Must be `true`. |
+| `gate.optInEnv` | no | When set (e.g. `HAR_FIXTURE_E2E`), the gate is skipped unless that env is `1`. |
+| `gate.stages[].fromStation` | yes | The ratchet tag: required from this station onward. |
+| `extraStages[]` | no | Stages this line adds beyond the profile defaults. |
+| `handoff.autonomousShip` | yes | Must be `false`. |
+| `traveler` | no | Where durable notes live given the repo's merge policy. |
+| `prototypeNotes[]` | no | Instance tactics that must not leak into the primitive. |
+
+## 2. The manifest (`line.manifest.json`)
+
+```json
+{
+  "kind": "line",
+  "id": "your-line",
+  "program": "line.json",
+  "files": [
+    { "src": "stages/your-gate.sh", "dest": ".har/stages/your-gate.sh", "executable": true }
+  ],
+  "stages": [{ "id": "your-gate", "kind": "test", "script": "stages/your-gate.sh", "tier": "full" }]
+}
+```
+
+- `files[]` are copied into the target repo verbatim.
+- `stages[]` are **registered** in `.har/stages.json` — and nothing else. They
+  are not appended to `verificationStages`, and the CLI refuses to write if
+  applying the bundle would have moved that list.
+- Declaring `verificationStages` here is a schema error, not a warning.
+
+## 3. The gate stage
+
+A line stage is an ordinary HAR stage script: stdout is one JSON result object,
+stderr is progress, `$1` is the agent slot id, artifacts go under
+`.har/artifacts/<stage-id>/`. See `.har/STAGES.md` in any harness for the full
+contract.
+
+Run it through the line, not through verify:
+
+```bash
+har line gate S2 --line your-line
+```
+
+## 4. Growing the ratchet
+
+To ask a question the previous gate forgot:
+
+1. Add a stage (or a `doctor` check) that asks it.
+2. Tag it `fromStation` of the station that made the question askable.
+3. Leave every earlier tag in place.
+
+That is how a review comment becomes a permanent question instead of a habit.
+
+## 5. Publish
+
+```bash
+git init && git commit -am "feat: my line"
+gh repo create your-org/your-line --public --source . --push
+```
+
+Consumers install with `har line add github:your-org/your-line`. For npm, keep
+`package.json` and `npm publish` — `har line add @your-org/your-line` packs it
+with `npm pack` and reads `line.manifest.json` from the package root.

--- a/src/templates/lines/example-line/line.json
+++ b/src/templates/lines/example-line/line.json
@@ -1,0 +1,72 @@
+{
+  "contractVersion": 1,
+  "id": "example-line",
+  "title": "Example factory line",
+  "description": "A three-station program showing the shape a factory line takes: stations that produce something, a cumulative gate that grows as the line grows, and a handoff that a human owns. Rename it and make the stations describe your own work.",
+  "skills": [
+    {
+      "id": "factory-line",
+      "role": "orchestrator",
+      "install": "repo:.claude/skills/factory-line"
+    }
+  ],
+  "mcp": [
+    {
+      "name": "github",
+      "why": "issue tracker and pull requests",
+      "required": false
+    }
+  ],
+  "plugins": [],
+  "stations": [
+    {
+      "id": "S1",
+      "title": "Draft",
+      "description": "Agree the contract before anyone writes code: schema, interfaces, the invariant that must hold.",
+      "work": { "source": "none", "ids": [], "optional": true }
+    },
+    {
+      "id": "S2",
+      "title": "Build",
+      "description": "Implement the contract in isolated slots, one work unit per slot.",
+      "work": { "source": "none", "ids": [], "optional": true }
+    },
+    {
+      "id": "S3",
+      "title": "Prove",
+      "description": "Demonstrate the invariant on a real repository, then hand off for human review.",
+      "work": { "source": "none", "ids": [], "optional": true }
+    }
+  ],
+  "gate": {
+    "cumulative": true,
+    "optInEnv": null,
+    "stages": [
+      {
+        "id": "example-gate",
+        "fromStation": "S2",
+        "tier": "full"
+      }
+    ]
+  },
+  "extraStages": [
+    {
+      "id": "example-gate",
+      "kind": "test",
+      "tier": "full",
+      "description": "Line-owned gate — registered in .har/stages.json, absent from verificationStages"
+    }
+  ],
+  "handoff": {
+    "autonomousShip": false,
+    "waitFor": "human review before merge or release"
+  },
+  "traveler": {
+    "kind": "github-issue-comment",
+    "note": "Durable notes live on the tracker issue — a squash merge drops commit-body footers."
+  },
+  "prototypeNotes": [
+    "Station names (Draft/Build/Prove) are instance data — rename them for your program.",
+    "This example binds no tracker work; set stations[].work.source and .ids to bind GitHub or Linear."
+  ]
+}

--- a/src/templates/lines/example-line/line.manifest.json
+++ b/src/templates/lines/example-line/line.manifest.json
@@ -1,0 +1,37 @@
+{
+  "kind": "line",
+  "id": "example-line",
+  "title": "Example factory line",
+  "program": "line.json",
+  "files": [
+    {
+      "src": "stages/example-gate.sh",
+      "dest": ".har/stages/example-gate.sh",
+      "executable": true
+    }
+  ],
+  "stages": [
+    {
+      "id": "example-gate",
+      "kind": "test",
+      "description": "Line-owned gate for example-line — registered, never on verify",
+      "script": "stages/example-gate.sh",
+      "requiresAgentId": true,
+      "artifacts": [
+        {
+          "path": ".har/artifacts/example-gate",
+          "kind": "directory",
+          "description": "Artifacts for the example-gate stage"
+        }
+      ],
+      "tier": "full"
+    }
+  ],
+  "nextSteps": [
+    "Edit .har/lines/example-line/line.json — rename the line and describe your stations",
+    "Edit .har/stages/example-gate.sh — replace the TODO with the real gate",
+    "har line status example-line",
+    "har line gate S2 --line example-line"
+  ],
+  "docsPath": ".har/lines/example-line/README.md"
+}

--- a/src/templates/lines/example-line/scripts/check-manifest.mjs
+++ b/src/templates/lines/example-line/scripts/check-manifest.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Validate this line bundle without installing it.
+ *
+ * Checks the invariants that make a line a line — most importantly that the
+ * manifest declares no `verificationStages`, so applying it can never widen
+ * `har env verify --full`.
+ *
+ * Usage: node scripts/check-manifest.mjs [bundle-dir]
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const bundleDir = resolve(process.argv[2] ?? join(dirname(fileURLToPath(import.meta.url)), '..'));
+const errors = [];
+const warnings = [];
+
+function readJson(relPath) {
+  const abs = join(bundleDir, relPath);
+  if (!existsSync(abs)) {
+    errors.push(`missing file: ${relPath}`);
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(abs, 'utf8'));
+  } catch (err) {
+    errors.push(`invalid JSON in ${relPath}: ${err.message}`);
+    return null;
+  }
+}
+
+const manifest = readJson('line.manifest.json');
+
+if (manifest) {
+  if (manifest.kind !== 'line') {
+    errors.push('line.manifest.json must declare "kind": "line" (a plugin manifest is not a line)');
+  }
+  if (manifest.verificationStages !== undefined) {
+    errors.push(
+      'line.manifest.json must NOT declare verificationStages — line gate stages are opt-in and run via `har line gate`',
+    );
+  }
+  if (typeof manifest.id !== 'string' || !/^[a-z0-9][a-z0-9._-]*$/.test(manifest.id)) {
+    errors.push('line.manifest.json id must be a lowercase slug');
+  }
+  for (const file of manifest.files ?? []) {
+    if (!existsSync(join(bundleDir, file.src))) {
+      errors.push(`files[].src not found: ${file.src}`);
+    }
+  }
+}
+
+const program = manifest ? readJson(manifest.program ?? 'line.json') : null;
+
+if (manifest && program) {
+  if (program.id !== manifest.id) {
+    errors.push(`program id "${program.id}" does not match manifest id "${manifest.id}"`);
+  }
+  if (program.contractVersion !== 1) {
+    errors.push('program contractVersion must be 1');
+  }
+  if (program.gate?.cumulative !== true) {
+    errors.push('gate.cumulative must be true — a line never drops an earlier station\'s stages');
+  }
+  if (program.handoff?.autonomousShip !== false) {
+    errors.push('handoff.autonomousShip must be false — agents hand off, they do not ship');
+  }
+
+  const stationIds = (program.stations ?? []).map((s) => s.id);
+  if (stationIds.length === 0) {
+    errors.push('program needs at least one station');
+  }
+  if (new Set(stationIds).size !== stationIds.length) {
+    errors.push('station ids must be unique');
+  }
+
+  const registeredIds = new Set((manifest.stages ?? []).map((s) => s.id));
+  for (const stage of program.gate?.stages ?? []) {
+    if (!stationIds.includes(stage.fromStation)) {
+      errors.push(`gate stage "${stage.id}" tags unknown station "${stage.fromStation}"`);
+    }
+    if (!registeredIds.has(stage.id)) {
+      warnings.push(
+        `gate stage "${stage.id}" is not registered by this bundle — the target repo must already provide it (e.g. via a verification plugin)`,
+      );
+    }
+  }
+}
+
+for (const warning of warnings) {
+  console.warn(`warn: ${warning}`);
+}
+
+if (errors.length > 0) {
+  for (const err of errors) {
+    console.error(`error: ${err}`);
+  }
+  console.error(`\n${errors.length} error(s) in ${bundleDir}`);
+  process.exit(1);
+}
+
+console.log(`ok: ${bundleDir} is a valid HAR line bundle`);

--- a/src/templates/lines/example-line/stages/example-gate.sh
+++ b/src/templates/lines/example-line/stages/example-gate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Line-owned gate for example-line (never on verify)
+# Custom HAR stage: example-gate (kind: test)
+#
+# Stage script contract (full reference: .har/STAGES.md):
+#   - stdout: a single JSON result object (status, stageId, agent_id, ...)
+#   - stderr: human-readable progress
+#   - $1: agent slot id; extra args may follow
+#   - artifacts: write reports/screenshots/logs under .har/artifacts/example-gate/
+#   - exit code: the real status (0 = pass)
+#
+# Usage: ./.har/stages/example-gate.sh <agent-id> [extra args...]
+set -euo pipefail
+
+# 1.0 stage surface: the runner exports WORK_DIR, ENV_FILE, AGENT_ID and
+# HAR_HARNESS_DIR, with harness.env and the slot env file already sourced —
+# agent-slot.sh is retired (1.0 migration).
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+REPO_ROOT="$(cd "$HARNESS_DIR/.." && pwd)"
+
+AGENT_ID="${1:-${AGENT_ID:?Usage: example-gate.sh <agent-id> [extra args...]}}"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+
+# JSON-escape step output; truncate to 50 lines in node (avoids SIGPIPE under pipefail).
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
+ENV_FILE="${ENV_FILE:?No slot env for agent ${AGENT_ID} — run har env launch ${AGENT_ID} first}"
+WORK_DIR="${WORK_DIR:?No slot work dir for agent ${AGENT_ID} — run har env launch ${AGENT_ID} first}"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/example-gate"
+mkdir -p "$ARTIFACTS_DIR"
+
+echo "==> [example-gate agent-${AGENT_ID}] running in ${WORK_DIR}" >&2
+START=$(now_ms)
+
+# ── TODO: implement the stage ────────────────────────────────────────────────
+# Run your checks from $WORK_DIR (the agent's isolated checkout); the slot's
+# ports and env are loaded from $ENV_FILE. Save artifacts to $ARTIFACTS_DIR.
+set +e
+OUTPUT=$(cd "$WORK_DIR" && echo "TODO: implement .har/stages/example-gate.sh" && false)
+EXIT_CODE=$?
+set -e
+
+END=$(now_ms)
+STATUS="fail"
+[ "$EXIT_CODE" = "0" ] && STATUS="pass"
+OUTPUT_JSON=$(escape_step_output "$OUTPUT")
+
+node -e "process.stdout.write(JSON.stringify({
+  status: '$STATUS',
+  stageId: 'example-gate',
+  kind: 'test',
+  agent_id: $AGENT_ID,
+  total_ms: $(( END - START )),
+  output: $OUTPUT_JSON
+}, null, 2) + '\n');"
+
+exit "$EXIT_CODE"

--- a/tests/lines.test.ts
+++ b/tests/lines.test.ts
@@ -1,0 +1,278 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { scaffoldHarnessBoilerplate } from '../src/harness/generator';
+import { applyLine, readInstalledLineProgram } from '../src/harness/lines';
+import { applyPlugin } from '../src/harness/plugins';
+import { createLine } from '../src/harness/line-create';
+import { readLineLedger } from '../src/harness/line-ledger';
+import { listBundledLineIds } from '../src/harness/line-resolve';
+import { cumulativeGateStages, getLineStatus, listInstalledLineIds } from '../src/core/lines';
+import { runDoctor } from '../src/harness/doctor';
+import { readStageRegistry } from '../src/harness/stages';
+
+function makeTempRepo(name: string): string {
+  const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
+  fs.writeFileSync(
+    path.join(repoPath, 'package.json'),
+    JSON.stringify({ name: 'test-app', version: '1.0.0' }, null, 2) + '\n',
+  );
+  scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'cli' });
+  return repoPath;
+}
+
+describe('factory lines', () => {
+  it('ships the example line as a bundled bundle', () => {
+    expect(listBundledLineIds()).toContain('example-line');
+  });
+
+  it('applies a line without changing verificationStages', () => {
+    const repoPath = makeTempRepo('har-line-apply');
+    const before = readStageRegistry(repoPath);
+    const verificationBefore = [...(before.verificationStages ?? [])];
+
+    const result = applyLine(repoPath, 'example-line');
+
+    expect(result.lineId).toBe('example-line');
+    expect(result.stageIds).toEqual(['example-gate']);
+    expect(result.stationIds).toEqual(['S1', 'S2', 'S3']);
+
+    const after = readStageRegistry(repoPath);
+
+    // The hard invariant (#304): apply may register stages, never widen verify.
+    expect(after.verificationStages).toEqual(verificationBefore);
+    expect(after.verificationStages ?? []).not.toContain('example-gate');
+
+    // …and the stage really is registered.
+    expect(after.stages.find((s) => s.id === 'example-gate')).toMatchObject({
+      id: 'example-gate',
+      kind: 'test',
+      script: 'stages/example-gate.sh',
+    });
+
+    const stagePath = path.join(repoPath, '.har', 'stages', 'example-gate.sh');
+    expect(fs.existsSync(stagePath)).toBe(true);
+    expect(fs.statSync(stagePath).mode & 0o111).not.toBe(0);
+
+    expect(fs.existsSync(path.join(repoPath, '.har', 'lines', 'example-line', 'line.json'))).toBe(
+      true,
+    );
+    expect(
+      fs.existsSync(path.join(repoPath, '.har', 'ADAPT-PROMPT-line-example-line.md')),
+    ).toBe(true);
+  });
+
+  it('records the install in .har/lines.json', () => {
+    const repoPath = makeTempRepo('har-line-ledger');
+    applyLine(repoPath, 'example-line');
+
+    const ledger = readLineLedger(repoPath);
+    expect(ledger?.lines).toHaveLength(1);
+    expect(ledger?.lines[0]).toMatchObject({
+      id: 'example-line',
+      source: 'bundled',
+      stageIds: ['example-gate'],
+      programPath: '.har/lines/example-line/line.json',
+    });
+    expect(listInstalledLineIds(repoPath)).toEqual(['example-line']);
+  });
+
+  it('leaves the verify plan alone even next to an installed plugin', () => {
+    const repoPath = makeTempRepo('har-line-with-plugin');
+    applyPlugin(repoPath, 'playwright', { skipCi: true });
+    const verificationBefore = [...(readStageRegistry(repoPath).verificationStages ?? [])];
+    expect(verificationBefore).toContain('browser-e2e');
+
+    applyLine(repoPath, 'example-line');
+
+    expect(readStageRegistry(repoPath).verificationStages).toEqual(verificationBefore);
+  });
+
+  it('refuses a line bundle from add-plugin', () => {
+    const repoPath = makeTempRepo('har-line-poka-plugin');
+    const bundleDir = path.join(
+      __dirname,
+      '..',
+      'src',
+      'templates',
+      'lines',
+      'example-line',
+    );
+    // add-plugin resolves template.manifest.json; point it at the line bundle
+    // via a copy that uses the plugin manifest name.
+    const disguised = fs.mkdtempSync(path.join(os.tmpdir(), 'har-line-disguised-'));
+    fs.cpSync(bundleDir, disguised, { recursive: true });
+    fs.renameSync(
+      path.join(disguised, 'line.manifest.json'),
+      path.join(disguised, 'template.manifest.json'),
+    );
+
+    expect(() => applyPlugin(repoPath, disguised)).toThrow(/factory line bundle/i);
+    expect(() => applyPlugin(repoPath, disguised)).toThrow(/har line add/);
+  });
+
+  it('refuses a verification plugin from line add', () => {
+    const repoPath = makeTempRepo('har-line-poka-line');
+    const pluginDir = path.join(__dirname, '..', 'src', 'templates', 'plugins', 'playwright');
+
+    expect(() => applyLine(repoPath, pluginDir)).toThrow(/not a factory line bundle/i);
+    expect(() => applyLine(repoPath, pluginDir)).toThrow(/har env add-plugin/);
+  });
+
+  it('scaffolds a project-owned line that installs unchanged', () => {
+    const repoPath = makeTempRepo('har-line-create');
+    const created = createLine(repoPath, { id: 'my-line', stations: ['A', 'B', 'C'] });
+
+    expect(created.filesWritten).toEqual(
+      expect.arrayContaining([
+        '.har/lines/my-line/line.manifest.json',
+        '.har/lines/my-line/line.json',
+        '.har/lines/my-line/stages/my-line-gate.sh',
+        '.har/lines/my-line/README.md',
+      ]),
+    );
+
+    const verificationBefore = [...(readStageRegistry(repoPath).verificationStages ?? [])];
+    const applied = applyLine(repoPath, 'my-line');
+
+    expect(applied.source).toBe('local');
+    expect(applied.stageIds).toEqual(['my-line-gate']);
+    expect(readStageRegistry(repoPath).verificationStages).toEqual(verificationBefore);
+    expect(readInstalledLineProgram(repoPath, 'my-line')?.stations.map((s) => s.id)).toEqual([
+      'A',
+      'B',
+      'C',
+    ]);
+  });
+
+  it('rejects a manifest that declares verificationStages', () => {
+    const repoPath = makeTempRepo('har-line-reject-verify');
+    const bundleDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-line-bad-'));
+    fs.cpSync(
+      path.join(__dirname, '..', 'src', 'templates', 'lines', 'example-line'),
+      bundleDir,
+      { recursive: true },
+    );
+    const manifestPath = path.join(bundleDir, 'line.manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.verificationStages = ['example-gate'];
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+    expect(() => applyLine(repoPath, bundleDir)).toThrow(/verificationStages/);
+  });
+
+  describe('the ratchet', () => {
+    it('accumulates gate stages forward, never backward', () => {
+      const repoPath = makeTempRepo('har-line-ratchet');
+      applyLine(repoPath, 'example-line');
+      const program = readInstalledLineProgram(repoPath, 'example-line');
+      expect(program).not.toBeNull();
+
+      expect(cumulativeGateStages(program!, 'S1').map((s) => s.id)).toEqual([]);
+      expect(cumulativeGateStages(program!, 'S2').map((s) => s.id)).toEqual(['example-gate']);
+      // Later stations keep every earlier station's stages.
+      expect(cumulativeGateStages(program!, 'S3').map((s) => s.id)).toEqual(['example-gate']);
+    });
+
+    it('reports station progress with no green stations before any run', () => {
+      const repoPath = makeTempRepo('har-line-status');
+      applyLine(repoPath, 'example-line');
+
+      const status = getLineStatus(repoPath, 'example-line');
+      expect(status.lineId).toBe('example-line');
+      expect(status.verifyLeaks).toEqual([]);
+      expect(status.handoffAutonomousShip).toBe(false);
+
+      // S1 has no gate stages, so it is trivially green; S2 is where work starts.
+      expect(status.stations[0]).toMatchObject({ id: 'S1', green: true, requiredStageIds: [] });
+      expect(status.stations[1]).toMatchObject({
+        id: 'S2',
+        green: false,
+        requiredStageIds: ['example-gate'],
+        neverRunStageIds: ['example-gate'],
+      });
+      expect(status.nextStationId).toBe('S2');
+      expect(status.currentStationId).toBe('S1');
+    });
+
+    it('flags a line stage that leaked onto the verify plan', () => {
+      const repoPath = makeTempRepo('har-line-leak');
+      applyLine(repoPath, 'example-line');
+
+      // Simulate a hand edit that puts the line stage on verify.
+      const registryPath = path.join(repoPath, '.har', 'stages.json');
+      const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+      registry.verificationStages = [...(registry.verificationStages ?? []), 'example-gate'];
+      fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+
+      const status = getLineStatus(repoPath, 'example-line');
+      expect(status.verifyLeaks).toEqual(['example-gate']);
+      expect(status.warnings.join(' ')).toMatch(/must stay off/);
+
+      // doctor turns the same leak into a hard failure, so launch catches it.
+      const report = runDoctor(repoPath);
+      expect(report.ok).toBe(false);
+      expect(report.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            check: 'factory-lines',
+            severity: 'error',
+            message: expect.stringContaining('example-gate'),
+          }),
+        ]),
+      );
+    });
+
+    it('passes doctor on a correctly installed line', () => {
+      const repoPath = makeTempRepo('har-line-doctor-ok');
+      applyLine(repoPath, 'example-line');
+
+      const report = runDoctor(repoPath);
+      expect(report.findings.filter((f) => f.check === 'factory-lines')).toEqual([]);
+      expect(report.checks.find((c) => c.id === 'factory-lines')?.status).toBe('pass');
+    });
+  });
+
+  describe('CLI', () => {
+    const cli = path.join(__dirname, '..', 'dist', 'index.js');
+
+    it('installs a line and leaves the verify plan byte-identical', () => {
+      const repoPath = makeTempRepo('har-line-cli');
+      const registryPath = path.join(repoPath, '.har', 'stages.json');
+      const before = JSON.parse(fs.readFileSync(registryPath, 'utf8')).verificationStages;
+
+      execFileSync(process.execPath, [cli, 'line', 'add', 'example-line', '--repo', repoPath], {
+        encoding: 'utf8',
+      });
+
+      const after = JSON.parse(fs.readFileSync(registryPath, 'utf8')).verificationStages;
+      expect(after).toEqual(before);
+
+      const status = JSON.parse(
+        execFileSync(
+          process.execPath,
+          [cli, 'line', 'status', 'example-line', '--repo', repoPath, '--json'],
+          { encoding: 'utf8' },
+        ),
+      );
+      expect(status.lineId).toBe('example-line');
+      expect(status.verifyLeaks).toEqual([]);
+      expect(status.nextStationId).toBe('S2');
+    });
+
+    it('refuses the line bundle from env add-plugin', () => {
+      const repoPath = makeTempRepo('har-line-cli-refuse');
+      const bundleDir = path.join(__dirname, '..', 'src', 'templates', 'lines', 'example-line');
+
+      const result = spawnSync(
+        process.execPath,
+        [cli, 'env', 'add-plugin', bundleDir, '--repo', repoPath],
+        { encoding: 'utf8' },
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toMatch(/har line add/);
+    });
+  });
+});

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -25,6 +25,10 @@ describe('HAR MCP tool schemas', () => {
       'har_list_runs',
       'har_get_run',
       'har_control_up',
+      'har_line_create',
+      'har_add_line',
+      'har_line_status',
+      'har_run_line_gate',
     ]);
     expect(names).not.toContain('run_playwright');
   });


### PR DESCRIPTION
Closes #304. Closes #322. Phase 2 of #302.

A factory line is now an **installable program bundle**, not a loose `*.line.json` an agent is pointed at. It reuses the plugin install channels (path → git → bundled id → npm) and the ordinary stage runner. What differs is the apply path — and it is the whole product.

## The invariant

Installing a line registers stages in `.har/stages.json` but **never** touches `verificationStages`. Default `har env verify --full` takes exactly as long as it did before.

Verified against the freshly published template repo, not a mock:

```
har line add github:os-factory/har-line   →  source: git
before: ["typecheck", "unit-tests", "lint", "readiness"]
after : ["typecheck", "unit-tests", "lint", "readiness"]   UNCHANGED
example-gate registered in stages[]
```

The apply path is deliberately **not** `applyPlugin` / `patchStageRegistry` with an empty array — that function exists to append to `verificationStages`. `registerStagesOnly` snapshots the verify plan, and apply re-reads it afterwards and throws rather than write if it moved.

## What ships

| Piece | Where |
|---|---|
| Program + bundle manifest schemas | `packages/schemas/src/line.ts` — a manifest declaring `verificationStages` is a schema error, not a warning |
| Shared install channels | `src/harness/bundle-resolve.ts` — `plugin-resolve.ts` is now a thin wrapper over it, so there is one resolver, not two |
| Apply / scaffold / ledger | `src/harness/lines.ts`, `line-create.ts`, `line-ledger.ts` (`.har/lines.json`) |
| Cumulative gate + status | `src/core/lines.ts` — `fromStation ≤ station` as data, progress from `.har/runs/`, execution through `RunService` |
| CLI | `har line create \| add \| status \| gate \| list` |
| MCP (parity) | `har_line_create`, `har_add_line`, `har_line_status`, `har_run_line_gate` |
| Template content | `src/templates/lines/example-line/` — bundled so it is installable and testable, and the seed for the template repo |

## Poka-yoke, three ways

- `har env add-plugin` on a line bundle fails with a pointer at `har line add` (the plugin resolver now accepts `line.manifest.json` precisely so the error can be specific instead of "not a HAR plugin bundle").
- `har line add` on a plugin manifest fails with a pointer at `har env add-plugin`.
- A new `factory-lines` doctor check **fails** when a line stage appears in `verificationStages` — so a hand edit is caught before the next launch, not six milestones later.

## Companion repo

[`os-factory/har-line`](https://github.com/os-factory/har-line) is live as a public GitHub template (sibling of `har-plugin`): manifest, program, an off-verify gate stage, `AGENTS.md` on line-vs-plugin, `docs/AUTHORING.md`, `scripts/check-manifest.mjs`, and CI. Its own workflow passed on first push.

## Skill follow-ups folded in

- The `factory-line` skill (repo copy and packaged copy) now reads the **installed** bundle via `har line status` and gates with `har line gate`, instead of a file the user points at. `examples/*.line.json` are relabelled as authoring seeds.
- `LINE.schema.md`'s "Phase 2 — do not freeze here" open decisions are recorded as **closed**, including "a line is a plugin-style bundle with a separate apply path".

## Not doing

No `add-plugin` path for lines. No fourth marketplace. No second stage runner. Line gate stages never join `verify --full`.

## Evidence

- `har env verify 3 --full`: pass (26.6s) — typecheck, build, docs-check, docs-build, unit-tests, lint, readiness, docs-drift, fixture-e2e.
- `fixture-e2e` run properly from the worktree against its own build (`HAR_FIXTURE_E2E=1`): gate passed. The 4ms entry above is the opt-in skip.
- Full jest: 992 passed, 106 suites. `tests/lines.test.ts` adds 14, including a CLI-level before/after diff of `verificationStages` and the same assertion with the playwright plugin already installed.
- Docs drift current: 24 CLI signatures, 23 MCP tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)