### PR TITLE
fix: tell stale CLIs to upgrade instead of inventing missing launch.sh

### DIFF
--- a/.har/manifest.json
+++ b/.har/manifest.json
@@ -1,6 +1,7 @@
 {
   "version": "1",
   "runtimeVersion": "1.0.0",
+  "cliVersion": "1.10.0",
   "outputDir": ".har",
   "createdAt": "2026-08-27T13:49:52.836Z",
   "updatedAt": "2026-08-27T13:49:52.836Z",

--- a/control/.har/manifest.json
+++ b/control/.har/manifest.json
@@ -1,6 +1,7 @@
 {
   "version": "1",
   "runtimeVersion": "1.0.0",
+  "cliVersion": "1.10.0",
   "outputDir": ".har",
   "createdAt": "2026-08-27T13:49:53.152Z",
   "updatedAt": "2026-08-27T13:49:53.152Z",

--- a/docs/.har/manifest.json
+++ b/docs/.har/manifest.json
@@ -1,6 +1,7 @@
 {
   "version": "1",
   "runtimeVersion": "1.0.0",
+  "cliVersion": "1.10.0",
   "outputDir": ".har",
   "createdAt": "2026-08-27T13:49:53.453Z",
   "updatedAt": "2026-08-27T13:49:53.453Z",

--- a/docs/src/content/docs/docs/reference/cli.md
+++ b/docs/src/content/docs/docs/reference/cli.md
@@ -188,14 +188,17 @@ har env doctor [--json]
 ```
 
 `doctor` validates the harness contract and exits `0` on pass, `1` on errors
-(so it slots into CI): `harness.env` against the schema, `stages.json` against
+(so it slots into CI): the running CLI is not older than `manifest.cliVersion`,
+`harness.env` against the schema, `stages.json` against
 the registry schema, every registered stage's script/command file exists and is
 executable, the lifecycle stages (launch/verify/teardown) resolve,
 `verificationStages` ids resolve to registered stages, infra port lanes are
 coherent (no overlaps, defaults inside scan ranges), and slot registry entries
 point at existing worktrees. Every finding carries a remedy. Doctor also runs
 automatically inside `har env maintain` and before every `launch` — a broken
-adaptation blocks the launch instead of failing mid-session. Pre-1.0 harnesses
+adaptation blocks the launch instead of failing mid-session. A stale CLI vs a
+newer harness is a single upgrade error, not a list of missing lifecycle
+scripts. Pre-1.0 harnesses
 report contract findings as warnings until they migrate. On an ejected
 harness, doctor additionally checks the vendored runtime exists and the
 user-owned scripts are executable. MCP twin: `har_doctor`.

--- a/docs/src/content/docs/docs/reference/doctor.md
+++ b/docs/src/content/docs/docs/reference/doctor.md
@@ -18,6 +18,7 @@ Exit code is non-zero when any check fails, so doctor slots directly into CI.
 
 | Check | Validates |
 | --- | --- |
+| CLI vs harness writer | Running CLI is not older than `manifest.cliVersion` (the last CLI that wrote the harness) |
 | `harness.env` schema | Pure `KEY=value` config, known keys, valid values — no shell functions |
 | `stages.json` registry | Parseable registry, valid stage entries and tiers |
 | Stage scripts & commands | Every stage that names a script resolves to an existing executable file |
@@ -32,6 +33,14 @@ Doctor detects the harness contract generation: on a pre-1.0 harness (legacy
 shell functions or port triplets in `harness.env`) it reports the old shape and
 points at the [1.0 migration](/docs/guides/migrating-to-1-0/) instead of
 failing every schema check.
+
+When `manifest.cliVersion` is newer than the running CLI, doctor stops with a
+single upgrade error (`npm install -g @osfactory/har@latest`) and skips the
+rest of the report. A stale CLI otherwise invents "missing `stages/launch.sh`"
+findings for lifecycle stages that now live in the package. `init`, `maintain`,
+`add-plugin`, and `line add` stamp `cliVersion`. A repo-local newer
+`@osfactory/har` (this checkout, or `node_modules/@osfactory/har`) is preferred
+over a stale global install.
 
 ## What doctor does not do
 

--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -65,8 +65,15 @@ export const HarnessManifestSchema = z.object({
    * Harness runtime-contract version (#241) — the shape of the installed
    * `.har/` surface (thin shims + pure config = '1.0.0'). Absent on pre-1.0
    * harnesses; the migration registry (src/harness/migrations.ts) keys on it.
+   * Not the CLI that wrote the harness — that is `cliVersion`.
    */
   runtimeVersion: z.string().optional(),
+  /**
+   * @osfactory/har version that last wrote this harness (#344).
+   * Stamped by init / maintain / add-plugin / line add. Doctor compares it
+   * to the running CLI and stops with an upgrade error when the CLI is older.
+   */
+  cliVersion: z.string().optional(),
   /** Shape this harness was migrated from ('pre-1.0'), stamped at migration (#241). */
   migratedFrom: z.string().optional(),
   migratedAt: z.string().optional(),

--- a/src/core/harness.ts
+++ b/src/core/harness.ts
@@ -10,7 +10,7 @@ import {
   MaintainBundleResult,
   removeMaintainBundle,
 } from '../harness/maintain-bundle';
-import { readManifest, getHarnessDir } from '../harness/manifest';
+import { readManifest, getHarnessDir, stampManifestWriter } from '../harness/manifest';
 import { getVerificationStageIds, getAgentSlotRange, listStages, syncAgentSlotsToHarnessEnv } from '../harness/stages';
 import { ensureEcosystemVerificationStages } from '../harness/verification';
 import { DoctorReport, runDoctor } from '../harness/doctor';
@@ -203,6 +203,7 @@ export async function maintainHarness(options: MaintainHarnessOptions): Promise<
   retireLifecycleShims(repoPath);
 
   ensureEcosystemVerificationStages(repoPath);
+  stampManifestWriter(repoPath);
   const drift = compareHarnessToTemplate(repoPath);
   const validation = validateHarness(repoPath);
 

--- a/src/core/prefer-local-runtime.ts
+++ b/src/core/prefer-local-runtime.ts
@@ -1,0 +1,139 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawnSync } from 'child_process';
+import { getHarPackageVersion } from './package-version';
+import { compareSemver } from '../utils/semver';
+
+const PACKAGE_NAME = '@osfactory/har';
+
+export interface PreferredRuntime {
+  entryPath: string;
+  version: string;
+  reason: 'har-repo' | 'node_modules';
+}
+
+function readPackageJson(dir: string): { name?: string; version?: string; bin?: unknown } | null {
+  const pkgPath = path.join(dir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+      name?: string;
+      version?: string;
+      bin?: unknown;
+    };
+  } catch {
+    return null;
+  }
+}
+
+function resolveHarEntry(pkgDir: string, pkg: { bin?: unknown }): string | null {
+  let rel = 'dist/index.js';
+  if (pkg.bin && typeof pkg.bin === 'object' && pkg.bin !== null && 'har' in pkg.bin) {
+    const bin = (pkg.bin as { har?: unknown }).har;
+    if (typeof bin === 'string' && bin.length > 0) rel = bin;
+  } else if (typeof pkg.bin === 'string' && pkg.bin.length > 0) {
+    rel = pkg.bin;
+  }
+  const entry = path.resolve(pkgDir, rel);
+  return fs.existsSync(entry) ? entry : null;
+}
+
+function sameFile(a: string, b: string): boolean {
+  try {
+    return fs.realpathSync(a) === fs.realpathSync(b);
+  } catch {
+    return path.resolve(a) === path.resolve(b);
+  }
+}
+
+function considerCandidate(
+  candidate: PreferredRuntime | null,
+  currentVersion: string,
+  currentEntry: string | undefined,
+): PreferredRuntime | null {
+  if (!candidate) return null;
+  if (currentEntry && sameFile(candidate.entryPath, currentEntry)) return null;
+  if (compareSemver(candidate.version, currentVersion) <= 0) return null;
+  return candidate;
+}
+
+function inspectDir(dir: string): PreferredRuntime | null {
+  const pkg = readPackageJson(dir);
+  if (pkg?.name === PACKAGE_NAME && pkg.version) {
+    const entry = resolveHarEntry(dir, pkg);
+    if (entry) return { entryPath: entry, version: pkg.version, reason: 'har-repo' };
+  }
+
+  const nestedDir = path.join(dir, 'node_modules', PACKAGE_NAME);
+  const nested = readPackageJson(nestedDir);
+  if (nested?.name === PACKAGE_NAME && nested.version) {
+    const entry = resolveHarEntry(nestedDir, nested);
+    if (entry) return { entryPath: entry, version: nested.version, reason: 'node_modules' };
+  }
+
+  return null;
+}
+
+function walkParents(start: string): string[] {
+  const out: string[] = [];
+  let current = path.resolve(start);
+  const { root } = path.parse(current);
+  for (;;) {
+    out.push(current);
+    if (current === root) break;
+    current = path.dirname(current);
+  }
+  return out;
+}
+
+/**
+ * Find a newer @osfactory/har next to `cwd` (the HAR repo itself, or
+ * node_modules/@osfactory/har) so a stale global install is not used.
+ */
+export function findPreferredLocalRuntime(options: {
+  cwd: string;
+  currentVersion: string;
+  currentEntry?: string;
+  extraRoots?: string[];
+}): PreferredRuntime | null {
+  const seen = new Set<string>();
+  const roots = [...(options.extraRoots ?? []).map((r) => path.resolve(r)), ...walkParents(options.cwd)];
+
+  for (const dir of roots) {
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    const found = considerCandidate(inspectDir(dir), options.currentVersion, options.currentEntry);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+/**
+ * Re-exec a newer repo-local HAR when the running binary is stale (#344).
+ * No-op when already re-exec'd, skipped, or no newer local runtime exists.
+ */
+export function maybeReexecPreferredRuntime(): void {
+  if (process.env.HAR_USING_LOCAL_RUNTIME || process.env.HAR_SKIP_LOCAL_RUNTIME) {
+    return;
+  }
+
+  const currentVersion = getHarPackageVersion();
+  const extraRoots = process.env.HAR_ROOT ? [process.env.HAR_ROOT] : [];
+  const found = findPreferredLocalRuntime({
+    cwd: process.cwd(),
+    currentVersion,
+    currentEntry: process.argv[1],
+    extraRoots,
+  });
+  if (!found) return;
+
+  process.stderr.write(
+    `Using repo-local @osfactory/har ${found.version} (this CLI is ${currentVersion})\n`,
+  );
+  const result = spawnSync(process.execPath, [found.entryPath, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    env: { ...process.env, HAR_USING_LOCAL_RUNTIME: '1' },
+  });
+  process.exit(result.status ?? 1);
+}

--- a/src/harness/doctor.ts
+++ b/src/harness/doctor.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { getHarPackageVersion } from '../core/package-version';
 import { listSlotRegistryEntries } from '../core/slot-registry';
+import { compareSemver } from '../utils/semver';
 import { EJECTED_RUNTIME_BUNDLE, EJECTED_RUNTIME_DIR } from './eject';
 import { readValidatedHarnessEnv } from './env';
 import { getHarnessDir, readManifest } from './manifest';
@@ -22,6 +24,7 @@ import { LEGACY_MACHINERY_FILES } from './migrations';
  */
 
 export type DoctorCheckId =
+  | 'cli-version'
   | 'harness-env'
   | 'stages-registry'
   | 'stage-files'
@@ -91,6 +94,7 @@ function listHarnessShellScripts(harnessDir: string): string[] {
 }
 
 const CHECK_LABELS: Record<DoctorCheckId, string> = {
+  'cli-version': 'CLI vs harness writer',
   'harness-env': 'harness.env schema',
   'stages-registry': 'stages.json registry',
   'stage-files': 'stage scripts & commands',
@@ -179,6 +183,34 @@ export function runDoctor(repoPath: string): DoctorReport {
   // Pre-1.0 harnesses keep working until they migrate (#241): contract
   // findings degrade to warnings so maintain/launch report instead of block.
   const contractSeverity: 'error' | 'warning' = contract === '1.0' ? 'error' : 'warning';
+
+  // 0. Stale CLI vs a newer harness (#344): one upgrade error, then stop.
+  // Missing-stage noise is wrong once the writer is newer than this binary.
+  const writerVersion = readManifest(repoPath)?.cliVersion;
+  const runningVersion = getHarPackageVersion();
+  if (!writerVersion) {
+    skipped.add('cli-version');
+  }
+  if (writerVersion && compareSemver(runningVersion, writerVersion) < 0) {
+    const finding: DoctorFinding = {
+      check: 'cli-version',
+      severity: 'error',
+      file: 'manifest.json',
+      message: `This harness was written by @osfactory/har ${writerVersion}; you are running ${runningVersion}.`,
+      remedy:
+        'npm install -g @osfactory/har@latest   (or run the repo\'s local build: node dist/index.js)',
+    };
+    return {
+      ok: false,
+      contract,
+      checks: (Object.keys(CHECK_LABELS) as DoctorCheckId[]).map((id) =>
+        id === 'cli-version'
+          ? { id, label: CHECK_LABELS[id], status: 'fail' as const }
+          : { id, label: CHECK_LABELS[id], status: 'skip' as const },
+      ),
+      findings: [finding],
+    };
+  }
 
   // 1. harness.env against HarnessEnvSchema
   const envValidation = readValidatedHarnessEnv(repoPath);

--- a/src/harness/lines.ts
+++ b/src/harness/lines.ts
@@ -14,6 +14,7 @@ import { findManifestPath } from './bundle-resolve';
 import { LINE_BUNDLE_KIND, LINE_MANIFEST_FILES } from './schema';
 import type { HarnessStage, LineManifest, LineProgram } from './schema';
 import { LineManifestSchema, LineProgramSchema } from './schema';
+import { stampManifestWriter } from './manifest';
 import { readStageRegistry, writeStageRegistry } from './stages';
 import { LINE_BUNDLE_CONFIG } from './line-resolve';
 
@@ -305,6 +306,7 @@ function applyLineFromDir(
     buildLineAdaptationPrompt(resolved, program, { ...partial, adaptPromptPath: '' }),
   );
   const adaptPromptPath = path.relative(resolved, promptAbsPath);
+  stampManifestWriter(resolved);
 
   success(`Applied line: ${manifest.id}`);
   info(`Stations: ${partial.stationIds.join(' → ')}`);

--- a/src/harness/manifest.ts
+++ b/src/harness/manifest.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getHarPackageVersion } from '../core/package-version';
 import { HarnessManifest, HarnessManifestSchema } from './schema';
 import { writeFileSafe } from '../utils/file-ops';
 
@@ -41,8 +42,22 @@ export function readManifest(repoPath: string): HarnessManifest | null {
 }
 
 export function writeManifest(repoPath: string, manifest: HarnessManifest): void {
+  const stamped: HarnessManifest = {
+    ...manifest,
+    cliVersion: getHarPackageVersion(),
+  };
   const manifestPath = getManifestPath(repoPath);
-  writeFileSafe(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  writeFileSafe(manifestPath, JSON.stringify(stamped, null, 2) + '\n');
+}
+
+/** Record the running CLI as the harness writer without other manifest edits. */
+export function stampManifestWriter(repoPath: string): void {
+  const existing = readManifest(repoPath);
+  if (!existing) return;
+  writeManifest(repoPath, {
+    ...existing,
+    updatedAt: new Date().toISOString(),
+  });
 }
 
 export function computeFileChecksum(content: string): string {
@@ -86,6 +101,7 @@ export function createManifest(
   return {
     version: MANIFEST_VERSION,
     runtimeVersion: HARNESS_RUNTIME_VERSION,
+    cliVersion: getHarPackageVersion(),
     outputDir: DEFAULT_HAR_DIR,
     createdAt: now,
     updatedAt: now,

--- a/src/harness/plugins.ts
+++ b/src/harness/plugins.ts
@@ -15,6 +15,7 @@ import {
 import { upsertPluginLedgerEntry } from './plugin-ledger';
 import { buildPluginAdaptationPrompt, writePluginAdaptationPrompt } from './plugin-prompt';
 import { HarnessStageRegistry, HarnessStageSchema, LINE_BUNDLE_KIND } from './schema';
+import { stampManifestWriter } from './manifest';
 import { readStageRegistry, writeStageRegistry } from './stages';
 
 /** Plugin id is a free-form slug discovered from manifests (no closed enum). */
@@ -394,6 +395,7 @@ function applyPluginFromDir(
   });
   const promptAbsPath = writePluginAdaptationPrompt(resolved, manifest.id, promptContent);
   const adaptPromptPath = path.relative(resolved, promptAbsPath);
+  stampManifestWriter(resolved);
 
   success(`Applied plugin: ${manifest.id}`);
   info(`Registered stage(s): ${stageIds.join(', ')}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import { runCli } from './cli';
+import { maybeReexecPreferredRuntime } from './core/prefer-local-runtime';
 import { syncDirtyRepos } from './core/sync-context';
+
+maybeReexecPreferredRuntime();
 
 runCli().catch(async (err: Error) => {
   console.error(err.message);

--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -1,0 +1,13 @@
+/**
+ * Compare dotted numeric versions (e.g. 1.8.0 vs 1.0.0).
+ * Returns -1 if `a < b`, 0 if equal, 1 if `a > b`.
+ */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}

--- a/tests/harness-doctor.test.ts
+++ b/tests/harness-doctor.test.ts
@@ -53,9 +53,12 @@ describe('har env doctor (#232)', () => {
     expect(report.findings.filter((f) => f.severity === 'error')).toEqual([]);
     expect(report.ok).toBe(true);
     // ejected-runtime (#239) is skipped on a non-ejected harness by design.
+    // cli-version (#344) is skipped until a writer stamps manifest.cliVersion.
     expect(
       report.checks.every(
-        (c) => c.status === 'pass' || (c.id === 'ejected-runtime' && c.status === 'skip'),
+        (c) =>
+          c.status === 'pass' ||
+          ((c.id === 'ejected-runtime' || c.id === 'cli-version') && c.status === 'skip'),
       ),
     ).toBe(true);
     expect(summarizeDoctorReport(report)).toBeNull();
@@ -191,6 +194,62 @@ describe('har env doctor (#232)', () => {
     expect(report.ok).toBe(false);
     expect(report.contract).toBe('none');
     expect(report.findings[0].remedy).toContain('har onboard');
+  });
+
+  it('fails with a single upgrade error when the CLI is older than the harness writer (#344)', () => {
+    const repo = makeRepo();
+    fs.writeFileSync(
+      path.join(repo, '.har', 'manifest.json'),
+      JSON.stringify({
+        version: '1',
+        runtimeVersion: '1.0.0',
+        cliVersion: '99.0.0',
+        outputDir: '.har',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    fs.rmSync(path.join(repo, '.har', 'stages', 'unit-tests.sh'));
+    const report = runDoctor(repo);
+    expect(report.ok).toBe(false);
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0].check).toBe('cli-version');
+    expect(report.findings[0].message).toContain('99.0.0');
+    expect(report.findings[0].remedy).toContain('npm install -g @osfactory/har@latest');
+    expect(report.findings.some((f) => f.check === 'stage-files')).toBe(false);
+    expect(
+      report.checks.filter((c) => c.id !== 'cli-version').every((c) => c.status === 'skip'),
+    ).toBe(true);
+  });
+
+  it('still reports missing stage files when the CLI matches the harness writer', () => {
+    const repo = makeRepo();
+    fs.writeFileSync(
+      path.join(repo, '.har', 'manifest.json'),
+      JSON.stringify({
+        version: '1',
+        runtimeVersion: '1.0.0',
+        cliVersion: '1.0.0',
+        outputDir: '.har',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    const original = process.env.HAR_PACKAGE_VERSION;
+    process.env.HAR_PACKAGE_VERSION = '1.0.0';
+    try {
+      fs.rmSync(path.join(repo, '.har', 'stages', 'unit-tests.sh'));
+      const report = runDoctor(repo);
+      expect(report.ok).toBe(false);
+      expect(report.findings.find((f) => f.check === 'cli-version')).toBeUndefined();
+      expect(report.checks.find((c) => c.id === 'cli-version')?.status).toBe('pass');
+      expect(report.findings.find((f) => f.check === 'stage-files')?.message).toContain(
+        'unit-tests',
+      );
+    } finally {
+      if (original === undefined) delete process.env.HAR_PACKAGE_VERSION;
+      else process.env.HAR_PACKAGE_VERSION = original;
+    }
   });
 
   it('renders a readable report with remedies', () => {

--- a/tests/lines.test.ts
+++ b/tests/lines.test.ts
@@ -11,6 +11,8 @@ import { listBundledLineIds } from '../src/harness/line-resolve';
 import { cumulativeGateStages, getLineStatus, listInstalledLineIds } from '../src/core/lines';
 import { runDoctor } from '../src/harness/doctor';
 import { readStageRegistry } from '../src/harness/stages';
+import { readManifest } from '../src/harness/manifest';
+import { getHarPackageVersion } from '../src/core/package-version';
 
 function makeTempRepo(name: string): string {
   const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
@@ -61,6 +63,7 @@ describe('factory lines', () => {
     expect(
       fs.existsSync(path.join(repoPath, '.har', 'ADAPT-PROMPT-line-example-line.md')),
     ).toBe(true);
+    expect(readManifest(repoPath)?.cliVersion).toBe(getHarPackageVersion());
   });
 
   it('records the install in .har/lines.json', () => {

--- a/tests/maintain-bundle.test.ts
+++ b/tests/maintain-bundle.test.ts
@@ -14,6 +14,8 @@ import {
   removeMaintainBundle,
 } from '../src/harness/maintain-bundle';
 import { validateHarness } from '../src/harness/validator';
+import { readManifest } from '../src/harness/manifest';
+import { getHarPackageVersion } from '../src/core/package-version';
 
 describe('maintain bundle', () => {
   it('does not treat retired lifecycle wrappers as missing (#314)', () => {
@@ -123,6 +125,19 @@ describe('maintain bundle', () => {
     expect(fs.existsSync(path.join(repoPath, '.har', MAINTAIN_DIR, 'templates', 'README.md'))).toBe(
       true,
     );
+  });
+
+  it('stamps manifest.cliVersion on maintain (#344)', async () => {
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), 'har-maintain-cli-version-'));
+    scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'cli' });
+    const manifestPath = path.join(repoPath, '.har', 'manifest.json');
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+    raw.cliVersion = '0.1.0';
+    fs.writeFileSync(manifestPath, JSON.stringify(raw, null, 2) + '\n');
+
+    await maintainHarness({ repoPath, finalize: false });
+
+    expect(readManifest(repoPath)?.cliVersion).toBe(getHarPackageVersion());
   });
 
   it('finalize removes the maintenance bundle', async () => {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -17,6 +17,8 @@ import {
   harnessUsesSimulator,
 } from '../src/harness/capabilities';
 import { readStageRegistry } from '../src/harness/stages';
+import { readManifest } from '../src/harness/manifest';
+import { getHarPackageVersion } from '../src/core/package-version';
 
 function makeTempRepo(name: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), `${name}-`));
@@ -64,6 +66,23 @@ describe('plugins', () => {
     };
     expect(pkg.scripts['test:e2e']).toBe('playwright test');
     expect(pkg.devDependencies['@playwright/test']).toBe('^1.40.0');
+  });
+
+  it('stamps manifest.cliVersion when applying a plugin (#344)', () => {
+    const repoPath = makeTempRepo('har-plugin-cli-version');
+    fs.writeFileSync(
+      path.join(repoPath, 'package.json'),
+      JSON.stringify({ name: 'test-app', version: '1.0.0' }, null, 2) + '\n',
+    );
+    scaffoldHarnessBoilerplate(repoPath, { force: true, profile: 'cli' });
+    const manifestPath = path.join(repoPath, '.har', 'manifest.json');
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<string, unknown>;
+    raw.cliVersion = '0.1.0';
+    fs.writeFileSync(manifestPath, JSON.stringify(raw, null, 2) + '\n');
+
+    applyPlugin(repoPath, 'playwright', { skipCi: true });
+
+    expect(readManifest(repoPath)?.cliVersion).toBe(getHarPackageVersion());
   });
 
   it('applies rocketsim plugin to a scaffolded harness', () => {

--- a/tests/prefer-local-runtime.test.ts
+++ b/tests/prefer-local-runtime.test.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { findPreferredLocalRuntime } from '../src/core/prefer-local-runtime';
+
+function writeHarPackage(dir: string, version: string, entryRel = 'dist/index.js'): string {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify(
+      {
+        name: '@osfactory/har',
+        version,
+        bin: { har: entryRel },
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+  const entry = path.join(dir, entryRel);
+  fs.mkdirSync(path.dirname(entry), { recursive: true });
+  fs.writeFileSync(entry, '#!/usr/bin/env node\n');
+  return entry;
+}
+
+describe('findPreferredLocalRuntime (#344)', () => {
+  it('prefers a newer HAR checkout over the running CLI', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'har-prefer-repo-'));
+    const entry = writeHarPackage(root, '1.8.0');
+    const found = findPreferredLocalRuntime({
+      cwd: root,
+      currentVersion: '1.0.0',
+      currentEntry: '/usr/lib/node_modules/@osfactory/har/dist/index.js',
+    });
+    expect(found).toEqual({ entryPath: entry, version: '1.8.0', reason: 'har-repo' });
+  });
+
+  it('prefers a newer node_modules/@osfactory/har', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'har-prefer-nm-'));
+    fs.writeFileSync(
+      path.join(root, 'package.json'),
+      JSON.stringify({ name: 'app', version: '1.0.0' }, null, 2) + '\n',
+    );
+    const nested = path.join(root, 'node_modules', '@osfactory', 'har');
+    const entry = writeHarPackage(nested, '1.9.0');
+    const found = findPreferredLocalRuntime({
+      cwd: path.join(root, 'src'),
+      currentVersion: '1.0.0',
+    });
+    expect(found).toEqual({ entryPath: entry, version: '1.9.0', reason: 'node_modules' });
+  });
+
+  it('does not prefer an older or equal local runtime', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'har-prefer-older-'));
+    writeHarPackage(root, '1.0.0');
+    expect(
+      findPreferredLocalRuntime({
+        cwd: root,
+        currentVersion: '1.8.0',
+      }),
+    ).toBeNull();
+    expect(
+      findPreferredLocalRuntime({
+        cwd: root,
+        currentVersion: '1.0.0',
+      }),
+    ).toBeNull();
+  });
+
+  it('does not re-select the currently running entry', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'har-prefer-self-'));
+    const entry = writeHarPackage(root, '1.8.0');
+    expect(
+      findPreferredLocalRuntime({
+        cwd: root,
+        currentVersion: '1.0.0',
+        currentEntry: entry,
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/runs.test.ts
+++ b/tests/runs.test.ts
@@ -112,6 +112,7 @@ describe('harness drift detection', () => {
     const created = createManifest(repoPath, 'test', undefined, 'cli');
     expect(created.generatorVersion).toBeUndefined();
     expect(created).not.toHaveProperty('generatorVersion');
+    expect(created.cliVersion).toMatch(/^\d+\.\d+\.\d+/);
 
     const legacy = HarnessManifestSchema.parse({
       version: '1',


### PR DESCRIPTION
## Summary
- Stamp `manifest.cliVersion` on init / maintain / add-plugin / line add so doctor knows which CLI wrote the harness (`runtimeVersion` stays the 1.0 migration contract).
- When the running CLI is older than that writer, doctor emits a single upgrade error and skips the fake “missing `stages/launch.sh`” findings that blocked launch.
- Prefer a newer repo-local `@osfactory/har` (this checkout or `node_modules/@osfactory/har`) over a stale global install, with a one-line notice.

Closes #344

## Test plan
- [x] `har env verify 4 --full` (typecheck, build, docs, unit tests, lint, docs-drift)
- [x] Doctor fixture with `cliVersion` newer than the CLI yields exactly the version error
- [x] Matching CLI still reports real missing stage files
- [x] Prefer-local picks a newer HAR checkout / `node_modules` and ignores older, equal, or self entries


Made with [Cursor](https://cursor.com)