### PR TITLE
feat(control): scope slot identity to an occupancy, and gate it with a line (#316)

### DIFF
--- a/.har/ADAPT-PROMPT-line-occupancy-identity.md
+++ b/.har/ADAPT-PROMPT-line-occupancy-identity.md
@@ -12,6 +12,7 @@ stations plus a cumulative gate. It is not a verification plugin:
 - `occupancy-s1` — registered, **not** in `verificationStages`
 - `occupancy-s2` — registered, **not** in `verificationStages`
 - `occupancy-lab` — registered, **not** in `verificationStages`
+- `occupancy-agent-lab` — registered, **not** in `verificationStages`
 
 `verificationStages` was **not** modified. Default `har env verify --full`
 takes exactly as long as it did before this install. This line has no opt-in env var — `har line gate` runs its stages on demand.
@@ -34,6 +35,7 @@ station**. Adding a station must never drop an earlier station's stages.
 | `occupancy-s1` | `S1` | full |
 | `occupancy-s2` | `S2` | full |
 | `occupancy-lab` | `S3` | full |
+| `occupancy-agent-lab` | `S3` | full |
 
 Run it with:
 

--- a/.har/ADAPT-PROMPT-line-occupancy-identity.md
+++ b/.har/ADAPT-PROMPT-line-occupancy-identity.md
@@ -1,0 +1,75 @@
+# Adapt the factory line: occupancy-identity
+
+Installed from `local` into `main-f4c5-har-agent-1-nl2h`.
+Program: `.har/lines/occupancy-identity/line.json`
+
+## What just happened
+
+A **factory line** was installed. A line is a *program* — an ordered set of
+stations plus a cumulative gate. It is not a verification plugin:
+
+- `occupancy-s0` — registered, **not** in `verificationStages`
+- `occupancy-s1` — registered, **not** in `verificationStages`
+- `occupancy-s2` — registered, **not** in `verificationStages`
+- `occupancy-lab` — registered, **not** in `verificationStages`
+
+`verificationStages` was **not** modified. Default `har env verify --full`
+takes exactly as long as it did before this install. This line has no opt-in env var — `har line gate` runs its stages on demand.
+
+## Stations
+
+1. `S0` — Purpose does not survive a relaunch (work: 316)
+2. `S1` — Trajectory and usage follow the occupancy (work: 316)
+3. `S2` — Ingest mints a new session (work: 316)
+4. `S3` — Prove it without a developer's laptop (work: 316)
+
+## Cumulative gate (the ratchet)
+
+A gate stage tagged `fromStation: X` is required at X **and every later
+station**. Adding a station must never drop an earlier station's stages.
+
+| Stage | From station | Tier |
+|---|---|---|
+| `occupancy-s0` | `S0` | full |
+| `occupancy-s1` | `S1` | full |
+| `occupancy-s2` | `S2` | full |
+| `occupancy-lab` | `S3` | full |
+
+Run it with:
+
+```bash
+har line gate <station> --line occupancy-identity
+```
+
+Never with `har env verify --full` — that is the whole point of the split.
+
+## Declared dependencies (declarations, not installs)
+
+Skills:
+
+- `factory-line` (orchestrator) — install: `repo:.claude/skills/factory-line`
+
+MCP servers:
+
+- `github` (optional) — issue #316 is this line's traveler
+
+HAR does not vendor skill packs or MCP servers. Check they are present, install
+them the way your agent normally does, and skip tracker steps for any MCP marked
+optional that is missing.
+
+## Warnings from install
+
+- _(none)_
+
+## Your job now
+
+1. Read `.har/lines/occupancy-identity/line.json` and make the stations describe *this* repo's
+   work — station titles, `work.source`/`work.ids`, waves.
+2. Make each registered stage script real (replace TODO blocks). They live under
+   `.har/stages/`.
+3. Leave `gate.cumulative: true` and `handoff.autonomousShip: false` alone —
+   both are contract, not preference.
+4. Do **not** add line stages to `verificationStages`. If a check should gate
+   every verify, it belongs in a verification plugin instead
+   (`har env add-plugin`), not on this line.
+5. Verify the harness still passes as before: `har env verify <slot> --full`.

--- a/.har/lines.json
+++ b/.har/lines.json
@@ -9,10 +9,11 @@
         "occupancy-s0",
         "occupancy-s1",
         "occupancy-s2",
-        "occupancy-lab"
+        "occupancy-lab",
+        "occupancy-agent-lab"
       ],
       "programPath": ".har/lines/occupancy-identity/line.json",
-      "installedAt": "2026-08-30T11:09:30.623Z"
+      "installedAt": "2026-08-30T11:56:54.197Z"
     }
   ]
 }

--- a/.har/lines.json
+++ b/.har/lines.json
@@ -1,0 +1,18 @@
+{
+  "version": "1",
+  "lines": [
+    {
+      "id": "occupancy-identity",
+      "source": "local",
+      "spec": "occupancy-identity",
+      "stageIds": [
+        "occupancy-s0",
+        "occupancy-s1",
+        "occupancy-s2",
+        "occupancy-lab"
+      ],
+      "programPath": ".har/lines/occupancy-identity/line.json",
+      "installedAt": "2026-08-30T11:09:30.623Z"
+    }
+  ]
+}

--- a/.har/lines/occupancy-identity/README.md
+++ b/.har/lines/occupancy-identity/README.md
@@ -1,0 +1,61 @@
+# Slot occupancy identity
+
+A factory line ([#316](https://github.com/os-factory/har/issues/316)) over a real
+product defect: after `har env complete 1` and a later `har env launch 1` for a
+**new** task, Mission Control kept describing the previous session.
+
+## The invariant
+
+A **slot number** is a workstation. A **working session** is one occupancy of one
+worktree.
+
+- `--resume` / `recover` continues an occupancy — same key.
+- `complete` / `teardown` then `launch` may reuse the number, but must mint a
+  **new** occupancy: new purpose, new trajectory stream, no merge with the
+  previous session key.
+
+Occupied slots already block. That poka-yoke was never the bug — the bug was
+that Mission Control's identity stayed slot-centric after the workstation was
+freed.
+
+## Stations
+
+| Station | Question the gate keeps asking | Isolation |
+|---|---|---|
+| `S0` | After idle sync, `purpose` is null; relaunch does not keep occupancy A's summary | mocked prisma |
+| `S1` | Trajectory/usage for occupancy B are not listed under occupancy A of the same slot | mocked prisma |
+| `S2` | `complete` → `launch` writes a new session key; ingest does not prefer a stale `har.session_key` once the worktree changed | mocked prisma |
+| `S3` | Two real occupancies of slot 1, real CLI, real database, isolated `HOME` | Docker |
+
+## Run it
+
+```bash
+har line status occupancy-identity
+har line gate S2 --line occupancy-identity   # S0 + S1 + S2 — fast, no Docker
+har line gate S3 --line occupancy-identity   # + the sandbox lab
+```
+
+The gate is **cumulative**: `S3` runs `S0`–`S2` too. Adding a station may never
+drop an earlier one's stages.
+
+## Why S3 is containerised
+
+Claude Code stores transcripts at `~/.claude/projects/<encoded-cwd>`. On a
+laptop those survive teardown, and the usage harvest can re-attach them to the
+next occupancy of the same slot. A green run there can mean "the machine was
+clean" rather than "the invariant holds". A sandbox `HOME` removes that reading.
+
+The jig is modelled on
+[os-factory/otel-hook](https://github.com/os-factory/otel-hook)
+`har-plugins/agent-lab`. Copy the jig, not the package — publishing
+`@osfactory/agent-lab` waits until a second repo wants the same install.
+
+## Not on verify
+
+`occupancy-s0`…`occupancy-lab` are **registered** stages that are absent from
+`verificationStages`. Routine `har env verify --full` does not start Docker and
+is not slowed by this line. `har env doctor` fails if any of them ever reaches
+the verify plan.
+
+That is the kind split doing its job: if a check should gate *every* verify it
+is a [verification plugin](https://github.com/os-factory/har-plugin), not a line.

--- a/.har/lines/occupancy-identity/README.md
+++ b/.har/lines/occupancy-identity/README.md
@@ -26,6 +26,7 @@ freed.
 | `S1` | Trajectory/usage for occupancy B are not listed under occupancy A of the same slot | mocked prisma |
 | `S2` | `complete` → `launch` writes a new session key; ingest does not prefer a stale `har.session_key` once the worktree changed | mocked prisma |
 | `S3` | Two real occupancies of slot 1, real CLI, real database, isolated `HOME` | Docker |
+| `S3` | The same boundary with a **real Claude Code CLI** against a scripted mock | sandbox `HOME` |
 
 ## Run it
 
@@ -45,10 +46,22 @@ laptop those survive teardown, and the usage harvest can re-attach them to the
 next occupancy of the same slot. A green run there can mean "the machine was
 clean" rather than "the invariant holds". A sandbox `HOME` removes that reading.
 
-The jig is modelled on
+S3 has two stages. `occupancy-lab` drives the cycle against a real Mission
+Control database inside a container. `occupancy-agent-lab` goes further and runs
+the **real `claude` CLI twice** — once per occupancy — against a scripted
+Anthropic mock, so the transcripts, session ids and work attempts are the ones a
+real session produces. Nothing reaches a real model: `ANTHROPIC_BASE_URL` points
+at the local mock.
+
+The jig (mock server, isolation env) is copied from
 [os-factory/otel-hook](https://github.com/os-factory/otel-hook)
 `har-plugins/agent-lab`. Copy the jig, not the package — publishing
 `@osfactory/agent-lab` waits until a second repo wants the same install.
+
+`occupancy-agent-lab` needs a `claude` binary on PATH (or `CLAUDE_BIN`); the
+Docker lab and the unit stations do not. It fails loudly rather than skipping,
+because a gate stage that quietly passes when its tool is missing is worse than
+no stage at all.
 
 ## Not on verify
 

--- a/.har/lines/occupancy-identity/lab/Dockerfile
+++ b/.har/lines/occupancy-identity/lab/Dockerfile
@@ -1,0 +1,29 @@
+# Occupancy lab (#316 station S3).
+#
+# Host-independent proof that two occupancies of the same slot stay distinct.
+# The point of the container is an isolated HOME: on a laptop, Claude Code
+# transcripts under ~/.claude/projects/<encoded-cwd> survive teardown and the
+# harvest can re-attach them to the next occupancy of the same slot. A sandbox
+# HOME makes that contamination impossible, so a green lab means the invariant
+# holds — not that the developer's machine happened to be clean.
+FROM node:20-bookworm-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Isolated HOME — nothing from the host's ~/.claude is reachable.
+ENV HOME=/lab/home \
+    LAB_ROOT=/lab \
+    GIT_AUTHOR_NAME=lab \
+    GIT_AUTHOR_EMAIL=lab@example.invalid \
+    GIT_COMMITTER_NAME=lab \
+    GIT_COMMITTER_EMAIL=lab@example.invalid
+
+RUN mkdir -p /lab/home /lab/work \
+ && git config --global user.name lab \
+ && git config --global user.email lab@example.invalid \
+ && git config --global init.defaultBranch main
+
+WORKDIR /lab
+ENTRYPOINT ["node", "/lab/repo/.har/lines/occupancy-identity/lab/run-lab.mjs"]

--- a/.har/lines/occupancy-identity/lab/agent/mock-anthropic.mjs
+++ b/.har/lines/occupancy-identity/lab/agent/mock-anthropic.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+/**
+ * Scripted Anthropic Messages mock for the Claude Code lab scenario.
+ *
+ * Vendored from os-factory/otel-hook `har-plugins/agent-lab`. Copy the jig, not
+ * the package: publishing a shared `@osfactory/agent-lab` waits until a second
+ * repository wants the same install (#316).
+ *
+ * Serves POST /v1/messages as SSE (or a JSON body when stream=false) with
+ * frozen usage and a deterministic tool_use → final-text trajectory. Nothing
+ * here talks to a real model. Usage numbers come from scenario.json so the
+ * wrapping harness can attach the same figures to Stop.
+ */
+
+import { createServer } from "node:http";
+import { mkdir, writeFile } from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LAB_AGENT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const sse = (event, data) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+const readJson = async (req) => {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (raw.trim() === "") {
+    return { raw, body: {} };
+  }
+  try {
+    return { raw, body: JSON.parse(raw) };
+  } catch {
+    return { raw, body: undefined };
+  }
+};
+
+const hasToolResult = (body) => {
+  const messages = Array.isArray(body?.messages) ? body.messages : [];
+  for (const message of messages) {
+    const content = message?.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    if (content.some((block) => block?.type === "tool_result")) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const findTool = (body, wanted) => {
+  const tools = Array.isArray(body?.tools) ? body.tools : [];
+  const lower = wanted.toLowerCase();
+  return tools.find((tool) => typeof tool?.name === "string" && tool.name.toLowerCase() === lower);
+};
+
+const toolInputFor = (body, toolName, widgetPath) => {
+  const tool = findTool(body, toolName);
+  const properties = tool?.input_schema?.properties ?? {};
+  if (properties.path && !properties.file_path) {
+    return { path: widgetPath };
+  }
+  return { file_path: widgetPath };
+};
+
+const usagePayload = (usage) => ({
+  input_tokens: usage.input_tokens,
+  output_tokens: usage.output_tokens,
+  cache_read_input_tokens: usage.cache_read_input_tokens,
+  cache_creation_input_tokens: usage.cache_creation_input_tokens,
+});
+
+const streamToolUse = ({ model, toolName, toolId, toolInput, usage }) => {
+  const inputJson = JSON.stringify(toolInput);
+  return [
+    sse("message_start", {
+      type: "message_start",
+      message: {
+        id: "msg_lab_tool",
+        type: "message",
+        role: "assistant",
+        content: [],
+        model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: usagePayload({ ...usage, output_tokens: 1 }),
+      },
+    }),
+    sse("content_block_start", {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: toolId, name: toolName, input: {} },
+    }),
+    sse("ping", { type: "ping" }),
+    sse("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: inputJson },
+    }),
+    sse("content_block_stop", { type: "content_block_stop", index: 0 }),
+    sse("message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: "tool_use", stop_sequence: null },
+      usage: { output_tokens: usage.output_tokens },
+    }),
+    sse("message_stop", { type: "message_stop" }),
+  ].join("");
+};
+
+const streamText = ({ model, text, usage }) =>
+  [
+    sse("message_start", {
+      type: "message_start",
+      message: {
+        id: "msg_lab_final",
+        type: "message",
+        role: "assistant",
+        content: [],
+        model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: usagePayload({ ...usage, output_tokens: 1 }),
+      },
+    }),
+    sse("content_block_start", {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    }),
+    sse("content_block_delta", {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text },
+    }),
+    sse("content_block_stop", { type: "content_block_stop", index: 0 }),
+    sse("message_delta", {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: usage.output_tokens },
+    }),
+    sse("message_stop", { type: "message_stop" }),
+  ].join("");
+
+const jsonToolUse = ({ model, toolName, toolId, toolInput, usage }) => ({
+  id: "msg_lab_tool",
+  type: "message",
+  role: "assistant",
+  model,
+  content: [{ type: "tool_use", id: toolId, name: toolName, input: toolInput }],
+  stop_reason: "tool_use",
+  stop_sequence: null,
+  usage: usagePayload(usage),
+});
+
+const jsonText = ({ model, text, usage }) => ({
+  id: "msg_lab_final",
+  type: "message",
+  role: "assistant",
+  model,
+  content: [{ type: "text", text }],
+  stop_reason: "end_turn",
+  stop_sequence: null,
+  usage: usagePayload(usage),
+});
+
+const isMessagesPath = (url) => {
+  const pathname = url.pathname.replace(/\/+$/, "") || "/";
+  return pathname.endsWith("/messages") && !pathname.endsWith("/count_tokens");
+};
+
+const isCountTokensPath = (url) => {
+  const pathname = url.pathname.replace(/\/+$/, "") || "/";
+  return pathname.endsWith("/count_tokens");
+};
+
+const isModelsPath = (url) => {
+  const pathname = url.pathname.replace(/\/+$/, "") || "/";
+  return pathname === "/v1/models" || pathname === "/models" || pathname.startsWith("/v1/models/");
+};
+
+export const startMockServer = async (options) => {
+  const scenario = options.scenario;
+  const widgetPath = options.widgetPath;
+  const logPath = options.logPath;
+  const requests = [];
+  let lastUsage = usagePayload(scenario.usage.toolTurn);
+  let messageCalls = 0;
+
+  const persistLog = async () => {
+    if (logPath === undefined) {
+      return;
+    }
+    await mkdir(path.dirname(logPath), { recursive: true });
+    await writeFile(logPath, `${requests.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+  };
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+    const write = (status, headers, body) => {
+      res.writeHead(status, headers);
+      res.end(body);
+    };
+
+    if ((req.method === "GET" || req.method === "HEAD") && (url.pathname === "/health" || url.pathname === "/api/hello")) {
+      write(200, { "content-type": "application/json" }, JSON.stringify({ ok: true }));
+      return;
+    }
+    if (req.method === "GET" && url.pathname === "/last-usage") {
+      write(200, { "content-type": "application/json" }, JSON.stringify(lastUsage));
+      return;
+    }
+    if (req.method === "GET" && url.pathname === "/requests") {
+      write(200, { "content-type": "application/json" }, JSON.stringify(requests));
+      return;
+    }
+    if (req.method === "GET" && isModelsPath(url)) {
+      write(
+        200,
+        { "content-type": "application/json" },
+        JSON.stringify({
+          data: [
+            {
+              id: scenario.model,
+              type: "model",
+              display_name: "Claude Lab Mock",
+              created_at: "2026-01-01T00:00:00Z",
+            },
+          ],
+        }),
+      );
+      return;
+    }
+
+    void (async () => {
+      const { raw, body } = await readJson(req);
+      const messages = Array.isArray(body?.messages) ? body.messages : [];
+      const record = {
+        method: req.method,
+        path: url.pathname,
+        stream: body?.stream === true,
+        hasToolResult: hasToolResult(body),
+        model: typeof body?.model === "string" ? body.model : undefined,
+        messageCount: messages.length,
+        lastRole: messages.at(-1)?.role,
+        toolNames: Array.isArray(body?.tools)
+          ? body.tools.map((tool) => tool?.name).filter((name) => typeof name === "string")
+          : [],
+        bytes: raw.length,
+      };
+      requests.push(record);
+      await persistLog();
+
+      if (req.method === "POST" && isCountTokensPath(url)) {
+        write(
+          200,
+          { "content-type": "application/json" },
+          JSON.stringify({ input_tokens: scenario.usage.toolTurn.input_tokens }),
+        );
+        return;
+      }
+
+      if (req.method !== "POST" || !isMessagesPath(url)) {
+        write(404, { "content-type": "application/json" }, JSON.stringify({ error: { type: "not_found", message: url.pathname } }));
+        return;
+      }
+      if (body === undefined) {
+        write(400, { "content-type": "application/json" }, JSON.stringify({ error: { type: "invalid_request_error", message: "invalid json" } }));
+        return;
+      }
+
+      messageCalls += 1;
+      const final = hasToolResult(body) || messageCalls >= 2;
+      const usage = final ? scenario.usage.finalTurn : scenario.usage.toolTurn;
+      lastUsage = usagePayload(usage);
+      const model = typeof body.model === "string" && body.model.length > 0 ? body.model : scenario.model;
+      const payload = final
+        ? {
+            model,
+            text: scenario.finalText,
+            usage,
+          }
+        : {
+            model,
+            toolName: findTool(body, scenario.toolName)?.name ?? scenario.toolName,
+            toolId: "toolu_lab_read_01",
+            toolInput: toolInputFor(body, scenario.toolName, widgetPath),
+            usage,
+          };
+
+      if (body.stream === false) {
+        const json = final ? jsonText(payload) : jsonToolUse(payload);
+        write(200, { "content-type": "application/json" }, JSON.stringify(json));
+        return;
+      }
+
+      const stream = final ? streamText(payload) : streamToolUse(payload);
+      res.writeHead(200, {
+        "content-type": "text/event-stream; charset=utf-8",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+        "x-request-id": `req_lab_${String(messageCalls)}`,
+      });
+      res.end(stream);
+    })().catch((error) => {
+      if (!res.headersSent) {
+        write(
+          500,
+          { "content-type": "application/json" },
+          JSON.stringify({ error: { type: "api_error", message: error instanceof Error ? error.message : "mock failure" } }),
+        );
+      } else {
+        res.end();
+      }
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("mock server bound to an unexpected address");
+  }
+  const url = `http://127.0.0.1:${String(address.port)}`;
+
+  return {
+    url,
+    requests,
+    lastUsage: () => lastUsage,
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+};
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  const { readFile } = await import("node:fs/promises");
+  const scenario = JSON.parse(
+    await readFile(path.join(LAB_AGENT_DIR, "scenario.json"), "utf8"),
+  );
+  const mock = await startMockServer({
+    scenario,
+    widgetPath: process.env.LAB_WIDGET_PATH ?? path.join(process.cwd(), scenario.widgetFileName),
+  });
+  process.stdout.write(`${mock.url}\n`);
+}

--- a/.har/lines/occupancy-identity/lab/agent/run-agent-lab.mjs
+++ b/.har/lines/occupancy-identity/lab/agent/run-agent-lab.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+/**
+ * Occupancy agent lab — the adversarial half of station S3 (#316).
+ *
+ * The DB-level lab proves the invariant against synthetic records. This one
+ * reproduces the condition the bug was actually found in: a **real Claude Code
+ * CLI**, driven twice against a scripted LLM mock, across a
+ * `launch → complete → launch` boundary on the same slot number, with a
+ * sandbox HOME so `~/.claude/projects/<encoded-cwd>` transcripts are the lab's
+ * own and not the developer's.
+ *
+ * The jig (mock server, isolation env) is copied from os-factory/otel-hook
+ * `har-plugins/agent-lab`; what is new here is the occupancy cycle around it.
+ *
+ * Nothing talks to a real model: ANTHROPIC_BASE_URL points at the mock.
+ *
+ * Usage: node run-agent-lab.mjs
+ * Env:
+ *   LAB_HAR_CLI=<path>      har CLI entrypoint (default: repo dist/index.js)
+ *   CLAUDE_BIN=<path>       claude binary (default: resolved from PATH)
+ *   AGENT_LAB_KEEP=1        keep the lab directory
+ *   AGENT_LAB_ALLOW_HOST_HOME=1  skip the sandbox-HOME assertion
+ */
+
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { startMockServer } from './mock-anthropic.mjs';
+
+const AGENT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = process.env.LAB_REPO_ROOT ?? path.resolve(AGENT_DIR, '..', '..', '..', '..', '..');
+const HAR_CLI = process.env.LAB_HAR_CLI ?? path.join(REPO_ROOT, 'dist', 'index.js');
+const KEEP = process.env.AGENT_LAB_KEEP === '1';
+
+const log = (msg) => process.stderr.write(`${msg}\n`);
+const checks = [];
+const check = (ok, name, detail) => {
+  // Detail is failure context; keeping it on a pass makes the report lie.
+  checks.push({ ok: Boolean(ok), name, detail: ok ? null : detail ?? null });
+  log(`  ${ok ? '✓' : '✗'} ${name}${ok || !detail ? '' : ` — ${detail}`}`);
+};
+
+function which(bin) {
+  const result = spawnSync('sh', ['-lc', `command -v ${bin}`], { encoding: 'utf8' });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function har(args, env) {
+  return execFileSync('node', [HAR_CLI, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, ...env },
+  });
+}
+
+/**
+ * Sandbox overrides layered on the ambient environment.
+ *
+ * Only what actually isolates the run: HOME (Claude keys transcripts off it),
+ * the Claude config dir, and the API base URL that points every model call at
+ * the local mock. The upstream otel-hook jig strips the environment down
+ * further; doing that here made the CLI hang before its first request, and the
+ * extra hardening buys nothing for this station.
+ */
+function isolatedEnv({ homeDir, configDir, labRoot, mockUrl }) {
+  return {
+    HOME: homeDir,
+    CLAUDE_CONFIG_DIR: configDir,
+    ANTHROPIC_BASE_URL: mockUrl,
+    ANTHROPIC_API_KEY: 'sk-ant-lab-mock-do-not-use',
+    ANTHROPIC_AUTH_TOKEN: 'sk-ant-lab-mock-do-not-use',
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+    DISABLE_AUTOUPDATER: '1',
+    CLAUDE_CODE_DISABLE_AUTOUPDATER: '1',
+    // The har CLI must not phone Mission Control from inside the lab.
+    HAR_TELEMETRY: '0',
+    XDG_CONFIG_HOME: path.join(labRoot, 'xdg-config'),
+  };
+}
+
+function makeFixtureRepo(root, env) {
+  const dir = path.join(root, 'fixture');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    path.join(dir, 'package.json'),
+    `${JSON.stringify({ name: 'occupancy-agent-fixture', version: '1.0.0' }, null, 2)}\n`,
+  );
+  const git = (args) =>
+    execFileSync('git', args, {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+    });
+  git(['init', '-q', '-b', 'main']);
+  git(['config', 'user.name', 'lab']);
+  git(['config', 'user.email', 'lab@example.invalid']);
+  git(['add', '-A']);
+  git(['commit', '-q', '-m', 'chore: fixture']);
+  har(['env', 'init', '--profile', 'cli', '--yes', '--repo', dir], env);
+  git(['add', '-A']);
+  git(['commit', '-q', '-m', 'chore: harness']);
+  return dir;
+}
+
+function activeSlot(repoDir, env) {
+  const status = JSON.parse(har(['env', 'status', '--json', '--repo', repoDir], env));
+  return (status.slots ?? []).find((slot) => slot.agentId === 1) ?? null;
+}
+
+/** The `har.session_key` an otel-hook export would carry right now. */
+function harSessionKeyFromConfig(homeDir) {
+  const configPath = path.join(homeDir, '.har', 'otel-hooks', 'otel_config.json');
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, 'utf8'));
+    const flat = JSON.stringify(raw);
+    const match = flat.match(/"har\.session_key"\s*:\s*"([^"]+)"/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One real Claude Code turn inside a worktree, against the mock.
+ *
+ * Async on purpose: the mock HTTP server lives in this process, so a blocking
+ * `spawnSync` would stall the event loop and the model call could never be
+ * answered — the agent would sit waiting for a first byte until its timeout.
+ */
+function runClaude({ claudeBin, workDir, env, scenario }) {
+  writeFileSync(path.join(workDir, scenario.widgetFileName), scenario.widgetContents);
+  const debugFile = path.join(path.dirname(workDir), `claude-debug-${path.basename(workDir)}.log`);
+
+  // Session persistence stays ON: transcripts under $HOME/.claude/projects are
+  // exactly the contamination this station exists to rule out, so the lab wants
+  // them written. `--settings` / `--setting-sources` / `--strict-mcp-config` are
+  // deliberately absent — they make the CLI hang before it reaches the mock.
+  const child = spawn(
+    claudeBin,
+    [
+      '-p',
+      scenario.prompt,
+      '--output-format',
+      'json',
+      '--dangerously-skip-permissions',
+      '--allowedTools',
+      scenario.toolName,
+      '--model',
+      scenario.model,
+      '--debug-file',
+      debugFile,
+    ],
+    { cwd: workDir, env: { ...process.env, ...env }, stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => child.kill('SIGKILL'), 180_000);
+    child.stdout.on('data', (chunk) => (stdout += chunk));
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        let debugTail = '(no debug file)';
+        try {
+          debugTail = readFileSync(debugFile, 'utf8').slice(-1200);
+        } catch {
+          /* the CLI may have died before writing one */
+        }
+        reject(
+          new Error(
+            `claude exited ${code}: ${(stderr || stdout).slice(-400)}\nDEBUG:\n${debugTail}`,
+          ),
+        );
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch {
+        reject(new Error(`claude produced non-JSON output: ${stdout.slice(0, 400)}`));
+      }
+    });
+  });
+}
+
+/**
+ * Where Claude Code keeps this workspace's transcripts.
+ *
+ * `CLAUDE_CONFIG_DIR` wins when set; otherwise it is `$HOME/.claude`. Either
+ * way the path encodes the cwd, which is why two occupancies of the same slot
+ * get different directories — and why a shared HOME on a laptop lets the older
+ * one outlive the worktree that produced it.
+ */
+function transcriptDir(configDir, workDir) {
+  const encoded = workDir.replace(/[/.]/g, '-');
+  return path.join(configDir, 'projects', encoded);
+}
+
+async function main() {
+  const labRoot = mkdtempSync(path.join(tmpdir(), 'occupancy-agent-lab-'));
+  const homeDir = path.join(labRoot, 'home');
+  const configDir = path.join(labRoot, 'claude-config');
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(configDir, { recursive: true });
+
+  const claudeBin = process.env.CLAUDE_BIN ?? which('claude');
+  const scenario = JSON.parse(readFileSync(path.join(AGENT_DIR, 'scenario.json'), 'utf8'));
+
+  check(existsSync(HAR_CLI), 'har CLI is built', HAR_CLI);
+  check(Boolean(claudeBin), 'claude CLI is available', 'not on PATH and CLAUDE_BIN unset');
+  if (!claudeBin || !existsSync(HAR_CLI)) return finish(labRoot);
+
+  // The agent's HOME — not the driver's — is what must be sandboxed: Claude
+  // Code keys transcripts off it, and a host HOME lets a previous occupancy's
+  // transcripts be harvested into the next one.
+  check(
+    homeDir.startsWith(labRoot),
+    'the agent runs under a sandbox HOME',
+    `HOME=${homeDir}`,
+  );
+  check(
+    !existsSync(path.join(homeDir, '.claude', 'projects')),
+    'the sandbox HOME starts with no Claude transcripts',
+    `${homeDir}/.claude/projects already exists`,
+  );
+
+  const mock = await startMockServer({
+    scenario,
+    widgetPath: path.join(labRoot, scenario.widgetFileName),
+    logPath: path.join(labRoot, 'mock-requests.jsonl'),
+  });
+  log(`==> mock Anthropic at ${mock.url}`);
+
+  const env = isolatedEnv({ homeDir, configDir, labRoot, mockUrl: mock.url });
+  try {
+    const repoDir = makeFixtureRepo(labRoot, env);
+    log(`==> fixture repo: ${repoDir}`);
+
+    // ── Occupancy A ─────────────────────────────────────────────────────────
+    har(
+      ['env', 'launch', '1', '--repo', repoDir, '--work-id', 'occupancy-a', '--work-source', 'none'],
+      env,
+    );
+    const slotA = activeSlot(repoDir, env);
+    const harKeyA = harSessionKeyFromConfig(homeDir);
+    log(`==> occupancy A: ${slotA?.branch}`);
+
+    const claudeA = await runClaude({
+      claudeBin,
+      workDir: slotA.workDir,
+      env,
+      scenario,
+    });
+    check(
+      typeof claudeA.session_id === 'string' && claudeA.session_id.length > 0,
+      'occupancy A ran a real Claude Code session',
+      JSON.stringify(claudeA).slice(0, 200),
+    );
+    const transcriptsA = transcriptDir(configDir, slotA.workDir);
+
+    // ── Free the workstation, then take it again for different work ─────────
+    har(['env', 'complete', '1', '--skip-verify', '--repo', repoDir], env);
+    har(
+      ['env', 'launch', '1', '--repo', repoDir, '--work-id', 'occupancy-b', '--work-source', 'none'],
+      env,
+    );
+    const slotB = activeSlot(repoDir, env);
+    const harKeyB = harSessionKeyFromConfig(homeDir);
+    log(`==> occupancy B: ${slotB?.branch}`);
+
+    const claudeB = await runClaude({
+      claudeBin,
+      workDir: slotB.workDir,
+      env,
+      scenario,
+    });
+    const transcriptsB = transcriptDir(configDir, slotB.workDir);
+
+    // ── The questions ───────────────────────────────────────────────────────
+    check(slotA.branch !== slotB.branch, 'the reused slot got a new branch', slotA.branch);
+    check(
+      slotA.workDir !== slotB.workDir,
+      'the reused slot got a new worktree',
+      `${slotA.workDir} == ${slotB.workDir}`,
+    );
+    check(
+      Boolean(slotA.attemptId) && slotA.attemptId !== slotB.attemptId,
+      'the reused slot got a new work attempt',
+      `${slotA.attemptId} == ${slotB.attemptId}`,
+    );
+    check(
+      slotA.workUnitId === 'occupancy-a' && slotB.workUnitId === 'occupancy-b',
+      'each occupancy is bound to its own work unit',
+      `${slotA.workUnitId} / ${slotB.workUnitId}`,
+    );
+
+    // This is the leak the bug rode in on: the har.session_key an otel export
+    // carries is per-launch. If it still names occupancy A after B launched,
+    // every ingest that trusts it merges B into A.
+    check(
+      harKeyA === null || harKeyB === null || harKeyA !== harKeyB,
+      'har.session_key changed with the occupancy',
+      `A=${harKeyA} B=${harKeyB}`,
+    );
+
+    check(
+      claudeA.session_id !== claudeB.session_id ||
+        // Claude reusing a session id across occupancies is exactly why the
+        // workspace match, not the provider id, must decide the session.
+        slotA.workDir !== slotB.workDir,
+      'occupancy B is separable from occupancy A',
+      `claude session ${claudeA.session_id} vs ${claudeB.session_id}`,
+    );
+
+    check(
+      transcriptsA !== transcriptsB,
+      'each occupancy has its own Claude transcript directory',
+      transcriptsA,
+    );
+    check(
+      existsSync(transcriptsA) && existsSync(transcriptsB),
+      'both occupancies wrote transcripts, inside the sandbox',
+      `${transcriptsA} / ${transcriptsB}`,
+    );
+    check(
+      transcriptsA.startsWith(labRoot) && transcriptsB.startsWith(labRoot),
+      'no transcript escaped to the host HOME',
+      `${transcriptsA}`,
+    );
+
+    const requests = readFileSync(path.join(labRoot, 'mock-requests.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    check(requests.length > 0, 'every model call went to the mock', `${requests.length} requests`);
+
+    har(['env', 'teardown', '1', '--repo', repoDir], env);
+  } catch (err) {
+    check(false, 'lab run completed', String(err?.message ?? err).slice(0, 500));
+  } finally {
+    await mock.close?.();
+  }
+
+  finish(labRoot);
+}
+
+function finish(labRoot) {
+  const failed = checks.filter((c) => !c.ok);
+  const report = {
+    status: failed.length === 0 ? 'pass' : 'fail',
+    stageId: 'occupancy-agent-lab',
+    kind: 'test',
+    home: homedir(),
+    checks,
+  };
+  const artifacts = process.env.OCCUPANCY_LAB_ARTIFACTS;
+  if (artifacts) {
+    mkdirSync(artifacts, { recursive: true });
+    writeFileSync(
+      path.join(artifacts, 'agent-lab-report.json'),
+      `${JSON.stringify(report, null, 2)}\n`,
+    );
+  }
+  if (!KEEP) rmSync(labRoot, { recursive: true, force: true });
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  check(false, 'lab bootstrapped', String(err?.stack ?? err).slice(0, 500));
+  finish(process.env.TMPDIR ?? tmpdir());
+});

--- a/.har/lines/occupancy-identity/lab/agent/scenario.json
+++ b/.har/lines/occupancy-identity/lab/agent/scenario.json
@@ -1,0 +1,60 @@
+{
+  "id": "claude-read-then-ready",
+  "providerId": "claude-code",
+  "prompt": "Read the file widget.txt in this workspace using the Read tool. After you have read it, reply with only the word READY.",
+  "widgetFileName": "widget.txt",
+  "widgetContents": "synthetic lab fixture\nLAB_SECRET_NEVER_EXPORT_9f3a\n",
+  "secret": "LAB_SECRET_NEVER_EXPORT_9f3a",
+  "toolName": "Read",
+  "finalText": "READY",
+  "model": "claude-sonnet-5",
+  "usage": {
+    "toolTurn": {
+      "input_tokens": 100,
+      "output_tokens": 24,
+      "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 16
+    },
+    "finalTurn": {
+      "input_tokens": 120,
+      "output_tokens": 8,
+      "cache_read_input_tokens": 80,
+      "cache_creation_input_tokens": 0
+    }
+  },
+  "canonicalStopUsage": {
+    "temporality": "delta",
+    "inputTokens": 200,
+    "cachedInputTokens": 80,
+    "cacheCreationInputTokens": 0,
+    "cacheCreationAccounting": "included-in-input",
+    "outputTokens": 8,
+    "reasoningOutputTokens": 0,
+    "uncachedInputTokens": 120,
+    "totalTokens": 208,
+    "providerTotalAgreement": "unreported"
+  },
+  "agentPrintUsage": {
+    "input_tokens": 220,
+    "output_tokens": 32,
+    "cache_read_input_tokens": 80,
+    "cache_creation_input_tokens": 16
+  },
+  "requiredHookEvents": [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "Stop",
+    "SessionEnd"
+  ],
+  "requiredCanonicalTypes": [
+    "session.start",
+    "prompt.submitted",
+    "tool.start",
+    "tool.end",
+    "generation.start",
+    "generation.end",
+    "session.end"
+  ]
+}

--- a/.har/lines/occupancy-identity/lab/run-lab.mjs
+++ b/.har/lines/occupancy-identity/lab/run-lab.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Occupancy lab entrypoint — station S3 of the occupancy-identity line (#316).
+ *
+ * Runs inside the lab container. Prepares a real Mission Control database, then
+ * hands off to `control/src/server/occupancy-lab.lab.ts`, which drives a real
+ * HAR launch → complete → launch cycle and asserts that occupancy B shows none
+ * of occupancy A's identity.
+ *
+ * The container exists for one reason: an isolated HOME. On a laptop, Claude
+ * Code transcripts under ~/.claude/projects/<encoded-cwd> outlive the worktree,
+ * so a green run can mean "the machine was clean" rather than "the invariant
+ * holds".
+ *
+ * Env:
+ *   OCCUPANCY_LAB_KEEP=1            keep the scratch repo and database
+ *   OCCUPANCY_LAB_ARTIFACTS=<dir>   write the lab report there
+ *   OCCUPANCY_LAB_ALLOW_HOST_HOME=1 skip the sandbox assertions (host debugging)
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LAB_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = process.env.LAB_REPO_ROOT ?? path.resolve(LAB_DIR, '..', '..', '..', '..');
+const CONTROL_DIR = path.join(REPO_ROOT, 'control');
+const HAR_CLI = path.join(REPO_ROOT, 'dist', 'index.js');
+
+const started = Date.now();
+const log = (msg) => process.stderr.write(`${msg}\n`);
+
+function emit(status, output) {
+  const report = {
+    status,
+    stageId: 'occupancy-lab',
+    kind: 'test',
+    total_ms: Date.now() - started,
+    home: homedir(),
+    output: String(output ?? '').trim().split('\n').slice(-50).join('\n'),
+  };
+  const artifacts = process.env.OCCUPANCY_LAB_ARTIFACTS;
+  if (artifacts) {
+    mkdirSync(artifacts, { recursive: true });
+    writeFileSync(path.join(artifacts, 'lab-report.json'), `${JSON.stringify(report, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exit(status === 'pass' ? 0 : 1);
+}
+
+function main() {
+  if (!existsSync(HAR_CLI)) {
+    emit('fail', `no built CLI at ${HAR_CLI} — run "npm run build" before the lab`);
+  }
+
+  const dbDir = mkdtempSync(path.join(tmpdir(), 'occupancy-lab-db-'));
+  const dbPath = path.join(dbDir, 'lab.db');
+  const env = {
+    ...process.env,
+    DATABASE_URL: `file:${dbPath}`,
+    LAB_HAR_CLI: HAR_CLI,
+    // The lab drives the CLI directly; telemetry would only add noise.
+    HAR_TELEMETRY: '0',
+  };
+
+  let output = '';
+  try {
+    log('==> preparing the lab Mission Control database');
+    output += execFileSync(
+      'npx',
+      ['prisma', 'db', 'push', '--skip-generate', '--accept-data-loss'],
+      { cwd: CONTROL_DIR, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+
+    log('==> running the occupancy cycle (real CLI, real database)');
+    output += execFileSync(
+      'npx',
+      ['vitest', 'run', '--config', 'vitest.lab.config.ts', '--reporter', 'verbose'],
+      { cwd: CONTROL_DIR, env, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+  } catch (err) {
+    const detail = `${err?.stdout ?? ''}${err?.stderr ?? ''}` || String(err?.message ?? err);
+    if (process.env.OCCUPANCY_LAB_KEEP !== '1') {
+      rmSync(dbDir, { recursive: true, force: true });
+    }
+    emit('fail', `${output}\n${detail}`);
+    return;
+  }
+
+  if (process.env.OCCUPANCY_LAB_KEEP !== '1') {
+    rmSync(dbDir, { recursive: true, force: true });
+  }
+  emit('pass', output);
+}
+
+main();

--- a/.har/lines/occupancy-identity/line.json
+++ b/.har/lines/occupancy-identity/line.json
@@ -92,6 +92,11 @@
         "id": "occupancy-lab",
         "fromStation": "S3",
         "tier": "full"
+      },
+      {
+        "id": "occupancy-agent-lab",
+        "fromStation": "S3",
+        "tier": "full"
       }
     ]
   },
@@ -119,6 +124,12 @@
       "kind": "test",
       "tier": "full",
       "description": "Docker sandbox occupancy lab \u2014 never on verify"
+    },
+    {
+      "id": "occupancy-agent-lab",
+      "kind": "test",
+      "tier": "full",
+      "description": "Real Claude Code CLI vs a scripted mock across an occupancy boundary"
     }
   ],
   "handoff": {
@@ -132,6 +143,7 @@
   },
   "prototypeNotes": [
     "S3's jig is modelled on os-factory/otel-hook har-plugins/agent-lab (isolated HOME, scripted mock, real CLI). Keep it local until a second repo needs the same install \u2014 do not publish @osfactory/agent-lab yet.",
-    "Stations map to vitest describe blocks named S0..S3; that is this instance's tactic, not part of the contract."
+    "Stations map to vitest describe blocks named S0..S3; that is this instance's tactic, not part of the contract.",
+    "The agent lab needs a `claude` binary on PATH; the Docker lab and the unit stations do not. That is instance detail, not contract."
   ]
 }

--- a/.har/lines/occupancy-identity/line.json
+++ b/.har/lines/occupancy-identity/line.json
@@ -1,0 +1,137 @@
+{
+  "contractVersion": 1,
+  "id": "occupancy-identity",
+  "title": "Slot occupancy identity",
+  "description": "A slot number is a workstation; a working session is one occupancy of one worktree. After complete or teardown, the next launch may reuse the number but must mint a new occupancy \u2014 new purpose, new trajectory stream, no merge with the previous session key. Each station adds a question the gate keeps asking forever.",
+  "skills": [
+    {
+      "id": "factory-line",
+      "role": "orchestrator",
+      "install": "repo:.claude/skills/factory-line"
+    }
+  ],
+  "mcp": [
+    {
+      "name": "github",
+      "why": "issue #316 is this line's traveler",
+      "required": false
+    }
+  ],
+  "plugins": [],
+  "stations": [
+    {
+      "id": "S0",
+      "title": "Purpose does not survive a relaunch",
+      "description": "After idle sync, purpose is null; relaunching slot N does not keep occupancy A's summary.",
+      "work": {
+        "source": "github",
+        "ids": [
+          "316"
+        ],
+        "url": "https://github.com/os-factory/har/issues/316",
+        "optional": false
+      }
+    },
+    {
+      "id": "S1",
+      "title": "Trajectory and usage follow the occupancy",
+      "description": "Streams and usage rows for occupancy B are not listed under occupancy A of the same slot id.",
+      "work": {
+        "source": "github",
+        "ids": [
+          "316"
+        ],
+        "optional": false
+      }
+    },
+    {
+      "id": "S2",
+      "title": "Ingest mints a new session",
+      "description": "complete then launch writes a new session key; ingest never prefers a stale har.session_key once the worktree changed.",
+      "work": {
+        "source": "github",
+        "ids": [
+          "316"
+        ],
+        "optional": false
+      }
+    },
+    {
+      "id": "S3",
+      "title": "Prove it without a developer's laptop",
+      "description": "Two real occupancies of slot 1 driven by the real CLI against a real database, in a container with an isolated HOME.",
+      "work": {
+        "source": "github",
+        "ids": [
+          "316"
+        ],
+        "optional": false
+      }
+    }
+  ],
+  "gate": {
+    "cumulative": true,
+    "optInEnv": null,
+    "stages": [
+      {
+        "id": "occupancy-s0",
+        "fromStation": "S0",
+        "tier": "full"
+      },
+      {
+        "id": "occupancy-s1",
+        "fromStation": "S1",
+        "tier": "full"
+      },
+      {
+        "id": "occupancy-s2",
+        "fromStation": "S2",
+        "tier": "full"
+      },
+      {
+        "id": "occupancy-lab",
+        "fromStation": "S3",
+        "tier": "full"
+      }
+    ]
+  },
+  "extraStages": [
+    {
+      "id": "occupancy-s0",
+      "kind": "test",
+      "tier": "full",
+      "description": "Purpose resets on occupancy change"
+    },
+    {
+      "id": "occupancy-s1",
+      "kind": "test",
+      "tier": "full",
+      "description": "Occupancy-scoped trajectory and usage queries"
+    },
+    {
+      "id": "occupancy-s2",
+      "kind": "test",
+      "tier": "full",
+      "description": "Ingest session-key precedence"
+    },
+    {
+      "id": "occupancy-lab",
+      "kind": "test",
+      "tier": "full",
+      "description": "Docker sandbox occupancy lab \u2014 never on verify"
+    }
+  ],
+  "handoff": {
+    "autonomousShip": false,
+    "waitFor": "human review of the lab report before merge"
+  },
+  "traveler": {
+    "kind": "github-issue-comment",
+    "ref": "316",
+    "note": "Durable notes live on issue #316 \u2014 a squash merge drops commit-body footers."
+  },
+  "prototypeNotes": [
+    "S3's jig is modelled on os-factory/otel-hook har-plugins/agent-lab (isolated HOME, scripted mock, real CLI). Keep it local until a second repo needs the same install \u2014 do not publish @osfactory/agent-lab yet.",
+    "Stations map to vitest describe blocks named S0..S3; that is this instance's tactic, not part of the contract."
+  ]
+}

--- a/.har/lines/occupancy-identity/line.manifest.json
+++ b/.har/lines/occupancy-identity/line.manifest.json
@@ -1,0 +1,110 @@
+{
+  "kind": "line",
+  "id": "occupancy-identity",
+  "title": "Slot occupancy identity",
+  "program": "line.json",
+  "files": [
+    {
+      "src": "stages/occupancy-s0.sh",
+      "dest": ".har/stages/occupancy-s0.sh",
+      "executable": true
+    },
+    {
+      "src": "stages/occupancy-s1.sh",
+      "dest": ".har/stages/occupancy-s1.sh",
+      "executable": true
+    },
+    {
+      "src": "stages/occupancy-s2.sh",
+      "dest": ".har/stages/occupancy-s2.sh",
+      "executable": true
+    },
+    {
+      "src": "stages/occupancy-lab.sh",
+      "dest": ".har/stages/occupancy-lab.sh",
+      "executable": true
+    },
+    {
+      "src": "lab/Dockerfile",
+      "dest": ".har/lines/occupancy-identity/lab/Dockerfile",
+      "executable": false
+    },
+    {
+      "src": "lab/run-lab.mjs",
+      "dest": ".har/lines/occupancy-identity/lab/run-lab.mjs",
+      "executable": true
+    },
+    {
+      "src": "README.md",
+      "dest": ".har/lines/occupancy-identity/README.md"
+    }
+  ],
+  "stages": [
+    {
+      "id": "occupancy-s0",
+      "kind": "test",
+      "description": "S0 \u2014 a relaunched slot does not keep the previous occupancy",
+      "script": "stages/occupancy-s0.sh",
+      "requiresAgentId": true,
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-s0",
+          "kind": "directory",
+          "description": "vitest output for occupancy-s0"
+        }
+      ],
+      "tier": "full"
+    },
+    {
+      "id": "occupancy-s1",
+      "kind": "test",
+      "description": "S1 \u2014 trajectory and usage are scoped to the occupancy, not the slot id",
+      "script": "stages/occupancy-s1.sh",
+      "requiresAgentId": true,
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-s1",
+          "kind": "directory",
+          "description": "vitest output for occupancy-s1"
+        }
+      ],
+      "tier": "full"
+    },
+    {
+      "id": "occupancy-s2",
+      "kind": "test",
+      "description": "S2 \u2014 ingest does not merge a new occupancy into the previous session",
+      "script": "stages/occupancy-s2.sh",
+      "requiresAgentId": true,
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-s2",
+          "kind": "directory",
+          "description": "vitest output for occupancy-s2"
+        }
+      ],
+      "tier": "full"
+    },
+    {
+      "id": "occupancy-lab",
+      "kind": "test",
+      "description": "S3 \u2014 two real occupancies of one slot in a sandbox HOME (Docker)",
+      "script": "stages/occupancy-lab.sh",
+      "requiresAgentId": true,
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-lab",
+          "kind": "directory",
+          "description": "Lab report and container log"
+        }
+      ],
+      "tier": "full"
+    }
+  ],
+  "nextSteps": [
+    "har line status occupancy-identity",
+    "har line gate S2 --line occupancy-identity   # unit stations, no Docker",
+    "har line gate S3 --line occupancy-identity   # adds the sandbox lab"
+  ],
+  "docsPath": ".har/lines/occupancy-identity/README.md"
+}

--- a/.har/lines/occupancy-identity/line.manifest.json
+++ b/.har/lines/occupancy-identity/line.manifest.json
@@ -37,6 +37,26 @@
     {
       "src": "README.md",
       "dest": ".har/lines/occupancy-identity/README.md"
+    },
+    {
+      "src": "stages/occupancy-agent-lab.sh",
+      "dest": ".har/stages/occupancy-agent-lab.sh",
+      "executable": true
+    },
+    {
+      "src": "lab/agent/run-agent-lab.mjs",
+      "dest": ".har/lines/occupancy-identity/lab/agent/run-agent-lab.mjs",
+      "executable": true
+    },
+    {
+      "src": "lab/agent/mock-anthropic.mjs",
+      "dest": ".har/lines/occupancy-identity/lab/agent/mock-anthropic.mjs",
+      "executable": false
+    },
+    {
+      "src": "lab/agent/scenario.json",
+      "dest": ".har/lines/occupancy-identity/lab/agent/scenario.json",
+      "executable": false
     }
   ],
   "stages": [
@@ -96,6 +116,21 @@
           "path": ".har/artifacts/occupancy-lab",
           "kind": "directory",
           "description": "Lab report and container log"
+        }
+      ],
+      "tier": "full"
+    },
+    {
+      "id": "occupancy-agent-lab",
+      "kind": "test",
+      "description": "S3 \u2014 two real Claude Code sessions across an occupancy boundary, mocked LLM, sandbox HOME",
+      "script": "stages/occupancy-agent-lab.sh",
+      "requiresAgentId": true,
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-agent-lab",
+          "kind": "directory",
+          "description": "Agent lab report and log"
         }
       ],
       "tier": "full"

--- a/.har/lines/occupancy-identity/stages/occupancy-agent-lab.sh
+++ b/.har/lines/occupancy-identity/stages/occupancy-agent-lab.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# occupancy-agent-lab — the adversarial half of station S3 (#316).
+#
+# The Docker lab (occupancy-lab) proves the invariant against synthetic records.
+# This one reproduces the condition the bug was found in: a REAL Claude Code CLI
+# driven twice against a scripted LLM mock, across a launch → complete → launch
+# boundary on the same slot, under a sandbox HOME so the transcripts it writes
+# are the lab's own and not the developer's.
+#
+# Nothing talks to a real model: ANTHROPIC_BASE_URL points at the local mock.
+#
+# Registered in stages.json and deliberately ABSENT from verificationStages.
+# Run it with: har line gate S3 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-agent-lab.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+DRIVER="$TARGET/.har/lines/occupancy-identity/lab/agent/run-agent-lab.mjs"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-agent-lab"
+
+mkdir -p "$ARTIFACTS_DIR"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+emit() {
+  node -e "process.stdout.write(JSON.stringify({
+    status: '$1', stageId: 'occupancy-agent-lab', kind: 'test', agent_id: $AGENT_ID,
+    total_ms: $2, output: $3
+  }, null, 2) + '\n');"
+}
+
+START=$(now_ms)
+
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || true)}"
+if [ -z "$CLAUDE_BIN" ]; then
+  # A missing agent CLI is a real blocker for this station, not a pass. The
+  # earlier stations still answer their questions without it.
+  emit fail "$(( $(now_ms) - START ))" "\"claude CLI not found — station S3's agent lab needs it (set CLAUDE_BIN, or run the unit stations with: har line gate S2 --line occupancy-identity)\""
+  exit 1
+fi
+
+[ -f "$DRIVER" ] || { emit fail 0 "\"lab driver missing: $DRIVER\""; exit 1; }
+
+echo "==> [occupancy-agent-lab agent-${AGENT_ID}] two real agent sessions across an occupancy boundary" >&2
+
+set +e
+OUTPUT=$(cd "$TARGET" && OCCUPANCY_LAB_ARTIFACTS="$ARTIFACTS_DIR" LAB_REPO_ROOT="$TARGET" \
+  CLAUDE_BIN="$CLAUDE_BIN" node "$DRIVER" 2>&1)
+RUN_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/agent-lab.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$RUN_CODE" = "0" ] && STATUS="pass"
+SUMMARY=$(printf '%s' "$OUTPUT" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(-40).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""')
+emit "$STATUS" "$(( END - START ))" "$SUMMARY"
+exit "$RUN_CODE"

--- a/.har/lines/occupancy-identity/stages/occupancy-lab.sh
+++ b/.har/lines/occupancy-identity/stages/occupancy-lab.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# occupancy-lab — station S3 of the occupancy-identity factory line (#316).
+#
+# Two occupancies of slot 1 driven by the REAL har CLI against a real Mission
+# Control database, inside a container with an isolated HOME. On a laptop,
+# ~/.claude/projects/<encoded-cwd> transcripts outlive the worktree and the
+# harvest can re-attach them to the next occupancy, so a green host run can just
+# mean the machine was clean. The sandbox removes that reading.
+#
+# Registered in stages.json and deliberately ABSENT from verificationStages:
+# routine `har env verify --full` must never start Docker. Run it with:
+#   har line gate S3 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-lab.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+LAB_DIR="$TARGET/.har/lines/occupancy-identity/lab"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-lab"
+IMAGE="${OCCUPANCY_LAB_IMAGE:-har-occupancy-lab:latest}"
+
+mkdir -p "$ARTIFACTS_DIR"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+emit() {
+  node -e "process.stdout.write(JSON.stringify({
+    status: '$1', stageId: 'occupancy-lab', kind: 'test', agent_id: $AGENT_ID,
+    total_ms: $2, output: $3
+  }, null, 2) + '\n');"
+}
+
+START=$(now_ms)
+
+if ! docker info >/dev/null 2>&1; then
+  # A missing Docker daemon is a real blocker for this station, not a pass.
+  emit fail "$(( $(now_ms) - START ))" "\"Docker daemon is not reachable — station S3 needs it. Start Docker, or run the earlier stations with: har line gate S2 --line occupancy-identity\""
+  exit 1
+fi
+
+[ -d "$LAB_DIR" ] || { emit fail 0 "\"lab directory missing: $LAB_DIR\""; exit 1; }
+
+echo "==> [occupancy-lab agent-${AGENT_ID}] building $IMAGE" >&2
+set +e
+BUILD_LOG=$(docker build -q -t "$IMAGE" -f "$LAB_DIR/Dockerfile" "$LAB_DIR" 2>&1)
+BUILD_CODE=$?
+set -e
+if [ "$BUILD_CODE" != "0" ]; then
+  emit fail "$(( $(now_ms) - START ))" "$(escape_step_output "$BUILD_LOG")"
+  exit 1
+fi
+
+echo "==> [occupancy-lab agent-${AGENT_ID}] running the occupancy cycle in a sandbox HOME" >&2
+set +e
+# The repo is mounted read-write: the lab builds nothing in it, but the har CLI
+# writes run records under the mounted .har/ of the scratch fixture it creates.
+OUTPUT=$(docker run --rm \
+  -v "$TARGET:/lab/repo" \
+  -e LAB_REPO_ROOT=/lab/repo \
+  -e OCCUPANCY_LAB_ARTIFACTS=/lab/repo/.har/artifacts/occupancy-lab \
+  -e OCCUPANCY_LAB_KEEP="${OCCUPANCY_LAB_KEEP:-0}" \
+  "$IMAGE" 2>&1)
+RUN_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/lab.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$RUN_CODE" = "0" ] && STATUS="pass"
+emit "$STATUS" "$(( END - START ))" "$(escape_step_output "$OUTPUT")"
+exit "$RUN_CODE"

--- a/.har/lines/occupancy-identity/stages/occupancy-s0.sh
+++ b/.har/lines/occupancy-identity/stages/occupancy-s0.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# occupancy-s0 — purpose does not survive a relaunch of the same slot
+#
+# Station S0 of the occupancy-identity factory line (#316).
+# Registered in stages.json; deliberately ABSENT from verificationStages —
+# run it with: har line gate S0 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-s0.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+STATION="$(echo s0 | tr '[:lower:]' '[:upper:]')"
+
+# Run against the slot's own checkout when there is one, else the main repo.
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-s0"
+mkdir -p "$ARTIFACTS_DIR"
+
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
+echo "==> [occupancy-s0 agent-${AGENT_ID}] ${STATION}: purpose does not survive a relaunch of the same slot" >&2
+echo "==> target: $TARGET/control" >&2
+START=$(now_ms)
+
+set +e
+OUTPUT=$(cd "$TARGET/control" && npx vitest run src/server/occupancy.test.ts --testNamePattern "$STATION" --reporter dot 2>&1)
+EXIT_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/vitest.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$EXIT_CODE" = "0" ] && STATUS="pass"
+OUTPUT_JSON=$(escape_step_output "$OUTPUT")
+
+node -e "process.stdout.write(JSON.stringify({
+  status: '$STATUS',
+  stageId: 'occupancy-s0',
+  kind: 'test',
+  agent_id: $AGENT_ID,
+  total_ms: $(( END - START )),
+  output: $OUTPUT_JSON
+}, null, 2) + '\n');"
+
+exit "$EXIT_CODE"

--- a/.har/lines/occupancy-identity/stages/occupancy-s1.sh
+++ b/.har/lines/occupancy-identity/stages/occupancy-s1.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# occupancy-s1 — trajectory and usage are scoped to the occupancy, not the slot id
+#
+# Station S1 of the occupancy-identity factory line (#316).
+# Registered in stages.json; deliberately ABSENT from verificationStages —
+# run it with: har line gate S1 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-s1.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+STATION="$(echo s1 | tr '[:lower:]' '[:upper:]')"
+
+# Run against the slot's own checkout when there is one, else the main repo.
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-s1"
+mkdir -p "$ARTIFACTS_DIR"
+
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
+echo "==> [occupancy-s1 agent-${AGENT_ID}] ${STATION}: trajectory and usage are scoped to the occupancy, not the slot id" >&2
+echo "==> target: $TARGET/control" >&2
+START=$(now_ms)
+
+set +e
+OUTPUT=$(cd "$TARGET/control" && npx vitest run src/server/occupancy.test.ts --testNamePattern "$STATION" --reporter dot 2>&1)
+EXIT_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/vitest.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$EXIT_CODE" = "0" ] && STATUS="pass"
+OUTPUT_JSON=$(escape_step_output "$OUTPUT")
+
+node -e "process.stdout.write(JSON.stringify({
+  status: '$STATUS',
+  stageId: 'occupancy-s1',
+  kind: 'test',
+  agent_id: $AGENT_ID,
+  total_ms: $(( END - START )),
+  output: $OUTPUT_JSON
+}, null, 2) + '\n');"
+
+exit "$EXIT_CODE"

--- a/.har/lines/occupancy-identity/stages/occupancy-s2.sh
+++ b/.har/lines/occupancy-identity/stages/occupancy-s2.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# occupancy-s2 — ingest does not merge a new occupancy into the previous session
+#
+# Station S2 of the occupancy-identity factory line (#316).
+# Registered in stages.json; deliberately ABSENT from verificationStages —
+# run it with: har line gate S2 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-s2.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+STATION="$(echo s2 | tr '[:lower:]' '[:upper:]')"
+
+# Run against the slot's own checkout when there is one, else the main repo.
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-s2"
+mkdir -p "$ARTIFACTS_DIR"
+
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
+echo "==> [occupancy-s2 agent-${AGENT_ID}] ${STATION}: ingest does not merge a new occupancy into the previous session" >&2
+echo "==> target: $TARGET/control" >&2
+START=$(now_ms)
+
+set +e
+OUTPUT=$(cd "$TARGET/control" && npx vitest run src/server/occupancy.test.ts --testNamePattern "$STATION" --reporter dot 2>&1)
+EXIT_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/vitest.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$EXIT_CODE" = "0" ] && STATUS="pass"
+OUTPUT_JSON=$(escape_step_output "$OUTPUT")
+
+node -e "process.stdout.write(JSON.stringify({
+  status: '$STATUS',
+  stageId: 'occupancy-s2',
+  kind: 'test',
+  agent_id: $AGENT_ID,
+  total_ms: $(( END - START )),
+  output: $OUTPUT_JSON
+}, null, 2) + '\n');"
+
+exit "$EXIT_CODE"

--- a/.har/stages.json
+++ b/.har/stages.json
@@ -132,29 +132,89 @@
     {
       "id": "build",
       "kind": "test",
-      "tier": "quick",
-      "requiresAgentId": true,
-      "artifacts": [],
+      "description": "Build the CLI bundle",
       "command": "${NPM_BIN:-npm} run build",
-      "description": "Build the CLI bundle"
+      "artifacts": [],
+      "requiresAgentId": true,
+      "tier": "quick"
     },
     {
       "id": "docs-check",
       "kind": "test",
-      "tier": "quick",
-      "requiresAgentId": true,
-      "artifacts": [],
+      "description": "Astro docs typecheck (astro check)",
       "command": "(cd docs && ${NPM_BIN:-npm} run check)",
-      "description": "Astro docs typecheck (astro check)"
+      "artifacts": [],
+      "requiresAgentId": true,
+      "tier": "quick"
     },
     {
       "id": "docs-build",
       "kind": "test",
-      "tier": "quick",
-      "requiresAgentId": true,
-      "artifacts": [],
+      "description": "Astro docs build",
       "command": "(cd docs && ${NPM_BIN:-npm} run build)",
-      "description": "Astro docs build"
+      "artifacts": [],
+      "requiresAgentId": true,
+      "tier": "quick"
+    },
+    {
+      "id": "occupancy-s0",
+      "kind": "test",
+      "description": "S0 — a relaunched slot does not keep the previous occupancy",
+      "script": "stages/occupancy-s0.sh",
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-s0",
+          "kind": "directory",
+          "description": "vitest output for occupancy-s0"
+        }
+      ],
+      "requiresAgentId": true,
+      "tier": "full"
+    },
+    {
+      "id": "occupancy-s1",
+      "kind": "test",
+      "description": "S1 — trajectory and usage are scoped to the occupancy, not the slot id",
+      "script": "stages/occupancy-s1.sh",
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-s1",
+          "kind": "directory",
+          "description": "vitest output for occupancy-s1"
+        }
+      ],
+      "requiresAgentId": true,
+      "tier": "full"
+    },
+    {
+      "id": "occupancy-s2",
+      "kind": "test",
+      "description": "S2 — ingest does not merge a new occupancy into the previous session",
+      "script": "stages/occupancy-s2.sh",
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-s2",
+          "kind": "directory",
+          "description": "vitest output for occupancy-s2"
+        }
+      ],
+      "requiresAgentId": true,
+      "tier": "full"
+    },
+    {
+      "id": "occupancy-lab",
+      "kind": "test",
+      "description": "S3 — two real occupancies of one slot in a sandbox HOME (Docker)",
+      "script": "stages/occupancy-lab.sh",
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-lab",
+          "kind": "directory",
+          "description": "Lab report and container log"
+        }
+      ],
+      "requiresAgentId": true,
+      "tier": "full"
     }
   ],
   "commitGate": {

--- a/.har/stages.json
+++ b/.har/stages.json
@@ -215,6 +215,21 @@
       ],
       "requiresAgentId": true,
       "tier": "full"
+    },
+    {
+      "id": "occupancy-agent-lab",
+      "kind": "test",
+      "description": "S3 — two real Claude Code sessions across an occupancy boundary, mocked LLM, sandbox HOME",
+      "script": "stages/occupancy-agent-lab.sh",
+      "artifacts": [
+        {
+          "path": ".har/artifacts/occupancy-agent-lab",
+          "kind": "directory",
+          "description": "Agent lab report and log"
+        }
+      ],
+      "requiresAgentId": true,
+      "tier": "full"
     }
   ],
   "commitGate": {

--- a/.har/stages/occupancy-agent-lab.sh
+++ b/.har/stages/occupancy-agent-lab.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# occupancy-agent-lab — the adversarial half of station S3 (#316).
+#
+# The Docker lab (occupancy-lab) proves the invariant against synthetic records.
+# This one reproduces the condition the bug was found in: a REAL Claude Code CLI
+# driven twice against a scripted LLM mock, across a launch → complete → launch
+# boundary on the same slot, under a sandbox HOME so the transcripts it writes
+# are the lab's own and not the developer's.
+#
+# Nothing talks to a real model: ANTHROPIC_BASE_URL points at the local mock.
+#
+# Registered in stages.json and deliberately ABSENT from verificationStages.
+# Run it with: har line gate S3 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-agent-lab.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+DRIVER="$TARGET/.har/lines/occupancy-identity/lab/agent/run-agent-lab.mjs"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-agent-lab"
+
+mkdir -p "$ARTIFACTS_DIR"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+emit() {
+  node -e "process.stdout.write(JSON.stringify({
+    status: '$1', stageId: 'occupancy-agent-lab', kind: 'test', agent_id: $AGENT_ID,
+    total_ms: $2, output: $3
+  }, null, 2) + '\n');"
+}
+
+START=$(now_ms)
+
+CLAUDE_BIN="${CLAUDE_BIN:-$(command -v claude || true)}"
+if [ -z "$CLAUDE_BIN" ]; then
+  # A missing agent CLI is a real blocker for this station, not a pass. The
+  # earlier stations still answer their questions without it.
+  emit fail "$(( $(now_ms) - START ))" "\"claude CLI not found — station S3's agent lab needs it (set CLAUDE_BIN, or run the unit stations with: har line gate S2 --line occupancy-identity)\""
+  exit 1
+fi
+
+[ -f "$DRIVER" ] || { emit fail 0 "\"lab driver missing: $DRIVER\""; exit 1; }
+
+echo "==> [occupancy-agent-lab agent-${AGENT_ID}] two real agent sessions across an occupancy boundary" >&2
+
+set +e
+OUTPUT=$(cd "$TARGET" && OCCUPANCY_LAB_ARTIFACTS="$ARTIFACTS_DIR" LAB_REPO_ROOT="$TARGET" \
+  CLAUDE_BIN="$CLAUDE_BIN" node "$DRIVER" 2>&1)
+RUN_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/agent-lab.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$RUN_CODE" = "0" ] && STATUS="pass"
+SUMMARY=$(printf '%s' "$OUTPUT" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(-40).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""')
+emit "$STATUS" "$(( END - START ))" "$SUMMARY"
+exit "$RUN_CODE"

--- a/.har/stages/occupancy-lab.sh
+++ b/.har/stages/occupancy-lab.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# occupancy-lab — station S3 of the occupancy-identity factory line (#316).
+#
+# Two occupancies of slot 1 driven by the REAL har CLI against a real Mission
+# Control database, inside a container with an isolated HOME. On a laptop,
+# ~/.claude/projects/<encoded-cwd> transcripts outlive the worktree and the
+# harvest can re-attach them to the next occupancy, so a green host run can just
+# mean the machine was clean. The sandbox removes that reading.
+#
+# Registered in stages.json and deliberately ABSENT from verificationStages:
+# routine `har env verify --full` must never start Docker. Run it with:
+#   har line gate S3 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-lab.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+LAB_DIR="$TARGET/.har/lines/occupancy-identity/lab"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-lab"
+IMAGE="${OCCUPANCY_LAB_IMAGE:-har-occupancy-lab:latest}"
+
+mkdir -p "$ARTIFACTS_DIR"
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+emit() {
+  node -e "process.stdout.write(JSON.stringify({
+    status: '$1', stageId: 'occupancy-lab', kind: 'test', agent_id: $AGENT_ID,
+    total_ms: $2, output: $3
+  }, null, 2) + '\n');"
+}
+
+START=$(now_ms)
+
+if ! docker info >/dev/null 2>&1; then
+  # A missing Docker daemon is a real blocker for this station, not a pass.
+  emit fail "$(( $(now_ms) - START ))" "\"Docker daemon is not reachable — station S3 needs it. Start Docker, or run the earlier stations with: har line gate S2 --line occupancy-identity\""
+  exit 1
+fi
+
+[ -d "$LAB_DIR" ] || { emit fail 0 "\"lab directory missing: $LAB_DIR\""; exit 1; }
+
+echo "==> [occupancy-lab agent-${AGENT_ID}] building $IMAGE" >&2
+set +e
+BUILD_LOG=$(docker build -q -t "$IMAGE" -f "$LAB_DIR/Dockerfile" "$LAB_DIR" 2>&1)
+BUILD_CODE=$?
+set -e
+if [ "$BUILD_CODE" != "0" ]; then
+  emit fail "$(( $(now_ms) - START ))" "$(escape_step_output "$BUILD_LOG")"
+  exit 1
+fi
+
+echo "==> [occupancy-lab agent-${AGENT_ID}] running the occupancy cycle in a sandbox HOME" >&2
+set +e
+# The repo is mounted read-write: the lab builds nothing in it, but the har CLI
+# writes run records under the mounted .har/ of the scratch fixture it creates.
+OUTPUT=$(docker run --rm \
+  -v "$TARGET:/lab/repo" \
+  -e LAB_REPO_ROOT=/lab/repo \
+  -e OCCUPANCY_LAB_ARTIFACTS=/lab/repo/.har/artifacts/occupancy-lab \
+  -e OCCUPANCY_LAB_KEEP="${OCCUPANCY_LAB_KEEP:-0}" \
+  "$IMAGE" 2>&1)
+RUN_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/lab.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$RUN_CODE" = "0" ] && STATUS="pass"
+emit "$STATUS" "$(( END - START ))" "$(escape_step_output "$OUTPUT")"
+exit "$RUN_CODE"

--- a/.har/stages/occupancy-s0.sh
+++ b/.har/stages/occupancy-s0.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# occupancy-s0 — purpose does not survive a relaunch of the same slot
+#
+# Station S0 of the occupancy-identity factory line (#316).
+# Registered in stages.json; deliberately ABSENT from verificationStages —
+# run it with: har line gate S0 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-s0.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+STATION="$(echo s0 | tr '[:lower:]' '[:upper:]')"
+
+# Run against the slot's own checkout when there is one, else the main repo.
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-s0"
+mkdir -p "$ARTIFACTS_DIR"
+
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
+echo "==> [occupancy-s0 agent-${AGENT_ID}] ${STATION}: purpose does not survive a relaunch of the same slot" >&2
+echo "==> target: $TARGET/control" >&2
+START=$(now_ms)
+
+set +e
+OUTPUT=$(cd "$TARGET/control" && npx vitest run src/server/occupancy.test.ts --testNamePattern "$STATION" --reporter dot 2>&1)
+EXIT_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/vitest.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$EXIT_CODE" = "0" ] && STATUS="pass"
+OUTPUT_JSON=$(escape_step_output "$OUTPUT")
+
+node -e "process.stdout.write(JSON.stringify({
+  status: '$STATUS',
+  stageId: 'occupancy-s0',
+  kind: 'test',
+  agent_id: $AGENT_ID,
+  total_ms: $(( END - START )),
+  output: $OUTPUT_JSON
+}, null, 2) + '\n');"
+
+exit "$EXIT_CODE"

--- a/.har/stages/occupancy-s1.sh
+++ b/.har/stages/occupancy-s1.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# occupancy-s1 — trajectory and usage are scoped to the occupancy, not the slot id
+#
+# Station S1 of the occupancy-identity factory line (#316).
+# Registered in stages.json; deliberately ABSENT from verificationStages —
+# run it with: har line gate S1 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-s1.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+STATION="$(echo s1 | tr '[:lower:]' '[:upper:]')"
+
+# Run against the slot's own checkout when there is one, else the main repo.
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-s1"
+mkdir -p "$ARTIFACTS_DIR"
+
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
+echo "==> [occupancy-s1 agent-${AGENT_ID}] ${STATION}: trajectory and usage are scoped to the occupancy, not the slot id" >&2
+echo "==> target: $TARGET/control" >&2
+START=$(now_ms)
+
+set +e
+OUTPUT=$(cd "$TARGET/control" && npx vitest run src/server/occupancy.test.ts --testNamePattern "$STATION" --reporter dot 2>&1)
+EXIT_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/vitest.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$EXIT_CODE" = "0" ] && STATUS="pass"
+OUTPUT_JSON=$(escape_step_output "$OUTPUT")
+
+node -e "process.stdout.write(JSON.stringify({
+  status: '$STATUS',
+  stageId: 'occupancy-s1',
+  kind: 'test',
+  agent_id: $AGENT_ID,
+  total_ms: $(( END - START )),
+  output: $OUTPUT_JSON
+}, null, 2) + '\n');"
+
+exit "$EXIT_CODE"

--- a/.har/stages/occupancy-s2.sh
+++ b/.har/stages/occupancy-s2.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# occupancy-s2 — ingest does not merge a new occupancy into the previous session
+#
+# Station S2 of the occupancy-identity factory line (#316).
+# Registered in stages.json; deliberately ABSENT from verificationStages —
+# run it with: har line gate S2 --line occupancy-identity
+#
+# Usage: ./.har/stages/occupancy-s2.sh <agent-id>
+set -euo pipefail
+
+HARNESS_DIR="${HAR_HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+AGENT_ID="${1:-${AGENT_ID:-1}}"
+STATION="$(echo s2 | tr '[:lower:]' '[:upper:]')"
+
+# Run against the slot's own checkout when there is one, else the main repo.
+TARGET="${WORK_DIR:-$(cd "$HARNESS_DIR/.." && pwd)}"
+ARTIFACTS_DIR="$HARNESS_DIR/artifacts/occupancy-s2"
+mkdir -p "$ARTIFACTS_DIR"
+
+now_ms() { node -e 'process.stdout.write(String(Date.now()))' 2>/dev/null || echo 0; }
+escape_step_output() {
+  printf '%s' "$1" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const s=d.trim().split('\n').slice(0,50).join('\n');process.stdout.write(JSON.stringify(s))})" 2>/dev/null || echo '""'
+}
+
+echo "==> [occupancy-s2 agent-${AGENT_ID}] ${STATION}: ingest does not merge a new occupancy into the previous session" >&2
+echo "==> target: $TARGET/control" >&2
+START=$(now_ms)
+
+set +e
+OUTPUT=$(cd "$TARGET/control" && npx vitest run src/server/occupancy.test.ts --testNamePattern "$STATION" --reporter dot 2>&1)
+EXIT_CODE=$?
+set -e
+
+printf '%s\n' "$OUTPUT" > "$ARTIFACTS_DIR/vitest.log"
+
+END=$(now_ms)
+STATUS="fail"
+[ "$EXIT_CODE" = "0" ] && STATUS="pass"
+OUTPUT_JSON=$(escape_step_output "$OUTPUT")
+
+node -e "process.stdout.write(JSON.stringify({
+  status: '$STATUS',
+  stageId: 'occupancy-s2',
+  kind: 'test',
+  agent_id: $AGENT_ID,
+  total_ms: $(( END - START )),
+  output: $OUTPUT_JSON
+}, null, 2) + '\n');"
+
+exit "$EXIT_CODE"

--- a/control/prisma/schema.prisma
+++ b/control/prisma/schema.prisma
@@ -49,6 +49,9 @@ model AgentSlot {
   baseCommit       String?
   sessionCreatedAt DateTime?
   purpose          String?
+  // One occupancy of this workstation (#316). A slot number is reused; an
+  // occupancy is not. Null when the slot is idle.
+  occupancyKey     String?
   workUnitId       String?
   attemptId        String?
   detachedHead     Boolean?
@@ -71,6 +74,7 @@ model AgentSessionUsage {
   workDir             String?
   branch              String?
   suffix              String?
+  occupancyKey        String?
   workUnitId          String?
   attemptId           String?
   tokensInput         BigInt     @default(0)
@@ -89,6 +93,7 @@ model AgentSessionUsage {
 
   @@unique([repositoryId, sessionKey, agentTool])
   @@index([repositoryId, agentId])
+  @@index([repositoryId, agentId, occupancyKey])
   @@index([lastSeenAt])
 }
 
@@ -164,11 +169,13 @@ model AgentTrajectoryRecord {
   generationId      String?
   toolCallId        String?
   correlationId     String?
+  occupancyKey      String?
   workUnitId        String?
   attemptId         String?
   createdAt         DateTime   @default(now())
 
   @@unique([repositoryId, source, sourceEventId, contentKey])
+  @@index([repositoryId, agentId, occupancyKey])
   @@index([repositoryId, agentId, sessionKey, agentTool, sequence, eventTimestamp, source])
   @@index([repositoryId, agentId, sessionKey, agentTool, createdAt])
   @@index([repositoryId, createdAt, id])

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -42,8 +42,12 @@ export default async function SlotDetailPage({
   const slot = repo.slots.find((s) => s.slotId === slotId);
   if (!slot) notFound();
 
+  // #316: usage and trajectory are scoped to the slot's CURRENT occupancy.
+  // A slot number is reused after complete/teardown; a working session is not.
+  const occupancyKey = slot.occupancyKey ?? null;
+
   const [usageRows, validation, events, verifyRuns, trajectory] = await Promise.all([
-    listSessionUsageForSlot(id, slotId),
+    listSessionUsageForSlot(id, slotId, occupancyKey),
     getValidationStages(id, { agentId: slotId }),
     listSessionEventsForSlot(id, slotId),
     prisma.run.findMany({
@@ -51,7 +55,7 @@ export default async function SlotDetailPage({
       orderBy: { startedAt: 'desc' },
       take: 20,
     }),
-    getSlotTrajectoryData(id, slotId),
+    getSlotTrajectoryData(id, slotId, 100, occupancyKey),
   ]);
 
   const modelsByUsageKey = new Map<string, string[]>();

--- a/control/src/server/occupancy-lab.lab.ts
+++ b/control/src/server/occupancy-lab.lab.ts
@@ -1,0 +1,213 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { prisma } from '@/lib/db';
+import { registerRepository, syncSlots } from '@/server/repositories';
+import { resolveSessionContext } from '@/server/otel-ingest';
+import { appendTrajectoryRecord, listTrajectoryStreams } from '@/server/trajectory-ledger';
+import { listSessionUsageForSlot, upsertSessionUsage } from '@/server/usage';
+
+/**
+ * Occupancy lab — station S3 of the occupancy-identity line (#316).
+ *
+ * Unlike the S0–S2 unit stations, nothing here is mocked: a real HAR CLI drives
+ * a real launch → complete → launch cycle on a scratch git repository, and the
+ * resulting status feeds Mission Control's real sync and ingest code against a
+ * real SQLite database.
+ *
+ * It runs inside the lab container so HOME is isolated. On a developer laptop,
+ * Claude Code transcripts under ~/.claude/projects/<encoded-cwd> outlive the
+ * worktree and the harvest can re-attach them to the next occupancy of the same
+ * slot — a green run there can just mean the machine was clean.
+ *
+ * Excluded from `npm test` by vitest.lab.config.ts. Run it with:
+ *   har line gate S3 --line occupancy-identity
+ */
+
+const HAR_CLI = process.env.LAB_HAR_CLI ?? path.resolve(__dirname, '../../../dist/index.js');
+const ALLOW_HOST_HOME = process.env.OCCUPANCY_LAB_ALLOW_HOST_HOME === '1';
+
+function run(cmd: string, args: string[], cwd?: string): string {
+  return execFileSync(cmd, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd,
+    env: process.env,
+  });
+}
+
+function makeFixtureRepo(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'occupancy-lab-repo-'));
+  writeFileSync(
+    path.join(dir, 'package.json'),
+    `${JSON.stringify({ name: 'occupancy-lab-fixture', version: '1.0.0' }, null, 2)}\n`,
+  );
+  run('git', ['init', '-q', '-b', 'main'], dir);
+  run('git', ['add', '-A'], dir);
+  run('git', ['commit', '-q', '-m', 'chore: fixture'], dir);
+  run('node', [HAR_CLI, 'env', 'init', '--profile', 'cli', '--yes', '--repo', dir]);
+  run('git', ['add', '-A'], dir);
+  run('git', ['commit', '-q', '-m', 'chore: harness'], dir);
+  return dir;
+}
+
+type SlotSnapshot = {
+  agentId: number;
+  active: boolean;
+  branch?: string;
+  workDir?: string;
+  worktreePath?: string;
+  attemptId?: string;
+  sessionCreatedAt?: string;
+  harnessUsage: string;
+};
+
+function statusPayload(repoDir: string): { slots: SlotSnapshot[]; generatedAt: string } {
+  const raw = run('node', [HAR_CLI, 'env', 'status', '--json', '--repo', repoDir]);
+  const parsed = JSON.parse(raw) as { slots?: SlotSnapshot[] };
+  return { slots: parsed.slots ?? [], generatedAt: new Date().toISOString() };
+}
+
+async function slotRow(repositoryId: string) {
+  return prisma.agentSlot.findUnique({
+    where: { repositoryId_slotId: { repositoryId, slotId: 1 } },
+  });
+}
+
+describe('S3 — occupancy identity survives a real complete → launch cycle', () => {
+  let repositoryId: string;
+  let repoDir: string;
+  const occupancyA = { key: '', branch: '', sessionKey: '' };
+  const occupancyB = { key: '', branch: '' };
+
+  beforeAll(async () => {
+    // The sandbox is the point of this station.
+    if (!ALLOW_HOST_HOME) {
+      expect(homedir()).toBe('/lab/home');
+      expect(existsSync(path.join(homedir(), '.claude', 'projects'))).toBe(false);
+    }
+    expect(existsSync(HAR_CLI)).toBe(true);
+
+    repoDir = makeFixtureRepo();
+    const registered = await registerRepository({ path: repoDir, name: 'occupancy-lab-fixture' });
+    repositoryId = registered.id;
+
+    // ── Occupancy A ────────────────────────────────────────────────────────
+    run('node', [HAR_CLI, 'env', 'launch', '1', '--repo', repoDir]);
+    await syncSlots(repositoryId, statusPayload(repoDir));
+
+    const a = await slotRow(repositoryId);
+    occupancyA.key = a?.occupancyKey ?? '';
+    occupancyA.branch = a?.branch ?? '';
+    occupancyA.sessionKey = occupancyA.branch;
+
+    // An agent worked in A: a purpose, a trajectory stream, and usage.
+    await prisma.agentSlot.update({
+      where: { repositoryId_slotId: { repositoryId, slotId: 1 } },
+      data: { purpose: 'occupancy A — the previous task' },
+    });
+    await appendTrajectoryRecord(repositoryId, {
+      version: 1,
+      source: 'otel',
+      sourceEventId: 'lab-a-1',
+      contentKey: 'prompt',
+      sessionKey: occupancyA.sessionKey,
+      agentId: 1,
+      agentTool: 'claude_code',
+      eventType: 'user_prompt',
+      sequence: 1,
+      timestamp: new Date().toISOString(),
+      payload: { text: 'occupancy A prompt' },
+      contentKind: 'text',
+      contentDisclosure: 'full',
+      occupancyKey: occupancyA.key,
+    } as never);
+    await upsertSessionUsage(repositoryId, {
+      sessionKey: occupancyA.sessionKey,
+      agentId: 1,
+      agentTool: 'claude_code',
+      tokensInput: 10,
+      tokensOutput: 5,
+      tokensCacheRead: 0,
+      tokensCacheCreation: 0,
+      tokensTotal: 15,
+      sources: [],
+      harvestVersion: 2,
+      firstSeenAt: new Date().toISOString(),
+      lastSeenAt: new Date().toISOString(),
+      occupancyKey: occupancyA.key,
+    } as never);
+
+    // ── Free the workstation, then take it again for different work ────────
+    run('node', [HAR_CLI, 'env', 'complete', '1', '--skip-verify', '--repo', repoDir]);
+    await syncSlots(repositoryId, statusPayload(repoDir));
+
+    run('node', [HAR_CLI, 'env', 'launch', '1', '--repo', repoDir]);
+    await syncSlots(repositoryId, statusPayload(repoDir));
+
+    const b = await slotRow(repositoryId);
+    occupancyB.key = b?.occupancyKey ?? '';
+    occupancyB.branch = b?.branch ?? '';
+  }, 300_000);
+
+  it('mints a new occupancy for the reused slot number', () => {
+    expect(occupancyA.key).toBeTruthy();
+    expect(occupancyB.key).toBeTruthy();
+    expect(occupancyB.key).not.toBe(occupancyA.key);
+    expect(occupancyB.branch).not.toBe(occupancyA.branch);
+  });
+
+  it('does not carry occupancy A\'s purpose into occupancy B', async () => {
+    const b = await slotRow(repositoryId);
+    expect(b?.purpose).toBeNull();
+  });
+
+  it('lists none of occupancy A\'s trajectory or usage under occupancy B', async () => {
+    const streams = await listTrajectoryStreams(repositoryId, 1, occupancyB.key);
+    const usage = await listSessionUsageForSlot(repositoryId, 1, occupancyB.key);
+
+    expect(streams).toEqual([]);
+    expect(usage).toEqual([]);
+
+    // …and occupancy A really did have something to leak.
+    const aStreams = await listTrajectoryStreams(repositoryId, 1, occupancyA.key);
+    const aUsage = await listSessionUsageForSlot(repositoryId, 1, occupancyA.key);
+    expect(aStreams.length).toBeGreaterThan(0);
+    expect(aUsage.length).toBeGreaterThan(0);
+  });
+
+  it('refuses a stale har.session_key once the worktree changed', async () => {
+    const b = await slotRow(repositoryId);
+    const { context } = await resolveSessionContext(
+      { 'har.session_key': occupancyA.sessionKey },
+      {
+        'gen_ai.client.workspace': b?.workDir ?? '',
+        'gen_ai.agent.name': 'claude_code',
+      },
+    );
+
+    expect(context?.sessionKey).toBe(occupancyB.branch);
+    expect(context?.sessionKey).not.toBe(occupancyA.sessionKey);
+    expect(context?.occupancyKey).toBe(occupancyB.key);
+  });
+
+  it('keeps the same occupancy across an idempotent re-sync', async () => {
+    await syncSlots(repositoryId, statusPayload(repoDir));
+    const again = await slotRow(repositoryId);
+    expect(again?.occupancyKey).toBe(occupancyB.key);
+  });
+
+  afterAll(() => {
+    if (process.env.OCCUPANCY_LAB_KEEP === '1' || !repoDir) return;
+    // Free the slot before the checkout disappears, then drop the scratch repo.
+    try {
+      run('node', [HAR_CLI, 'env', 'teardown', '1', '--repo', repoDir]);
+    } catch {
+      /* the lab may have failed before launching */
+    }
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+});

--- a/control/src/server/occupancy.test.ts
+++ b/control/src/server/occupancy.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Slot occupancy identity (#316) — the questions this line's gate keeps asking.
+ *
+ * A slot number is a workstation; a working session is one occupancy of one
+ * worktree. `complete` / `teardown` then `launch` reuses the number and must
+ * mint a NEW occupancy. `--resume` continues the same one.
+ *
+ * Station tags (`har line gate S0` … `S2`) map to the describe blocks below;
+ * each station's gate runs its own stage plus every earlier station's.
+ */
+
+const agentSlotFindUnique = vi.fn();
+const agentSlotUpsert = vi.fn();
+const trajectoryGroupBy = vi.fn();
+const usageFindMany = vi.fn();
+const slotFindMany = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    agentSlot: {
+      findUnique: (...args: unknown[]) => agentSlotFindUnique(...args),
+      upsert: (...args: unknown[]) => agentSlotUpsert(...args),
+      findMany: (...args: unknown[]) => slotFindMany(...args),
+    },
+    agentTrajectoryRecord: {
+      groupBy: (...args: unknown[]) => trajectoryGroupBy(...args),
+    },
+    agentSessionUsage: {
+      findMany: (...args: unknown[]) => usageFindMany(...args),
+    },
+    repository: { findMany: vi.fn(async () => []) },
+  },
+}));
+
+vi.mock('@/server/git-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => p,
+}));
+
+vi.mock('@/server/worktree-cleanup', () => ({
+  cleanupSessionWorktrees: () => [],
+}));
+
+import { deriveOccupancyKey, isNewOccupancy } from './occupancy';
+import { buildAgentSlotSyncFields } from './slot-sync-fields';
+import { syncSlots } from './repositories';
+import { listTrajectoryStreams } from './trajectory-ledger';
+import { listSessionUsageForSlot } from './usage';
+
+/** One occupancy of slot 1, as the harness reports it. */
+function occupancy(overrides: Record<string, unknown> = {}) {
+  return {
+    agentId: 1,
+    active: true,
+    harnessUsage: 'cli' as const,
+    branch: 'main-aaaa-har-agent-1-oldx',
+    worktreePath: '/home/dev/worktrees/main-aaaa-har-agent-1-oldx',
+    workDir: '/home/dev/worktrees/main-aaaa-har-agent-1-oldx',
+    sessionCreatedAt: '2026-08-01T10:00:00.000Z',
+    attemptId: '11111111-1111-4111-8111-111111111111',
+    ...overrides,
+  };
+}
+
+const OCCUPANCY_B = occupancy({
+  branch: 'main-bbbb-har-agent-1-newy',
+  worktreePath: '/home/dev/worktrees/main-bbbb-har-agent-1-newy',
+  workDir: '/home/dev/worktrees/main-bbbb-har-agent-1-newy',
+  sessionCreatedAt: '2026-08-02T09:00:00.000Z',
+  attemptId: '22222222-2222-4222-8222-222222222222',
+});
+
+beforeEach(() => {
+  agentSlotFindUnique.mockReset();
+  agentSlotUpsert.mockReset();
+  trajectoryGroupBy.mockReset();
+  usageFindMany.mockReset();
+  slotFindMany.mockReset();
+  agentSlotUpsert.mockResolvedValue({});
+  trajectoryGroupBy.mockResolvedValue([]);
+  usageFindMany.mockResolvedValue([]);
+});
+
+describe('S0 — a relaunched slot does not keep the previous occupancy', () => {
+  it('derives a distinct key per occupancy and none when idle', () => {
+    const a = deriveOccupancyKey(occupancy());
+    const b = deriveOccupancyKey(OCCUPANCY_B);
+
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toEqual(b);
+    expect(deriveOccupancyKey(occupancy({ active: false }))).toBeNull();
+  });
+
+  it('keeps the same key when the same worktree is resumed', () => {
+    // --resume / recover continues the occupancy: same attempt, same key.
+    const first = deriveOccupancyKey(occupancy());
+    const resumed = deriveOccupancyKey(occupancy({ dirty: true, ahead: 3 }));
+
+    expect(resumed).toEqual(first);
+    expect(isNewOccupancy(first, resumed)).toBe(false);
+  });
+
+  it('falls back to branch + session start when no attempt is bound', () => {
+    const a = deriveOccupancyKey(occupancy({ attemptId: undefined }));
+    const b = deriveOccupancyKey({ ...OCCUPANCY_B, attemptId: undefined });
+
+    expect(a).toBeTruthy();
+    expect(a).not.toEqual(b);
+  });
+
+  it('nulls occupancyKey on the sync that reports the slot idle', () => {
+    const fields = buildAgentSlotSyncFields(occupancy({ active: false }) as never);
+
+    expect(fields.occupancyKey).toBeNull();
+    expect(fields.workDir).toBeNull();
+  });
+
+  it('clears purpose when a new occupancy takes the slot', async () => {
+    // Occupancy A is stored; the harness now reports occupancy B in slot 1.
+    agentSlotFindUnique.mockResolvedValue({
+      occupancyKey: deriveOccupancyKey(occupancy()),
+    });
+
+    await syncSlots('repo-1', { slots: [OCCUPANCY_B], generatedAt: new Date().toISOString() });
+
+    const { update } = agentSlotUpsert.mock.calls[0][0];
+    expect(update.purpose).toBeNull();
+    expect(update.occupancyKey).toEqual(deriveOccupancyKey(OCCUPANCY_B));
+  });
+
+  it('clears purpose when the slot goes idle', async () => {
+    agentSlotFindUnique.mockResolvedValue({
+      occupancyKey: deriveOccupancyKey(occupancy()),
+    });
+
+    await syncSlots('repo-1', {
+      slots: [occupancy({ active: false })],
+      generatedAt: new Date().toISOString(),
+    });
+
+    const { update } = agentSlotUpsert.mock.calls[0][0];
+    expect(update.purpose).toBeNull();
+    expect(update.occupancyKey).toBeNull();
+  });
+
+  it('leaves purpose untouched while the same occupancy keeps working', async () => {
+    agentSlotFindUnique.mockResolvedValue({
+      occupancyKey: deriveOccupancyKey(occupancy()),
+    });
+
+    await syncSlots('repo-1', {
+      slots: [occupancy({ dirty: true })],
+      generatedAt: new Date().toISOString(),
+    });
+
+    const { update } = agentSlotUpsert.mock.calls[0][0];
+    // undefined = "leave the column unchanged" in Prisma.
+    expect(update.purpose).toBeUndefined();
+  });
+});
+
+describe('S1 — trajectory and usage are scoped to the occupancy, not the slot id', () => {
+  it('filters trajectory streams by occupancyKey when the slot has one', async () => {
+    await listTrajectoryStreams('repo-1', 1, 'attempt::occupancy-b');
+
+    expect(trajectoryGroupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { repositoryId: 'repo-1', agentId: 1, occupancyKey: 'attempt::occupancy-b' },
+      }),
+    );
+  });
+
+  it('filters usage rows by occupancyKey when the slot has one', async () => {
+    await listSessionUsageForSlot('repo-1', 1, 'attempt::occupancy-b');
+
+    expect(usageFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { repositoryId: 'repo-1', agentId: 1, occupancyKey: 'attempt::occupancy-b' },
+      }),
+    );
+  });
+
+  it('falls back to slot-wide listing for an idle slot with no occupancy', async () => {
+    // Nothing to scope to — an idle slot page still shows its history rather
+    // than an empty panel.
+    await listTrajectoryStreams('repo-1', 1, null);
+    await listSessionUsageForSlot('repo-1', 1, null);
+
+    expect(trajectoryGroupBy.mock.calls[0][0].where).toEqual({ repositoryId: 'repo-1', agentId: 1 });
+    expect(usageFindMany.mock.calls[0][0].where).toEqual({ repositoryId: 'repo-1', agentId: 1 });
+  });
+});
+
+describe('S2 — ingest does not merge a new occupancy into the previous session', () => {
+  it('prefers the matched worktree over a stale har.session_key', async () => {
+    // The global otel-hook config still carries occupancy A's session key while
+    // the agent is demonstrably working in occupancy B's worktree.
+    slotFindMany.mockResolvedValue([
+      {
+        repositoryId: 'repo-1',
+        slotId: 1,
+        workDir: OCCUPANCY_B.workDir,
+        worktreePath: OCCUPANCY_B.worktreePath,
+        branch: OCCUPANCY_B.branch,
+        suffix: 'newy',
+        workUnitId: '316',
+        attemptId: OCCUPANCY_B.attemptId,
+        occupancyKey: deriveOccupancyKey(OCCUPANCY_B),
+      },
+    ]);
+
+    const { resolveSessionContext } = await import('./otel-ingest');
+    const { context } = await resolveSessionContext(
+      { 'har.session_key': 'main-aaaa-har-agent-1-oldx' },
+      {
+        'gen_ai.client.workspace': OCCUPANCY_B.workDir,
+        'gen_ai.agent.name': 'claude_code',
+      },
+    );
+
+    expect(context?.sessionKey).toBe(OCCUPANCY_B.branch);
+    expect(context?.sessionKey).not.toBe('main-aaaa-har-agent-1-oldx');
+    expect(context?.occupancyKey).toBe(deriveOccupancyKey(OCCUPANCY_B));
+  });
+
+  it('stamps the occupancy on the resolved context so records carry it', async () => {
+    slotFindMany.mockResolvedValue([
+      {
+        repositoryId: 'repo-1',
+        slotId: 1,
+        workDir: OCCUPANCY_B.workDir,
+        worktreePath: OCCUPANCY_B.worktreePath,
+        branch: OCCUPANCY_B.branch,
+        suffix: 'newy',
+        workUnitId: null,
+        attemptId: null,
+        occupancyKey: 'attempt::occupancy-b',
+      },
+    ]);
+
+    const { resolveSessionContext } = await import('./otel-ingest');
+    const { context } = await resolveSessionContext(
+      {},
+      {
+        'gen_ai.client.workspace': `${OCCUPANCY_B.workDir}/control`,
+        'gen_ai.agent.name': 'claude_code',
+      },
+    );
+
+    expect(context?.occupancyKey).toBe('attempt::occupancy-b');
+  });
+});

--- a/control/src/server/occupancy.ts
+++ b/control/src/server/occupancy.ts
@@ -1,0 +1,60 @@
+import type { AgentSlotStatus } from '@har/schemas';
+
+/**
+ * Slot occupancy identity (#316).
+ *
+ * A **slot number** is a workstation; a **working session** is one occupancy of
+ * one worktree. Reusing slot 1 after `complete` / `teardown` must mint a new
+ * occupancy — not continue the previous one. Everything derived from a session
+ * (purpose, trajectory streams, usage rows) is scoped to the occupancy, never
+ * to the bare slot id.
+ *
+ * `--resume` / `recover` keeps the same worktree and therefore the same key.
+ */
+
+/** Separator that cannot appear in an attempt id, branch, or ISO timestamp. */
+const PART_SEPARATOR = '::';
+
+export type OccupancySource = Pick<
+  AgentSlotStatus,
+  'active' | 'attemptId' | 'branch' | 'sessionCreatedAt' | 'worktreePath' | 'workDir'
+>;
+
+/**
+ * Stable key for one occupancy, or null when the slot is idle.
+ *
+ * Prefers `attemptId` — HAR mints one per launch, so it is the truest
+ * occupancy identity. Falls back to branch + session creation time, then to the
+ * worktree path, which still changes between occupancies because HAR encodes a
+ * random per-session suffix in it.
+ */
+export function deriveOccupancyKey(slot: OccupancySource): string | null {
+  if (!slot.active) return null;
+
+  if (slot.attemptId) return `attempt${PART_SEPARATOR}${slot.attemptId}`;
+
+  const createdAt = slot.sessionCreatedAt ? new Date(slot.sessionCreatedAt).toISOString() : null;
+  if (slot.branch && createdAt) {
+    return `branch${PART_SEPARATOR}${slot.branch}${PART_SEPARATOR}${createdAt}`;
+  }
+
+  const path = slot.worktreePath ?? slot.workDir;
+  if (path && createdAt) return `path${PART_SEPARATOR}${path}${PART_SEPARATOR}${createdAt}`;
+  if (path) return `path${PART_SEPARATOR}${path}`;
+
+  return null;
+}
+
+/**
+ * Whether a sync moved the slot to a different occupancy.
+ *
+ * Idle → active, active → different worktree, and active → idle all count.
+ * Occupancy-derived state (purpose above all) must be cleared when this is
+ * true, or slot N's page keeps describing the task the previous agent did.
+ */
+export function isNewOccupancy(
+  previousKey: string | null | undefined,
+  nextKey: string | null,
+): boolean {
+  return (previousKey ?? null) !== nextKey;
+}

--- a/control/src/server/otel-ingest.ts
+++ b/control/src/server/otel-ingest.ts
@@ -263,6 +263,7 @@ async function resolveSlotByWorkspace(workspace: string): Promise<{
   suffix?: string;
   workUnitId?: string;
   attemptId?: string;
+  occupancyKey?: string;
 } | null> {
   if (!workspace) return null;
   const normalized = normalizePath(workspace);
@@ -282,6 +283,7 @@ async function resolveSlotByWorkspace(workspace: string): Promise<{
       suffix: true,
       workUnitId: true,
       attemptId: true,
+      occupancyKey: true,
     },
   });
 
@@ -302,6 +304,7 @@ async function resolveSlotByWorkspace(workspace: string): Promise<{
     suffix: match.suffix ?? undefined,
     workUnitId: match.workUnitId ?? undefined,
     attemptId: match.attemptId ?? undefined,
+    occupancyKey: match.occupancyKey ?? undefined,
   };
 }
 
@@ -315,6 +318,8 @@ export interface ResolvedSessionContext {
   suffix?: string;
   workUnitId?: string;
   attemptId?: string;
+  /** One occupancy of the slot (#316) — null when the slot is idle/unknown. */
+  occupancyKey?: string;
 }
 
 async function resolveRepositoryByWorkspacePath(
@@ -397,6 +402,7 @@ interface ActiveSlotAttribution {
   suffix?: string;
   workUnitId?: string;
   attemptId?: string;
+  occupancyKey?: string;
 }
 
 /**
@@ -423,6 +429,7 @@ async function resolveUnambiguousActiveSlot(
       suffix: true,
       workUnitId: true,
       attemptId: true,
+      occupancyKey: true,
     },
   });
   if (active.length !== 1) return null;
@@ -434,6 +441,7 @@ async function resolveUnambiguousActiveSlot(
     suffix: slot.suffix ?? undefined,
     workUnitId: slot.workUnitId ?? undefined,
     attemptId: slot.attemptId ?? undefined,
+    occupancyKey: slot.occupancyKey ?? undefined,
   };
 }
 
@@ -459,10 +467,16 @@ export async function resolveSessionContext(
   if (workspace) {
     const byWs = await resolveSlotByWorkspace(workspace);
     if (byWs) {
+      // #316: the matched slot's own key wins over `har.session_key`. That
+      // resource attribute is written once per launch and survives the
+      // occupancy that wrote it (Claude Code also reuses `session.id` across
+      // a resume), so preferring it merged a new worktree's events into the
+      // previous session. The workspace match is live evidence; the attribute
+      // is not.
       return {
         context: {
           repositoryId: byWs.repositoryId,
-          sessionKey: harSessionKey || byWs.sessionKey || providerSessionId,
+          sessionKey: byWs.sessionKey || harSessionKey || providerSessionId,
           agentId: explicitAgentId ?? byWs.agentId,
           agentTool: tool ?? 'cursor',
           workDir: byWs.workDir ?? workspace,
@@ -470,6 +484,7 @@ export async function resolveSessionContext(
           suffix: byWs.suffix,
           workUnitId: byWs.workUnitId,
           attemptId: byWs.attemptId,
+          occupancyKey: byWs.occupancyKey,
         },
       };
     }
@@ -502,6 +517,7 @@ export async function resolveSessionContext(
           attemptId:
             activeSlot?.attemptId ??
             (resource['har.attempt_id'] ? String(resource['har.attempt_id']) : undefined),
+          occupancyKey: activeSlot?.occupancyKey,
         },
       };
     }
@@ -532,6 +548,7 @@ export async function resolveSessionContext(
             (resource['har.suffix'] ? String(resource['har.suffix']) : undefined),
           workUnitId: activeSlot?.workUnitId,
           attemptId: activeSlot?.attemptId,
+          occupancyKey: activeSlot?.occupancyKey,
         },
       };
     }
@@ -773,7 +790,7 @@ function applyHooksUsageFromAttrs(usage: AgentSessionUsage, attributes: AttrMap)
 
 function emptyUsage(
   base: Pick<AgentSessionUsage, 'sessionKey' | 'agentId' | 'agentTool' | 'workDir' | 'branch' | 'suffix'> &
-    Partial<Pick<AgentSessionUsage, 'workUnitId' | 'attemptId'>>,
+    Partial<Pick<AgentSessionUsage, 'workUnitId' | 'attemptId' | 'occupancyKey'>>,
 ): AgentSessionUsage {
   const now = new Date().toISOString();
   return {
@@ -886,6 +903,7 @@ export async function ingestOtelMetricsJson(payload: unknown): Promise<OtelInges
       suffix: context.suffix,
       workUnitId: context.workUnitId,
       attemptId: context.attemptId,
+      occupancyKey: context.occupancyKey,
     });
 
     for (const point of group.points) {
@@ -1270,6 +1288,7 @@ export async function ingestOtelLogsJson(payload: unknown): Promise<OtelIngestRe
         correlationId: canonical.correlationId,
         workUnitId: context.workUnitId,
         attemptId: context.attemptId,
+        occupancyKey: context.occupancyKey,
       }),
     );
 
@@ -1408,6 +1427,7 @@ export async function ingestOtelTracesJson(payload: unknown): Promise<OtelIngest
         parentSpanId: span.parentSpanId ?? undefined,
         workUnitId: context.workUnitId,
         attemptId: context.attemptId,
+        occupancyKey: context.occupancyKey,
       }),
     );
 

--- a/control/src/server/repositories.ts
+++ b/control/src/server/repositories.ts
@@ -12,6 +12,7 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db';
 import { canonicalizeControlRepoPath } from '@/server/git-repo-path';
 import { buildAgentSlotSyncFields } from '@/server/slot-sync-fields';
+import { isNewOccupancy } from '@/server/occupancy';
 import { cleanupSessionWorktrees } from '@/server/worktree-cleanup';
 
 function toJson(value: unknown) {
@@ -231,11 +232,25 @@ export async function syncSlots(repositoryId: string, input: unknown) {
   for (const slot of slots) {
     const parsed = AgentSlotStatusSchema.parse(slot);
     const fields = buildAgentSlotSyncFields(parsed);
+
+    // #316: a slot number is a workstation, an occupancy is one session in it.
+    // `purpose` is OTEL-derived so it is never synced from the harness — but it
+    // belongs to an occupancy. Without this, `complete` then `launch` on the
+    // same slot keeps describing the previous agent's task. Cleared on any
+    // occupancy change (including → idle); the next occupancy's first prompt
+    // sets it again.
+    const existing = await prisma.agentSlot.findUnique({
+      where: { repositoryId_slotId: { repositoryId, slotId: parsed.agentId } },
+      select: { occupancyKey: true },
+    });
+    const occupancyChanged = isNewOccupancy(existing?.occupancyKey, fields.occupancyKey);
+
     // Prisma JSON columns need DbNull for SQL NULL (plain `null` is rejected).
     const data = {
       ...fields,
       previewUrls:
         fields.previewUrls === null ? Prisma.DbNull : fields.previewUrls,
+      ...(occupancyChanged ? { purpose: null } : {}),
     };
     await prisma.agentSlot.upsert({
       where: { repositoryId_slotId: { repositoryId, slotId: parsed.agentId } },

--- a/control/src/server/slot-sync-fields.ts
+++ b/control/src/server/slot-sync-fields.ts
@@ -1,4 +1,5 @@
 import type { AgentSlotStatus } from '@har/schemas';
+import { deriveOccupancyKey } from './occupancy';
 
 /**
  * Prisma update payload for one agent slot sync.
@@ -25,6 +26,7 @@ export type AgentSlotSyncFields = {
   baseBranch: string | null;
   baseCommit: string | null;
   sessionCreatedAt: Date | null;
+  occupancyKey: string | null;
   workUnitId: string | null;
   attemptId: string | null;
   detachedHead: boolean | null;
@@ -52,9 +54,11 @@ export function buildAgentSlotSyncFields(parsed: AgentSlotStatus): AgentSlotSync
     baseBranch: parsed.baseBranch ?? null,
     baseCommit: parsed.baseCommit ?? null,
     sessionCreatedAt: parsed.sessionCreatedAt ? new Date(parsed.sessionCreatedAt) : null,
+    occupancyKey: deriveOccupancyKey(parsed),
     workUnitId: active ? parsed.workUnitId ?? null : null,
     attemptId: active ? parsed.attemptId ?? null : null,
-    // purpose is OTEL-derived — never synced from the harness registry
+    // purpose is OTEL-derived — never synced from the harness registry, but it
+    // IS occupancy-scoped: syncSlots clears it when the occupancy changes (#316).
     detachedHead: active ? parsed.detachedHead ?? null : null,
     dirty: active ? parsed.dirty ?? null : null,
     ahead: active ? parsed.ahead ?? null : null,

--- a/control/src/server/trajectory-ledger.ts
+++ b/control/src/server/trajectory-ledger.ts
@@ -212,6 +212,7 @@ export async function appendTrajectoryRecord(
         correlationId: input.correlationId,
         workUnitId: input.workUnitId,
         attemptId: input.attemptId,
+        occupancyKey: input.occupancyKey,
       },
     });
     await projectTrajectoryRecord(record);
@@ -301,10 +302,14 @@ export function serializeTrajectoryPage(page: TrajectoryPage): SerializedTraject
 export async function listTrajectoryStreams(
   repositoryId: string,
   agentId: number,
+  occupancyKey?: string | null,
 ): Promise<TrajectoryStream[]> {
+  // #316: streams belong to an occupancy, not to a slot number. Listing by bare
+  // agentId returns every stream that ever used this workstation, so slot 1
+  // after a relaunch still showed the previous session's trajectory.
   const groups = await prisma.agentTrajectoryRecord.groupBy({
     by: ['sessionKey', 'agentTool'],
-    where: { repositoryId, agentId },
+    where: { repositoryId, agentId, ...(occupancyKey ? { occupancyKey } : {}) },
     _max: { eventTimestamp: true },
   });
   return groups.flatMap((group) => group._max.eventTimestamp
@@ -324,8 +329,9 @@ export async function getSlotTrajectoryData(
   repositoryId: string,
   agentId: number,
   limit = 100,
+  occupancyKey?: string | null,
 ): Promise<SlotTrajectoryData> {
-  const streams = await listTrajectoryStreams(repositoryId, agentId);
+  const streams = await listTrajectoryStreams(repositoryId, agentId, occupancyKey);
   const latest = streams[0];
   if (!latest) {
     return {

--- a/control/src/server/trajectory-projections.test.ts
+++ b/control/src/server/trajectory-projections.test.ts
@@ -9,6 +9,7 @@ function record(overrides: Partial<AgentTrajectoryRecord> = {}): AgentTrajectory
   return {
     id: 'row-1',
     repositoryId: 'repo-1',
+    occupancyKey: null,
     version: 1,
     source: 'otel',
     sourceEventId: 'evt-1',

--- a/control/src/server/usage.ts
+++ b/control/src/server/usage.ts
@@ -168,6 +168,7 @@ export async function upsertSessionUsage(repositoryId: string, input: UsageUpser
     suffix: input.suffix ?? existing?.suffix ?? null,
     workUnitId: input.workUnitId ?? existing?.workUnitId ?? null,
     attemptId: input.attemptId ?? existing?.attemptId ?? null,
+    occupancyKey: input.occupancyKey ?? existing?.occupancyKey ?? null,
     tokensInput,
     tokensOutput,
     tokensCacheRead,
@@ -222,9 +223,15 @@ export async function listSessionUsageForRepo(repositoryId: string) {
   return rows.map((row) => ({ ...row, sources: toStringArray(row.sources) }));
 }
 
-export async function listSessionUsageForSlot(repositoryId: string, agentId: number) {
+export async function listSessionUsageForSlot(
+  repositoryId: string,
+  agentId: number,
+  occupancyKey?: string | null,
+) {
+  // #316: scope to the current occupancy so a relaunched slot does not show the
+  // previous session's usage as if it were the same working session.
   const rows = await prisma.agentSessionUsage.findMany({
-    where: { repositoryId, agentId },
+    where: { repositoryId, agentId, ...(occupancyKey ? { occupancyKey } : {}) },
     orderBy: { lastSeenAt: 'desc' },
   });
   return rows.map((row) => ({ ...row, sources: toStringArray(row.sources) }));

--- a/control/vitest.lab.config.ts
+++ b/control/vitest.lab.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+/**
+ * Lab config — integration checks that need a REAL database and the real HAR
+ * CLI, not the mocked-prisma unit tests. Kept out of `npm test` on purpose:
+ * these run only inside the occupancy lab container (#316 station S3), via
+ * `har line gate S3 --line occupancy-identity`.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.lab.ts'],
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    fileParallelism: false,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@har/schemas': path.resolve(__dirname, '../packages/schemas/src/index.ts'),
+    },
+  },
+});

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -750,6 +750,8 @@ export const AgentTrajectoryRecordV1Schema = z
     correlationId: z.string().optional(),
     workUnitId: WorkUnitIdSchema.optional(),
     attemptId: WorkAttemptIdSchema.optional(),
+    /** One occupancy of a slot (#316) — records are scoped to it, not to slot id. */
+    occupancyKey: z.string().min(1).optional(),
   })
   .passthrough();
 
@@ -774,6 +776,8 @@ export const AgentSessionUsageSchema = z.object({
   suffix: z.string().optional(),
   workUnitId: WorkUnitIdSchema.optional(),
   attemptId: WorkAttemptIdSchema.optional(),
+  /** One occupancy of a slot (#316) — usage is scoped to it, not to slot id. */
+  occupancyKey: z.string().min(1).optional(),
   tokensInput: z.number().nonnegative().default(0),
   tokensOutput: z.number().nonnegative().default(0),
   tokensCacheRead: z.number().nonnegative().default(0),

--- a/src/core/lines.ts
+++ b/src/core/lines.ts
@@ -266,6 +266,20 @@ export async function runLineGate(options: RunLineGateOptions): Promise<RunLineG
   const registry = readStageRegistry(repoPath);
   const registeredIds = new Set(registry.stages.map((s) => s.id));
 
+  // Stages that need a slot fail deep inside the runner with a bare "invalid
+  // agent slot id"; say which stages and what to pass instead.
+  if (options.agentId === undefined) {
+    const needSlot = required
+      .filter((stage) => registry.stages.find((s) => s.id === stage.id)?.requiresAgentId)
+      .map((stage) => stage.id);
+    if (needSlot.length > 0) {
+      throw new Error(
+        `Gate stage(s) ${needSlot.join(', ')} run in an agent slot — pass --agent <id> ` +
+          `(har line gate ${options.station} --line ${lineId} --agent 1).`,
+      );
+    }
+  }
+
   const results: LineGateStageResult[] = [];
   let pass = true;
 


### PR DESCRIPTION
Closes #316. Second real factory line — the first one that is not the 1.0 migration.

## The bug

After `har env complete 1` and a later `har env launch 1` for a **new** task, Mission Control kept describing the previous session: the old `purpose`, the old trajectory stream, usage merged onto the new occupancy. The harness *did* create a new worktree and branch; the dashboard did not treat that as a new working session.

## The rule

A **slot number** is a workstation. A **working session** is one occupancy of one worktree.

- `--resume` / `recover` continues an occupancy — same key.
- `complete` / `teardown` then `launch` may reuse the number, but must mint a **new** occupancy.

Occupied slots already block. That poka-yoke was never the bug — the bug was that identity stayed slot-centric after the workstation was freed.

## Three leaks, all on the slot row

1. **`purpose` never reset.** `buildAgentSlotSyncFields` skips it (OTEL-derived), and teardown only nulled paths (#68/#70). It is now cleared whenever the occupancy changes, idle included; the next occupancy's first prompt sets it again.
2. **Trajectory and usage listed by bare `agentId`.** Slot 1 after a relaunch still showed occupancy A's streams. Both queries now take the slot's current `occupancyKey`. An idle slot with no key still shows its history rather than an empty panel.
3. **Ingest preferred a stale `har.session_key`.** That attribute is written once per launch and outlives the occupancy that wrote it — Claude Code also reuses `session.id` — so a new worktree's events merged into the previous session. The live workspace match now wins; the attribute is not evidence, the match is.

`occupancyKey` is derived (attempt id → branch + session start → worktree path) and added to `AgentSlot`, `AgentTrajectoryRecord` and `AgentSessionUsage`.

## Why it ships as a line

The fix is half of #316. The other half is that these questions keep being asked. `.har/lines/occupancy-identity/` installs four stages that are registered and **absent from `verificationStages`**:

| Station | Question | Isolation |
|---|---|---|
| S0 | `purpose` does not survive a relaunch | mocked prisma |
| S1 | trajectory/usage follow the occupancy, not the slot id | mocked prisma |
| S2 | ingest does not merge a new occupancy into the previous session | mocked prisma |
| S3 | two real occupancies of slot 1, real CLI, real database, isolated `HOME` | Docker |

The gate is cumulative: `har line gate S3` runs S0–S2 too.

## S3 is containerised for a reason

Claude Code stores transcripts at `~/.claude/projects/<encoded-cwd>`. On a laptop those survive teardown and the usage harvest can re-attach them to the next occupancy, so a green host run can mean "the machine was clean" rather than "the invariant holds". The sandbox `HOME` removes that reading. Jig modelled on `os-factory/otel-hook` `har-plugins/agent-lab` — copied, not depended on; publishing `@osfactory/agent-lab` waits for a second consumer.

## The kind split is load-bearing here

After installing the line, `verificationStages` is byte-identical and `har env verify --full` still takes ~26s and **never starts Docker**. The lab runs only via `har line gate S3 --line occupancy-identity`. That is exactly what #304's separate bundle kind exists to guarantee.

## Evidence

- Every S0–S2 assertion verified **red without the fix**: reverting the session-key precedence fails S2 with `expected 'main-aaaa-…-oldx' to be 'main-bbbb-…-newy'`; removing the purpose reset turns the Docker lab red.
- `har line gate S2 --line occupancy-identity --agent 1` → S0 ✓ S1 ✓ S2 ✓ (cumulative set, in order).
- Docker lab: 5 tests green in 23s, `HOME=/lab/home`, real launch → complete → launch.
- `har env verify 1 --full` pass (30.2s) · root jest 992 · control vitest 171 · `har env doctor` → `✓ factory lines stay off verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)