### PR TITLE
fix(launch): run HARNESS_DB_SEED_CMD per slot for file-backed databases (#345)

### DIFF
--- a/docs/src/content/docs/docs/reference/environment.md
+++ b/docs/src/content/docs/docs/reference/environment.md
@@ -102,7 +102,7 @@ registry and environment. Consumers should never assume the default remains free
 | `HARNESS_TEMPLATE_DB` | Database cloned for each slot |
 | `HARNESS_TEMPLATE_DBS` | Optional logical-name/template pairs for multiple stores |
 | `HARNESS_DB_MIGRATE_CMD` | Idempotent schema command |
-| `HARNESS_DB_SEED_CMD` | Template seed command |
+| `HARNESS_DB_SEED_CMD` | Seed command — once against the Postgres template DB, or once per slot at launch for file-backed databases |
 | `HARNESS_DB_MINIMAL_BOOTSTRAP_CMD` | Optional small per-slot bootstrap |
 | `HARNESS_INFRA_PORT_LANES` | Port lane per service: `<lane>=<default>:<scan_start>-<scan_end>` |
 

--- a/src/runtime/launch.ts
+++ b/src/runtime/launch.ts
@@ -16,6 +16,7 @@ import {
   infraPortDefault,
   HttpRequestFn,
 } from './infra';
+import { planSlotDatabaseSteps } from './slot-database';
 import {
   createSessionWorktree,
   GitRunner,
@@ -358,17 +359,19 @@ export async function launchSession(options: LaunchSessionOptions): Promise<Laun
 
     // Apply the database schema per slot (pre-1.0 launch.sh parity, idempotent)
     // — otherwise schema drift after a code change surfaces as runtime 500s in
-    // the slot instead of a clear launch error. Runs from the work dir with the
-    // slot env sourced, so DATABASE_URL points at the slot's database. "" means
-    // not configured (the #241 migration normalizes the pre-1.0 `true` no-op
-    // sentinel away, so the runtime carries no sentinel special cases).
-    if (pm !== 'simulator' && env.HARNESS_DB_MIGRATE_CMD) {
-      log(`Applying database schema: ${env.HARNESS_DB_MIGRATE_CMD}`);
-      const migrate = exec('bash', [
+    // the slot instead of a clear launch error — then seed file-backed databases
+    // (#345: with a shared Postgres service the template is seeded once instead).
+    // Runs from the work dir with the slot env sourced, so DATABASE_URL points at
+    // the slot's database. "" means not configured (the #241 migration normalizes
+    // the pre-1.0 `true` no-op sentinel away, so the runtime carries no sentinel
+    // special cases).
+    for (const step of planSlotDatabaseSteps(env, pm)) {
+      log(step.label);
+      const result = exec('bash', [
         '-c',
-        `cd ${JSON.stringify(session.workDir)} && set -a && . ${JSON.stringify(session.envFile)} && set +a && eval "$HARNESS_DB_MIGRATE_CMD"`,
+        `cd ${JSON.stringify(session.workDir)} && set -a && . ${JSON.stringify(session.envFile)} && set +a && eval "$${step.envVar}"`,
       ], { env: { ...process.env, ...env } });
-      if (migrate.code !== 0) throw new Error(`database migrate command failed (${migrate.code})`);
+      if (result.code !== 0) throw new Error(`database ${step.what} command failed (${result.code})`);
     }
 
     // ── Per-profile app runtime ────────────────────────────────────────────────

--- a/src/runtime/slot-database.ts
+++ b/src/runtime/slot-database.ts
@@ -1,0 +1,48 @@
+import { infraEnabled } from './infra';
+
+export interface SlotDatabaseStep {
+  /** harness.env variable holding the command; the shell evaluates it with the slot env sourced. */
+  envVar: 'HARNESS_DB_MIGRATE_CMD' | 'HARNESS_DB_SEED_CMD';
+  /** Log line prefix, e.g. `Applying database schema: npx prisma db push`. */
+  label: string;
+  command: string;
+  /** Used in the launch error: `database <what> command failed (<code>)`. */
+  what: 'migrate' | 'seed';
+}
+
+/**
+ * Database steps launch runs per slot, in order (#345).
+ *
+ * - Schema (`HARNESS_DB_MIGRATE_CMD`) always runs per slot: with a shared Postgres
+ *   service the slot database is cloned from the template, but code may have moved
+ *   since the template was built; for file-backed databases it is the only schema step.
+ * - Seeds (`HARNESS_DB_SEED_CMD`) run per slot ONLY when no shared `db` service is
+ *   enabled. With Postgres the template database is seeded once in setup-infra and
+ *   every slot clones it, so seeding again would duplicate rows.
+ *
+ * Simulator profiles have no database. Empty strings mean "not configured".
+ */
+export function planSlotDatabaseSteps(
+  env: Record<string, string>,
+  processManager: string,
+): SlotDatabaseStep[] {
+  if (processManager === 'simulator') return [];
+  const steps: SlotDatabaseStep[] = [];
+  if (env.HARNESS_DB_MIGRATE_CMD) {
+    steps.push({
+      envVar: 'HARNESS_DB_MIGRATE_CMD',
+      label: `Applying database schema: ${env.HARNESS_DB_MIGRATE_CMD}`,
+      command: env.HARNESS_DB_MIGRATE_CMD,
+      what: 'migrate',
+    });
+  }
+  if (env.HARNESS_DB_SEED_CMD && !infraEnabled(env, 'db')) {
+    steps.push({
+      envVar: 'HARNESS_DB_SEED_CMD',
+      label: `Running seeds: ${env.HARNESS_DB_SEED_CMD}`,
+      command: env.HARNESS_DB_SEED_CMD,
+      what: 'seed',
+    });
+  }
+  return steps;
+}

--- a/src/templates/har-boilerplate-cli/harness.env
+++ b/src/templates/har-boilerplate-cli/harness.env
@@ -38,8 +38,13 @@ export HARNESS_ECOSYSTEM="auto"
 # compose file, then list the ones this project needs here (e.g. "db redis").
 export HARNESS_INFRA_SERVICES=""
 
-# Database setup commands (run once against template DB in setup-infra.sh).
-# Empty = not configured; setup-infra.sh skips the step.
+# Database setup commands. Both run from the work dir with the slot env sourced.
+# - MIGRATE runs once against the Postgres template DB (when "db" is in
+#   HARNESS_INFRA_SERVICES) and again per slot at launch, so schema drift after a
+#   code change surfaces as a launch error, not runtime 500s.
+# - SEED runs once against the Postgres template DB (slots clone it), or once per
+#   slot at launch for file-backed databases such as SQLite (#345).
+# Empty = not configured; the step is skipped.
 export HARNESS_DB_MIGRATE_CMD=""
 export HARNESS_DB_SEED_CMD=""
 

--- a/src/templates/har-boilerplate/harness.env
+++ b/src/templates/har-boilerplate/harness.env
@@ -50,8 +50,13 @@ export HARNESS_ECOSYSTEM="auto"
 # list the ones this project needs here (e.g. "db redis mailpit").
 export HARNESS_INFRA_SERVICES="db"
 
-# Database setup commands (run once against template DB in setup-infra.sh).
-# Empty = not configured; setup-infra.sh skips the step.
+# Database setup commands. Both run from the work dir with the slot env sourced.
+# - MIGRATE runs once against the Postgres template DB (when "db" is in
+#   HARNESS_INFRA_SERVICES) and again per slot at launch, so schema drift after a
+#   code change surfaces as a launch error, not runtime 500s.
+# - SEED runs once against the Postgres template DB (slots clone it), or once per
+#   slot at launch for file-backed databases such as SQLite (#345).
+# Empty = not configured; the step is skipped.
 export HARNESS_DB_MIGRATE_CMD=""
 export HARNESS_DB_SEED_CMD=""
 

--- a/tests/slot-database.test.ts
+++ b/tests/slot-database.test.ts
@@ -1,0 +1,31 @@
+import { planSlotDatabaseSteps } from '../src/runtime/slot-database';
+
+/** #345: HARNESS_DB_SEED_CMD must run per slot when no shared db service seeds a template. */
+describe('planSlotDatabaseSteps (#345)', () => {
+  const sqliteEnv = {
+    HARNESS_INFRA_SERVICES: '',
+    HARNESS_DB_MIGRATE_CMD: 'npx prisma db push',
+    HARNESS_DB_SEED_CMD: 'node scripts/seed-dev-data.cjs',
+  };
+
+  it('migrates then seeds a file-backed database at launch', () => {
+    const steps = planSlotDatabaseSteps(sqliteEnv, 'pm2');
+    expect(steps.map((s) => s.what)).toEqual(['migrate', 'seed']);
+    expect(steps[0].label).toBe('Applying database schema: npx prisma db push');
+    expect(steps[1]).toMatchObject({
+      envVar: 'HARNESS_DB_SEED_CMD',
+      label: 'Running seeds: node scripts/seed-dev-data.cjs',
+    });
+  });
+
+  it('does not seed again per slot when the Postgres template is seeded once', () => {
+    const steps = planSlotDatabaseSteps({ ...sqliteEnv, HARNESS_INFRA_SERVICES: 'db redis' }, 'pm2');
+    expect(steps.map((s) => s.what)).toEqual(['migrate']);
+  });
+
+  it('skips unset commands and the simulator profile entirely', () => {
+    expect(planSlotDatabaseSteps({ ...sqliteEnv, HARNESS_DB_SEED_CMD: '' }, 'pm2').map((s) => s.what)).toEqual(['migrate']);
+    expect(planSlotDatabaseSteps({ HARNESS_DB_SEED_CMD: 'seed' }, 'pm2').map((s) => s.what)).toEqual(['seed']);
+    expect(planSlotDatabaseSteps(sqliteEnv, 'simulator')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #345.

## What happened
`HARNESS_DB_SEED_CMD` was only read inside the PostgreSQL template-database branch of setup-infra. A SQLite project (Mission Control's own `control/.har`) that sets it launched with an empty per-slot database and every agent seeded by hand.

## Fix
- `src/runtime/slot-database.ts`: `planSlotDatabaseSteps(env, pm)` yields the per-slot database steps in order — schema (`HARNESS_DB_MIGRATE_CMD`) always, then seeds (`HARNESS_DB_SEED_CMD`) **only when no shared `db` service is enabled**, so Postgres projects keep seeding the template once and cloning it. Simulator profiles get no steps.
- `launch.ts` runs the plan from the work dir with the slot env sourced (same shape as the existing migrate step); a failing step blocks launch with `database seed command failed (<code>)`.
- `harness.env` templates (default + cli) and the environment reference say where each command runs.

## Verification
- `tests/slot-database.test.ts` covers SQLite (migrate → seed), Postgres (`db` enabled → migrate only), unset commands and simulator.
- `har env verify 1 --full` passes on the root harness (typecheck, build, docs check/build, unit tests, lint, readiness, docs-drift, fixture-e2e).
- Integration: launched `control` slot 2 with the built CLI — the log shows `Applying database schema: npx prisma db push` then `Running seeds: node scripts/seed-dev-data.cjs`, and the slot DB holds 3 repositories / 60 runs. Torn down afterwards.
- `har env init --force --profile cli` on a scratch fixture renders the new template comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
