### PR TITLE
fix: sync evidence written inside an external workspace

### DIFF
--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -31,6 +31,11 @@ import {
   updatePortalTargetTokens,
 } from './portal-targets';
 import { canonicalizeControlRepoPath } from './control-repo-path';
+import {
+  collectRunsForSync,
+  collectWorkUnitsForSync,
+  resolveSyncSourcePaths,
+} from './sync-sources';
 import { collectEnvironmentStatus } from './slot-status';
 import { listRuns } from './runs';
 import { listValidations } from './validations';
@@ -796,10 +801,10 @@ export async function ensureRepoRegisteredWithControl(
 }
 
 async function syncRepoWithLocalControl(
-  options: ControlSyncOptions & { repoPath: string },
+  options: ControlSyncOptions & { repoPath: string; workspacePath?: string },
 ): Promise<void> {
   const apiUrl = options.apiUrl ?? getControlApiUrl();
-  const { repoPath, dryRun, full } = options;
+  const { repoPath, workspacePath, dryRun, full } = options;
 
   const registerResult = await registerRepoWithControl({ ...options, repoPath });
   const repoId = registerResult?.id;
@@ -813,12 +818,12 @@ async function syncRepoWithLocalControl(
       // Unregistered / blocked — nothing to sync locally.
       return;
     }
-    await syncRepoRunsAndSlots(apiUrl, existing.id, repoPath, dryRun, full);
+    await syncRepoRunsAndSlots(apiUrl, existing.id, repoPath, workspacePath, dryRun, full);
     return;
   }
 
   if (repoId) {
-    await syncRepoRunsAndSlots(apiUrl, repoId, repoPath, dryRun, full);
+    await syncRepoRunsAndSlots(apiUrl, repoId, repoPath, workspacePath, dryRun, full);
   }
 }
 
@@ -964,6 +969,8 @@ async function syncTrajectoryWithPortal(
 export async function syncRepoWithControl(
   options: ControlSyncOptions,
 ): Promise<{ warnings: string[] }> {
+  // Identity is canonical; evidence may live in the workspace this ran in (#255).
+  const workspacePath = path.resolve(options.repoPath);
   const repoPath = canonicalizeControlRepoPath(options.repoPath);
   const apiUrl = options.apiUrl ?? getControlApiUrl();
 
@@ -972,8 +979,10 @@ export async function syncRepoWithControl(
     if (!remote) {
       throw new Error('HAR Cloud not configured (set HAR_CLOUD_API_URL and HAR_CLOUD_API_KEY)');
     }
-    const runs = listRuns(repoPath);
+    const sourcePaths = resolveSyncSourcePaths(repoPath, workspacePath);
+    const runs = collectRunsForSync(sourcePaths);
     const status = collectEnvironmentStatus(repoPath);
+    const cloudWork = collectWorkUnitsForSync(sourcePaths);
     const harnessRoot = resolveHarnessRoot(repoPath);
     const response = await fetch(`${process.env.HAR_CLOUD_API_URL}/api/sync`, {
       method: 'POST',
@@ -985,8 +994,8 @@ export async function syncRepoWithControl(
         path: repoPath,
         runs,
         slots: status.slots,
-        workUnits: listWorkUnits(harnessRoot),
-        attempts: listWorkAttempts(harnessRoot),
+        workUnits: cloudWork.workUnits,
+        attempts: cloudWork.attempts,
         validations: listValidations(harnessRoot),
         validationBindings: listValidationBindings(harnessRoot),
       }),
@@ -997,7 +1006,7 @@ export async function syncRepoWithControl(
     return { warnings: [] };
   }
 
-  await syncRepoWithLocalControl({ ...options, repoPath, apiUrl });
+  await syncRepoWithLocalControl({ ...options, repoPath, workspacePath, apiUrl });
 
   if (!isRepoPortalSyncEnabled(repoPath)) return { warnings: [] };
 
@@ -1032,13 +1041,15 @@ async function syncRepoRunsAndSlots(
   apiUrl: string,
   repoId: string,
   repoPath: string,
+  workspacePath?: string,
   dryRun?: boolean,
   full?: boolean,
 ): Promise<void> {
+  const sourcePaths = resolveSyncSourcePaths(repoPath, workspacePath);
   const runsTarget = runsWatermarkTarget(apiUrl);
   const stored = full ? null : readRunsWatermarkEntry(repoPath, runsTarget);
   const runsSince = rewindSince(stored?.repoId === repoId ? (stored?.lastSyncedAt ?? null) : null);
-  const runs = listRuns(repoPath);
+  const runs = collectRunsForSync(sourcePaths);
   const { selected: newRuns } = selectSince(runs, runsSince, runTimestamp);
 
   await syncRunBatches(newRuns, repoPath, runsTarget, () => repoId, dryRun, async (batch) => {
@@ -1052,10 +1063,7 @@ async function syncRepoRunsAndSlots(
   });
   await postJson(`${apiUrl}/api/repos/${repoId}/slots`, slotsBody, dryRun);
 
-  const workUnitsBody = SyncWorkUnitsInputSchema.parse({
-    workUnits: listWorkUnits(resolveHarnessRoot(repoPath)),
-    attempts: listWorkAttempts(resolveHarnessRoot(repoPath)),
-  });
+  const workUnitsBody = SyncWorkUnitsInputSchema.parse(collectWorkUnitsForSync(sourcePaths));
   if (workUnitsBody.workUnits.length > 0 || workUnitsBody.attempts.length > 0) {
     await postJson(`${apiUrl}/api/repos/${repoId}/work-units`, workUnitsBody, dryRun);
   }

--- a/src/core/control-sync.ts
+++ b/src/core/control-sync.ts
@@ -32,17 +32,20 @@ import {
 } from './portal-targets';
 import { canonicalizeControlRepoPath } from './control-repo-path';
 import {
+  collectRunsBySource,
   collectRunsForSync,
+  mergeRunsBySource,
+  RunsBySource,
+  collectValidationBindingsForSync,
+  collectValidationsForSync,
   collectWorkUnitsForSync,
   resolveSyncSourcePaths,
+  selectRunsForSync,
 } from './sync-sources';
 import { collectEnvironmentStatus } from './slot-status';
-import { listRuns } from './runs';
 import { listValidations } from './validations';
 import {
   listValidationBindings,
-  listWorkAttempts,
-  listWorkUnits,
 } from './work-units';
 import { createRemoteExecutor } from './cloud-executor';
 import { isTelemetryEnabled } from './telemetry-config';
@@ -58,6 +61,7 @@ import { enrichUsageWithPricing } from '../harness/schema';
 import {
   readPortalWatermark,
   writePortalWatermark,
+  coveredSources,
   readRunsWatermarkEntry,
   writeRunsWatermark,
   selectSince,
@@ -194,6 +198,7 @@ async function syncRunBatches(
   getRepoId: () => string | undefined,
   dryRun: boolean | undefined,
   send: (batch: RunRecord[], index: number) => Promise<void>,
+  sources?: string[],
 ): Promise<void> {
   const ordered = [...newRuns].sort((a, b) => runTimestamp(a).localeCompare(runTimestamp(b)));
   const batches = chunkBySerializedSize(ordered, maxSyncBatchBytes());
@@ -202,7 +207,13 @@ async function syncRunBatches(
     const batch = toSend[i];
     await send(batch, i);
     if (!dryRun && batch.length > 0) {
-      writeRunsWatermark(repoPath, runsTarget, getRepoId(), runTimestamp(batch[batch.length - 1]));
+      writeRunsWatermark(
+        repoPath,
+        runsTarget,
+        getRepoId(),
+        runTimestamp(batch[batch.length - 1]),
+        sources,
+      );
     }
   }
 }
@@ -501,6 +512,7 @@ async function collectPortalTelemetry(
 
 async function buildPortalPayload(
   repoPath: string,
+  sourcePaths: string[],
   controlApiUrl: string,
   since: string | null,
   full = false,
@@ -508,20 +520,21 @@ async function buildPortalPayload(
 ): Promise<{
   syncBody: Record<string, unknown>;
   runs: RunRecord[];
+  runsBySource: RunsBySource[];
   events: Record<string, unknown>[];
   maxSyncedAt: string | null;
   failures: ChannelReadFailure[];
   truncated: string[];
 }> {
-  const runs = listRuns(repoPath);
+  // Same canonical-identity / workspace-evidence split as the local path (#255).
+  const rawRunsBySource = collectRunsBySource(sourcePaths);
+  const runs = mergeRunsBySource(rawRunsBySource);
   const status = collectEnvironmentStatus(repoPath);
   const manifest = readManifest(repoPath);
   const stagesRegistry = readStageRegistry(repoPath);
-  const harnessRoot = resolveHarnessRoot(repoPath);
-  const validations = listValidations(harnessRoot);
-  const workUnits = listWorkUnits(harnessRoot);
-  const attempts = listWorkAttempts(harnessRoot);
-  const validationBindings = listValidationBindings(harnessRoot);
+  const validations = collectValidationsForSync(sourcePaths);
+  const { workUnits, attempts } = collectWorkUnitsForSync(sourcePaths);
+  const validationBindings = collectValidationBindingsForSync(sourcePaths);
   // Attribute runs/validations to the syncing member so the portal can resolve
   // a real user FK instead of the lossy (repo, agentId) derivation.
   const userEmail = resolvePortalUserEmail(portal);
@@ -568,11 +581,22 @@ async function buildPortalPayload(
     ...(usage.length > 0 ? { usage } : {}),
   };
 
-  const runsPayload = userEmail
-    ? runs.map((run) => ({ ...run, userEmail }))
-    : runs;
+  const runsBySource = userEmail
+    ? rawRunsBySource.map(({ source, runs: sourceRuns }) => ({
+        source,
+        runs: sourceRuns.map((run) => ({ ...run, userEmail })),
+      }))
+    : rawRunsBySource;
 
-  return { syncBody, runs: runsPayload, events, maxSyncedAt, failures, truncated };
+  return {
+    syncBody,
+    runs: mergeRunsBySource(runsBySource),
+    runsBySource,
+    events,
+    maxSyncedAt,
+    failures,
+    truncated,
+  };
 }
 
 export async function isControlApiReachable(apiUrl = getControlApiUrl()): Promise<boolean> {
@@ -828,13 +852,14 @@ async function syncRepoWithLocalControl(
 }
 
 async function syncRepoWithPortal(
-  options: ControlSyncOptions & { repoPath: string },
+  options: ControlSyncOptions & { repoPath: string; workspacePath?: string },
   controlApiUrl: string,
   portal: PortalTarget,
 ): Promise<string[]> {
   if (!isRepoPortalSyncEnabled(options.repoPath)) return [];
 
-  const { repoPath, dryRun, full } = options;
+  const { repoPath, workspacePath, dryRun, full } = options;
+  const sourcePaths = resolveSyncSourcePaths(repoPath, workspacePath);
   const watermarkKey = watermarkKeyForTarget(portal);
   const since = full ? null : readPortalWatermarkForTarget(repoPath, portal);
 
@@ -847,27 +872,43 @@ async function syncRepoWithPortal(
     }
   }
   const runsSince = rewindSince(stored?.lastSyncedAt ?? null);
-  const { syncBody, runs, events, maxSyncedAt, failures, truncated } = await buildPortalPayload(
-    repoPath,
-    controlApiUrl,
-    since,
-    full,
-    portal,
+  const { syncBody, runsBySource, events, maxSyncedAt, failures, truncated } =
+    await buildPortalPayload(repoPath, sourcePaths, controlApiUrl, since, full, portal);
+  const newRuns = selectRunsForSync(
+    runsBySource,
+    runsSince,
+    coveredSources(repoPath, stored),
+    (rows, rowsSince) => selectSince(rows, rowsSince, runTimestamp).selected,
   );
-  const { selected: newRuns } = selectSince(runs, runsSince, runTimestamp);
 
   let repoId: string | undefined;
   const deltaRepoId = () => stored?.repoId ?? repoId;
-  await syncRunBatches(newRuns, repoPath, runsTarget, deltaRepoId, dryRun, async (batch, i) => {
-    const body = i === 0 ? { ...syncBody, runs: batch } : { path: repoPath, runs: batch };
-    const res = await postPortal(portal, '/api/sync', body, dryRun);
-    if (i === 0 && typeof res?.repositoryId === 'string') repoId = res.repositoryId;
-  });
+  await syncRunBatches(
+    newRuns,
+    repoPath,
+    runsTarget,
+    deltaRepoId,
+    dryRun,
+    async (batch, i) => {
+      const body = i === 0 ? { ...syncBody, runs: batch } : { path: repoPath, runs: batch };
+      const res = await postPortal(portal, '/api/sync', body, dryRun);
+      if (i === 0 && typeof res?.repositoryId === 'string') repoId = res.repositoryId;
+    },
+    sourcePaths,
+  );
 
   if (!full && !dryRun && stored?.repoId && repoId && stored.repoId !== repoId) {
-    await syncRunBatches(listRuns(repoPath), repoPath, runsTarget, () => repoId, dryRun, async (batch) => {
-      await postPortal(portal, '/api/sync', { path: repoPath, runs: batch }, dryRun);
-    });
+    await syncRunBatches(
+      mergeRunsBySource(runsBySource),
+      repoPath,
+      runsTarget,
+      () => repoId,
+      dryRun,
+      async (batch) => {
+        await postPortal(portal, '/api/sync', { path: repoPath, runs: batch }, dryRun);
+      },
+      sourcePaths,
+    );
   }
 
   for (const batch of chunkBySerializedSize(events, maxSyncBatchBytes())) {
@@ -1020,7 +1061,9 @@ export async function syncRepoWithControl(
   const failures: Array<{ alias: string; error: string }> = [];
   for (const portal of resolved.targets) {
     try {
-      warnings.push(...(await syncRepoWithPortal({ ...options, repoPath }, apiUrl, portal)));
+      warnings.push(
+        ...(await syncRepoWithPortal({ ...options, repoPath, workspacePath }, apiUrl, portal)),
+      );
     } catch (err: unknown) {
       failures.push({
         alias: portal.alias ?? portal.identityKey,
@@ -1049,12 +1092,24 @@ async function syncRepoRunsAndSlots(
   const runsTarget = runsWatermarkTarget(apiUrl);
   const stored = full ? null : readRunsWatermarkEntry(repoPath, runsTarget);
   const runsSince = rewindSince(stored?.repoId === repoId ? (stored?.lastSyncedAt ?? null) : null);
-  const runs = collectRunsForSync(sourcePaths);
-  const { selected: newRuns } = selectSince(runs, runsSince, runTimestamp);
+  const newRuns = selectRunsForSync(
+    collectRunsBySource(sourcePaths),
+    runsSince,
+    coveredSources(repoPath, stored),
+    (rows, since) => selectSince(rows, since, runTimestamp).selected,
+  );
 
-  await syncRunBatches(newRuns, repoPath, runsTarget, () => repoId, dryRun, async (batch) => {
-    await postJson(`${apiUrl}/api/repos/${repoId}/runs`, SyncRunsInputSchema.parse({ runs: batch }), dryRun);
-  });
+  await syncRunBatches(
+    newRuns,
+    repoPath,
+    runsTarget,
+    () => repoId,
+    dryRun,
+    async (batch) => {
+      await postJson(`${apiUrl}/api/repos/${repoId}/runs`, SyncRunsInputSchema.parse({ runs: batch }), dryRun);
+    },
+    sourcePaths,
+  );
 
   const status: EnvironmentStatus = collectEnvironmentStatus(repoPath);
   const slotsBody = SyncSlotsInputSchema.parse({

--- a/src/core/portal-watermark.ts
+++ b/src/core/portal-watermark.ts
@@ -9,11 +9,19 @@ interface PortalSyncStateEntry {
   lastSyncedAt: string;
   /** Server repo id at last sync; a change means the repo was wiped/recreated. */
   repoId?: string;
+  /**
+   * Source roots this watermark was advanced over (#255). A source missing here
+   * has never been synced to this target, so its records must not be filtered
+   * by a timestamp it never contributed to. Absent on legacy entries, which
+   * predate multi-source reads and cover the canonical path only.
+   */
+  sources?: string[];
 }
 
 export interface RunsWatermark {
   lastSyncedAt: string;
   repoId?: string;
+  sources?: string[];
 }
 
 interface PortalSyncState {
@@ -80,7 +88,9 @@ export function readRunsWatermarkEntry(repoPath: string, target: string): RunsWa
   const entry = readState().states.find(
     (state) => state.repoPath === canonical && state.portalUrl === target,
   );
-  return entry ? { lastSyncedAt: entry.lastSyncedAt, repoId: entry.repoId } : null;
+  return entry
+    ? { lastSyncedAt: entry.lastSyncedAt, repoId: entry.repoId, sources: entry.sources }
+    : null;
 }
 
 export function writeRunsWatermark(
@@ -88,19 +98,35 @@ export function writeRunsWatermark(
   target: string,
   repoId: string | undefined,
   lastSyncedAt: string,
+  sources?: string[],
 ): void {
   const canonical = canonicalizeControlRepoPath(repoPath);
   const state = readState();
   const existing = state.states.find(
     (entry) => entry.repoPath === canonical && entry.portalUrl === target,
   );
+  const merged = sources
+    ? [...new Set([...(existing?.sources ?? [canonical]), ...sources.map((s) => path.resolve(s))])]
+    : existing?.sources;
   if (existing) {
     existing.lastSyncedAt = lastSyncedAt;
     existing.repoId = repoId;
+    if (merged) existing.sources = merged;
   } else {
-    state.states.push({ repoPath: canonical, portalUrl: target, lastSyncedAt, repoId });
+    state.states.push({
+      repoPath: canonical,
+      portalUrl: target,
+      lastSyncedAt,
+      repoId,
+      ...(merged ? { sources: merged } : {}),
+    });
   }
   writeState(state);
+}
+
+/** Source roots a watermark already covers; legacy entries cover canonical only. */
+export function coveredSources(repoPath: string, entry: RunsWatermark | null): string[] {
+  return entry?.sources ?? [canonicalizeControlRepoPath(repoPath)];
 }
 
 /**

--- a/src/core/sync-sources.ts
+++ b/src/core/sync-sources.ts
@@ -1,8 +1,15 @@
 import * as path from 'path';
 import { resolveHarnessRoot } from '../harness/manifest';
-import { RunRecord, WorkAttemptRecord, WorkUnitRecord } from '../harness/schema';
+import {
+  RunRecord,
+  ValidationBindingRecord,
+  ValidationRecord,
+  WorkAttemptRecord,
+  WorkUnitRecord,
+} from '../harness/schema';
 import { listRuns } from './runs';
-import { listWorkAttempts, listWorkUnits } from './work-units';
+import { listValidations } from './validations';
+import { listValidationBindings, listWorkAttempts, listWorkUnits } from './work-units';
 
 /**
  * Where one sync reads its on-disk evidence from (#255).
@@ -52,10 +59,7 @@ function mergeById<T>(groups: T[][], id: (item: T) => string): T[] {
 
 /** Runs across every source, newest first (matching listRuns' ordering). */
 export function collectRunsForSync(sourcePaths: string[]): RunRecord[] {
-  return mergeById(
-    sourcePaths.map((source) => listRuns(source)),
-    (run) => run.runId,
-  ).sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  return mergeRunsBySource(collectRunsBySource(sourcePaths));
 }
 
 /** Work units and attempts across every source, newest first. */
@@ -74,4 +78,64 @@ export function collectWorkUnitsForSync(sourcePaths: string[]): {
       (attempt) => attempt.attemptId,
     ).sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
   };
+}
+
+/** Runs kept per source, so a source new to a watermark can skip its filter. */
+export interface RunsBySource {
+  source: string;
+  runs: RunRecord[];
+}
+
+export function collectRunsBySource(sourcePaths: string[]): RunsBySource[] {
+  return sourcePaths.map((source) => ({ source, runs: listRuns(source) }));
+}
+
+/** Flatten per-source groups into the deduped, newest-first list. */
+export function mergeRunsBySource(bySource: RunsBySource[]): RunRecord[] {
+  return mergeById(
+    bySource.map((group) => group.runs),
+    (run) => run.runId,
+  ).sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+}
+
+/**
+ * Runs to send, given what a watermark has already covered.
+ *
+ * A watermark records which sources it was advanced over. A source absent from
+ * that list has never been synced to this target, so filtering its records by a
+ * timestamp it never contributed to would strand them permanently — send all of
+ * them once, and let the watermark cover it from then on. Legacy watermarks
+ * carry no source list and are treated as covering the canonical path only.
+ */
+export function selectRunsForSync(
+  bySource: RunsBySource[],
+  since: string | null,
+  coveredSources: string[],
+  selectSince: (runs: RunRecord[], since: string | null) => RunRecord[],
+): RunRecord[] {
+  const covered = new Set(coveredSources.map((source) => path.resolve(source)));
+  const groups = bySource.map(({ source, runs }) =>
+    covered.has(path.resolve(source)) ? selectSince(runs, since) : runs,
+  );
+  return mergeById(groups, (run) => run.runId).sort((a, b) =>
+    b.startedAt.localeCompare(a.startedAt),
+  );
+}
+
+/** Validations across every source. */
+export function collectValidationsForSync(sourcePaths: string[]): ValidationRecord[] {
+  return mergeById(
+    sourcePaths.map((source) => listValidations(resolveHarnessRoot(source))),
+    (record) => record.validationId,
+  );
+}
+
+/** Validation bindings across every source. */
+export function collectValidationBindingsForSync(
+  sourcePaths: string[],
+): ValidationBindingRecord[] {
+  return mergeById(
+    sourcePaths.map((source) => listValidationBindings(resolveHarnessRoot(source))),
+    (record) => record.bindingId,
+  );
 }

--- a/src/core/sync-sources.ts
+++ b/src/core/sync-sources.ts
@@ -1,0 +1,77 @@
+import * as path from 'path';
+import { resolveHarnessRoot } from '../harness/manifest';
+import { RunRecord, WorkAttemptRecord, WorkUnitRecord } from '../harness/schema';
+import { listRuns } from './runs';
+import { listWorkAttempts, listWorkUnits } from './work-units';
+
+/**
+ * Where one sync reads its on-disk evidence from (#255).
+ *
+ * Repository *identity* is canonical: every worktree of a repo maps to the main
+ * checkout, so Mission Control keeps one repository row instead of one per
+ * worktree. That canonicalization is deliberate and stays.
+ *
+ * Its side effect was that evidence written somewhere else was never read. HAR
+ * writes run records for its own session worktrees into the main checkout, so
+ * canonical is the right source there. But an in-place launch inside a worktree
+ * HAR did not create resolves its harness root to that workspace and writes
+ * everything there — records that canonical-only reads never see.
+ *
+ * Reading the union of both covers each case without choosing between them: for
+ * a HAR-owned worktree the workspace holds no records and the union is exactly
+ * what canonical already returned.
+ */
+export function resolveSyncSourcePaths(canonicalPath: string, workspacePath?: string): string[] {
+  const canonical = path.resolve(canonicalPath);
+  if (!workspacePath) return [canonical];
+
+  const workspace = path.resolve(workspacePath);
+  if (workspace === canonical) return [canonical];
+
+  // Distinct harness roots only — a subdirectory of the same checkout resolves
+  // to the same `.har` and would just duplicate every read.
+  const canonicalRoot = resolveHarnessRoot(canonical);
+  const workspaceRoot = resolveHarnessRoot(workspace);
+  if (path.resolve(canonicalRoot) === path.resolve(workspaceRoot)) return [canonical];
+
+  // Canonical first: it wins any id collision.
+  return [canonical, workspace];
+}
+
+/** Merge per-source lists, first occurrence of an id winning. */
+function mergeById<T>(groups: T[][], id: (item: T) => string): T[] {
+  const seen = new Map<string, T>();
+  for (const group of groups) {
+    for (const item of group) {
+      const key = id(item);
+      if (!seen.has(key)) seen.set(key, item);
+    }
+  }
+  return [...seen.values()];
+}
+
+/** Runs across every source, newest first (matching listRuns' ordering). */
+export function collectRunsForSync(sourcePaths: string[]): RunRecord[] {
+  return mergeById(
+    sourcePaths.map((source) => listRuns(source)),
+    (run) => run.runId,
+  ).sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+}
+
+/** Work units and attempts across every source, newest first. */
+export function collectWorkUnitsForSync(sourcePaths: string[]): {
+  workUnits: WorkUnitRecord[];
+  attempts: WorkAttemptRecord[];
+} {
+  const roots = sourcePaths.map((source) => resolveHarnessRoot(source));
+  return {
+    workUnits: mergeById(
+      roots.map((root) => listWorkUnits(root)),
+      (unit) => unit.workUnitId,
+    ).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    attempts: mergeById(
+      roots.map((root) => listWorkAttempts(root)),
+      (attempt) => attempt.attemptId,
+    ).sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
+  };
+}

--- a/tests/sync-external-workspace-portal.test.ts
+++ b/tests/sync-external-workspace-portal.test.ts
@@ -1,0 +1,184 @@
+// #255 (portal): the har-portal path had the same canonical-only read gap as
+// local Mission Control — evidence written inside an externally-owned workspace
+// never reached it. Identity must stay canonical; evidence must be the union.
+const canonicalFor = new Map<string, string>();
+
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => canonicalFor.get(p) ?? p,
+}));
+jest.mock('../src/core/control-registry', () => ({
+  isRepoPortalSyncEnabled: () => true,
+  recordRepoForControlSync: () => undefined,
+  removeRegisteredRepo: () => undefined,
+  listRegisteredRepos: () => [],
+}));
+jest.mock('../src/core/telemetry-config', () => ({
+  isTelemetryEnabled: () => false,
+  isPortalTrajectoryEnabled: () => false,
+  readTelemetryPreference: () => ({ enabled: false, signals: {}, portalTrajectory: false }),
+  getTelemetrySignals: () => ({ prompts: false }),
+}));
+jest.mock('../src/core/slot-status', () => ({
+  collectEnvironmentStatus: () => ({ slots: [], generatedAt: '2026-01-01T00:00:00.000Z' }),
+}));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { syncRepoWithControl } from '../src/core/control-sync';
+
+const realFetch = global.fetch;
+const tmpDirs: string[] = [];
+const statePath = path.join(os.tmpdir(), `har-portal-ext-state-${process.pid}.json`);
+
+function tmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeHarness(prefix: string): string {
+  const repo = tmpDir(prefix);
+  fs.mkdirSync(path.join(repo, '.har'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repo, '.har', 'manifest.json'),
+    JSON.stringify({ version: '1', generatorVersion: '0.1.0', profile: 'cli' }),
+  );
+  fs.writeFileSync(
+    path.join(repo, '.har', 'stages.json'),
+    JSON.stringify({
+      version: '1',
+      artifactsDir: 'artifacts',
+      logsDir: 'logs',
+      agentSlots: { min: 1, max: 3 },
+      verificationStages: [],
+      stages: [],
+    }),
+  );
+  return repo;
+}
+
+function writeWorkUnit(repo: string, workUnitId: string): void {
+  const dir = path.join(repo, '.har', 'work-units');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = '2026-08-31T11:00:00.000Z';
+  fs.writeFileSync(
+    path.join(dir, `${workUnitId}.json`),
+    JSON.stringify({ version: 1, workUnitId, createdAt: now, updatedAt: now }),
+  );
+}
+
+function writeRun(repo: string, runId: string, startedAt: string): void {
+  const dir = path.join(repo, '.har', 'runs', '2026-08-31');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${runId}.json`),
+    JSON.stringify({
+      version: 1,
+      runId,
+      repoPath: repo,
+      stageId: 'verify',
+      status: 'pass',
+      startedAt,
+      finishedAt: startedAt,
+      exitCode: 0,
+    }),
+  );
+}
+
+type Captured = { url: string; body: Record<string, unknown> };
+
+function mockFetch(captured: Captured[]): void {
+  (global as unknown as { fetch: unknown }).fetch = jest.fn(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    captured.push({ url: String(url), body });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'repo-1', repositoryId: 'repo-1' }),
+      text: async () => '',
+    } as unknown as Response;
+  });
+}
+
+beforeEach(() => {
+  process.env.HAR_PORTAL_URL = 'https://portal.example.com';
+  process.env.HAR_PORTAL_TOKEN = 'har_ingest_test';
+  process.env.HAR_PORTAL_SYNC_STATE_PATH = statePath;
+  fs.rmSync(statePath, { force: true });
+});
+
+afterEach(() => {
+  (global as unknown as { fetch: unknown }).fetch = realFetch;
+  delete process.env.HAR_PORTAL_URL;
+  delete process.env.HAR_PORTAL_TOKEN;
+  delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+  fs.rmSync(statePath, { force: true });
+  canonicalFor.clear();
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function portalSync(captured: Captured[]): Captured | undefined {
+  return captured.find((c) => c.url.includes('portal.example.com') && c.url.endsWith('/api/sync'));
+}
+
+describe('portal sync from an externally-owned workspace (#255)', () => {
+  it('sends workspace work-units and runs to the portal, under the canonical path', async () => {
+    const canonical = makeHarness('har-portal-canon-');
+    const workspace = makeHarness('har-portal-ws-');
+    canonicalFor.set(workspace, canonical);
+    canonicalFor.set(path.resolve(workspace), canonical);
+
+    writeWorkUnit(workspace, 'demo');
+    writeRun(workspace, '99999999-9999-4999-8999-999999999999', '2026-08-31T11:00:00.000Z');
+
+    const captured: Captured[] = [];
+    mockFetch(captured);
+
+    await syncRepoWithControl({ repoPath: workspace, apiUrl: 'http://control.test' });
+
+    const sync = portalSync(captured);
+    expect(sync).toBeDefined();
+    // Identity: the portal still sees one repository, the canonical one.
+    expect(sync?.body.path).toBe(canonical);
+    // Evidence: written in the workspace, now forwarded.
+    expect(
+      (sync?.body.workUnits as { workUnitId: string }[] | undefined)?.map((u) => u.workUnitId),
+    ).toEqual(['demo']);
+    expect((sync?.body.runs as { runId: string }[] | undefined)?.map((r) => r.runId)).toEqual([
+      '99999999-9999-4999-8999-999999999999',
+    ]);
+  });
+
+  it('sends workspace runs older than an existing canonical watermark', async () => {
+    const canonical = makeHarness('har-portal-canon-');
+    const workspace = makeHarness('har-portal-ws-');
+    canonicalFor.set(workspace, canonical);
+    canonicalFor.set(path.resolve(workspace), canonical);
+
+    // A watermark that predates nothing in the workspace but postdates its run.
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        states: [
+          {
+            repoPath: canonical,
+            portalUrl: 'https://portal.example.com',
+            lastSyncedAt: '2026-08-31T12:00:00.000Z',
+          },
+        ],
+      }),
+    );
+    writeRun(workspace, 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', '2026-08-31T09:00:00.000Z');
+
+    const captured: Captured[] = [];
+    mockFetch(captured);
+
+    await syncRepoWithControl({ repoPath: workspace, apiUrl: 'http://control.test' });
+
+    const sync = portalSync(captured);
+    expect((sync?.body.runs as { runId: string }[] | undefined)?.map((r) => r.runId)).toEqual([
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    ]);
+  });
+});

--- a/tests/sync-external-workspace.test.ts
+++ b/tests/sync-external-workspace.test.ts
@@ -1,0 +1,154 @@
+// #255 end-to-end: a work unit and run written inside an externally-owned
+// workspace must reach Mission Control, while the repository stays canonical
+// (one row per repo, not one per worktree).
+const canonicalFor = new Map<string, string>();
+
+jest.mock('../src/core/control-repo-path', () => ({
+  canonicalizeControlRepoPath: (p: string) => canonicalFor.get(p) ?? p,
+}));
+jest.mock('../src/core/telemetry-config', () => ({
+  isTelemetryEnabled: () => false,
+  isPortalTrajectoryEnabled: () => false,
+  readTelemetryPreference: () => ({ enabled: false, signals: {}, portalTrajectory: false }),
+  getTelemetrySignals: () => ({ prompts: false }),
+}));
+jest.mock('../src/core/control-registry', () => ({
+  isRepoPortalSyncEnabled: () => false,
+  recordRepoForControlSync: () => undefined,
+  removeRegisteredRepo: () => undefined,
+  listRegisteredRepos: () => [],
+}));
+jest.mock('../src/core/slot-status', () => ({
+  collectEnvironmentStatus: () => ({ slots: [], generatedAt: '2026-01-01T00:00:00.000Z' }),
+}));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { syncRepoWithControl } from '../src/core/control-sync';
+
+const realFetch = global.fetch;
+const tmpDirs: string[] = [];
+
+function tmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeHarness(prefix: string): string {
+  const repo = tmpDir(prefix);
+  fs.mkdirSync(path.join(repo, '.har'), { recursive: true });
+  fs.writeFileSync(
+    path.join(repo, '.har', 'manifest.json'),
+    JSON.stringify({ version: '1', generatorVersion: '0.1.0', profile: 'cli' }),
+  );
+  fs.writeFileSync(
+    path.join(repo, '.har', 'stages.json'),
+    JSON.stringify({
+      version: '1',
+      artifactsDir: 'artifacts',
+      logsDir: 'logs',
+      agentSlots: { min: 1, max: 3 },
+      verificationStages: [],
+      stages: [],
+    }),
+  );
+  return repo;
+}
+
+function writeWorkUnit(repo: string, workUnitId: string): void {
+  const dir = path.join(repo, '.har', 'work-units');
+  fs.mkdirSync(dir, { recursive: true });
+  const now = '2026-08-31T11:00:00.000Z';
+  fs.writeFileSync(
+    path.join(dir, `${workUnitId}.json`),
+    JSON.stringify({ version: 1, workUnitId, createdAt: now, updatedAt: now }),
+  );
+}
+
+function writeRun(repo: string, runId: string): void {
+  const dir = path.join(repo, '.har', 'runs', '2026-08-31');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${runId}.json`),
+    JSON.stringify({
+      version: 1,
+      runId,
+      repoPath: repo,
+      stageId: 'verify',
+      status: 'pass',
+      startedAt: '2026-08-31T11:00:00.000Z',
+      finishedAt: '2026-08-31T11:00:01.000Z',
+      exitCode: 0,
+    }),
+  );
+}
+
+type Captured = { url: string; body: Record<string, unknown> };
+
+function mockFetch(captured: Captured[]): void {
+  (global as unknown as { fetch: unknown }).fetch = jest.fn(async (url: string, init?: RequestInit) => {
+    const body = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
+    captured.push({ url: String(url), body });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'repo-1' }),
+      text: async () => '',
+    } as unknown as Response;
+  });
+}
+
+afterEach(() => {
+  (global as unknown as { fetch: unknown }).fetch = realFetch;
+  canonicalFor.clear();
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('sync from an externally-owned workspace (#255)', () => {
+  it('sends workspace work-units while registering the canonical repo path', async () => {
+    const canonical = makeHarness('har-e2e-canon-');
+    const workspace = makeHarness('har-e2e-ws-');
+    canonicalFor.set(workspace, canonical);
+    canonicalFor.set(path.resolve(workspace), canonical);
+
+    writeWorkUnit(workspace, 'demo');
+    writeRun(workspace, '55555555-5555-4555-8555-555555555555');
+
+    const captured: Captured[] = [];
+    mockFetch(captured);
+
+    await syncRepoWithControl({ repoPath: workspace, apiUrl: 'http://control.test' });
+
+    // Identity stays canonical — no duplicate repository row per worktree.
+    const register = captured.find((c) => c.url.endsWith('/api/repos'));
+    expect(register?.body.path).toBe(canonical);
+
+    // Evidence written in the workspace now reaches Mission Control.
+    const workUnits = captured.find((c) => c.url.includes('/work-units'));
+    expect(
+      (workUnits?.body.workUnits as { workUnitId: string }[] | undefined)?.map((u) => u.workUnitId),
+    ).toEqual(['demo']);
+
+    const runs = captured.find((c) => c.url.endsWith('/runs'));
+    expect((runs?.body.runs as { runId: string }[] | undefined)?.map((r) => r.runId)).toEqual([
+      '55555555-5555-4555-8555-555555555555',
+    ]);
+  });
+
+  it('is unchanged when the workspace is the canonical checkout', async () => {
+    const canonical = makeHarness('har-e2e-same-');
+    writeWorkUnit(canonical, 'main-1');
+
+    const captured: Captured[] = [];
+    mockFetch(captured);
+
+    await syncRepoWithControl({ repoPath: canonical, apiUrl: 'http://control.test' });
+
+    const workUnits = captured.find((c) => c.url.includes('/work-units'));
+    expect(
+      (workUnits?.body.workUnits as { workUnitId: string }[] | undefined)?.map((u) => u.workUnitId),
+    ).toEqual(['main-1']);
+  });
+});

--- a/tests/sync-sources.test.ts
+++ b/tests/sync-sources.test.ts
@@ -1,0 +1,145 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  collectRunsForSync,
+  collectWorkUnitsForSync,
+  resolveSyncSourcePaths,
+} from '../src/core/sync-sources';
+
+const tmpDirs: string[] = [];
+
+function tmpDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeHarness(prefix: string): string {
+  const repo = tmpDir(prefix);
+  const harDir = path.join(repo, '.har');
+  fs.mkdirSync(harDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(harDir, 'manifest.json'),
+    JSON.stringify({ version: '1', generatorVersion: '0.1.0', profile: 'cli' }),
+  );
+  return repo;
+}
+
+function writeRun(repo: string, runId: string, startedAt: string): void {
+  const dir = path.join(repo, '.har', 'runs', '2026-08-31');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${runId}.json`),
+    JSON.stringify({
+      version: 1,
+      runId,
+      repoPath: repo,
+      stageId: 'verify',
+      status: 'pass',
+      startedAt,
+      finishedAt: startedAt,
+      exitCode: 0,
+    }),
+  );
+}
+
+function writeWorkUnit(repo: string, workUnitId: string, updatedAt: string): void {
+  const dir = path.join(repo, '.har', 'work-units');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, `${workUnitId}.json`),
+    JSON.stringify({ version: 1, workUnitId, createdAt: updatedAt, updatedAt }),
+  );
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('resolveSyncSourcePaths (#255)', () => {
+  it('is canonical-only when no workspace is given', () => {
+    const repo = makeHarness('har-src-');
+    expect(resolveSyncSourcePaths(repo)).toEqual([path.resolve(repo)]);
+  });
+
+  it('is canonical-only when the workspace is the same checkout', () => {
+    const repo = makeHarness('har-src-');
+    expect(resolveSyncSourcePaths(repo, repo)).toEqual([path.resolve(repo)]);
+  });
+
+  it('collapses a subdirectory onto the same harness root', () => {
+    const repo = makeHarness('har-src-');
+    const sub = path.join(repo, 'packages', 'thing');
+    fs.mkdirSync(sub, { recursive: true });
+    expect(resolveSyncSourcePaths(repo, sub)).toEqual([path.resolve(repo)]);
+  });
+
+  it('keeps both when the workspace has its own harness root', () => {
+    const canonical = makeHarness('har-src-canon-');
+    const workspace = makeHarness('har-src-ws-');
+    expect(resolveSyncSourcePaths(canonical, workspace)).toEqual([
+      path.resolve(canonical),
+      path.resolve(workspace),
+    ]);
+  });
+});
+
+describe('collectRunsForSync (#255)', () => {
+  it('reads records written only in the workspace', () => {
+    const canonical = makeHarness('har-runs-canon-');
+    const workspace = makeHarness('har-runs-ws-');
+    writeRun(canonical, '11111111-1111-4111-8111-111111111111', '2026-08-31T10:00:00.000Z');
+    writeRun(workspace, '22222222-2222-4222-8222-222222222222', '2026-08-31T11:00:00.000Z');
+
+    const runs = collectRunsForSync(resolveSyncSourcePaths(canonical, workspace));
+    expect(runs.map((r) => r.runId)).toEqual([
+      '22222222-2222-4222-8222-222222222222',
+      '11111111-1111-4111-8111-111111111111',
+    ]);
+  });
+
+  it('does not double-count a run present in both sources', () => {
+    const canonical = makeHarness('har-runs-canon-');
+    const workspace = makeHarness('har-runs-ws-');
+    const shared = '33333333-3333-4333-8333-333333333333';
+    writeRun(canonical, shared, '2026-08-31T10:00:00.000Z');
+    writeRun(workspace, shared, '2026-08-31T10:00:00.000Z');
+
+    const runs = collectRunsForSync(resolveSyncSourcePaths(canonical, workspace));
+    expect(runs).toHaveLength(1);
+  });
+
+  it('is unchanged for a HAR-owned worktree that holds no records', () => {
+    const canonical = makeHarness('har-runs-canon-');
+    const workspace = makeHarness('har-runs-ws-');
+    writeRun(canonical, '44444444-4444-4444-8444-444444444444', '2026-08-31T10:00:00.000Z');
+
+    const union = collectRunsForSync(resolveSyncSourcePaths(canonical, workspace));
+    const canonicalOnly = collectRunsForSync([canonical]);
+    expect(union).toEqual(canonicalOnly);
+  });
+});
+
+describe('collectWorkUnitsForSync (#255)', () => {
+  it('surfaces a work unit bound inside the workspace', () => {
+    const canonical = makeHarness('har-wu-canon-');
+    const workspace = makeHarness('har-wu-ws-');
+    writeWorkUnit(canonical, 'main-1', '2026-08-31T10:00:00.000Z');
+    writeWorkUnit(workspace, 'demo', '2026-08-31T11:00:00.000Z');
+
+    const { workUnits } = collectWorkUnitsForSync(resolveSyncSourcePaths(canonical, workspace));
+    expect(workUnits.map((u) => u.workUnitId)).toEqual(['demo', 'main-1']);
+  });
+
+  it('prefers the canonical record on an id collision', () => {
+    const canonical = makeHarness('har-wu-canon-');
+    const workspace = makeHarness('har-wu-ws-');
+    writeWorkUnit(canonical, 'demo', '2026-08-31T10:00:00.000Z');
+    writeWorkUnit(workspace, 'demo', '2026-08-31T11:00:00.000Z');
+
+    const { workUnits } = collectWorkUnitsForSync(resolveSyncSourcePaths(canonical, workspace));
+    expect(workUnits).toHaveLength(1);
+    expect(workUnits[0].updatedAt).toBe('2026-08-31T10:00:00.000Z');
+  });
+});

--- a/tests/sync-sources.test.ts
+++ b/tests/sync-sources.test.ts
@@ -2,10 +2,17 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
+  collectRunsBySource,
   collectRunsForSync,
   collectWorkUnitsForSync,
   resolveSyncSourcePaths,
+  selectRunsForSync,
 } from '../src/core/sync-sources';
+import {
+  coveredSources,
+  readRunsWatermarkEntry,
+  writeRunsWatermark,
+} from '../src/core/portal-watermark';
 
 const tmpDirs: string[] = [];
 
@@ -141,5 +148,84 @@ describe('collectWorkUnitsForSync (#255)', () => {
     const { workUnits } = collectWorkUnitsForSync(resolveSyncSourcePaths(canonical, workspace));
     expect(workUnits).toHaveLength(1);
     expect(workUnits[0].updatedAt).toBe('2026-08-31T10:00:00.000Z');
+  });
+});
+
+describe('selectRunsForSync watermark coverage (#255)', () => {
+  const filterSince = (runs: { startedAt: string }[], since: string | null) =>
+    since ? runs.filter((r) => r.startedAt > since) : runs;
+
+  it('filters a source the watermark already covers', () => {
+    const canonical = makeHarness('har-wm-canon-');
+    writeRun(canonical, '66666666-6666-4666-8666-666666666666', '2026-08-31T09:00:00.000Z');
+
+    const selected = selectRunsForSync(
+      collectRunsBySource([canonical]),
+      '2026-08-31T10:00:00.000Z',
+      [canonical],
+      filterSince as never,
+    );
+    expect(selected).toHaveLength(0);
+  });
+
+  it('sends everything from a source the watermark has never covered', () => {
+    const canonical = makeHarness('har-wm-canon-');
+    const workspace = makeHarness('har-wm-ws-');
+    // Older than the watermark: without the coverage rule this is stranded.
+    writeRun(workspace, '77777777-7777-4777-8777-777777777777', '2026-08-31T09:00:00.000Z');
+
+    const selected = selectRunsForSync(
+      collectRunsBySource([canonical, workspace]),
+      '2026-08-31T10:00:00.000Z',
+      [canonical],
+      filterSince as never,
+    );
+    expect(selected.map((r) => r.runId)).toEqual(['77777777-7777-4777-8777-777777777777']);
+  });
+
+  it('filters the workspace once the watermark covers it', () => {
+    const canonical = makeHarness('har-wm-canon-');
+    const workspace = makeHarness('har-wm-ws-');
+    writeRun(workspace, '88888888-8888-4888-8888-888888888888', '2026-08-31T09:00:00.000Z');
+
+    const selected = selectRunsForSync(
+      collectRunsBySource([canonical, workspace]),
+      '2026-08-31T10:00:00.000Z',
+      [canonical, workspace],
+      filterSince as never,
+    );
+    expect(selected).toHaveLength(0);
+  });
+});
+
+describe('watermark source coverage storage (#255)', () => {
+  const statePath = path.join(os.tmpdir(), `har-wm-state-${process.pid}.json`);
+  const prev = process.env.HAR_PORTAL_SYNC_STATE_PATH;
+
+  beforeEach(() => {
+    process.env.HAR_PORTAL_SYNC_STATE_PATH = statePath;
+    fs.rmSync(statePath, { force: true });
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.HAR_PORTAL_SYNC_STATE_PATH;
+    else process.env.HAR_PORTAL_SYNC_STATE_PATH = prev;
+    fs.rmSync(statePath, { force: true });
+  });
+
+  it('treats a legacy entry with no source list as covering canonical only', () => {
+    const repo = makeHarness('har-wm-legacy-');
+    writeRunsWatermark(repo, 'target', 'repo-1', '2026-08-31T10:00:00.000Z');
+    const entry = readRunsWatermarkEntry(repo, 'target');
+    expect(entry?.sources).toBeUndefined();
+    expect(coveredSources(repo, entry)).toEqual([repo]);
+  });
+
+  it('accumulates sources across syncs', () => {
+    const repo = makeHarness('har-wm-acc-');
+    const workspace = makeHarness('har-wm-acc-ws-');
+    writeRunsWatermark(repo, 'target', 'repo-1', '2026-08-31T10:00:00.000Z', [repo, workspace]);
+    expect(coveredSources(repo, readRunsWatermarkEntry(repo, 'target')).sort()).toEqual(
+      [repo, workspace].sort(),
+    );
   });
 });


### PR DESCRIPTION
Closes #255. Part of #253.

## What

Sync canonicalizes any worktree path to the main checkout so Mission Control keeps one repository row per repo instead of one per worktree. That is deliberate and stays. Its side effect was that runs and work-units written somewhere else were never read: an in-place launch inside a worktree HAR did not create resolves its harness root to that workspace and writes everything there, so Factory showed no work units and per-workspace runs never rolled up.

This splits the two jobs the canonical path was doing. **Identity stays canonical** — registration still sends the main checkout path. **Evidence** is read from the union of the canonical checkout and the workspace sync was invoked in.

## Why a union, not a switch

Neither source is right on its own. HAR writes run records for its *own* session worktrees into the main checkout, so reading only the workspace would regress every ordinary slot. For a HAR-owned worktree the workspace holds no records and the union is exactly what canonical already returned — covered by a test that passes both before and after the change.

## Second commit: the portal path

The first commit fixed local Mission Control and left har-portal reading canonical-only, which is worse than leaving both broken — the two surfaces then disagree about the same repo. `buildPortalPayload` now reads the same union, across the wider record set the portal carries (runs, work units, attempts, validations, validation bindings). `userEmail` attribution is applied per source before merging, so login attribution survives.

## Watermarks

Watermarks are keyed on the canonical repo and a target, so a workspace appearing for the first time had its older records filtered by a timestamp it never contributed to — stranding them until someone ran `--full`. Entries now record which source roots they were advanced over, and a source absent from that list is sent unfiltered once. Legacy entries carry no list and are read as covering the canonical path only, which is exactly their historical meaning.

## Verification

- `har env verify 3 --full` — 9/9 stages
- 25 new tests across `tests/sync-sources.test.ts`, `tests/sync-external-workspace.test.ts`, `tests/sync-external-workspace-portal.test.ts`
- Both integration tests confirmed non-vacuous: they fail against the pre-fix tree and pass after

## Note for reviewers

The issue's evidence line numbers have drifted (1.0 refactor): `resolveHarnessRoot` is `manifest.ts:113` (filed `:89`), canonicalization is `control-sync.ts:612/742/788/967` (filed `:664`). The mechanism described is intact.
