### PR TITLE
feat(control): factory line board over the installed bundle (#305)

### DIFF
--- a/control/src/app/repos/[id]/lines/page.tsx
+++ b/control/src/app/repos/[id]/lines/page.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { LineBoard } from '@/components/line-board';
+import { getRepository } from '@/server/repositories';
+import { listLineBoards, repositoryHasHarness } from '@/server/lines';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Factory line board (#305) — read-only view of the lines installed in a repo.
+ *
+ * Explainable from `har line status`: same ledger, same program, same run
+ * records. Installing a line here is not offered on purpose — that is
+ * `har line add` plus the adaptation prompt it writes.
+ */
+export default async function RepoLinesPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const repo = await getRepository(id);
+  if (!repo) notFound();
+
+  const [boards, hasHarness] = await Promise.all([
+    listLineBoards(id),
+    repositoryHasHarness(id),
+  ]);
+  const repoName = repo.path.split('/').pop() ?? repo.path;
+
+  return (
+    <div className="space-y-6 p-6" data-testid="line-board-page">
+      <div>
+        <h1 className="text-2xl font-semibold">Factory lines</h1>
+        <p className="text-sm text-muted-foreground">
+          <Link href={`/repos/${id}`} className="underline">
+            {repoName}
+          </Link>{' '}
+          · stations, cumulative gate, and the workstations in use
+        </p>
+      </div>
+
+      {boards.length === 0 ? (
+        <Card data-testid="line-board-empty">
+          <CardHeader>
+            <CardTitle>No factory line installed</CardTitle>
+            <CardDescription>
+              {hasHarness
+                ? 'This repository has a HAR harness but no line bundle.'
+                : 'This repository has no HAR harness yet.'}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              A factory line is a program: an ordered set of stations plus a cumulative gate.
+              Installing one registers stages but never adds them to <code>verificationStages</code>,
+              so routine verification is unaffected.
+            </p>
+            <pre className="overflow-x-auto rounded-md border bg-muted/40 p-3 text-xs">
+              <code>
+                har line create my-line{'\n'}
+                har line add github:os-factory/har-line
+              </code>
+            </pre>
+            <p>
+              Lines are installed from the CLI, not from Mission Control — the install writes an
+              adaptation prompt for your coding agent.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {boards.map((board) => (
+            <LineBoard key={board.id} board={board} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/control/src/app/repos/[id]/page.tsx
+++ b/control/src/app/repos/[id]/page.tsx
@@ -58,6 +58,13 @@ export default async function RepoDetailPage({
           </Link>
           <h2 className="mt-2 text-2xl font-semibold">{repo.path}</h2>
           {repo.gitRemote && <p className="text-sm text-muted-foreground">{repo.gitRemote}</p>}
+          <Link
+            href={`/repos/${repo.id}/lines`}
+            className="mt-2 inline-block text-sm underline"
+            data-testid="repo-lines-link"
+          >
+            Factory lines →
+          </Link>
         </div>
         <UnregisterRepoButton
           repoId={repo.id}

--- a/control/src/components/line-board.tsx
+++ b/control/src/components/line-board.tsx
@@ -1,0 +1,202 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { LineBoard as LineBoardData } from '@/server/lines';
+
+/**
+ * Factory line board (#305) — the traveler for one installed line.
+ *
+ * A view over records Mission Control already has. It never runs a stage,
+ * installs a bundle, or edits a tracker: `har line gate` and `har line add` own
+ * those, and the handoff stays human.
+ */
+
+function stationTone(station: LineBoardData['stations'][number], isNext: boolean): string {
+  if (station.green) return 'border-emerald-500/40 bg-emerald-500/5';
+  if (station.failedStageIds.length > 0) return 'border-red-500/40 bg-red-500/5';
+  if (isNext) return 'border-amber-500/40 bg-amber-500/5';
+  return 'border-border';
+}
+
+function stationMark(station: LineBoardData['stations'][number], isNext: boolean): string {
+  if (station.green) return '✓';
+  if (station.failedStageIds.length > 0) return '✗';
+  if (isNext) return '▶';
+  return '·';
+}
+
+export function LineBoard({ board }: { board: LineBoardData }) {
+  return (
+    <Card data-testid={`line-board-${board.id}`}>
+      <CardHeader>
+        <div className="flex flex-wrap items-center gap-2">
+          <CardTitle>{board.title}</CardTitle>
+          <Badge variant="outline">{board.id}</Badge>
+          <Badge variant="secondary">{board.source}</Badge>
+        </div>
+        {board.description ? <CardDescription>{board.description}</CardDescription> : null}
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* The verify-pipeline callout: line stages are off verify BY DESIGN.
+            Drawing them as missing verification stages would report a healthy
+            pipeline as broken. */}
+        {board.verifyLeaks.length > 0 ? (
+          <p className="rounded-md border border-red-500/40 bg-red-500/5 p-3 text-sm">
+            <strong>{board.verifyLeaks.join(', ')}</strong> {board.verifyLeaks.length === 1 ? 'is' : 'are'}{' '}
+            listed in <code>verificationStages</code>. Line gate stages are opt-in — remove them
+            from <code>.har/stages.json</code>, or ship the check as a verification plugin instead.
+          </p>
+        ) : (
+          <p className="rounded-md border border-border bg-muted/40 p-3 text-sm text-muted-foreground">
+            {board.registeredStageIds.length > 0 ? (
+              <>
+                <strong>{board.registeredStageIds.length}</strong> registered line{' '}
+                {board.registeredStageIds.length === 1 ? 'stage' : 'stages'} (
+                <code>{board.registeredStageIds.join(', ')}</code>) — none on the verify plan.
+                Default <code>har env verify --full</code> is unaffected.
+              </>
+            ) : (
+              <>This line registers no extra stages; its gate tags stages the harness already has.</>
+            )}
+            {board.optInEnv ? (
+              <>
+                {' '}
+                Gate is opt-in via <code>{board.optInEnv}=1</code>.
+              </>
+            ) : null}
+          </p>
+        )}
+
+        {/* The traveler: stations in order, earlier ones stay visible. */}
+        <ol className="space-y-2">
+          {board.stations.map((station) => {
+            const isNext = station.id === board.nextStationId;
+            return (
+              <li
+                key={station.id}
+                data-testid={`line-station-${station.id}`}
+                data-green={station.green ? 'true' : 'false'}
+                className={`rounded-md border p-3 ${stationTone(station, isNext)}`}
+              >
+                <div className="flex flex-wrap items-baseline gap-2">
+                  <span aria-hidden className="font-mono">
+                    {stationMark(station, isNext)}
+                  </span>
+                  <span className="font-mono text-sm">{station.id}</span>
+                  <span className="font-medium">{station.title}</span>
+                  {isNext ? <Badge variant="outline">next</Badge> : null}
+                  {station.work?.ids.length ? (
+                    <Badge variant="secondary">
+                      {station.work.source} {station.work.ids.join(', ')}
+                    </Badge>
+                  ) : null}
+                </div>
+
+                {station.description ? (
+                  <p className="mt-1 text-sm text-muted-foreground">{station.description}</p>
+                ) : null}
+
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {station.requiredStageIds.length === 0 ? (
+                    'no gate stages'
+                  ) : (
+                    <>
+                      {station.passedStageIds.length}/{station.requiredStageIds.length} gate stages
+                      green — <code>{station.requiredStageIds.join(', ')}</code>
+                    </>
+                  )}
+                </p>
+
+                {station.missingStageIds.length > 0 ? (
+                  <p className="mt-1 text-xs text-red-500">
+                    not registered: <code>{station.missingStageIds.join(', ')}</code>
+                  </p>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+
+        {board.latestGateRuns.length > 0 ? (
+          <div>
+            <h3 className="mb-2 text-sm font-medium">Latest gate runs</h3>
+            <ul className="space-y-1 text-sm">
+              {board.latestGateRuns.map((run) => (
+                <li key={run.stageId} className="flex flex-wrap items-center gap-2">
+                  <Badge variant={run.status === 'pass' ? 'secondary' : 'destructive'}>
+                    {run.status}
+                  </Badge>
+                  <code className="text-xs">{run.stageId}</code>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(run.startedAt).toLocaleString()}
+                    {run.durationMs ? ` · ${(run.durationMs / 1000).toFixed(1)}s` : ''}
+                    {run.agentId ? ` · agent ${run.agentId}` : ''}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {board.slotsInFlight.length > 0 ? (
+          <div>
+            <h3 className="mb-2 text-sm font-medium">Workstations in use</h3>
+            <ul className="space-y-1 text-sm">
+              {board.slotsInFlight.map((slot) => (
+                <li key={slot.slotId} className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">agent {slot.slotId}</Badge>
+                  <code className="text-xs">{slot.branch ?? slot.workDir ?? 'unknown'}</code>
+                  {slot.workUnitId ? (
+                    <span className="text-xs text-muted-foreground">work {slot.workUnitId}</span>
+                  ) : null}
+                  {slot.purpose ? (
+                    <span className="text-xs text-muted-foreground">{slot.purpose}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Occupied slots block a new launch — that is the poka-yoke, not a queue.
+            </p>
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <DeclaredList
+            title="Skills"
+            items={board.declared.skills.map((s) => `${s.id} (${s.role})`)}
+          />
+          <DeclaredList
+            title="MCP servers"
+            items={board.declared.mcp.map((m) => `${m.name}${m.required ? ' (required)' : ''}`)}
+          />
+          <DeclaredList title="Plugins" items={board.declared.plugins} />
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          Declared, not installed — Mission Control reports what a station needs; it never
+          installs skills or MCP servers. Agents hand off: this line ships nothing on its own.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DeclaredList({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div>
+      <h3 className="mb-1 text-sm font-medium">{title}</h3>
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">none declared</p>
+      ) : (
+        <ul className="space-y-0.5 text-xs text-muted-foreground">
+          {items.map((item) => (
+            <li key={item}>
+              <code>{item}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/control/src/server/lines.test.ts
+++ b/control/src/server/lines.test.ts
@@ -1,0 +1,208 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const repositoryFindUnique = vi.fn();
+const agentSlotFindMany = vi.fn();
+const runFindMany = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    repository: { findUnique: (...a: unknown[]) => repositoryFindUnique(...a) },
+    agentSlot: { findMany: (...a: unknown[]) => agentSlotFindMany(...a) },
+    run: { findMany: (...a: unknown[]) => runFindMany(...a) },
+  },
+}));
+
+import { listLineBoards, repositoryHasHarness } from './lines';
+
+let repoPath: string;
+
+/** A repo with a harness and one installed two-station line. */
+function scaffoldRepo(options: { verificationStages?: string[]; installLine?: boolean } = {}) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'line-board-'));
+  mkdirSync(path.join(dir, '.har', 'lines', 'demo-line'), { recursive: true });
+
+  writeFileSync(
+    path.join(dir, '.har', 'stages.json'),
+    JSON.stringify({
+      version: '1',
+      verificationStages: options.verificationStages ?? ['typecheck', 'unit-tests'],
+      stages: [
+        { id: 'typecheck', kind: 'test' },
+        { id: 'unit-tests', kind: 'test' },
+        { id: 'demo-s1', kind: 'test' },
+        { id: 'demo-s2', kind: 'test' },
+      ],
+    }),
+  );
+
+  if (options.installLine !== false) {
+    writeFileSync(
+      path.join(dir, '.har', 'lines.json'),
+      JSON.stringify({
+        version: '1',
+        lines: [
+          {
+            id: 'demo-line',
+            source: 'git',
+            spec: 'github:acme/demo-line',
+            stageIds: ['demo-s1', 'demo-s2'],
+            programPath: '.har/lines/demo-line/line.json',
+            installedAt: '2026-08-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    );
+    writeFileSync(
+      path.join(dir, '.har', 'lines', 'demo-line', 'line.json'),
+      JSON.stringify({
+        contractVersion: 1,
+        id: 'demo-line',
+        title: 'Demo line',
+        description: 'Two stations and a growing gate.',
+        skills: [{ id: 'factory-line', role: 'orchestrator' }],
+        mcp: [{ name: 'github', required: false }],
+        plugins: [],
+        stations: [
+          { id: 'S1', title: 'First', work: { source: 'github', ids: ['42'] } },
+          { id: 'S2', title: 'Second' },
+        ],
+        gate: {
+          cumulative: true,
+          optInEnv: null,
+          stages: [
+            { id: 'demo-s1', fromStation: 'S1', tier: 'full' },
+            { id: 'demo-s2', fromStation: 'S2', tier: 'full' },
+          ],
+        },
+        extraStages: [],
+        handoff: { autonomousShip: false },
+        prototypeNotes: [],
+      }),
+    );
+  }
+  return dir;
+}
+
+beforeEach(() => {
+  repositoryFindUnique.mockReset();
+  agentSlotFindMany.mockReset();
+  runFindMany.mockReset();
+  agentSlotFindMany.mockResolvedValue([]);
+  runFindMany.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+});
+
+describe('factory line board', () => {
+  it('reads stations and the cumulative gate from the installed bundle', async () => {
+    repoPath = scaffoldRepo();
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+
+    const [board] = await listLineBoards('repo-1');
+
+    expect(board.id).toBe('demo-line');
+    expect(board.source).toBe('git');
+    // The ratchet: S2 requires S1's stage too.
+    expect(board.stations[0].requiredStageIds).toEqual(['demo-s1']);
+    expect(board.stations[1].requiredStageIds).toEqual(['demo-s1', 'demo-s2']);
+    expect(board.nextStationId).toBe('S1');
+    expect(board.currentStationId).toBeNull();
+  });
+
+  it('derives station greenness from synced run records', async () => {
+    repoPath = scaffoldRepo();
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+    runFindMany.mockResolvedValue([
+      {
+        stageId: 'demo-s1',
+        status: 'pass',
+        startedAt: new Date('2026-08-02T10:00:00Z'),
+        durationMs: 1200,
+        agentId: 1,
+      },
+    ]);
+
+    const [board] = await listLineBoards('repo-1');
+
+    expect(board.stations[0].green).toBe(true);
+    expect(board.stations[1].green).toBe(false);
+    expect(board.stations[1].neverRunStageIds).toEqual(['demo-s2']);
+    expect(board.currentStationId).toBe('S1');
+    expect(board.nextStationId).toBe('S2');
+    expect(board.latestGateRuns).toHaveLength(1);
+  });
+
+  it('reports no verify leak when line stages stay off the verify plan', async () => {
+    repoPath = scaffoldRepo();
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+
+    const [board] = await listLineBoards('repo-1');
+
+    expect(board.registeredStageIds).toEqual(['demo-s1', 'demo-s2']);
+    expect(board.verifyLeaks).toEqual([]);
+  });
+
+  it('flags a line stage that leaked into verificationStages', async () => {
+    repoPath = scaffoldRepo({ verificationStages: ['typecheck', 'demo-s1'] });
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+
+    const [board] = await listLineBoards('repo-1');
+
+    expect(board.verifyLeaks).toEqual(['demo-s1']);
+  });
+
+  it('marks a gate stage the harness never registered', async () => {
+    repoPath = scaffoldRepo();
+    // Drop demo-s2 from the registry: the program still tags it.
+    writeFileSync(
+      path.join(repoPath, '.har', 'stages.json'),
+      JSON.stringify({
+        version: '1',
+        verificationStages: ['typecheck'],
+        stages: [{ id: 'typecheck', kind: 'test' }, { id: 'demo-s1', kind: 'test' }],
+      }),
+    );
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+
+    const [board] = await listLineBoards('repo-1');
+
+    expect(board.stations[1].missingStageIds).toEqual(['demo-s2']);
+    expect(board.stations[1].green).toBe(false);
+  });
+
+  it('returns an empty board for a harness with no line bundle', async () => {
+    repoPath = scaffoldRepo({ installLine: false });
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+
+    await expect(listLineBoards('repo-1')).resolves.toEqual([]);
+    await expect(repositoryHasHarness('repo-1')).resolves.toBe(true);
+  });
+
+  it('lists active slots as workstations in use', async () => {
+    repoPath = scaffoldRepo();
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+    agentSlotFindMany.mockResolvedValue([
+      { slotId: 2, branch: 'feat/x', purpose: 'S1 work', workUnitId: '42', workDir: '/w/x' },
+    ]);
+
+    const [board] = await listLineBoards('repo-1');
+
+    expect(board.slotsInFlight).toEqual([
+      { slotId: 2, branch: 'feat/x', purpose: 'S1 work', workUnitId: '42', workDir: '/w/x' },
+    ]);
+  });
+
+  it('never claims a line ships on its own', async () => {
+    repoPath = scaffoldRepo();
+    repositoryFindUnique.mockResolvedValue({ path: repoPath });
+
+    const [board] = await listLineBoards('repo-1');
+
+    expect(board.handoffAutonomousShip).toBe(false);
+  });
+});

--- a/control/src/server/lines.ts
+++ b/control/src/server/lines.ts
@@ -1,0 +1,241 @@
+import { existsSync, readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { LineLedgerSchema, LineProgramSchema, type LineProgram } from '@har/schemas';
+import { prisma } from '@/lib/db';
+
+/**
+ * Factory line board read model (#305).
+ *
+ * A line is a *program* over records Mission Control already has: stations in
+ * order, slots occupying them, and a cumulative gate whose results are ordinary
+ * `Run` rows. This is a **view**, not a second execution engine — nothing here
+ * runs a stage, installs a bundle, or edits a tracker.
+ *
+ * The program itself is per-repo installed state (`.har/lines.json` +
+ * `.har/lines/<id>/line.json`), the same source `har line status` reads. It is
+ * deliberately not inferred from `verificationStages`: line gate stages are
+ * absent from the verify plan by design, and drawing them as verify stages
+ * would report a healthy pipeline as broken.
+ */
+
+export interface LineBoardStation {
+  id: string;
+  title: string;
+  description?: string;
+  index: number;
+  /** Cumulative: every gate stage tagged here or at an earlier station. */
+  requiredStageIds: string[];
+  passedStageIds: string[];
+  failedStageIds: string[];
+  neverRunStageIds: string[];
+  /** Required stages the harness does not have registered. */
+  missingStageIds: string[];
+  green: boolean;
+  work?: { source: string; ids: string[]; url?: string };
+}
+
+export interface LineBoardSlot {
+  slotId: number;
+  branch: string | null;
+  purpose: string | null;
+  workUnitId: string | null;
+  workDir: string | null;
+}
+
+export interface LineBoardGateRun {
+  stageId: string;
+  status: string;
+  startedAt: string;
+  durationMs: number | null;
+  agentId: number | null;
+}
+
+export interface LineBoard {
+  id: string;
+  title: string;
+  description?: string;
+  source: string;
+  spec: string;
+  installedAt: string;
+  programPath: string;
+  stations: LineBoardStation[];
+  currentStationId: string | null;
+  nextStationId: string | null;
+  optInEnv: string | null;
+  /** Stages this line registered — none of them are on the verify plan. */
+  registeredStageIds: string[];
+  /** Registered line stages that have leaked into `verificationStages`. */
+  verifyLeaks: string[];
+  latestGateRuns: LineBoardGateRun[];
+  slotsInFlight: LineBoardSlot[];
+  declared: {
+    skills: Array<{ id: string; role: string; install?: string }>;
+    mcp: Array<{ name: string; why?: string; required: boolean }>;
+    plugins: string[];
+  };
+  handoffAutonomousShip: false;
+}
+
+function readJson(file: string): unknown | null {
+  if (!existsSync(file)) return null;
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** `har line status`'s ratchet, as data: tagged at this station or earlier. */
+function cumulativeStageIds(program: LineProgram, stationId: string): string[] {
+  const order = new Map(program.stations.map((s, i) => [s.id, i]));
+  const target = order.get(stationId);
+  if (target === undefined) return [];
+  const ids = program.gate.stages
+    .filter((stage) => {
+      const from = order.get(stage.fromStation);
+      return from !== undefined && from <= target;
+    })
+    .map((stage) => stage.id);
+  return [...new Set(ids)];
+}
+
+function readVerificationStages(repoPath: string): { ids: string[]; registered: Set<string> } {
+  const registry = readJson(path.join(repoPath, '.har', 'stages.json')) as
+    | { verificationStages?: string[]; stages?: Array<{ id: string }> }
+    | null;
+  return {
+    ids: registry?.verificationStages ?? [],
+    registered: new Set((registry?.stages ?? []).map((s) => s.id)),
+  };
+}
+
+/**
+ * Every factory line installed in a repository, with station progress derived
+ * from synced run records. Returns [] when the repo has no line bundle — the
+ * board's empty state, not an error.
+ */
+export async function listLineBoards(repositoryId: string): Promise<LineBoard[]> {
+  const repo = await prisma.repository.findUnique({
+    where: { id: repositoryId },
+    select: { path: true },
+  });
+  if (!repo) return [];
+
+  const ledgerRaw = readJson(path.join(repo.path, '.har', 'lines.json'));
+  const ledger = LineLedgerSchema.safeParse(ledgerRaw);
+  if (!ledger.success || ledger.data.lines.length === 0) return [];
+
+  const { ids: verificationStages, registered } = readVerificationStages(repo.path);
+
+  const slots = await prisma.agentSlot.findMany({
+    where: { repositoryId, active: true },
+    orderBy: { slotId: 'asc' },
+    select: { slotId: true, branch: true, purpose: true, workUnitId: true, workDir: true },
+  });
+
+  const boards: LineBoard[] = [];
+
+  for (const entry of ledger.data.lines) {
+    const programRaw = readJson(path.join(repo.path, entry.programPath));
+    const parsed = LineProgramSchema.safeParse(programRaw);
+    if (!parsed.success) continue;
+    const program = parsed.data;
+
+    const gateStageIds = [...new Set(program.gate.stages.map((s) => s.id))];
+
+    // Latest run per gate stage — the same evidence `har line status` uses.
+    const runs = gateStageIds.length
+      ? await prisma.run.findMany({
+          where: { repositoryId, stageId: { in: gateStageIds } },
+          orderBy: { startedAt: 'desc' },
+        })
+      : [];
+    const latestByStage = new Map<string, (typeof runs)[number]>();
+    for (const run of runs) {
+      if (!latestByStage.has(run.stageId)) latestByStage.set(run.stageId, run);
+    }
+
+    const stations: LineBoardStation[] = program.stations.map((station, index) => {
+      const requiredStageIds = cumulativeStageIds(program, station.id);
+      const missingStageIds = requiredStageIds.filter((id) => !registered.has(id));
+      const passedStageIds = requiredStageIds.filter(
+        (id) => latestByStage.get(id)?.status === 'pass',
+      );
+      const failedStageIds = requiredStageIds.filter((id) => {
+        const status = latestByStage.get(id)?.status;
+        return status !== undefined && status !== 'pass';
+      });
+      const neverRunStageIds = requiredStageIds.filter((id) => !latestByStage.has(id));
+      return {
+        id: station.id,
+        title: station.title,
+        description: station.description,
+        index,
+        requiredStageIds,
+        passedStageIds,
+        failedStageIds,
+        neverRunStageIds,
+        missingStageIds,
+        green:
+          missingStageIds.length === 0 && passedStageIds.length === requiredStageIds.length,
+        work: station.work
+          ? { source: station.work.source, ids: station.work.ids, url: station.work.url }
+          : undefined,
+      };
+    });
+
+    let currentStationId: string | null = null;
+    for (const station of stations) {
+      if (station.green) currentStationId = station.id;
+      else break;
+    }
+
+    boards.push({
+      id: entry.id,
+      title: program.title,
+      description: program.description,
+      source: entry.source,
+      spec: entry.spec,
+      installedAt: entry.installedAt,
+      programPath: entry.programPath,
+      stations,
+      currentStationId,
+      nextStationId: stations.find((s) => !s.green)?.id ?? null,
+      optInEnv: program.gate.optInEnv,
+      registeredStageIds: entry.stageIds,
+      verifyLeaks: entry.stageIds.filter((id) => verificationStages.includes(id)),
+      latestGateRuns: gateStageIds.flatMap((stageId) => {
+        const run = latestByStage.get(stageId);
+        return run
+          ? [
+              {
+                stageId,
+                status: run.status,
+                startedAt: run.startedAt.toISOString(),
+                durationMs: run.durationMs,
+                agentId: run.agentId,
+              },
+            ]
+          : [];
+      }),
+      slotsInFlight: slots,
+      declared: {
+        skills: program.skills.map((s) => ({ id: s.id, role: s.role, install: s.install })),
+        mcp: program.mcp.map((m) => ({ name: m.name, why: m.why, required: m.required })),
+        plugins: program.plugins,
+      },
+      handoffAutonomousShip: false,
+    });
+  }
+
+  return boards;
+}
+
+/** Whether the repository has a `.har/` harness at all (drives the empty state). */
+export async function repositoryHasHarness(repositoryId: string): Promise<boolean> {
+  const repo = await prisma.repository.findUnique({
+    where: { id: repositoryId },
+    select: { path: true },
+  });
+  return Boolean(repo && existsSync(path.join(repo.path, '.har')));
+}

--- a/control/tests/frontend/factory-lines.spec.js
+++ b/control/tests/frontend/factory-lines.spec.js
@@ -1,0 +1,163 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+/**
+ * Factory line board (#305).
+ *
+ * The board is a view over the installed line bundle plus records Mission
+ * Control already has. Two things it must never do: offer to install a line
+ * (that is `har line add`), and draw line gate stages as if they belonged to
+ * the verify pipeline — they are off it by design, and reporting them as
+ * missing verification stages would call a healthy pipeline broken.
+ *
+ * A fixture repository is registered so the board renders real content instead
+ * of skipping on whatever happens to be synced into this environment.
+ */
+
+let fixtureDir;
+let repoId;
+
+function writeFixtureRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-line-e2e-'));
+  fs.mkdirSync(path.join(dir, '.har', 'lines', 'demo-line'), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(dir, '.har', 'stages.json'),
+    JSON.stringify({
+      version: '1',
+      // The line's stages are registered and deliberately absent here.
+      verificationStages: ['typecheck', 'unit-tests'],
+      stages: [
+        { id: 'typecheck', kind: 'test' },
+        { id: 'unit-tests', kind: 'test' },
+        { id: 'demo-s1', kind: 'test' },
+        { id: 'demo-s2', kind: 'test' },
+      ],
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(dir, '.har', 'lines.json'),
+    JSON.stringify({
+      version: '1',
+      lines: [
+        {
+          id: 'demo-line',
+          source: 'git',
+          spec: 'github:acme/demo-line',
+          stageIds: ['demo-s1', 'demo-s2'],
+          programPath: '.har/lines/demo-line/line.json',
+          installedAt: '2026-08-01T00:00:00.000Z',
+        },
+      ],
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(dir, '.har', 'lines', 'demo-line', 'line.json'),
+    JSON.stringify({
+      contractVersion: 1,
+      id: 'demo-line',
+      title: 'Demo line',
+      description: 'Two stations and a gate that only grows.',
+      skills: [{ id: 'factory-line', role: 'orchestrator' }],
+      mcp: [{ name: 'github', why: 'tracker', required: false }],
+      plugins: [],
+      stations: [
+        { id: 'S1', title: 'First station', work: { source: 'github', ids: ['42'] } },
+        { id: 'S2', title: 'Second station' },
+      ],
+      gate: {
+        cumulative: true,
+        optInEnv: null,
+        stages: [
+          { id: 'demo-s1', fromStation: 'S1', tier: 'full' },
+          { id: 'demo-s2', fromStation: 'S2', tier: 'full' },
+        ],
+      },
+      extraStages: [],
+      handoff: { autonomousShip: false },
+      prototypeNotes: [],
+    }),
+  );
+
+  return dir;
+}
+
+test.beforeAll(async ({ request }) => {
+  fixtureDir = writeFixtureRepo();
+  const response = await request.post('/api/repos', {
+    data: { path: fixtureDir, force: true },
+  });
+  expect(response.ok()).toBeTruthy();
+  repoId = (await response.json()).id;
+});
+
+test.afterAll(async ({ request }) => {
+  if (repoId) await request.delete(`/api/repos/${repoId}`).catch(() => {});
+  if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+test.describe('Factory line board', () => {
+  test('draws stations, the cumulative gate, and the off-verify callout', async ({ page }) => {
+    await page.goto(`/repos/${repoId}/lines`);
+
+    await expect(page.getByTestId('line-board-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Factory lines' })).toBeVisible();
+    await expect(page.getByTestId('line-board-demo-line')).toBeVisible();
+
+    // The traveler: both stations visible, earlier ones never hidden.
+    await expect(page.getByTestId('line-station-S1')).toBeVisible();
+    await expect(page.getByTestId('line-station-S2')).toBeVisible();
+
+    // The ratchet is legible: S2 requires S1's stage as well as its own.
+    await expect(page.getByTestId('line-station-S2')).toContainText('demo-s1, demo-s2');
+    await expect(page.getByTestId('line-station-S1')).toContainText('0/1 gate stages green');
+    await expect(page.getByTestId('line-station-S2')).toContainText('0/2 gate stages green');
+
+    // Nothing has run yet, so S1 is next.
+    await expect(page.getByTestId('line-station-S1')).toContainText('next');
+
+    // The verify pipeline is healthy: line stages are off it on purpose.
+    await expect(page.getByText(/none on the verify plan/i)).toBeVisible();
+    await expect(page.getByText(/har env verify --full/)).toBeVisible();
+
+    // Declared, never installed — and no install affordance anywhere.
+    await expect(page.getByText(/never installs skills or MCP servers/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /install/i })).toHaveCount(0);
+  });
+
+  test('links to the board from the repository page', async ({ page }) => {
+    await page.goto(`/repos/${repoId}`);
+    const link = page.getByTestId('repo-lines-link');
+    await expect(link).toBeVisible();
+    await link.click();
+    await page.waitForURL(/\/repos\/[^/]+\/lines$/, { timeout: 10_000 });
+    await expect(page.getByTestId('line-board-demo-line')).toBeVisible();
+  });
+
+  test('shows an empty state that points at the CLI, not an install button', async ({
+    page,
+    request,
+  }) => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-line-e2e-empty-'));
+    fs.mkdirSync(path.join(emptyDir, '.har'), { recursive: true });
+    const response = await request.post('/api/repos', {
+      data: { path: emptyDir, force: true },
+    });
+    const emptyId = (await response.json()).id;
+
+    await page.goto(`/repos/${emptyId}/lines`);
+
+    const empty = page.getByTestId('line-board-empty');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText('har line add');
+    await expect(empty).toContainText('verificationStages');
+    await expect(page.getByRole('button', { name: /install/i })).toHaveCount(0);
+
+    await request.delete(`/api/repos/${emptyId}`).catch(() => {});
+    fs.rmSync(emptyDir, { recursive: true, force: true });
+  });
+});

--- a/docs/src/content/docs/docs/guides/factory-lines.md
+++ b/docs/src/content/docs/docs/guides/factory-lines.md
@@ -154,7 +154,26 @@ The two bundle kinds are deliberately not interchangeable:
 - `har env doctor` fails when a line stage appears in `verificationStages` —
   so a hand edit is caught before the next launch.
 
+## The board
+
+Mission Control draws every installed line at `/repos/<id>/lines`: stations in
+order, the cumulative gate, which workstations are in use, and the latest gate
+run per stage. It reads the same ledger and program `har line status` reads, so
+the two always agree.
+
+It is a **view**. The board never runs a stage, installs a bundle, or edits a
+tracker — `har line gate`, `har line add`, and the adaptation prompt own those,
+and the handoff stays human. A repo with a harness and no line gets an empty
+state pointing at the CLI, not an install button.
+
+One thing the board is careful about: line gate stages are **absent from
+`verificationStages` by design**, so it never draws them as missing verify
+stages. It says so explicitly instead — and turns the leak case (a line stage
+that *has* reached the verify plan) into a visible error, matching
+`har env doctor`.
+
 ## Next
 
-Mission Control gets a line board over `.har/lines.json` and `har line status`
-([#305](https://github.com/os-factory/har/issues/305)).
+The second real line is [#316](https://github.com/os-factory/har/issues/316) —
+slot occupancy identity, whose S3 station is a Docker lab that must never join
+routine verification.

--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -119,6 +119,28 @@ Historical repositories remain compatible: runs, validations, and slots without
 work metadata continue to appear under Operations and repository detail. They are
 not guessed into work units.
 
+## Factory lines
+
+Repository detail links to **Factory lines** (`/repos/<id>/lines`): a board over
+the [factory lines](/docs/guides/factory-lines/) installed in that repository.
+It shows stations in order, the cumulative gate and which of its stages are
+green, the workstations currently in use, and the skills, MCP servers and
+plugins each line declares.
+
+The board reads the repository's own `.har/lines.json` and program — the same
+source `har line status` reads — so the dashboard and the CLI always agree. It
+is read-only: installing or adapting a line is `har line add` plus the
+adaptation prompt that install writes, and running a gate is
+`har line gate <station>`.
+
+Line gate stages are absent from `verificationStages` by design, so the board
+never lists them among verification stages. It says so on the card, and flags
+the reverse case — a line stage that has leaked onto the verify plan — as an
+error, matching `har env doctor`.
+
+A repository with a harness and no line bundle gets an empty state naming the
+CLI, not an install button.
+
 ## Operations: runtime and infrastructure
 
 The repository overview summarizes registered projects, total runs, active slots,


### PR DESCRIPTION
Closes #305. **Stacked on #325** — review that one first; this PR's diff is only the board.

Mission Control already shows slots, runs and verification. A factory line is a *program* over those records: stations in order, what is in flight, whether the cumulative gate is green. That is a board, not a second execution engine.

## What it reads

`/repos/<id>/lines` renders every line installed in a repository from its own `.har/lines.json` and program — the same source `har line status` reads, so the dashboard and the CLI cannot disagree. Station progress comes from synced `Run` rows. It does **not** infer a line from `verificationStages` and does not parse `.har/stages/*.sh`.

## What it deliberately does not do

- No install affordance — that is `har line add` plus the adaptation prompt the install writes.
- No gate trigger — that is `har line gate <station>`.
- No tracker edits — the tracker remains the tracker.
- No autonomous ship — the andon cord stays human.

## The verify callout is the part worth reviewing

Line gate stages are absent from `verificationStages` **by design**. A board that drew them as missing verification stages would report a healthy pipeline as broken, which is the exact confusion the separate bundle kind exists to prevent. So the card states it positively:

> **2** registered line stages (`demo-s1`, `demo-s2`) — none on the verify plan. Default `har env verify --full` is unaffected.

…and turns the reverse case — a line stage that *has* reached the verify plan — into a visible error, matching the `factory-lines` doctor check from #304.

## The ratchet is legible

Each station lists its cumulative set, so growing the line is visible rather than implied: S1 shows `0/1 — demo-s1`, S2 shows `0/2 — demo-s1, demo-s2`. Earlier stations never disappear when you move on.

## Empty state

Names the CLI rather than offering a button, and distinguishes "no harness" from "harness, no line".

## Evidence

- 8 read-model unit tests (`control/src/server/lines.test.ts`) — ratchet, greenness from run records, verify-leak detection, unregistered gate stage, empty state, slots in flight.
- 3 browser-e2e specs that register a fixture repository, so the board renders **real content** instead of skipping on whatever is synced into the environment.
- Control harness full verify: typecheck ✓ unit-tests ✓ api-health ✓ lint ✓ readiness ✓ browser-e2e ✓ docker-build ✓ (73s), screenshots under `control/.har/artifacts/browser-e2e/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)