### PR TITLE
feat: skip re-verify on complete unless the tree changed

### DIFF
--- a/.har/README.md
+++ b/.har/README.md
@@ -147,7 +147,7 @@ For Mission Control (Next.js + SQLite) or the docs site (Astro), launch `control
 - [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — reuse last passing full validation + teardown, branch kept. Pass `--verify` / `verify: true` if the tree may have changed.
 
 ### Session handoff
 
@@ -219,6 +219,7 @@ never in the main checkout.
   or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, resume with
   `har env launch <id> --resume` or `har env recover <id>`.
-- `har env complete <id>` finishes a session: full verify (recorded as a validation),
-  then teardown — branch kept.
+- `har env complete <id>` finishes a session: reuses the last matching passing
+  full validation, then teardown — branch kept. Pass `--verify` to re-run full
+  verify if the tree may have changed.
 - `--no-worktree` runs the slot from the repo root instead (single-agent mode).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,8 @@ har env verify 1                # typecheck + build + docs check/build
 har env verify 1 --full         # + unit tests, lint, docs-drift — required before declaring done
 # then: session handoff → wait for user → on approval of default (complete + PR):
 # push + open PR, then:
-har env complete 1              # full verify + validation + teardown; branch kept
+har env complete 1              # reuse last passing full validation + teardown; branch kept
+# har env complete 1 --verify   # re-run full verify first if the tree may have changed
 ```
 
 Or use MCP `har_run_verification` / `har_complete_environment` (preferred in Cursor). Prefer `complete` over bare `teardown` — it closes the work attempt.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Run harness commands from the directory that owns the harness (e.g. `cd control`
 2. **Edit only in that work dir** — never in the main checkout. Changes there hot-reload for running slots when applicable.
 3. **Verify through the harness** — `har env verify 1` (fast) then `har env verify 1 --full` before declaring done.
 4. **Commit in the session worktree** — if the commit gate is installed, commits that do not match a passing full-verify validation are blocked.
-5. **Complete or teardown when finished** — `har env complete 1` (full verify + validation + teardown) or `har env teardown 1`. The session **branch is kept** so you can push a PR.
+5. **Complete or teardown when finished** — `har env complete 1` (reuse last passing full validation + teardown; `--verify` to re-run) or `har env teardown 1`. The session **branch is kept** so you can push a PR.
 
 ```bash
 har env launch 1

--- a/control/.har/README.md
+++ b/control/.har/README.md
@@ -196,7 +196,7 @@ A task is complete only when:
 - [ ] Changes are committed **in the session worktree** with a clear message
 - [ ] The user got the app URL (the slot URL (`har env agent <id> url`)) to test themselves
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — reuse last passing full validation + teardown, branch kept. Pass `--verify` / `verify: true` if the tree may have changed.
 
 ### Session handoff
 
@@ -256,6 +256,7 @@ never in the main checkout.
   main checkout to your intended base first.
 - `teardown` removes the worktree but **keeps the session branch** so you can push it
   or open a PR (`--delete-branch` to drop it).
-- `har env complete <id>` finishes a session: full verify (recorded as a validation),
-  then teardown — branch kept.
+- `har env complete <id>` finishes a session: reuses the last matching passing
+  full validation, then teardown — branch kept. Pass `--verify` to re-run full
+  verify if the tree may have changed.
 - `--no-worktree` runs the slot from the repo root instead (single-agent mode).

--- a/docs/.har/README.md
+++ b/docs/.har/README.md
@@ -253,4 +253,4 @@ HEAD at `~/worktrees/<base>-<sha4>-har-agent-<id>-<rand4>`, with work dir under
 
 - Occupied slots block — `complete` / `teardown`, then `launch`
 - `teardown` keeps the session branch
-- `har env complete <id>` = full verify + validation + teardown (branch kept)
+- `har env complete <id>` = reuse last passing full validation + teardown (branch kept); `--verify` to re-run

--- a/docs/src/content/docs/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/docs/getting-started/quick-start.md
@@ -88,8 +88,9 @@ for approval before finishing. Then:
 har env complete 1
 ```
 
-`complete` runs full verification, records the exact validated tree hash, removes
-the runtime and worktree, and keeps the session branch for a pull request.
+`complete` reuses the last passing full validation for the current tree, removes
+the runtime and worktree, and keeps the session branch for a pull request. Pass
+`--verify` if the tree may have changed since that verify.
 
 If you only need cleanup, use `har env teardown 1`. It also keeps the branch unless
 you explicitly pass `--delete-branch`.

--- a/docs/src/content/docs/docs/guides/agent-workflow.md
+++ b/docs/src/content/docs/docs/guides/agent-workflow.md
@@ -92,7 +92,8 @@ when `gh` or GitHub MCP is available; it still requires explicit user approval
 
 1. **Complete + open a PR** (recommended when PR tooling is available) — push the
    session branch, open the PR, then `har env complete <id>` / MCP
-   `har_complete_environment` (full verify + validation + teardown; **branch kept**).
+   `har_complete_environment` (reuse last passing full validation + teardown; **branch kept**).
+   Pass `--verify` / `verify: true` if the tree may have changed after that verify.
 2. **Complete only** — same finish without a PR. Prefer `complete` over bare
    `teardown` when the work succeeded.
 3. **Something else** — keep the slot running, more changes, or push only.

--- a/docs/src/content/docs/docs/guides/verification.md
+++ b/docs/src/content/docs/docs/guides/verification.md
@@ -80,8 +80,18 @@ required validation against the intended state.
 
 ## Completion
 
-`har env complete 1` performs full verification before teardown and keeps the
-session branch. It is the simplest reliable end-of-task operation.
+`har env complete 1` reuses the last passing **full** validation whose tree hash
+matches the current worktree, then tears the slot down and keeps the session
+branch. Verify-before-done already recorded that proof — complete does not
+re-run the suite by default.
 
-`--skip-verify` exists for explicit cleanup, but it records no validation and should
-not be used to claim a completed task.
+If the tree changed after that verify (or there is no matching passing full
+validation), complete refuses and tells you to re-run:
+
+```bash
+har env complete 1 --verify
+```
+
+`--verify` is the previous default: full verification, record validation, then
+teardown. Use `har env teardown 1` for cleanup without claiming completion.
+`--skip-verify` is a deprecated no-op; skip is already the default.

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -52,7 +52,7 @@ With `--yes` and no `--agent-slots`, the profile template default is kept.
 | `launch <id>` | Start a fresh session (new worktree from `--repo` HEAD) |
 | `recover <id>` | Resume a failed or partial launch |
 | `verify <id>` | Run quick or full verification |
-| `complete <id>` | Full verify, record validation, teardown, keep branch |
+| `complete <id>` | Reuse last matching full validation, teardown, keep branch (`--verify` to re-run) |
 | `teardown <id>` | Free a slot without a completion validation; keep branch |
 | `doctor` | Validate the harness contract (schema, stages, scripts, port lanes) |
 | `eject` | Vendor the runtime into `.har/runtime/` for offline ownership |
@@ -167,9 +167,13 @@ launch. The same warning appears in `har env status --json`, MCP launch
 
 ```bash
 har env verify 1 [--full] [--json]
-har env complete 1 [--skip-verify]
+har env complete 1 [--verify]
 har env teardown 1 [--delete-branch]
 ```
+
+`complete` reuses the last passing full validation for the current tree. Pass
+`--verify` to re-run full verification if the worktree may have changed.
+`--skip-verify` is a deprecated no-op (skip is the default).
 
 Default verify output is the live progress lines on stderr (and a one-line
 summary). It does **not** reprint the machine JSON contract — that blob

--- a/docs/src/content/docs/docs/reference/mcp.md
+++ b/docs/src/content/docs/docs/reference/mcp.md
@@ -30,7 +30,7 @@ issue, Bitbucket). Omit work metadata for ad-hoc work with no tracker identity.
 | `har_recover_environment` | `agentId` | Resumed failed or partial launch |
 | `har_get_status` | optional `agentId` | Structured slot status (same source as `har env status --json`): worktree, branch, dirty state, readiness, last run/verify. A pure read — writes no run records |
 | `har_get_logs` | `agentId`, optional `service` | Recent service output |
-| `har_complete_environment` | `agentId`, `skipVerify` | Validation, teardown, and retained branch |
+| `har_complete_environment` | `agentId`, optional `verify` | Reuse last matching full validation (or re-run when `verify=true`), teardown, and retained branch |
 | `har_teardown_environment` | `agentId`, `deleteBranch` | Teardown result |
 
 Every launch creates a new session from the main checkout's current HEAD.

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -369,15 +369,21 @@ export const envCommand = {
       )
       .command(
         'complete <id>',
-        'Finish a session: full verify (recorded as validation), teardown, keep the branch for a PR',
+        'Finish a session: reuse the last matching full validation, teardown, keep the branch for a PR',
         (y: Argv) =>
           y
             .positional('id', { type: 'number', describe: 'Agent slot id (see .har/stages.json agentSlots)' })
             .option('repo', { type: 'string', default: '.' })
-            .option('skip-verify', {
+            .option('verify', {
               type: 'boolean',
               default: false,
-              describe: 'Tear down without running verification (no validation is recorded)',
+              describe:
+                'Re-run full verification before teardown (use when the tree may have changed since the last passing --full)',
+            })
+            .option('skip-verify', {
+              type: 'boolean',
+              hidden: true,
+              describe: 'Deprecated no-op: complete already skips re-verification by default',
             }),
         handleComplete,
       )
@@ -1174,13 +1180,15 @@ export async function handleTeardown(argv: {
 export async function handleComplete(argv: {
   id?: number;
   repo: string;
-  skipVerify: boolean;
+  verify?: boolean;
+  skipVerify?: boolean;
 }): Promise<void> {
   const repo = path.resolve(argv.repo);
   const agentId = validateAgentId(argv.id, repo);
   const result = await completeEnvironment({
     repoPath: repo,
     agentId,
+    verify: argv.verify,
     skipVerify: argv.skipVerify,
     capture: false,
   });

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -8,12 +8,12 @@ Typical agent workflow:
   har env launch <id>            # new session from the main checkout's HEAD
   # …edit only under the printed work dir…
   har env verify <id> --full
-  har env complete <id>          # done: verify + free the slot (branch kept for PR)
+  har env complete <id>          # done: reuse last full validation + free the slot (branch kept for PR)
 
 Slot lifecycle (do not confuse these):
   launch     start a NEW session (worktree from $REPO_ROOT HEAD)
   recover    resume a failed/partial launch (keeps the existing worktree)
-  complete   finish successfully: full verify, then teardown (frees the slot)
+  complete   finish successfully: reuse last matching full validation, then teardown (frees the slot)
   teardown   abandon / free the slot without a completion validation
 
 Occupied slots always block a new launch:
@@ -30,7 +30,7 @@ export const HAR_ENV_EPILOG = `Environment lifecycle:
   launch <id>      fresh session worktree from the main checkout's current HEAD
   recover <id>     alias for launch --resume (failed/starting only)
   verify <id>      run checks (--full before declaring done)
-  complete <id>    full verify + teardown; keeps branch for push/PR (frees slot)
+  complete <id>    reuse last full validation + teardown; --verify to re-run; keeps branch (frees slot)
   teardown <id>    free the slot without recording a completion validation
 
 Occupied slots:

--- a/src/core/onboarding.ts
+++ b/src/core/onboarding.ts
@@ -75,7 +75,7 @@ export const ONBOARDING_GUIDE_STEPS: readonly { title: string; body: string }[] 
     body: [
       'Quick:  har env verify <id>',
       'Done:   har env verify <id> --full   then   har env complete <id>',
-      '`complete` records a validation, frees the slot, and keeps the session branch for a PR.',
+      '`complete` reuses the last matching full validation, frees the slot, and keeps the session branch for a PR. Pass --verify if the tree changed.',
     ].join('\n'),
   },
   {

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -5,7 +5,11 @@ import { createRun, finishRun, resolveAgentWorkDir } from './runs';
 import { listSlotRegistryEntries, readSlotRegistry } from './slot-registry';
 import { checkLaunchGuard } from './slot-launch-guard';
 import { formatPreflightReport, inspectSlotReadiness } from './slot-preflight';
-import { recordValidation, resolveValidationCheckoutDir } from './validations';
+import {
+  findPassingFullValidation,
+  recordValidation,
+  resolveValidationCheckoutDir,
+} from './validations';
 import {
   bindValidationToAttempt,
   createWorkAttempt,
@@ -469,13 +473,16 @@ export class RunService {
   }
 
   /**
-   * Finish a session: full verification (recorded as a validation keyed by the
-   * worktree tree hash), then teardown. The session branch is kept so the user
-   * can push it and open a PR.
+   * Finish a session: reuse the last matching passing full validation (or
+   * re-run verify when asked), then teardown. The session branch is kept so
+   * the user can push it and open a PR.
    */
   async completeEnvironment(options: {
     repoPath: string;
     agentId: number;
+    /** Re-run full verification. Wins over `skipVerify`. */
+    verify?: boolean;
+    /** @deprecated Default is already skip. Only `false` still forces a re-run. */
     skipVerify?: boolean;
     capture?: boolean;
     trigger?: ExecutionContext['trigger'];
@@ -490,9 +497,12 @@ export class RunService {
       };
     }
 
+    const runVerify = shouldReverifyOnComplete(options);
     let verification: VerificationResult | null | undefined;
     let validation: import('../harness/schema').ValidationRecord | undefined;
-    if (!options.skipVerify) {
+    let reusedValidation = false;
+
+    if (runVerify) {
       const verify = await this.runVerification({
         repoPath: options.repoPath,
         agentId: options.agentId,
@@ -507,17 +517,31 @@ export class RunService {
           ...verify,
           stderr:
             verify.stderr +
-            '\nVerification failed — session NOT completed. Fix the failures and rerun, or complete with skipVerify.',
+            '\nVerification failed — session NOT completed. Fix the failures and rerun `complete --verify`, or use teardown to free the slot without claiming completion.',
         };
       }
+    } else {
+      const checkoutDir = resolveValidationCheckoutDir({
+        worktreePath: session.worktreePath,
+        workDir: session.workDir,
+        harnessRoot,
+      });
+      validation = findPassingFullValidation({ checkoutDir, harnessRoot });
+      if (!validation) {
+        return {
+          code: 1,
+          stdout: '',
+          stderr:
+            'No passing full validation matches the current worktree. ' +
+            'The tree may have changed since the last `har env verify --full`. ' +
+            `Re-run verification with: har env complete ${options.agentId} --verify\n` +
+            `Or free the slot without claiming completion: har env teardown ${options.agentId}`,
+        };
+      }
+      reusedValidation = true;
     }
 
-    if (
-      session.workUnitId &&
-      session.attemptId &&
-      !options.skipVerify &&
-      !validation
-    ) {
+    if (session.workUnitId && session.attemptId && runVerify && !validation) {
       return {
         code: 1,
         stdout: '',
@@ -545,12 +569,16 @@ export class RunService {
     });
     if (teardown.code !== 0) return { ...teardown, verification };
 
+    const reusedNote =
+      reusedValidation && validation
+        ? `Reused passing full validation ${validation.validationId} for tree ${validation.treeHash}.\n`
+        : '';
     const branchNote = session.branch
       ? `Branch kept: ${session.branch} — push it with: git push -u origin ${session.branch}\n`
       : '';
     return {
       ...teardown,
-      stdout: teardown.stdout + branchNote,
+      stdout: teardown.stdout + reusedNote + branchNote,
       branch: session.branch,
       workDir: session.workDir,
       worktreePath: session.worktreePath,
@@ -600,6 +628,15 @@ export class RunService {
     });
     return toEnvironmentRunResult(result);
   }
+}
+
+/** `verify: true` or explicit `skipVerify: false` re-runs full verification. */
+export function shouldReverifyOnComplete(options: {
+  verify?: boolean;
+  skipVerify?: boolean;
+}): boolean {
+  if (options.verify === true) return true;
+  return options.skipVerify === false;
 }
 
 const defaultRunService = new RunService();

--- a/src/core/validations.ts
+++ b/src/core/validations.ts
@@ -120,6 +120,23 @@ export function findValidation(
 }
 
 /**
+ * Last passing full validation whose tree hash matches the current worktree.
+ * Used by `complete` to reuse verify-before-done proof instead of re-running.
+ */
+export function findPassingFullValidation(input: {
+  checkoutDir: string;
+  harnessRoot?: string;
+}): ValidationRecord | undefined {
+  if (!isCheckoutRoot(input.checkoutDir)) return undefined;
+  const { treeHash } = computeWorktreeSnapshot(input.checkoutDir);
+  const record =
+    findValidation(input.checkoutDir, treeHash) ??
+    (input.harnessRoot ? findValidation(input.harnessRoot, treeHash) : undefined);
+  if (record?.status === 'pass' && record.full) return record;
+  return undefined;
+}
+
+/**
  * Associate a commit with the validation for its tree. Updates the checkout
  * copy and mirrors to the harness root recorded on the validation itself.
  */

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -137,10 +137,18 @@ export const PreflightEnvironmentOutputSchema = ShellRunOutputSchema.extend({
 export const CompleteEnvironmentInputSchema = z.object({
   repo: z.string().default('.'),
   agentId: agentIdSchema,
+  verify: z
+    .boolean()
+    .optional()
+    .describe(
+      'Re-run full verification before teardown when the tree may have changed since the last passing --full',
+    ),
   skipVerify: z
     .boolean()
-    .default(false)
-    .describe('Tear down without running verification (no validation is recorded)'),
+    .optional()
+    .describe(
+      'Deprecated. Complete already skips re-verification by default. Pass verify=true to re-run; skipVerify=false still forces a re-run.',
+    ),
 });
 
 export const CompleteEnvironmentOutputSchema = ShellRunOutputSchema.extend({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -287,14 +287,20 @@ export const HAR_MCP_TOOLS: Tool[] = [
   {
     name: 'har_complete_environment',
     description:
-      'Finish a session when the work is done: runs full verification (recorded as a validation of the worktree tree hash), tears the slot down, and KEEPS the session branch so the user can push it and open a PR.',
+      'Finish a session when the work is done: reuses the last passing full validation for the current worktree (or re-runs verify when verify=true), tears the slot down, and KEEPS the session branch so the user can push it and open a PR.',
     inputSchema: objectJsonSchema(
       {
         repo: repoJsonProperty,
         agentId: agentIdJsonProperty,
+        verify: {
+          type: 'boolean',
+          description:
+            'Re-run full verification before teardown when the tree may have changed since the last passing --full',
+        },
         skipVerify: {
           type: 'boolean',
-          description: 'Tear down without running verification (no validation is recorded)',
+          description:
+            'Deprecated. Complete already skips re-verification by default. Pass verify=true to re-run.',
         },
       },
       ['agentId'],
@@ -657,6 +663,7 @@ export async function handleMcpToolCall(
       const result = await completeEnvironment({
         repoPath: repo,
         agentId,
+        verify: input.verify,
         skipVerify: input.skipVerify,
         capture: true,
         trigger: 'mcp',

--- a/src/templates/agent-skills/har-wt.md
+++ b/src/templates/agent-skills/har-wt.md
@@ -57,7 +57,8 @@ Do not substitute ad-hoc test commands for harness verification. Any edit after 
 ## 5. Finish
 
 ```bash
-har env complete <id>   # full verify + validation record + teardown, keeps the session branch
+har env complete <id>   # reuse last passing full validation + teardown, keeps the session branch
+har env complete <id> --verify   # re-run full verify first if the tree may have changed
 ```
 
 Report to the user: verification result, the session branch name (so they can push / open a PR), and the slot preview URLs if the app is running.

--- a/src/templates/profiles/cli/docs/readme/definition-of-done.md
+++ b/src/templates/profiles/cli/docs/readme/definition-of-done.md
@@ -6,7 +6,7 @@
 - [ ] New behavior has automated test coverage
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — reuse last passing full validation + teardown, branch kept. Pass `--verify` / `verify: true` if the tree may have changed.
 
 ### Session handoff
 

--- a/src/templates/profiles/default/docs/readme/definition-of-done.md
+++ b/src/templates/profiles/default/docs/readme/definition-of-done.md
@@ -7,7 +7,7 @@
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] The user got the preview URLs to test the app themselves
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — reuse last passing full validation + teardown, branch kept. Pass `--verify` / `verify: true` if the tree may have changed.
 
 ### Session handoff
 

--- a/src/templates/profiles/ios/docs/readme/definition-of-done.md
+++ b/src/templates/profiles/ios/docs/readme/definition-of-done.md
@@ -6,7 +6,7 @@
 - [ ] New behavior has automated test coverage (unit tests via XCTest)
 - [ ] Changes committed **in the session worktree** with a clear message
 - [ ] Present session handoff (summary, branch, preview URLs) and **wait for user** before `complete`, push, or PR
-- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — full verify + validation + teardown, branch kept
+- [ ] On user approval of the default: push + open PR (when `gh`/GitHub MCP available), then `har env complete <id>` (or MCP `har_complete_environment`) — reuse last passing full validation + teardown, branch kept. Pass `--verify` / `verify: true` if the tree may have changed.
 
 ### Session handoff
 

--- a/src/templates/shared-docs/readme/session-lifecycle.md
+++ b/src/templates/shared-docs/readme/session-lifecycle.md
@@ -15,6 +15,7 @@ never in the main checkout.
   or open a PR (`--delete-branch` to drop it).
 - If launch fails after creating a worktree/env file, the registry records `status: failed`.
   Resume it instead of starting fresh: `har env launch <id> --resume` or `har env recover <id>`.
-- `har env complete <id>` finishes a session: full verify (recorded as a validation),
-  then teardown — branch kept.
+- `har env complete <id>` finishes a session: reuses the last matching passing
+  full validation, then teardown — branch kept. Pass `--verify` to re-run full
+  verify if the tree may have changed.
 - `--no-worktree` runs the slot from the repo root instead (single-agent mode).

--- a/tests/complete-environment.test.ts
+++ b/tests/complete-environment.test.ts
@@ -1,0 +1,189 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import {
+  completeEnvironment,
+  shouldReverifyOnComplete,
+} from '../src/core/run-service';
+import { recordValidation } from '../src/core/validations';
+import { createWorkAttempt, findWorkUnit, upsertWorkUnit } from '../src/core/work-units';
+import { getSlotRegistryPath } from '../src/core/slot-registry';
+import { buildVerifyPlan, teardownSession } from '../src/runtime';
+
+const FIXTURE = path.join(__dirname, 'fixtures/minimal-harness');
+
+jest.mock('../src/runtime', () => {
+  const actual = jest.requireActual('../src/runtime');
+  return {
+    ...actual,
+    launchSession: jest.fn(async () => ({ code: 0 })),
+    teardownSession: jest.fn(async (options: { agentId: number; out?: (line: string) => void }) => {
+      options.out?.(`==> Tearing down agent ${options.agentId}...`);
+      return { code: 0 };
+    }),
+    runSetupInfra: jest.fn(async () => ({ code: 0 })),
+    runAgentOp: jest.fn(async () => ({ code: 0 })),
+    buildVerifyPlan: jest.fn((_repo: string, agentId: number) => ({
+      shellCommand:
+        "echo '" +
+        JSON.stringify({
+          status: 'pass',
+          agent_id: agentId,
+          total_ms: 10,
+          stages: [{ name: 'smoke', pass: true }],
+        }) +
+        "'",
+      cwd: process.cwd(),
+      env: process.env,
+    })),
+  };
+});
+
+function sh(cwd: string, command: string): string {
+  return execSync(command, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+}
+
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-complete-'));
+  fs.cpSync(path.join(FIXTURE, '.har'), path.join(dir, '.har'), { recursive: true });
+  for (const name of ['runs', 'slots', 'work-units', 'work-attempts', 'validation-bindings']) {
+    fs.rmSync(path.join(dir, '.har', name), { recursive: true, force: true });
+  }
+  sh(dir, 'git init -q -b main');
+  sh(dir, 'git config user.email har@test.local');
+  sh(dir, 'git config user.name har');
+  fs.writeFileSync(path.join(dir, 'app.txt'), 'v1\n');
+  sh(dir, 'git add -A');
+  sh(dir, 'git commit -q -m init');
+  return dir;
+}
+
+function writeActiveSlot(repoPath: string, extra: Record<string, unknown> = {}): void {
+  const file = getSlotRegistryPath(repoPath, 1);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      agentId: 1,
+      projectName: 'minimal',
+      mode: 'root',
+      workDir: repoPath,
+      worktreePath: repoPath,
+      branch: 'session-branch',
+      createdAt: new Date().toISOString(),
+      status: 'active',
+      ...extra,
+    }),
+  );
+}
+
+describe('shouldReverifyOnComplete', () => {
+  it('skips by default and only re-runs when verify is true or skipVerify is false', () => {
+    expect(shouldReverifyOnComplete({})).toBe(false);
+    expect(shouldReverifyOnComplete({ skipVerify: true })).toBe(false);
+    expect(shouldReverifyOnComplete({ verify: true })).toBe(true);
+    expect(shouldReverifyOnComplete({ skipVerify: false })).toBe(true);
+    expect(shouldReverifyOnComplete({ verify: true, skipVerify: true })).toBe(true);
+  });
+});
+
+describe('completeEnvironment (#324)', () => {
+  const mockedPlan = buildVerifyPlan as jest.MockedFunction<typeof buildVerifyPlan>;
+  const mockedTeardown = teardownSession as jest.MockedFunction<typeof teardownSession>;
+
+  beforeEach(() => {
+    mockedPlan.mockClear();
+    mockedTeardown.mockClear();
+  });
+
+  it('reuses a matching passing full validation and does not re-run verify', async () => {
+    const dir = initRepo();
+    writeActiveSlot(dir);
+    const validation = recordValidation({
+      checkoutDir: dir,
+      harnessRoot: dir,
+      status: 'pass',
+      full: true,
+      agentId: 1,
+    });
+
+    const result = await completeEnvironment({ repoPath: dir, agentId: 1, capture: true });
+
+    expect(result.code).toBe(0);
+    expect(mockedPlan).not.toHaveBeenCalled();
+    expect(mockedTeardown).toHaveBeenCalledTimes(1);
+    expect(result.stdout).toContain(`Reused passing full validation ${validation.validationId}`);
+    expect(result.stdout).toContain('Branch kept: session-branch');
+  });
+
+  it('refuses when the tree drifted since the last passing full validation', async () => {
+    const dir = initRepo();
+    writeActiveSlot(dir);
+    recordValidation({ checkoutDir: dir, harnessRoot: dir, status: 'pass', full: true });
+    fs.writeFileSync(path.join(dir, 'app.txt'), 'v2\n');
+
+    const result = await completeEnvironment({ repoPath: dir, agentId: 1, capture: true });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('No passing full validation matches the current worktree');
+    expect(result.stderr).toContain('har env complete 1 --verify');
+    expect(mockedPlan).not.toHaveBeenCalled();
+    expect(mockedTeardown).not.toHaveBeenCalled();
+  });
+
+  it('refuses a quick-only validation for the current tree', async () => {
+    const dir = initRepo();
+    writeActiveSlot(dir);
+    recordValidation({ checkoutDir: dir, harnessRoot: dir, status: 'pass', full: false });
+
+    const result = await completeEnvironment({ repoPath: dir, agentId: 1, capture: true });
+
+    expect(result.code).toBe(1);
+    expect(mockedTeardown).not.toHaveBeenCalled();
+  });
+
+  it('re-runs full verify when verify is true', async () => {
+    const dir = initRepo();
+    writeActiveSlot(dir);
+    fs.writeFileSync(path.join(dir, 'app.txt'), 'v2\n');
+
+    const result = await completeEnvironment({
+      repoPath: dir,
+      agentId: 1,
+      verify: true,
+      capture: true,
+    });
+
+    expect(result.code).toBe(0);
+    expect(mockedPlan).toHaveBeenCalled();
+    expect(mockedTeardown).toHaveBeenCalledTimes(1);
+    expect(result.stdout).not.toContain('Reused passing full validation');
+  });
+
+  it('attaches a reused validation to a bound work unit', async () => {
+    const dir = initRepo();
+    const attemptId = '00000000-0000-4000-8000-000000000324';
+    upsertWorkUnit(dir, { workUnitId: '324', source: 'github' });
+    createWorkAttempt(dir, { attemptId, workUnitId: '324', agentId: 1 });
+    writeActiveSlot(dir, { workUnitId: '324', attemptId });
+    const validation = recordValidation({
+      checkoutDir: dir,
+      harnessRoot: dir,
+      status: 'pass',
+      full: true,
+      agentId: 1,
+    });
+
+    const result = await completeEnvironment({ repoPath: dir, agentId: 1, capture: true });
+
+    expect(result.code).toBe(0);
+    expect(findWorkUnit(dir, '324')?.outcome).toMatchObject({
+      decision: 'completed',
+      attemptId,
+      validationId: validation.validationId,
+      treeHash: validation.treeHash,
+    });
+  });
+});

--- a/tests/validations.test.ts
+++ b/tests/validations.test.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process';
 import { computeWorktreeSnapshot } from '../src/core/change-batch';
 import {
   attachCommit,
+  findPassingFullValidation,
   findValidation,
   listValidations,
   recordValidation,
@@ -118,6 +119,30 @@ describe('validation store', () => {
     fs.mkdirSync(path.join(dir, '.har', 'validations'), { recursive: true });
     fs.writeFileSync(path.join(dir, '.har', 'validations', 'garbage.json'), 'not json');
     expect(listValidations(dir)).toEqual([]);
+  });
+
+  it('findPassingFullValidation requires a pass + full record for the current tree', () => {
+    const dir = initRepo();
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'changed\n');
+
+    expect(findPassingFullValidation({ checkoutDir: dir })).toBeUndefined();
+
+    recordValidation({ checkoutDir: dir, harnessRoot: dir, status: 'pass', full: false });
+    expect(findPassingFullValidation({ checkoutDir: dir })).toBeUndefined();
+
+    recordValidation({ checkoutDir: dir, harnessRoot: dir, status: 'fail', full: true });
+    expect(findPassingFullValidation({ checkoutDir: dir })).toBeUndefined();
+
+    const passed = recordValidation({
+      checkoutDir: dir,
+      harnessRoot: dir,
+      status: 'pass',
+      full: true,
+    });
+    expect(findPassingFullValidation({ checkoutDir: dir })?.validationId).toBe(passed.validationId);
+
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'changed again\n');
+    expect(findPassingFullValidation({ checkoutDir: dir })).toBeUndefined();
   });
 
   it('prefers the worktree root over a nested harness workDir', () => {


### PR DESCRIPTION
## Summary
- `har env complete` / `har_complete_environment` no longer re-run full verification by default. They reuse the last passing **full** validation whose tree hash matches the current worktree, then tear down and keep the branch.
- `--verify` / `verify: true` re-runs full verify when the tree may have changed. If nothing matches, complete refuses (use `teardown` for cleanup without claiming done).
- `--skip-verify` is a deprecated no-op; skip is already the default. `skipVerify: false` still forces a re-run for old MCP callers.

Closes #324

## Test plan
- [x] Unit tests for reuse, drift refusal, quick-only refusal, `--verify` re-run, and work-unit attachment
- [x] `har env verify 2 --full` (typecheck, build, docs, unit tests, lint, docs-drift)
- [ ] After merge: `har env complete <id>` on a just-verified slot is fast and prints the reused validation
- [ ] After a post-verify edit, `complete` refuses until `--verify`

Made with [Cursor](https://cursor.com)