### PR TITLE
fix(telemetry): bound the agent hooks so an unreachable collector cannot stall a turn (#328)

### DIFF
--- a/docs/src/content/docs/docs/guides/mission-control.md
+++ b/docs/src/content/docs/docs/guides/mission-control.md
@@ -165,6 +165,23 @@ har telemetry off             # clear hooks OTLP export + stop MC auto-start; ke
 ```
 
 Preference is stored in `~/.har/telemetry.json`. Override with `HAR_TELEMETRY=0|1`.
+### Hooks never cost you a turn
+
+Hooks fire on session start, every prompt, before and after every tool call,
+and on stop — six or more times per turn. Telemetry that blocks would therefore
+be paid several times over on every single turn, so the registration HAR writes
+is bounded on both sides:
+
+- Each generated hook entry carries an explicit `timeout` (10s), instead of the
+  agent's much longer default.
+- The wrapper caps the export itself (1.5s) and the flush (0.5s), and always
+  exits 0. A dropped telemetry event must never fail a tool call.
+
+The practical consequence: if Mission Control is not running, a turn costs a
+fraction of a second per hook rather than stalling. `har telemetry status` warns
+when hooks are installed and the collector is unreachable, since that
+combination is pure cost.
+
 Hooks config lives at `~/.har/otel-hooks/otel_config.json` (`HAR_OTEL_HOOKS_HOME` to override).
 The package itself is installed under `~/.har/otel-hooks/node_modules` (pinned
 `@osfactory/otel-hook`).

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -70,6 +70,16 @@ async function handleStatus(argv: { json: boolean }): Promise<void> {
   info(`Mission Control: ${apiUrl} (${reachable ? 'reachable' : 'not reachable'})`);
   info(`OTLP endpoint: ${payload.otelEndpoint}`);
   info(`Hooks home:    ${payload.otelHooksHome}`);
+
+  // Hooks installed + collector down is the failure state worth naming (#328):
+  // every agent turn pays the export budget for telemetry nobody receives.
+  if (enabled && !reachable) {
+    warn(
+      'Agent hooks are installed but Mission Control is not reachable — each turn pays the export timeout for telemetry nobody receives.',
+    );
+    info('Start it with: har control up   •   or stop exporting: har telemetry off');
+  }
+
   printSignals();
 }
 

--- a/src/core/otel-hooks.ts
+++ b/src/core/otel-hooks.ts
@@ -8,6 +8,27 @@ import { getTelemetrySignals, isTelemetryEnabled } from './telemetry-config';
 /** Pinned npm package for reproducible installs (replaces Python opentelemetry-hooks). */
 export const OTEL_HOOKS_PACKAGE = '@osfactory/otel-hook@0.2.0';
 
+/**
+ * Budgets for the hooks HAR installs into agent settings (#328).
+ *
+ * A telemetry hook must never cost the user a turn. Hooks fire on session
+ * start, every prompt, before and after every tool call, and on stop — so an
+ * export that blocks compounds across a single turn. Without an explicit
+ * per-hook timeout the agent falls back to its own generous default, and an
+ * unreachable Mission Control stalls the session before its first model
+ * request, indistinguishable from a broken API.
+ *
+ * The export budget is deliberately well inside the per-hook ceiling, so the
+ * hook returns on its own rather than being killed by the agent. It is also
+ * kept small in absolute terms: six or more hooks fire per turn, so every
+ * second here is paid several times over whenever the collector is down. A
+ * local Mission Control answers in milliseconds, so this costs nothing in the
+ * normal case.
+ */
+export const HOOK_TIMEOUT_SECONDS = 10;
+const HOOK_EXPORT_TIMEOUT_MS = 1500;
+const HOOK_FLUSH_TIMEOUT_MS = 500;
+
 /** Providers HAR registers with `otel-hook setup --provider`. */
 export const OTEL_HOOKS_PROVIDERS = [
   { id: 'cursor', label: 'cursor' },
@@ -176,11 +197,22 @@ export function writeOtelHooksWrapper(
   const stateDir = getOtelHooksStateDir(hooksHome);
   const script = `#!/usr/bin/env bash
 # Managed by har telemetry — invokes @osfactory/otel-hook with HAR config.
-set -euo pipefail
-exec "${otelHookCommand}" run \\
+#
+# Two rules for this wrapper (#328):
+#   1. Bounded. Export and flush budgets keep it well inside the per-hook
+#      timeout the agent enforces, so an unreachable Mission Control costs
+#      milliseconds instead of stalling the session.
+#   2. Silent about its own failures. Dropped telemetry must never fail an
+#      agent turn, so the exit status is always 0 — a non-zero hook exit can
+#      block a tool call.
+set -uo pipefail
+"${otelHookCommand}" run \\
   --config-file "${configPath}" \\
   --state-dir "${stateDir}" \\
-  "$@"
+  --timeout-ms ${HOOK_EXPORT_TIMEOUT_MS} \\
+  --flush-timeout-ms ${HOOK_FLUSH_TIMEOUT_MS} \\
+  "$@" || true
+exit 0
 `;
   fs.writeFileSync(wrapperPath, script, { mode: 0o755 });
   try {
@@ -318,27 +350,42 @@ export const LEGACY_CURSOR_ONLY_HOOK_EVENTS = [
   'subagentStop',
 ] as const;
 
+/**
+ * Argv for `otel-hook setup`, split out so the hook budget is testable without
+ * spawning the installer.
+ */
+export function buildOtelHookSetupArgs(
+  providerId: OtelHooksProviderId,
+  hookCommand: string,
+): string[] {
+  return [
+    'setup',
+    '--provider',
+    providerId,
+    '--scope',
+    'global',
+    '--hook-command',
+    hookCommand,
+    '--managed-marker',
+    'otel-hook',
+    // Written into each generated hook entry so the agent bounds it (#328).
+    // Without this the agent falls back to its own default and an unreachable
+    // collector stalls the session before its first model request.
+    '--timeout-seconds',
+    String(HOOK_TIMEOUT_SECONDS),
+  ];
+}
+
 function runSetupProvider(
   providerId: OtelHooksProviderId,
   otelHookCommand: string,
   wrapperPath: string,
 ): { ok: boolean; detail: string } {
   const hookCommand = `${wrapperPath} --provider ${providerId}`;
-  const result = spawnSync(
-    otelHookCommand,
-    [
-      'setup',
-      '--provider',
-      providerId,
-      '--scope',
-      'global',
-      '--hook-command',
-      hookCommand,
-      '--managed-marker',
-      'otel-hook',
-    ],
-    { encoding: 'utf8', timeout: 60_000 },
-  );
+  const result = spawnSync(otelHookCommand, buildOtelHookSetupArgs(providerId, hookCommand), {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
   if (result.status === 0) {
     return { ok: true, detail: `setup --provider ${providerId}` };
   }

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -18,7 +18,9 @@ import {
   buildTelemetryEnvBlock,
 } from '../src/core/telemetry-env';
 import {
+  buildOtelHookSetupArgs,
   buildOtelHooksConfig,
+  HOOK_TIMEOUT_SECONDS,
   OTEL_HOOKS_PACKAGE,
   pruneLegacyCursorHookEvents,
   rewriteHookCommandsToWrapper,
@@ -442,10 +444,69 @@ describe('otel hooks config', () => {
     const binary = path.join(hooksHome, 'node_modules', '.bin', 'otel-hook');
     const wrapper = writeOtelHooksWrapper(binary, hooksHome);
     const script = fs.readFileSync(wrapper, 'utf8');
-    expect(script).toContain(`exec "${binary}" run`);
+    expect(script).toContain(`"${binary}" run`);
     expect(script).toContain(`--config-file "${path.join(hooksHome, 'otel_config.json')}"`);
     expect(script).toContain(`--state-dir "${path.join(hooksHome, 'state')}"`);
     expect(script).not.toContain('python');
     expect(fs.statSync(wrapper).mode & 0o111).not.toBe(0);
+  });
+
+  // #328: hooks fire on session start, every prompt, before/after every tool
+  // call and on stop. An unbounded export turns an unreachable Mission Control
+  // into a stalled agent session, which reads exactly like a broken model API.
+  describe('hook budgets', () => {
+    it('bounds the export so an unreachable collector cannot stall a turn', () => {
+      const hooksHome = path.join(tmpDir, 'hooks-budget');
+      const binary = path.join(hooksHome, 'node_modules', '.bin', 'otel-hook');
+      const script = fs.readFileSync(writeOtelHooksWrapper(binary, hooksHome), 'utf8');
+
+      const exportTimeout = script.match(/--timeout-ms (\d+)/);
+      const flushTimeout = script.match(/--flush-timeout-ms (\d+)/);
+
+      expect(exportTimeout).not.toBeNull();
+      expect(flushTimeout).not.toBeNull();
+      expect(Number(exportTimeout![1])).toBeGreaterThan(0);
+      // Both budgets must fit inside the per-hook ceiling the agent enforces,
+      // so the hook returns on its own instead of being killed.
+      expect(Number(exportTimeout![1]) + Number(flushTimeout![1])).toBeLessThan(
+        HOOK_TIMEOUT_SECONDS * 1000,
+      );
+    });
+
+    it('never fails an agent turn because telemetry failed', () => {
+      const hooksHome = path.join(tmpDir, 'hooks-exit');
+      const binary = path.join(hooksHome, 'node_modules', '.bin', 'otel-hook');
+      const script = fs.readFileSync(writeOtelHooksWrapper(binary, hooksHome), 'utf8');
+
+      // A non-zero hook exit can block a tool call; dropped telemetry must not.
+      expect(script).toContain('|| true');
+      expect(script.trim().endsWith('exit 0')).toBe(true);
+      // `exec` would replace the shell and leak the child's status.
+      expect(script).not.toContain('exec "');
+      expect(script).not.toContain('set -euo pipefail');
+    });
+
+    it('writes a per-hook timeout into every generated hook entry', () => {
+      const args = buildOtelHookSetupArgs('claude-code', '/home/dev/.har/otel-hooks/run-otel-hook.sh');
+      const index = args.indexOf('--timeout-seconds');
+
+      expect(index).toBeGreaterThan(-1);
+      expect(Number(args[index + 1])).toBe(HOOK_TIMEOUT_SECONDS);
+      expect(Number(args[index + 1])).toBeGreaterThan(0);
+    });
+
+    it('runs the wrapper successfully even when the hook binary is missing', () => {
+      const hooksHome = path.join(tmpDir, 'hooks-missing-binary');
+      const wrapper = writeOtelHooksWrapper(
+        path.join(hooksHome, 'node_modules', '.bin', 'does-not-exist'),
+        hooksHome,
+      );
+
+      const result = spawnSync('bash', [wrapper, '--provider', 'claude-code'], {
+        encoding: 'utf8',
+      });
+
+      expect(result.status).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Closes #328.

## The bug

`har env launch` registers Claude Code hooks on session start, every prompt, before and after every tool call, and on stop — **six or more invocations per turn**. None of the generated entries carried a `timeout`, so with Mission Control not running each one waited out the agent's own default and the session appeared to hang before its first model request.

The symptom is indistinguishable from a broken model API: nothing is logged, the CLI just sits there, and the natural next move is to blame the network. It is especially unfair because the hooks are invisible — written into the user's home directory by a command that is nominally about worktrees.

## The fix

Bounded on both sides:

- `otel-hook setup` is now passed `--timeout-seconds`, so every generated hook entry carries an explicit ceiling the agent enforces.
- The wrapper caps the export (1500ms) and the flush (500ms), deliberately well inside that ceiling so the hook returns on its own rather than being killed.
- The wrapper always exits **0**. A non-zero hook exit can block a tool call, and a dropped telemetry event must never cost the user a turn.

`har telemetry status` warns when hooks are installed and the collector is unreachable, since that combination is pure cost.

## Measured, not assumed

A real Claude Code turn against a mocked model, with the sandbox collector pointed at a dead port:

| | Turn |
|---|---|
| before | **hung** — killed at the 120s timeout, no output |
| after (3000/1500ms) | 22.2s |
| after (1500/500ms) | **8.4s**, exit 0, correct result |

A local Mission Control answers in milliseconds, so the normal path is unchanged.

Verified on a real `har env launch` that all 11 generated hook events now carry `"timeout": 10`, with none missing.

## Cover

The tests pin the *properties*, not the constants, so tuning the budget later does not require rewriting them:

- both budgets must fit inside the per-hook ceiling;
- the wrapper must not use `exec` or `set -e` — either one leaks the child's exit status to the agent;
- running the wrapper with a missing hook binary must still exit 0 (this one is red without the fix: the old `set -euo pipefail` + `exec` returned 127).

## Provenance

Found while building the occupancy agent lab in #325 — that lab works around it by disabling telemetry inside its sandbox, which is what made the cause visible.

Worth a follow-up: the same audit for the Cursor and Codex hook shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)