### PR TITLE
feat: represent externally-owned worktrees

### DIFF
--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -1,5 +1,18 @@
 import { z } from 'zod';
 
+/**
+ * How a slot got the checkout it runs in.
+ *
+ * - `worktree` — HAR created a session worktree for this launch and owns it.
+ * - `root`     — HAR runs in the main checkout (`--no-worktree`).
+ * - `external` — HAR runs inside a linked worktree that something else created
+ *                (an external orchestrator, a hand-rolled `git worktree add`).
+ *                HAR does **not** own it and must never remove it.
+ */
+export const HAR_SLOT_MODES = ['worktree', 'root', 'external'] as const;
+
+export type HarSlotMode = (typeof HAR_SLOT_MODES)[number];
+
 export const HAR_STAGE_KINDS = [
   'setup',
   'launch',
@@ -382,10 +395,14 @@ export const SlotRegistryEntrySchema = z
     version: z.number().int().default(1),
     agentId: z.number().int().min(HAR_AGENT_SLOT_MIN),
     projectName: z.string(),
-    mode: z.enum(['worktree', 'root']),
+    mode: z.enum(HAR_SLOT_MODES),
     /** Where edits/builds happen: worktree + monorepo prefix, or the repo root. */
     workDir: z.string(),
-    /** Git checkout root of the session worktree (absent in root mode). */
+    /**
+     * Git checkout root of the worktree the session runs in.
+     * Absent in root mode; in external mode this is the externally-owned
+     * checkout, which teardown must not remove.
+     */
     worktreePath: z.string().optional(),
     /** Session branch: <base-branch>-<sha4>-har-agent-<id>-<rand4>. */
     branch: z.string().optional(),
@@ -393,7 +410,7 @@ export const SlotRegistryEntrySchema = z
     baseBranch: z.string().optional(),
     /** HEAD sha at launch time. */
     baseCommit: z.string().optional(),
-    /** Random per-session chars; absent in root mode. */
+    /** Random per-session chars; a short base-commit tag in root/external mode. */
     suffix: z.string().optional(),
     createdAt: z.string(),
     ports: z.record(z.number()).optional(),
@@ -456,7 +473,7 @@ export const AgentSlotStatusSchema = z.object({
   lastRunAt: z.string().optional(),
   lastVerifyStatus: HarnessStageRunStatusSchema.optional(),
   lastBuildPass: z.boolean().optional(),
-  mode: z.enum(['worktree', 'root']).optional(),
+  mode: z.enum(HAR_SLOT_MODES).optional(),
   suffix: z.string().optional(),
   baseBranch: z.string().optional(),
   baseCommit: z.string().optional(),

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -2,7 +2,11 @@ import { parseVerificationResult } from './results';
 import * as crypto from 'crypto';
 import { localScriptExecutor } from './local-executor';
 import { createRun, finishRun, resolveAgentWorkDir } from './runs';
-import { listSlotRegistryEntries, readSlotRegistry } from './slot-registry';
+import {
+  listSlotRegistryEntries,
+  readSlotRegistry,
+  resolveSlotRegistryContext,
+} from './slot-registry';
 import { checkLaunchGuard } from './slot-launch-guard';
 import { formatPreflightReport, inspectSlotReadiness } from './slot-preflight';
 import {
@@ -94,7 +98,7 @@ export class RunService {
   async runStage(options: StageRunOptions & { trigger?: ExecutionContext['trigger'] }): Promise<StageResult> {
     const activeSession =
       options.agentId !== undefined && options.kind !== 'launch'
-        ? readSlotRegistry(resolveHarnessRoot(options.repoPath), options.agentId)
+        ? resolveSlotRegistryContext(options.repoPath, options.agentId)?.session
         : undefined;
     const ctx: ExecutionContext = {
       repoPath: options.repoPath,
@@ -383,8 +387,9 @@ export class RunService {
 
     if (verification) {
       try {
-        const harnessRoot = resolveHarnessRoot(options.repoPath);
-        const session = readSlotRegistry(harnessRoot, options.agentId);
+        const registry = resolveSlotRegistryContext(options.repoPath, options.agentId);
+        const harnessRoot = registry?.harnessRoot ?? resolveHarnessRoot(options.repoPath);
+        const session = registry?.session;
         const checkoutDir = resolveValidationCheckoutDir({
           worktreePath: session?.worktreePath,
           workDir: resolveAgentWorkDir(harnessRoot, options.agentId),
@@ -438,8 +443,9 @@ export class RunService {
   }): Promise<EnvironmentRunResult> {
     // Captured before teardown clears the slot registry — the attempt binding
     // is gone afterwards.
-    const harnessRoot = resolveHarnessRoot(options.repoPath);
-    const session = readSlotRegistry(harnessRoot, options.agentId);
+    const registry = resolveSlotRegistryContext(options.repoPath, options.agentId);
+    const harnessRoot = registry?.harnessRoot ?? resolveHarnessRoot(options.repoPath);
+    const session = registry?.session;
 
     const result = await this.runStage({
       repoPath: options.repoPath,
@@ -487,15 +493,15 @@ export class RunService {
     capture?: boolean;
     trigger?: ExecutionContext['trigger'];
   }): Promise<EnvironmentRunResult & { verification?: VerificationResult | null }> {
-    const harnessRoot = resolveHarnessRoot(options.repoPath);
-    const session = readSlotRegistry(harnessRoot, options.agentId);
-    if (!session) {
+    const registry = resolveSlotRegistryContext(options.repoPath, options.agentId);
+    if (!registry) {
       return {
         code: 1,
         stdout: '',
         stderr: `No active session for agent ${options.agentId}. Run launch first.`,
       };
     }
+    const { harnessRoot, session } = registry;
 
     const runVerify = shouldReverifyOnComplete(options);
     let verification: VerificationResult | null | undefined;

--- a/src/core/slot-registry.ts
+++ b/src/core/slot-registry.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { getHarnessDir } from '../harness/manifest';
-import { SlotRegistryEntry, SlotRegistryEntrySchema } from '../harness/schema';
+import { HarSlotMode, SlotRegistryEntry, SlotRegistryEntrySchema } from '../harness/schema';
 import { notifyControlSync } from './control-notify';
 
 export function getSlotRegistryDir(repoPath: string): string {
@@ -36,7 +36,7 @@ export function readSlotRegistry(
 export interface SlotRegistryWriteInput {
   agentId: number;
   projectName: string;
-  mode: 'worktree' | 'root';
+  mode: HarSlotMode;
   workDir: string;
   status?: 'starting' | 'active' | 'failed' | 'completed';
   suffix?: string;

--- a/src/core/slot-registry.ts
+++ b/src/core/slot-registry.ts
@@ -1,8 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { getHarnessDir } from '../harness/manifest';
+import { getHarnessDir, resolveHarnessRoot } from '../harness/manifest';
 import { HarSlotMode, SlotRegistryEntry, SlotRegistryEntrySchema } from '../harness/schema';
+import { canonicalizeControlRepoPath } from './control-repo-path';
 import { notifyControlSync } from './control-notify';
+
+export interface SlotRegistryContext {
+  harnessRoot: string;
+  session: SlotRegistryEntry;
+}
 
 export function getSlotRegistryDir(repoPath: string): string {
   return path.join(getHarnessDir(repoPath), 'slots');
@@ -15,6 +21,40 @@ export function getSlotRegistryPath(repoPath: string, agentId: number): string {
 /** Whether a partial launch can be resumed via --resume instead of tearing down first. */
 export function isSlotResumable(session: SlotRegistryEntry | undefined): boolean {
   return session?.status === 'failed' || session?.status === 'starting';
+}
+
+/**
+ * Resolve the harness root that owns a slot's registry entry.
+ * Session worktrees carry their own `.har/manifest.json`, so
+ * `resolveHarnessRoot(cwd)` may point at the worktree while the slot file
+ * lives under the main checkout — mirror teardown's cwd tolerance.
+ */
+export function resolveSlotRegistryContext(
+  repoPath: string,
+  agentId: number,
+): SlotRegistryContext | undefined {
+  const localHarnessRoot = resolveHarnessRoot(repoPath);
+  const localSession = readSlotRegistry(localHarnessRoot, agentId);
+  if (localSession) {
+    return { harnessRoot: localHarnessRoot, session: localSession };
+  }
+
+  const mainRepoPath = canonicalizeControlRepoPath(repoPath);
+  if (mainRepoPath === path.resolve(repoPath)) {
+    return undefined;
+  }
+
+  const mainHarnessRoot = resolveHarnessRoot(mainRepoPath);
+  if (mainHarnessRoot === localHarnessRoot) {
+    return undefined;
+  }
+
+  const mainSession = readSlotRegistry(mainHarnessRoot, agentId);
+  if (mainSession) {
+    return { harnessRoot: mainHarnessRoot, session: mainSession };
+  }
+
+  return undefined;
 }
 
 /** Read one slot's session entry; undefined when missing or invalid. */

--- a/src/core/slot-status.ts
+++ b/src/core/slot-status.ts
@@ -422,6 +422,9 @@ export function renderEnvironmentStatusText(status: EnvironmentStatus): string {
       lines.push(`  branch:      ${slot.branch}${drift.length ? ` [${drift.join(', ')}]` : ''}`);
     }
     if (slot.workDir) lines.push(`  work dir:    ${slot.workDir}`);
+    if (slot.mode === 'external') {
+      lines.push(`  worktree:    ${slot.worktreePath ?? slot.workDir} (externally owned — HAR will not remove it)`);
+    }
     if (slot.previewUrls && Object.keys(slot.previewUrls).length > 0) {
       lines.push(
         `  preview:     ${Object.entries(slot.previewUrls)

--- a/src/core/worktree-ownership.ts
+++ b/src/core/worktree-ownership.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import { run } from '../utils/shell';
+import { resolveMainWorkingTree } from './control-repo-path';
+
+/**
+ * Whether the checkout at `repoRoot` is a linked worktree HAR did not create.
+ *
+ * `--no-worktree` collapses two different situations: running in the main
+ * checkout, and running inside a worktree some external orchestrator created
+ * (Conductor, Cursor worktrees, a hand-rolled `git worktree add`, a cloud
+ * sandbox). They need different handling — most importantly, teardown may
+ * remove a worktree HAR created and must never remove one it did not (#254).
+ *
+ * Detection is deliberately tool-agnostic: a linked worktree is one whose
+ * top-level differs from the repository's main working tree. Nothing here
+ * matches on the name of the tool that created it.
+ */
+export function detectInPlaceSlotMode(repoRoot: string): 'root' | 'external' {
+  const resolved = path.resolve(repoRoot);
+
+  const toplevel = run('git rev-parse --show-toplevel', { cwd: resolved });
+  if (toplevel.code !== 0) return 'root';
+
+  const mainRoot = resolveMainWorkingTree(resolved);
+  if (!mainRoot) return 'root';
+
+  return path.resolve(toplevel.stdout.trim()) === path.resolve(mainRoot) ? 'root' : 'external';
+}
+
+/** Checkout root of the worktree `repoRoot` sits in, or '' when not a git tree. */
+export function resolveWorktreeRoot(repoRoot: string): string {
+  const toplevel = run('git rev-parse --show-toplevel', { cwd: path.resolve(repoRoot) });
+  return toplevel.code === 0 ? path.resolve(toplevel.stdout.trim()) : '';
+}

--- a/src/runtime/launch.ts
+++ b/src/runtime/launch.ts
@@ -1,11 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { readHarnessEnv } from '../harness/env';
+import { HarSlotMode } from '../harness/schema';
 import { getHarnessDir, readManifest, resolveHarnessRoot } from '../harness/manifest';
 import { harnessCapabilities, harnessUsesPm2 } from '../harness/capabilities';
 import { runLaunchPreflight } from '../core/slot-preflight';
 import { loadInfraState } from '../core/slot-ports';
 import { writeSlotRegistry } from '../core/slot-registry';
+import { detectInPlaceSlotMode, resolveWorktreeRoot } from '../core/worktree-ownership';
 import { defaultExec, ExecFn, LogFn, SleepFn, realSystemOps, SystemOps } from './exec';
 import {
   cloneAgentDatabase,
@@ -203,6 +205,7 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
     let suffix = '';
     let baseBranch = 'detached';
     let baseCommit = '';
+    let mode: HarSlotMode = useWorktree ? 'worktree' : 'root';
     if (useWorktree) {
       const created = createSessionWorktree({
         repoRoot,
@@ -222,11 +225,26 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
       });
       relPrefix = created.relPrefix;
     } else {
-      log('Using repo root (worktree disabled)');
       const head = exec('git', ['-C', repoRoot, 'rev-parse', '--abbrev-ref', 'HEAD']);
       baseBranch = head.code === 0 ? head.stdout.trim() : 'detached';
       const sha = exec('git', ['-C', repoRoot, 'rev-parse', 'HEAD']);
       baseCommit = sha.code === 0 ? sha.stdout.trim() : '';
+
+      // `--no-worktree` covers two different situations: the main checkout, and
+      // a linked worktree an external orchestrator created. Only the former is
+      // ours to tear down (#254).
+      mode = detectInPlaceSlotMode(repoRoot);
+      if (mode === 'external') {
+        worktreeDir = resolveWorktreeRoot(repoRoot) || repoRoot;
+        log(`Using externally-owned worktree at ${worktreeDir} (HAR will not remove it)`);
+      } else {
+        log('Using repo root (worktree disabled)');
+      }
+
+      // No random suffix is minted in place, so name the session after the
+      // commit it started from — otherwise the session key carries only an
+      // opaque timestamp (folded in from #257).
+      if (baseCommit) suffix = baseCommit.slice(0, 7);
     }
     seedGitExclude(repoRoot, options.git);
     if (pm === 'simulator') seedExtraExcludePattern(repoRoot, '.har/simulators', exec);
@@ -239,6 +257,7 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
       baseBranch,
       baseCommit,
       useWorktree,
+      mode,
       envFile: path.join(workDir, `.env.agent.${agentId}`),
     };
   }
@@ -293,7 +312,7 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
     writeSlotRegistry(repoRoot, {
       agentId,
       projectName,
-      mode: session.useWorktree ? 'worktree' : 'root',
+      mode: session.mode,
       workDir: session.workDir,
       suffix: session.suffix || undefined,
       worktreePath: session.worktreeDir || undefined,

--- a/src/runtime/teardown.ts
+++ b/src/runtime/teardown.ts
@@ -104,12 +104,16 @@ export async function teardownSession(options: TeardownSessionOptions): Promise<
     agentId,
     worktreePath,
     projectName,
+    mode: session?.mode,
     branch: branch || undefined,
     deleteBranch: options.deleteBranch,
     homeDir: options.homeDir,
     git: options.git,
   });
   if (removed.removedWorktree) out(`✓ Removed worktree: ${removed.removedWorktree}`);
+  if (removed.preservedWorktree) {
+    out(`✓ Kept externally-owned worktree: ${removed.preservedWorktree} (HAR did not create it)`);
+  }
   if (removed.deletedBranch) out(`✓ Deleted branch: ${removed.deletedBranch}`);
   if (removed.keptBranch) {
     out(`✓ Kept branch: ${removed.keptBranch} (push it or delete with: git branch -D ${removed.keptBranch})`);

--- a/src/runtime/worktree.ts
+++ b/src/runtime/worktree.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { HarSlotMode } from '../harness/schema';
 import { readSlotRegistry, isSlotResumable } from '../core/slot-registry';
 
 /**
@@ -177,6 +178,9 @@ export interface ResumedSession {
   baseBranch: string;
   baseCommit: string;
   useWorktree: boolean;
+  /** How this slot got its checkout — preserved so resume cannot downgrade
+   *  an externally-owned worktree to `root` and make it removable (#254). */
+  mode: HarSlotMode;
   envFile: string;
 }
 
@@ -232,6 +236,7 @@ export function resolveResumeSession(repoPath: string, agentId: number): ResumeR
       baseBranch: session?.baseBranch ?? '',
       baseCommit: session?.baseCommit ?? '',
       useWorktree: session?.mode === 'worktree',
+      mode: session?.mode ?? 'root',
       envFile,
     },
   };
@@ -253,6 +258,12 @@ export interface TeardownWorktreeOptions {
   agentId: number;
   /** From the slot registry; falls back to the legacy fixed path. */
   worktreePath?: string;
+  /**
+   * Slot mode from the registry. Only `worktree` is HAR-owned and removable.
+   * Undefined (registry missing/legacy) keeps the historical guess-and-remove
+   * behavior so orphan cleanup still works.
+   */
+  mode?: HarSlotMode;
   /** Legacy fallback path component (teardown.sh's HARNESS_PROJECT_NAME). */
   projectName?: string;
   branch?: string;
@@ -264,6 +275,8 @@ export interface TeardownWorktreeOptions {
 
 export interface TeardownWorktreeResult {
   removedWorktree?: string;
+  /** Set when a checkout was left alone because HAR does not own it (#254). */
+  preservedWorktree?: string;
   deletedBranch?: string;
   keptBranch?: string;
 }
@@ -282,6 +295,28 @@ export function removeSessionWorktree(options: TeardownWorktreeOptions): Teardow
   let worktreePath = options.worktreePath;
   if (!worktreePath && options.projectName) {
     worktreePath = path.join(homeDir, 'worktrees', `${options.projectName}-agent-${options.agentId}`);
+  }
+
+  // An externally-created worktree is a real linked worktree of this repo, so
+  // `git worktree remove` would happily succeed and take the orchestrator's
+  // workspace — and any uncommitted work in it — with it. HAR removes only what
+  // HAR created (#254). `root` has no session worktree to remove at all, so the
+  // legacy path guess must not be acted on either.
+  const owned = options.mode === undefined || options.mode === 'worktree';
+  if (!owned) {
+    if (worktreePath && fs.existsSync(worktreePath) && options.mode === 'external') {
+      result.preservedWorktree = worktreePath;
+    }
+    tryGit(git, ['worktree', 'prune'], options.repoRoot);
+    if (options.branch) {
+      if (options.deleteBranch) {
+        tryGit(git, ['branch', '-D', options.branch], options.repoRoot);
+        result.deletedBranch = options.branch;
+      } else {
+        result.keptBranch = options.branch;
+      }
+    }
+    return result;
   }
 
   if (worktreePath && fs.existsSync(worktreePath)) {

--- a/tests/complete-environment.test.ts
+++ b/tests/complete-environment.test.ts
@@ -186,4 +186,28 @@ describe('completeEnvironment (#324)', () => {
       treeHash: validation.treeHash,
     });
   });
+
+  it('finds the slot registry when cwd is a session worktree (#331)', async () => {
+    const main = initRepo();
+    const worktree = path.join(path.dirname(main), `${path.basename(main)}-wt`);
+    sh(main, `git worktree add -q -b session-branch "${worktree}"`);
+    writeActiveSlot(main, {
+      mode: 'worktree',
+      workDir: worktree,
+      worktreePath: worktree,
+    });
+    recordValidation({
+      checkoutDir: worktree,
+      harnessRoot: main,
+      status: 'pass',
+      full: true,
+      agentId: 1,
+    });
+
+    const result = await completeEnvironment({ repoPath: worktree, agentId: 1, capture: true });
+
+    expect(result.code).toBe(0);
+    expect(mockedPlan).not.toHaveBeenCalled();
+    expect(mockedTeardown).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/external-worktree.test.ts
+++ b/tests/external-worktree.test.ts
@@ -1,0 +1,177 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { removeSessionWorktree, resolveResumeSession } from '../src/runtime/worktree';
+import { detectInPlaceSlotMode, resolveWorktreeRoot } from '../src/core/worktree-ownership';
+
+const tmpDirs: string[] = [];
+
+function git(cwd: string, args: string): string {
+  return execSync(
+    `git -c user.email=har@example.com -c user.name=har -c commit.gpgsign=false ${args}`,
+    { cwd, encoding: 'utf8' },
+  ).trim();
+}
+
+function tmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+/** A repo plus a linked worktree standing in for an external orchestrator's. */
+function makeRepoWithExternalWorktree(): { repo: string; external: string } {
+  const repo = tmpDir('har-external-');
+  git(repo, 'init -q -b main');
+  fs.writeFileSync(path.join(repo, 'tracked.txt'), 'x\n');
+  git(repo, 'add tracked.txt');
+  git(repo, 'commit -qm init');
+
+  const external = path.join(tmpDir('har-external-ws-'), 'ext');
+  git(repo, `worktree add -q -b ext ${external}`);
+  return { repo, external };
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('detectInPlaceSlotMode', () => {
+  it('reports root for the main checkout', () => {
+    const { repo } = makeRepoWithExternalWorktree();
+    expect(detectInPlaceSlotMode(repo)).toBe('root');
+  });
+
+  it('reports external for a worktree HAR did not create', () => {
+    const { external } = makeRepoWithExternalWorktree();
+    expect(detectInPlaceSlotMode(external)).toBe('external');
+  });
+
+  it('reports root outside a git work tree', () => {
+    expect(detectInPlaceSlotMode(tmpDir('har-nogit-'))).toBe('root');
+  });
+
+  it('resolves the worktree checkout root', () => {
+    const { external } = makeRepoWithExternalWorktree();
+    expect(resolveWorktreeRoot(external)).toBe(fs.realpathSync(external));
+  });
+});
+
+describe('removeSessionWorktree ownership guard (#254)', () => {
+  it('never removes an externally-owned worktree', () => {
+    const { repo, external } = makeRepoWithExternalWorktree();
+    fs.writeFileSync(path.join(external, 'uncommitted.txt'), 'precious\n');
+
+    const result = removeSessionWorktree({
+      repoRoot: repo,
+      agentId: 1,
+      worktreePath: external,
+      mode: 'external',
+      branch: 'ext',
+    });
+
+    expect(fs.existsSync(external)).toBe(true);
+    expect(fs.existsSync(path.join(external, 'uncommitted.txt'))).toBe(true);
+    expect(result.removedWorktree).toBeUndefined();
+    expect(result.preservedWorktree).toBe(external);
+    // Branch handling is unchanged — kept by default.
+    expect(result.keptBranch).toBe('ext');
+  });
+
+  it('does not act on the legacy guessed path in root mode', () => {
+    const { repo } = makeRepoWithExternalWorktree();
+    const home = tmpDir('har-home-');
+    const guessed = path.join(home, 'worktrees', 'proj-agent-1');
+    fs.mkdirSync(guessed, { recursive: true });
+
+    const result = removeSessionWorktree({
+      repoRoot: repo,
+      agentId: 1,
+      projectName: 'proj',
+      mode: 'root',
+      homeDir: home,
+    });
+
+    expect(fs.existsSync(guessed)).toBe(true);
+    expect(result.removedWorktree).toBeUndefined();
+  });
+
+  it('still removes a worktree HAR created', () => {
+    const repo = tmpDir('har-owned-');
+    git(repo, 'init -q -b main');
+    fs.writeFileSync(path.join(repo, 'tracked.txt'), 'x\n');
+    git(repo, 'add tracked.txt');
+    git(repo, 'commit -qm init');
+    const owned = path.join(tmpDir('har-owned-wt-'), 'session');
+    git(repo, `worktree add -q -b session ${owned}`);
+
+    const result = removeSessionWorktree({
+      repoRoot: repo,
+      agentId: 1,
+      worktreePath: owned,
+      mode: 'worktree',
+      branch: 'session',
+    });
+
+    expect(fs.existsSync(owned)).toBe(false);
+    expect(result.removedWorktree).toBe(owned);
+  });
+
+  it('keeps legacy guess-and-remove when the registry has no mode', () => {
+    const repo = tmpDir('har-legacy-');
+    git(repo, 'init -q -b main');
+    fs.writeFileSync(path.join(repo, 'tracked.txt'), 'x\n');
+    git(repo, 'add tracked.txt');
+    git(repo, 'commit -qm init');
+    const home = tmpDir('har-legacy-home-');
+    const guessed = path.join(home, 'worktrees', 'proj-agent-1');
+    fs.mkdirSync(guessed, { recursive: true });
+
+    const result = removeSessionWorktree({
+      repoRoot: repo,
+      agentId: 1,
+      projectName: 'proj',
+      homeDir: home,
+    });
+
+    expect(result.removedWorktree).toBe(guessed);
+    expect(fs.existsSync(guessed)).toBe(false);
+  });
+});
+
+describe('resume preserves ownership (#254)', () => {
+  it('does not downgrade an external slot to root', () => {
+    const { external } = makeRepoWithExternalWorktree();
+    const harDir = path.join(external, '.har');
+    fs.mkdirSync(path.join(harDir, 'slots'), { recursive: true });
+    fs.writeFileSync(
+      path.join(harDir, 'manifest.json'),
+      JSON.stringify({ version: '1', generatorVersion: '0.1.0', profile: 'cli' }),
+    );
+    fs.writeFileSync(path.join(external, '.env.agent.1'), 'AGENT_ID=1\n');
+    fs.writeFileSync(
+      path.join(harDir, 'slots', 'agent-1.json'),
+      JSON.stringify({
+        version: 1,
+        agentId: 1,
+        projectName: 'p',
+        mode: 'external',
+        workDir: external,
+        worktreePath: external,
+        createdAt: new Date().toISOString(),
+        status: 'starting',
+      }),
+    );
+
+    const result = resolveResumeSession(external, 1);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.session.mode).toBe('external');
+      // A resumed external slot must stay non-owned, so teardown keeps it.
+      expect(result.session.useWorktree).toBe(false);
+    }
+  });
+});

--- a/tests/runtime-worktree.test.ts
+++ b/tests/runtime-worktree.test.ts
@@ -255,6 +255,7 @@ describe('resolveResumeSession', () => {
         baseBranch: 'main',
         baseCommit: 'deadbeef',
         useWorktree: true,
+        mode: 'worktree',
         envFile: path.join(repo, '.env.agent.1'),
       });
     }

--- a/tests/slot-registry-resolve.test.ts
+++ b/tests/slot-registry-resolve.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import {
+  getSlotRegistryPath,
+  resolveSlotRegistryContext,
+} from '../src/core/slot-registry';
+
+const FIXTURE = path.join(__dirname, 'fixtures/minimal-harness');
+
+function sh(cwd: string, command: string): string {
+  return execSync(command, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+}
+
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'har-slot-registry-'));
+  fs.cpSync(path.join(FIXTURE, '.har'), path.join(dir, '.har'), { recursive: true });
+  for (const name of ['runs', 'slots', 'work-units', 'work-attempts', 'validation-bindings']) {
+    fs.rmSync(path.join(dir, '.har', name), { recursive: true, force: true });
+  }
+  sh(dir, 'git init -q -b main');
+  sh(dir, 'git config user.email har@test.local');
+  sh(dir, 'git config user.name har');
+  fs.writeFileSync(path.join(dir, 'app.txt'), 'v1\n');
+  sh(dir, 'git add -A');
+  sh(dir, 'git commit -q -m init');
+  return dir;
+}
+
+function writeActiveSlot(
+  repoPath: string,
+  agentId: number,
+  extra: Record<string, unknown> = {},
+): void {
+  const file = getSlotRegistryPath(repoPath, agentId);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      agentId,
+      projectName: 'minimal',
+      mode: 'worktree',
+      workDir: repoPath,
+      worktreePath: repoPath,
+      branch: 'session-branch',
+      createdAt: new Date().toISOString(),
+      status: 'active',
+      ...extra,
+    }),
+  );
+}
+
+function addWorktree(main: string, branch = 'session-branch'): string {
+  const worktree = path.join(path.dirname(main), `${path.basename(main)}-wt`);
+  sh(main, `git worktree add -q "${worktree}" -b ${branch}`);
+  return worktree;
+}
+
+describe('resolveSlotRegistryContext (#331)', () => {
+  it('reads the registry from the main checkout when cwd is a session worktree', () => {
+    const main = initRepo();
+    const worktree = addWorktree(main);
+    writeActiveSlot(main, 2, { workDir: worktree, worktreePath: worktree });
+
+    const ctx = resolveSlotRegistryContext(worktree, 2);
+
+    expect(ctx).toBeDefined();
+    expect(ctx!.harnessRoot).toBe(path.resolve(main));
+    expect(ctx!.session.workDir).toBe(path.resolve(worktree));
+  });
+
+  it('prefers a registry colocated with cwd when present', () => {
+    const main = initRepo();
+    writeActiveSlot(main, 1);
+
+    const ctx = resolveSlotRegistryContext(main, 1);
+
+    expect(ctx).toEqual({
+      harnessRoot: path.resolve(main),
+      session: expect.objectContaining({ agentId: 1, status: 'active' }),
+    });
+  });
+
+  it('returns undefined when no registry exists on main or cwd', () => {
+    const main = initRepo();
+    const worktree = addWorktree(main);
+
+    expect(resolveSlotRegistryContext(worktree, 3)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #254. Part of #253.

## What

`--no-worktree` collapsed two different situations into `mode: root` — HAR running in the main checkout, and HAR running inside a linked worktree something else created (an external orchestrator, a hand-rolled `git worktree add`, a cloud sandbox). Adds a third slot mode, `external`.

Detection is tool-agnostic: it compares the checkout's top level against the repository's main working tree via git, so Warp, Conductor, Orca, deepseek-harness and anything else that produces a worktree are covered without HAR knowing their names.

## The ownership guard ships with the field

#254 asks for `worktreePath` to be populated in external mode. `removeSessionWorktree` removes whatever `worktreePath` points at, and an externally-created worktree is a real linked worktree — `git worktree remove` succeeds on it. Populating the field alone would let teardown delete the orchestrator's workspace and any uncommitted work in it.

To be precise about the counterfactual: **there is no data-loss bug on main today.** External worktrees survive teardown on main only incidentally, because root mode never records `worktreePath` and the fallback guess doesn't exist. The guard prevents a bug this change would otherwise introduce, which is why it is in the same commit rather than a follow-up.

`removeSessionWorktree` now removes only what HAR created. Root mode no longer acts on its legacy guessed path either. An absent mode (legacy or missing registry) keeps the historical guess-and-remove so orphan cleanup still works.

Resume carries `mode` rather than re-deriving a boolean, so a resumed external slot cannot be downgraded to `root` and become removable.

## Also

Folds in the residual from #257, closed as superseded by #316: in-place launches mint no random suffix, so the session is named after the commit it started from (`18a3845`) instead of carrying only an opaque timestamp.

## Verification

- `har env verify 1 --full` — 9/9 stages
- 9 new tests in `tests/external-worktree.test.ts`
- End-to-end: launched in an external worktree with uncommitted work, ran teardown, checkout and file intact, `✓ Kept externally-owned worktree`

## Note for reviewers

The issue's evidence cites `src/templates/har-boilerplate/launch.sh` and `agent-slot.sh`, both deleted in the 1.0 refactor. The live code is `src/runtime/launch.ts` and `src/core/slot-registry.ts`.
