### PR TITLE
fix(work): launch --work-id reopens a decided work unit instead of failing (#352)

### DIFF
--- a/packages/schemas/src/schema.ts
+++ b/packages/schemas/src/schema.ts
@@ -346,6 +346,8 @@ export const WorkUnitRecordSchema = WorkUnitMetadataSchema.extend({
   createdAt: z.string(),
   updatedAt: z.string(),
   outcome: WorkUnitOutcomeSchema.optional(),
+  /** Outcomes cleared by a later `launch --work-id` on the same unit (#352), oldest first. */
+  previousOutcomes: z.array(WorkUnitOutcomeSchema).optional(),
 }).passthrough();
 
 export type WorkUnitRecord = z.infer<typeof WorkUnitRecordSchema>;

--- a/src/core/run-service.ts
+++ b/src/core/run-service.ts
@@ -224,6 +224,8 @@ export class RunService {
       .join('');
     const doctorSummary = summarizeDoctorReport(doctor);
     if (doctorSummary) launchBanner += `WARN: ${doctorSummary}\n`;
+    // Advisory notices produced while binding work (#352); rendered like warnings.
+    const launchNotices: string[] = [];
     if (isTelemetryEnabled() && process.env.NODE_ENV !== 'test') {
       const ensured = await ensureTelemetryInfrastructure({ startIfNeeded: true });
       if (ensured.message) {
@@ -265,6 +267,9 @@ export class RunService {
           blocked: true,
         };
       }
+      // #352: a decided unit (torn down or completed earlier) is reopened by a
+      // new launch — the outcome closed one attempt, not the issue. Say so once.
+      const priorOutcome = findWorkUnit(harnessRoot, workUnitId)?.outcome;
       upsertWorkUnit(harnessRoot, {
         workUnitId,
         source: options.source,
@@ -273,6 +278,12 @@ export class RunService {
         parentWorkUnitId: options.parentWorkUnitId,
         relatedLinks: options.relatedLinks,
       });
+      if (priorOutcome) {
+        const reason = priorOutcome.reason ? `: ${priorOutcome.reason}` : '';
+        launchNotices.push(
+          `Reopened work unit ${workUnitId} (${priorOutcome.decision} ${priorOutcome.decidedAt}${reason})`,
+        );
+      }
       createWorkAttempt(harnessRoot, {
         attemptId,
         workUnitId,
@@ -344,13 +355,17 @@ export class RunService {
           });
         }
       }
+      if (launchNotices.length) {
+        launchBanner += launchNotices.map((notice) => `NOTE: ${notice}\n`).join('');
+      }
       if (launchBanner) {
         envResult.stderr = `${launchBanner}${envResult.stderr ?? ''}`;
       }
-      // Structured copy of the readiness warnings so surfaces can render them
-      // without scraping WARN: lines out of stderr.
-      if (guard.readiness?.warnings?.length) {
-        envResult.warnings = guard.readiness.warnings;
+      // Structured copy of the readiness warnings (and work-binding notices) so
+      // surfaces can render them without scraping lines out of stderr.
+      const warnings = [...(guard.readiness?.warnings ?? []), ...launchNotices];
+      if (warnings.length) {
+        envResult.warnings = warnings;
       }
     }
     return envResult;

--- a/src/core/work-units.ts
+++ b/src/core/work-units.ts
@@ -121,11 +121,6 @@ export function upsertWorkUnit(
   ensureWorkEvidenceIgnored(harnessRoot);
   const existing = findWorkUnit(harnessRoot, metadata.workUnitId);
   if (existing) {
-    if (existing.outcome) {
-      throw new Error(
-        `Work unit ${metadata.workUnitId} is already ${existing.outcome.decision}; reopening is not supported`,
-      );
-    }
     for (const field of ['source', 'sourceUrl', 'title', 'parentWorkUnitId'] as const) {
       if (
         metadata[field] !== undefined &&
@@ -155,7 +150,12 @@ export function upsertWorkUnit(
     version: 1,
     createdAt: existing?.createdAt ?? now,
     updatedAt: now,
-    outcome: existing?.outcome,
+    // A new launch on a decided unit reopens it (#352): a teardown or complete
+    // closed one attempt, not the issue. The old outcome stays on the record.
+    outcome: undefined,
+    previousOutcomes: existing?.outcome
+      ? [...(existing.previousOutcomes ?? []), existing.outcome]
+      : existing?.previousOutcomes,
   });
   writeRecord(
     hashedRecordPath(harnessRoot, WORK_UNITS_DIR, metadata.workUnitId),

--- a/tests/work-units.test.ts
+++ b/tests/work-units.test.ts
@@ -80,6 +80,30 @@ describe('durable work identity', () => {
     );
   });
 
+  it('reopens a decided unit on the next launch and keeps the old outcome (#352)', () => {
+    upsertWorkUnit(repo, { workUnitId: '338', title: 'Phase 2' });
+    decideWorkUnitOutcome(repo, '338', {
+      decision: 'abandoned',
+      decidedAt: '2026-09-03T08:45:00.000Z',
+      reason: 'Session torn down without completion.',
+    });
+    expect(findWorkUnit(repo, '338')?.outcome?.decision).toBe('abandoned');
+
+    const reopened = upsertWorkUnit(repo, { workUnitId: '338' });
+    expect(reopened.outcome).toBeUndefined();
+    expect(reopened.previousOutcomes).toEqual([
+      expect.objectContaining({ decision: 'abandoned', reason: 'Session torn down without completion.' }),
+    ]);
+    expect(reopened.title).toBe('Phase 2');
+
+    // Deciding and reopening again appends, oldest first.
+    decideWorkUnitOutcome(repo, '338', { decision: 'abandoned', decidedAt: '2026-09-03T09:00:00.000Z' });
+    expect(upsertWorkUnit(repo, { workUnitId: '338' }).previousOutcomes?.map((o) => o.decidedAt)).toEqual([
+      '2026-09-03T08:45:00.000Z',
+      '2026-09-03T09:00:00.000Z',
+    ]);
+  });
+
   it('requires completion to reference exact-tree proof', () => {
     upsertWorkUnit(repo, { workUnitId: 'ISSUE-9' });
 


### PR DESCRIPTION
Fixes #352 (split out of #344 point 4).

## What happened
`har env teardown` marks a `--work-id` unit **abandoned**; a later `har env launch --work-id <same>` failed with `Work unit 338 is already abandoned; reopening is not supported`. Hit twice today while working #338 (base-branch switch, then a second PR for the same issue); the workaround (`--work-id 338-history`) splits one issue into two Mission Control work units.

## Fix
- `upsertWorkUnit` reopens a decided unit: `outcome` is cleared and appended to a new `previousOutcomes[]` on the record (`WorkUnitRecordSchema`, oldest first). Metadata immutability rules are unchanged.
- `launchEnvironment` checks the prior outcome and emits one advisory line, in the stderr banner (`NOTE: Reopened work unit 338 (abandoned 2026-09-02T17:29:24.695Z: Session torn down without completion.)`) and in the structured `warnings[]` so MCP shows it too.
- `complete` / `teardown` keep recording outcomes as before. Mission Control's `syncWorkUnits` already writes `outcome: null` when the record has none, so the unit moves back to *active* on the next sync.

## Verification
- `tests/work-units.test.ts`: reopen clears the outcome, keeps the old one, appends on a second reopen, preserves title.
- `har env verify 1 --full` passes on the root harness.
- Integration: with the built CLI, `har env launch 2 --work-id 338` on this repo's `control` harness (unit 338 was abandoned yesterday) launched and printed `⚠ Reopened work unit 338 (abandoned 2026-09-02T17:29:24.695Z: Session torn down without completion.)`; torn down afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
