### PR TITLE
feat(control): legible sessions, cost through attempts and the slot health cell (#339)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,19 @@ jobs:
           CI: true
         run: har env verify 1 --full
 
+      # The verify log only carries the stage summary; the Playwright report and
+      # per-test traces/screenshots are what you need to see why browser-e2e failed.
+      - name: Upload browser-e2e report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mission-control-browser-e2e
+          path: |
+            control/.har/artifacts/browser-e2e/playwright-report
+            control/.har/artifacts/browser-e2e/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Teardown Mission Control harness
         if: always()
         working-directory: control

--- a/control/prisma/schema.prisma
+++ b/control/prisma/schema.prisma
@@ -84,6 +84,8 @@ model AgentSessionUsage {
   tokensCacheCreation BigInt     @default(0)
   tokensTotal         BigInt     @default(0)
   costUsd             Decimal?
+  /// Where costUsd comes from: "reported" by the agent, "estimated" via genai-prices, or null (#339).
+  costSource          String?
   modelBreakdown      Json?
   sources             Json       @default("[]")
   // Harvest generation behind these counters; 0 = pre-dedupe, reads high.

--- a/control/src/app/page.tsx
+++ b/control/src/app/page.tsx
@@ -6,12 +6,14 @@ import { WorktreeGrid, type WorktreeRow } from '@/components/worktree-grid';
 import { attentionItems } from '@/lib/attention';
 import { classifyWorktreeCleanup } from '@/lib/worktree-cleanup-plan';
 import { listSessionWorktrees } from '@/server/repositories';
+import { loadLatestVerifyBySlot } from '@/server/slot-verify';
 import { summarizeUsageForBranch } from '@/server/usage';
 
 export const dynamic = 'force-dynamic';
 
 export default async function NowPage() {
   const slots = await listSessionWorktrees();
+  const latestVerify = await loadLatestVerifyBySlot(slots);
   const rows: WorktreeRow[] = await Promise.all(
     slots.map(async (s) => {
       const usage = await summarizeUsageForBranch(s.repositoryId, s.branch, s.suffix);
@@ -41,7 +43,8 @@ export default async function NowPage() {
         previewUrls: s.previewUrls as Record<string, string> | null,
         harnessUsage: s.harnessUsage,
         lastRunAt: s.lastRunAt,
-        lastVerifyStatus: s.lastVerifyStatus,
+        lastVerifyStatus: latestVerify.get(`${s.repositoryId}:${s.slotId}`)?.status ?? s.lastVerifyStatus,
+        lastVerifyAt: latestVerify.get(`${s.repositoryId}:${s.slotId}`)?.startedAt ?? null,
         lastBuildPass: s.lastBuildPass,
         detachedHead: s.detachedHead,
         dirty: s.dirty,
@@ -54,6 +57,8 @@ export default async function NowPage() {
         agentTools: usage.agentTools,
         usageSources: usage.sources,
         onDisk,
+        // Idle rows fold the cleanup advice into the health sentence (#339).
+        cleanupHint: s.active ? null : cleanup.reason,
       };
     }),
   );

--- a/control/src/app/page.tsx
+++ b/control/src/app/page.tsx
@@ -90,7 +90,7 @@ export default async function NowPage() {
               <CardTitle className="text-base">{item.label}</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className={`text-2xl font-bold tabular-nums ${item.alert ? 'text-amber-500' : ''}`}>
+              <p className={`text-2xl font-bold tabular-nums ${item.alert ? 'text-amber-700 dark:text-amber-400' : ''}`}>
                 {item.value}
               </p>
             </CardContent>

--- a/control/src/app/repos/[id]/page.tsx
+++ b/control/src/app/repos/[id]/page.tsx
@@ -15,6 +15,7 @@ import { listLineBoards } from '@/server/lines';
 import { getSessionHistory } from '@/server/session-history';
 import { getValidationStages } from '@/server/validation-stages';
 import { listArtifactFiles } from '@/server/artifacts';
+import { loadLatestVerifyBySlot } from '@/server/slot-verify';
 import { listSessionUsageForRepo } from '@/server/usage';
 import { timeAgo } from '@/lib/time';
 
@@ -39,6 +40,8 @@ export default async function RepoDetailPage({
       listSessionUsageForRepo(id),
     ]);
   const artifacts = listArtifactFiles(repo.path);
+  // #339: "Verify" reads the latest verify run of each slot's occupancy, never a launch/teardown.
+  const verifyBySlot = await loadLatestVerifyBySlot(repo.slots);
 
   const byDate = new Map<string, { pass: number; fail: number }>();
   for (const point of trendRaw) {
@@ -186,7 +189,8 @@ export default async function RepoDetailPage({
                     previewUrls: s.previewUrls as Record<string, string> | null,
                     harnessUsage: s.harnessUsage,
                     lastRunAt: s.lastRunAt,
-                    lastVerifyStatus: s.lastVerifyStatus,
+                    lastVerifyStatus: verifyBySlot.get(`${id}:${s.slotId}`)?.status ?? s.lastVerifyStatus,
+                    lastVerifyAt: verifyBySlot.get(`${id}:${s.slotId}`)?.startedAt ?? null,
                     lastBuildPass: s.lastBuildPass,
                     detachedHead: s.detachedHead,
                     dirty: s.dirty,

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -8,6 +8,7 @@ import { VerifySummary } from '@/components/verify-summary';
 import { ValidationFlow } from '@/components/validation-flow';
 import { getRepository } from '@/server/repositories';
 import { listSessionEventsForSlot } from '@/server/session-events';
+import { pickDefaultSession } from '@/lib/slot-timeline';
 import { getSlotTimeline } from '@/server/slot-timeline';
 import { getValidationStages } from '@/server/validation-stages';
 
@@ -37,8 +38,8 @@ export default async function SlotDetailPage({
     listSessionEventsForSlot(id, slotId),
   ]);
 
-  // Open the newest agent session so its trajectory is readable without a click.
-  const newestSession = timeline.find((row) => row.kind === 'session');
+  // Open the newest agent session that has content so its trajectory is readable without a click.
+  const newestSession = pickDefaultSession(timeline);
   const previewUrls = (slot.previewUrls ?? null) as Record<string, string> | null;
   const previewEntries = slot.active && previewUrls ? Object.entries(previewUrls) : [];
   const repoName = repo.path.split('/').pop() ?? repo.path;

--- a/control/src/app/usage/page.tsx
+++ b/control/src/app/usage/page.tsx
@@ -21,12 +21,14 @@ export default async function UsagePage() {
     agentTool: row.agentTool,
     tokensTotal: Number(row.tokensTotal),
     costUsd: row.costUsd == null ? null : Number(row.costUsd),
+    costSource: row.costSource,
     sources: row.sources,
     preDedupe: isPreDedupeUsage(row),
     lastSeenAt: row.lastSeenAt,
   }));
 
   const preDedupeCount = rows.filter((row) => row.preDedupe).length;
+  const estimatedCount = rows.filter((row) => row.costSource === 'estimated').length;
 
   return (
     <div className="min-w-0 space-y-6 overflow-x-hidden px-4 py-4 md:px-6 md:py-6">
@@ -74,10 +76,15 @@ export default async function UsagePage() {
         </Card>
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Estimated cost</CardTitle>
+            <CardTitle className="text-base">Cost</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-2xl font-bold tabular-nums">{formatCostUsd(summary.costUsd)}</p>
+            {estimatedCount > 0 ? (
+              <p className="text-xs text-muted-foreground">
+                {estimatedCount} of {rows.filter((row) => row.costUsd != null).length} priced sessions estimated via genai-prices
+              </p>
+            ) : null}
           </CardContent>
         </Card>
         <Card>
@@ -96,7 +103,7 @@ export default async function UsagePage() {
         <CardHeader>
           <CardTitle>Sessions</CardTitle>
           <CardDescription>
-            Paginated usage sessions — search or filter, then open a slot for verify + timeline
+            One row per agent session. Filter by repository, agent or period; click a row to open its slot.
           </CardDescription>
         </CardHeader>
         <CardContent className="min-w-0">

--- a/control/src/components/attempt-record-panel.tsx
+++ b/control/src/components/attempt-record-panel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { AttemptRecordView } from '@/components/attempt-record';
 import { Skeleton } from '@/components/ui/skeleton';
+import { pickDefaultSession } from '@/lib/slot-timeline';
 import type { AttemptRecord } from '@/server/attempt-record';
 
 type State =
@@ -46,6 +47,5 @@ export function AttemptRecordPanel({ repositoryId, occupancyKey }: { repositoryI
   if (state.status === 'error') {
     return <p className="text-sm text-destructive">Could not load the attempt record: {state.message}</p>;
   }
-  const newestSession = state.record.timeline.find((row) => row.kind === 'session');
-  return <AttemptRecordView repositoryId={repositoryId} record={state.record} defaultExpandedId={newestSession?.id ?? null} />;
+  return <AttemptRecordView repositoryId={repositoryId} record={state.record} defaultExpandedId={pickDefaultSession(state.record.timeline)?.id ?? null} />;
 }

--- a/control/src/components/columns/slot-columns.tsx
+++ b/control/src/components/columns/slot-columns.tsx
@@ -7,6 +7,7 @@ import { type ColumnDef } from '@tanstack/react-table';
 
 import { Badge } from '@/components/ui/badge';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { describeSlotHealth, describeSlotVerify, type HealthTone } from '@/lib/slot-health';
 
 export interface SlotRow {
   slotId: number;
@@ -20,6 +21,8 @@ export interface SlotRow {
   harnessUsage: string;
   lastRunAt: Date | null;
   lastVerifyStatus: string | null;
+  /** Start of the latest verify run of the current occupancy (#339). */
+  lastVerifyAt?: Date | null;
   lastBuildPass: boolean | null;
   detachedHead: boolean | null;
   dirty: boolean | null;
@@ -27,55 +30,16 @@ export interface SlotRow {
   behind: number | null;
   stale: boolean | null;
   purpose?: string | null;
+  /** Whether Mission Control can see the worktree path on disk. */
+  onDisk?: boolean;
+  /** Cleanup advice folded into the health sentence for idle worktrees (Now page). */
+  cleanupHint?: string | null;
   /** When set, Slot column links to the detail page. */
   repoId?: string;
   tokensTotal?: number | null;
   costUsd?: number | null;
   agentTools?: string[];
   usageSources?: string[];
-}
-
-function driftLabel(row: SlotRow): string {
-  if (!row.worktreePath) return '';
-  const parts: string[] = [];
-  if (row.detachedHead) parts.push('detached');
-  if (row.dirty) parts.push('dirty');
-  if (row.stale) parts.push(`behind ${row.behind ?? '?'}`);
-  if ((row.ahead ?? 0) > 0) parts.push(`ahead ${row.ahead}`);
-  if (parts.length === 0) return 'fresh';
-  return parts.join(' ');
-}
-
-function driftBadges(row: SlotRow) {
-  if (!row.worktreePath) return <span className="text-muted-foreground">—</span>;
-  const badges = [];
-  if (row.detachedHead) badges.push(<Badge key="detached" variant="destructive">detached</Badge>);
-  if (row.dirty) badges.push(<Badge key="dirty" variant="warning">dirty</Badge>);
-  if (row.stale) {
-    badges.push(
-      <Badge key="stale" variant="warning">
-        behind {row.behind ?? '?'}
-      </Badge>,
-    );
-  }
-  if ((row.ahead ?? 0) > 0) badges.push(<Badge key="ahead" variant="secondary">ahead {row.ahead}</Badge>);
-  if (badges.length === 0) badges.push(<Badge key="fresh" variant="success">fresh</Badge>);
-  return <div className="flex flex-wrap gap-1">{badges}</div>;
-}
-
-function usageBadge(usage: string) {
-  switch (usage) {
-    case 'mcp':
-      return <Badge variant="success">MCP</Badge>;
-    case 'cli':
-      return <Badge variant="default">CLI</Badge>;
-    case 'script':
-      return <Badge variant="secondary">Script</Badge>;
-    case 'bypass_warning':
-      return <Badge variant="warning">Bypass?</Badge>;
-    default:
-      return <Badge variant="outline">None</Badge>;
-  }
 }
 
 function formatTokens(n: number | null | undefined): string {
@@ -92,7 +56,15 @@ function formatCost(n: number | null | undefined): string {
   return `$${n.toFixed(2)}`;
 }
 
-/** Priority: status, purpose, drift, last verify, agent, tokens/cost, then path/preview. */
+// Shades chosen for WCAG AA contrast on both themes (the a11y spec runs axe on Now).
+const TONE_CLASS: Record<HealthTone, string> = {
+  pass: 'text-emerald-700 dark:text-emerald-400',
+  warn: 'text-amber-800 dark:text-amber-400',
+  fail: 'text-red-700 dark:text-red-400',
+  neutral: 'text-muted-foreground',
+};
+
+/** Priority: slot, health, task, verify, agent, cost, preview, branch; tokens and path hidden by default. */
 export const slotColumns: ColumnDef<SlotRow>[] = [
   {
     accessorKey: 'slotId',
@@ -113,9 +85,17 @@ export const slotColumns: ColumnDef<SlotRow>[] = [
     },
   },
   {
-    accessorKey: 'active',
-    header: 'Status',
-    cell: ({ row }) => (row.original.active ? '● Active' : '○ Idle'),
+    id: 'health',
+    accessorFn: (row) => describeSlotHealth(row).text,
+    header: 'Health',
+    cell: ({ row }) => {
+      const health = describeSlotHealth(row.original);
+      return (
+        <span className={`block min-w-[14rem] max-w-sm text-sm ${TONE_CLASS[health.tone]}`} data-testid="slot-health" title={health.text}>
+          {health.text}
+        </span>
+      );
+    },
   },
   {
     id: 'purpose',
@@ -123,7 +103,7 @@ export const slotColumns: ColumnDef<SlotRow>[] = [
     header: 'Task',
     cell: ({ row }) =>
       row.original.purpose ? (
-        <span className="max-w-40 truncate" title={row.original.purpose}>
+        <span className="block max-w-64 truncate" title={row.original.purpose}>
           {row.original.purpose}
         </span>
       ) : (
@@ -131,24 +111,22 @@ export const slotColumns: ColumnDef<SlotRow>[] = [
       ),
   },
   {
-    id: 'drift',
-    accessorFn: (row) => driftLabel(row),
-    header: 'Drift',
-    cell: ({ row }) => driftBadges(row.original),
-  },
-  {
-    accessorKey: 'lastVerifyStatus',
-    header: 'Last verify',
-    cell: ({ row }) =>
-      row.original.lastVerifyStatus ? (
-        <Badge
-          variant={row.original.lastVerifyStatus === 'pass' ? 'success' : 'destructive'}
+    id: 'verify',
+    accessorFn: (row) => row.lastVerifyAt?.getTime() ?? 0,
+    header: 'Verify',
+    cell: ({ row }) => {
+      const verify = describeSlotVerify({ lastVerifyStatus: row.original.lastVerifyStatus, lastVerifyAt: row.original.lastVerifyAt ?? null });
+      return (
+        <span
+          className={`whitespace-nowrap text-sm ${TONE_CLASS[verify.tone]}`}
+          data-testid="slot-verify"
+          title={row.original.lastVerifyAt ? row.original.lastVerifyAt.toLocaleString() : undefined}
+          suppressHydrationWarning
         >
-          {row.original.lastVerifyStatus}
-        </Badge>
-      ) : (
-        '—'
-      ),
+          {verify.text}
+        </span>
+      );
+    },
   },
   {
     id: 'agentTools',
@@ -249,24 +227,6 @@ export const slotColumns: ColumnDef<SlotRow>[] = [
           {branch}
         </span>
       );
-    },
-  },
-  {
-    accessorKey: 'harnessUsage',
-    header: 'Harness',
-    cell: ({ row }) => usageBadge(row.original.harnessUsage),
-  },
-  {
-    accessorKey: 'lastBuildPass',
-    header: 'Build',
-    cell: ({ row }) => {
-      if (row.original.lastBuildPass === true) {
-        return <Badge variant="success">pass</Badge>;
-      }
-      if (row.original.lastBuildPass === false) {
-        return <Badge variant="destructive">fail</Badge>;
-      }
-      return '—';
     },
   },
 ];

--- a/control/src/components/columns/usage-columns.tsx
+++ b/control/src/components/columns/usage-columns.tsx
@@ -17,6 +17,7 @@ export interface UsageRow {
   agentTool: string;
   tokensTotal: number;
   costUsd: number | null;
+  costSource: string | null;
   sources: string[];
   preDedupe: boolean;
   lastSeenAt: Date | string;
@@ -93,7 +94,10 @@ export const usageColumns: ColumnDef<UsageRow>[] = [
     accessorFn: (row) => row.costUsd ?? -1,
     header: 'Cost',
     cell: ({ row }) => (
-      <span className="tabular-nums">{formatCostUsd(row.original.costUsd)}</span>
+      <span className="tabular-nums" title={row.original.costSource === 'estimated' ? 'Estimated from model usage via genai-prices' : row.original.costSource === 'reported' ? 'Reported by the agent' : undefined}>
+        {formatCostUsd(row.original.costUsd)}
+        {row.original.costSource === 'estimated' ? <span className="ml-1 text-[10px] uppercase text-muted-foreground">est.</span> : null}
+      </span>
     ),
   },
   {

--- a/control/src/components/columns/worktree-columns.tsx
+++ b/control/src/components/columns/worktree-columns.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { type ColumnDef } from '@tanstack/react-table';
 
-import { Badge } from '@/components/ui/badge';
 import { slotColumns, type SlotRow } from '@/components/columns/slot-columns';
 import { timeAgo } from '@/lib/time';
 import type { WorktreeCleanupRecommendation } from '@/lib/worktree-cleanup-plan';
@@ -56,69 +55,9 @@ const syncedColumn: ColumnDef<WorktreeRow> = {
   },
 };
 
-const onDiskColumn: ColumnDef<WorktreeRow> = {
-  id: 'onDisk',
-  accessorFn: (row) => (row.onDisk === false ? 0 : 1),
-  header: 'On disk',
-  cell: ({ row }) =>
-    row.original.onDisk === false ? (
-      <Badge variant="outline">missing</Badge>
-    ) : (
-      <Badge variant="secondary">yes</Badge>
-    ),
-};
-
-const CLEANUP_LABEL: Record<WorktreeCleanupRecommendation, string> = {
-  clear_missing: 'Path missing',
-  teardown: 'Safe to tear down',
-  review: 'Needs review',
-  keep: 'Keep',
-};
-
-/** The slot registry can still say "active" after the worktree directory was deleted. When
- *  Mission Control can see that the path is gone, say so instead of showing a healthy state. */
-const statusColumn: ColumnDef<WorktreeRow> = {
-  accessorKey: 'active',
-  header: 'Status',
-  cell: ({ row }) => {
-    if (row.original.onDisk === false) {
-      return (
-        <span title="Registered as active, but the worktree path no longer exists on disk">
-          ● Active · path missing
-        </span>
-      );
-    }
-    return row.original.active ? '● Active' : '○ Idle';
-  },
-};
-
-const cleanupColumn: ColumnDef<WorktreeRow> = {
-  id: 'cleanup',
-  accessorFn: (row) => row.cleanupRecommendation,
-  header: 'Cleanup',
-  cell: ({ row }) => {
-    const rec = row.original.cleanupRecommendation;
-    const variant =
-      rec === 'teardown' || rec === 'clear_missing'
-        ? 'success'
-        : rec === 'review'
-          ? 'warning'
-          : 'secondary';
-    return (
-      <div className="space-y-1">
-        <Badge variant={variant}>{CLEANUP_LABEL[rec]}</Badge>
-        <p className="max-w-xs text-xs text-muted-foreground">{row.original.cleanupReason}</p>
-      </div>
-    );
-  },
-};
-
+/** #339: the Health sentence carries status, drift, on-disk and cleanup advice; no separate columns. */
 export const worktreeColumns: ColumnDef<WorktreeRow>[] = [
   repoColumn,
-  cleanupColumn,
-  onDiskColumn,
-  ...(slotColumns as ColumnDef<WorktreeRow>[]).map((column) =>
-    'accessorKey' in column && column.accessorKey === 'active' ? statusColumn : column,
-  ),
+  ...(slotColumns as ColumnDef<WorktreeRow>[]),
   syncedColumn,
 ];

--- a/control/src/components/slot-grid.tsx
+++ b/control/src/components/slot-grid.tsx
@@ -18,7 +18,7 @@ export function SlotGrid({ slots }: { slots: SlotRow[] }) {
       showPagination={slots.length > 10}
       searchPlaceholder="Search slots…"
       searchAriaLabel="Search slots"
-      columnVisibility={{ harnessUsage: false, lastBuildPass: false, tokens: false, worktree: false }}
+      columnVisibility={{ tokens: false, worktree: false }}
       onRowClick={(slot) => {
         if (!slot.repoId) return;
         router.push(`/repos/${slot.repoId}/slots/${slot.slotId}`);

--- a/control/src/components/slot-timeline.tsx
+++ b/control/src/components/slot-timeline.tsx
@@ -17,6 +17,7 @@ import { formatAgentToolLabel } from '@/lib/agent-tool';
 import {
   TIMELINE_KIND_LABEL,
   describeTimeline,
+  formatDurationShort,
   formatTokenCount,
   summarizeTimeline,
   type TimelineKind,
@@ -24,7 +25,7 @@ import {
   type TimelineTone,
 } from '@/lib/slot-timeline';
 import { formatModelId } from '@/lib/usage-models';
-import { formatDurationMs } from '@/lib/work-unit-state';
+import { formatDuration } from '@/lib/stage-meta';
 
 const KIND_ORDER: TimelineKind[] = ['occupancy', 'session', 'run', 'snapshot', 'commit'];
 
@@ -146,7 +147,7 @@ function RunDetail({ row }: { row: TimelineRow }) {
     <div className="space-y-3" data-testid="timeline-run-detail">
       <dl className="grid gap-3 sm:grid-cols-4">
         <Field label="Result" value={<Badge variant={toneVariant(row.tone)}>{row.status}</Badge>} />
-        <Field label="Duration" value={run.durationMs != null ? formatDurationMs(run.durationMs) : '—'} />
+        <Field label="Duration" value={run.durationMs != null ? formatDurationShort(run.durationMs) : '—'} />
         <Field label="Trigger" value={run.trigger} />
         <Field label="Run id" value={run.runId} mono />
       </dl>
@@ -156,7 +157,7 @@ function RunDetail({ row }: { row: TimelineRow }) {
             <li key={stage.name}>
               <Badge variant={stage.pass ? 'success' : 'destructive'} className="gap-1 font-mono text-[11px]">
                 {stage.pass ? '✓' : '✗'} {stage.name}
-                {stage.ms != null ? <span className="opacity-70">{formatDurationMs(stage.ms)}</span> : null}
+                {stage.ms != null ? <span className="opacity-70">{formatDuration(stage.ms)}</span> : null}
               </Badge>
             </li>
           ))}
@@ -254,9 +255,12 @@ function SessionDetail({ row }: { row: TimelineRow }) {
           label="Models"
           value={session.models.length > 0 ? session.models.map(formatModelId).join(', ') : '—'}
         />
-        <Field label="Duration" value={session.durationMs != null ? formatDurationMs(session.durationMs) : '—'} />
+        <Field label="Duration" value={session.durationMs != null ? formatDurationShort(session.durationMs) : '—'} />
         <Field label="Tokens" value={formatTokenCount(session.tokensTotal)} />
-        <Field label="Cost" value={session.costUsd != null ? `$${session.costUsd.toFixed(4)}` : '—'} />
+        <Field
+          label={session.costSource === 'estimated' ? 'Cost (estimated)' : session.costSource === 'reported' ? 'Cost (agent-reported)' : 'Cost'}
+          value={session.costUsd != null ? `$${session.costUsd.toFixed(4)}` : '—'}
+        />
       </dl>
       <p className="font-mono text-[11px] text-muted-foreground">
         session {session.sessionKey}
@@ -396,7 +400,7 @@ export function SlotTimeline({
         </div>
       ) : null}
 
-      <TrajectoryDrawer repositoryId={repositoryId} />
+      <TrajectoryDrawer repositoryId={repositoryId} sessions={rows} />
 
       <ChangeBatchDiff
         repoId={repositoryId}

--- a/control/src/components/trajectory-drawer.tsx
+++ b/control/src/components/trajectory-drawer.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { TrajectoryViewer } from '@/components/trajectory-viewer';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { describeSession, type TimelineRow } from '@/lib/slot-timeline';
 import type { SerializedTrajectoryPage } from '@/lib/trajectory';
 
 /** URL parameters that address a trajectory (and optionally one turn / tool call) so it can be shared. */
@@ -64,7 +65,7 @@ export function useOpenTrajectory() {
  * opens it, and selecting a turn or tool call updates `trajectoryNode`, so the address
  * bar is always a shareable deep link to what is on screen.
  */
-export function TrajectoryDrawer({ repositoryId }: { repositoryId: string }) {
+export function TrajectoryDrawer({ repositoryId, sessions = [] }: { repositoryId: string; sessions?: TimelineRow[] }) {
   const searchParams = useSearchParams();
   const open = useOpenTrajectory();
   const target = readTrajectoryTarget(new URLSearchParams(searchParams.toString()));
@@ -72,6 +73,13 @@ export function TrajectoryDrawer({ repositoryId }: { repositoryId: string }) {
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const streamKey = target ? `${target.agentId}::${target.sessionKey}::${target.agentTool}` : null;
+  // #339: label the drawer with what the session is — first prompt, then tool · model ·
+  // duration · tokens · cost — instead of the IDE's session id.
+  const sessionRow = target
+    ? sessions.find(
+        (row) => row.kind === 'session' && row.session?.sessionKey === target.sessionKey && row.session.agentTool === target.agentTool,
+      )
+    : undefined;
 
   useEffect(() => {
     if (!target) {
@@ -122,14 +130,25 @@ export function TrajectoryDrawer({ repositoryId }: { repositoryId: string }) {
       >
         <SheetHeader className="space-y-1 pr-8 text-left">
           <div className="flex flex-wrap items-center gap-2">
-            <SheetTitle>Agent trajectory</SheetTitle>
+            <SheetTitle className="max-w-[60ch] truncate" title={sessionRow?.title}>
+              {sessionRow?.session?.firstPrompt ? sessionRow.title : 'Agent trajectory'}
+            </SheetTitle>
             <Button variant="outline" size="sm" onClick={() => void copyLink()} data-testid="trajectory-copy-link">
               {copied ? <Check className="mr-1.5 size-3.5" /> : <Link2 className="mr-1.5 size-3.5" />}
               {copied ? 'Link copied' : 'Copy link'}
             </Button>
           </div>
-          <SheetDescription>
-            {target ? `${formatAgentToolLabel(target.agentTool)} · slot ${target.agentId} · ${target.sessionKey}` : ''}
+          <SheetDescription data-testid="trajectory-session-label">
+            {target
+              ? [
+                  sessionRow ? new Date(sessionRow.at).toLocaleString() : null,
+                  formatAgentToolLabel(target.agentTool),
+                  sessionRow ? describeSession(sessionRow) : null,
+                  `slot ${target.agentId}`,
+                ]
+                  .filter(Boolean)
+                  .join(' · ')
+              : ''}
             {' '}— click a turn or tool call to put it in the link.
           </SheetDescription>
         </SheetHeader>

--- a/control/src/components/usage-table.tsx
+++ b/control/src/components/usage-table.tsx
@@ -7,19 +7,35 @@ import { useRouter } from 'next/navigation';
 import { usageColumns, type UsageRow } from '@/components/columns/usage-columns';
 import { DataTable } from '@/components/data-table/data-table';
 import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { USAGE_PERIODS, filterUsageRows, type UsagePeriodId } from '@/lib/usage-filters';
 import { matchesUsageSearch } from '@/lib/usage-models';
 
 export type { UsageRow };
+
+const ALL = '__all__';
 
 export function UsageTable({ rows }: { rows: UsageRow[] }) {
   const router = useRouter();
   const [globalFilter, setGlobalFilter] = useState('');
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [repositoryId, setRepositoryId] = useState<string>(ALL);
+  const [period, setPeriod] = useState<UsagePeriodId>('all');
 
   const agents = useMemo(
     () => Array.from(new Set(rows.map((row) => row.agentTool).filter(Boolean))).sort(),
     [rows],
+  );
+  const repositories = useMemo(() => {
+    const byId = new Map<string, string>();
+    for (const row of rows) byId.set(row.repositoryId, row.repositoryPath.split('/').pop() ?? row.repositoryPath);
+    return [...byId.entries()].sort((a, b) => a[1].localeCompare(b[1]));
+  }, [rows]);
+
+  const scoped = useMemo(
+    () => filterUsageRows(rows, { repositoryId: repositoryId === ALL ? null : repositoryId, period }),
+    [rows, repositoryId, period],
   );
 
   const activeAgent =
@@ -27,11 +43,11 @@ export function UsageTable({ rows }: { rows: UsageRow[] }) {
     null;
 
   const filteredCount = useMemo(() => {
-    return rows.filter((row) => {
+    return scoped.filter((row) => {
       if (activeAgent && row.agentTool !== activeAgent) return false;
       return matchesUsageSearch(row, globalFilter, formatAgentToolLabel);
     }).length;
-  }, [rows, globalFilter, activeAgent]);
+  }, [scoped, globalFilter, activeAgent]);
 
   if (rows.length === 0) {
     return (
@@ -44,33 +60,65 @@ export function UsageTable({ rows }: { rows: UsageRow[] }) {
 
   return (
     <div className="min-w-0 space-y-3">
-      {agents.length > 1 ? (
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            variant={activeAgent === null ? 'secondary' : 'outline'}
-            size="sm"
-            onClick={() => setColumnFilters([])}
-          >
-            All
-          </Button>
-          {agents.map((agent) => (
+      <div className="flex flex-wrap items-center gap-2">
+        {repositories.length > 1 ? (
+          <Select value={repositoryId} onValueChange={setRepositoryId}>
+            <SelectTrigger className="h-8 w-[14rem] text-xs" aria-label="Filter usage by repository">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All repositories ({repositories.length})</SelectItem>
+              {repositories.map(([id, name]) => (
+                <SelectItem key={id} value={id}>
+                  {name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+        <Select value={period} onValueChange={(value) => setPeriod(value as UsagePeriodId)}>
+          <SelectTrigger className="h-8 w-[11rem] text-xs" aria-label="Filter usage by period">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {USAGE_PERIODS.map((option) => (
+              <SelectItem key={option.id} value={option.id}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {agents.length > 1 ? (
+          <div className="flex flex-wrap items-center gap-1" role="group" aria-label="Filter by agent">
             <Button
-              key={agent}
-              variant={activeAgent === agent ? 'secondary' : 'outline'}
+              variant={activeAgent === null ? 'secondary' : 'outline'}
               size="sm"
-              onClick={() => setColumnFilters([{ id: 'agentTool', value: agent }])}
+              className="h-8"
+              onClick={() => setColumnFilters([])}
             >
-              {formatAgentToolLabel(agent)}
+              All
             </Button>
-          ))}
-        </div>
-      ) : null}
+            {agents.map((agent) => (
+              <Button
+                key={agent}
+                variant={activeAgent === agent ? 'secondary' : 'outline'}
+                size="sm"
+                className="h-8"
+                onClick={() => setColumnFilters([{ id: 'agentTool', value: agent }])}
+              >
+                {formatAgentToolLabel(agent)}
+              </Button>
+            ))}
+          </div>
+        ) : null}
+      </div>
 
       <DataTable
         columns={usageColumns}
-        data={rows}
+        data={scoped}
         getRowId={(row) => row.id}
-        pageSize={10}
+        showPagination={false}
+        maxBodyHeight="60vh"
         searchPlaceholder="Search repository, session, slot, agent…"
         searchAriaLabel="Search usage sessions"
         emptyMessage={

--- a/control/src/components/work-unit-attempts.tsx
+++ b/control/src/components/work-unit-attempts.tsx
@@ -6,6 +6,7 @@ import { AttemptRecordView } from '@/components/attempt-record';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { pickDefaultSession } from '@/lib/slot-timeline';
 import { timeAgo } from '@/lib/time';
 import type { AttemptRecord } from '@/server/attempt-record';
 
@@ -37,7 +38,6 @@ export function WorkUnitAttempts({ repositoryId, records }: { repositoryId: stri
       {records.map((record) => {
         const isOpen = open.has(record.occupancyKey);
         const latest = record.verification?.latestRun ?? null;
-        const newestSession = record.timeline.find((row) => row.kind === 'session');
         return (
           <Collapsible key={record.occupancyKey} open={isOpen} onOpenChange={() => toggle(record.occupancyKey)}>
             <div className="rounded-xl border">
@@ -74,7 +74,7 @@ export function WorkUnitAttempts({ repositoryId, records }: { repositoryId: stri
                   repositoryId={repositoryId}
                   record={record}
                   showWorkUnit={false}
-                  defaultExpandedId={newestSession?.id ?? null}
+                  defaultExpandedId={pickDefaultSession(record.timeline)?.id ?? null}
                 />
               </CollapsibleContent>
             </div>

--- a/control/src/lib/slot-health.test.ts
+++ b/control/src/lib/slot-health.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { describeSlotHealth, describeSlotVerify } from './slot-health';
+
+const base = { active: true, detachedHead: false, dirty: false, ahead: 0, behind: 0, stale: false, baseBranch: 'main', branch: 'feat/x' };
+
+describe('describeSlotHealth (#339)', () => {
+  it('reads as one sentence with the drift facts', () => {
+    expect(describeSlotHealth({ ...base, ahead: 2, behind: 113, stale: true, dirty: true })).toEqual({
+      text: 'Active · 2 commits ahead, 113 behind main, uncommitted changes',
+      tone: 'warn',
+    });
+    expect(describeSlotHealth(base)).toEqual({ text: 'Active · clean', tone: 'pass' });
+    expect(describeSlotHealth({ ...base, ahead: 1, detachedHead: true }).text).toBe('Active · detached HEAD, 1 commit ahead');
+    expect(describeSlotHealth({ ...base, detachedHead: true }).tone).toBe('fail');
+  });
+
+  it('flags a registry that says active while the path is gone', () => {
+    expect(describeSlotHealth({ ...base, onDisk: false })).toEqual({ text: 'Active · worktree path missing on disk', tone: 'fail' });
+  });
+
+  it('describes idle slots by their last branch or cleanup advice', () => {
+    expect(describeSlotHealth({ ...base, active: false })).toEqual({ text: 'Idle · last feat/x', tone: 'neutral' });
+    expect(describeSlotHealth({ ...base, active: false, cleanupHint: 'safe to tear down (14d)' }).text).toBe('Idle · safe to tear down (14d)');
+  });
+});
+
+describe('describeSlotVerify (#339)', () => {
+  const now = new Date('2026-09-03T12:00:00Z');
+  it('names the verify outcome and its age', () => {
+    expect(describeSlotVerify({ lastVerifyStatus: 'pass', lastVerifyAt: '2026-09-03T11:46:00Z', now })).toEqual({ text: 'Verified 14m ago', tone: 'pass' });
+    expect(describeSlotVerify({ lastVerifyStatus: 'fail', lastVerifyAt: '2026-09-03T10:00:00Z', now })).toEqual({ text: 'Verify fail 2h ago', tone: 'fail' });
+    expect(describeSlotVerify({ lastVerifyStatus: 'bypass_warning', lastVerifyAt: null })).toEqual({ text: 'Verify bypassed', tone: 'warn' });
+    expect(describeSlotVerify({ lastVerifyStatus: null, lastVerifyAt: null })).toEqual({ text: 'Not verified', tone: 'neutral' });
+  });
+});

--- a/control/src/lib/slot-health.ts
+++ b/control/src/lib/slot-health.ts
@@ -1,0 +1,81 @@
+import { timeAgo } from '@/lib/time';
+
+export type HealthTone = 'pass' | 'warn' | 'fail' | 'neutral';
+
+export interface SlotHealthInput {
+  active: boolean;
+  onDisk?: boolean;
+  detachedHead: boolean | null;
+  dirty: boolean | null;
+  ahead: number | null;
+  behind: number | null;
+  stale: boolean | null;
+  baseBranch: string | null;
+  branch: string | null;
+  /** Cleanup advice for idle worktrees (Now page); folded into the sentence. */
+  cleanupHint?: string | null;
+}
+
+export interface HealthCell {
+  text: string;
+  tone: HealthTone;
+}
+
+const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+/**
+ * One sentence instead of Status · Drift · Harness · Build · Cleanup columns (#339):
+ * "Active · 2 commits ahead, 113 behind main, uncommitted changes".
+ */
+export function describeSlotHealth(row: SlotHealthInput): HealthCell {
+  if (row.onDisk === false) {
+    return {
+      text: `${row.active ? 'Active' : 'Idle'} · worktree path missing on disk`,
+      tone: row.active ? 'fail' : 'warn',
+    };
+  }
+  if (!row.active) {
+    const hint = row.cleanupHint ? ` · ${row.cleanupHint}` : row.branch ? ` · last ${row.branch}` : '';
+    return { text: `Idle${hint}`, tone: 'neutral' };
+  }
+  const parts: string[] = [];
+  let tone: HealthTone = 'pass';
+  if (row.detachedHead) {
+    parts.push('detached HEAD');
+    tone = 'fail';
+  }
+  if ((row.ahead ?? 0) > 0) parts.push(`${plural(row.ahead!, 'commit')} ahead`);
+  if (row.stale) {
+    parts.push(`${row.behind ?? '?'} behind ${row.baseBranch ?? 'main'}`);
+    if (tone === 'pass') tone = 'warn';
+  }
+  if (row.dirty) {
+    parts.push('uncommitted changes');
+    if (tone === 'pass') tone = 'warn';
+  }
+  return { text: `Active · ${parts.length ? parts.join(', ') : 'clean'}`, tone };
+}
+
+export interface SlotVerifyInput {
+  lastVerifyStatus: string | null;
+  /** Start of the latest *verify* run of the current occupancy — never a launch or teardown. */
+  lastVerifyAt: Date | string | null;
+  now?: Date;
+}
+
+/** "Verified 14 min ago" / "Verify failed 2 h ago" / "Not verified" (#339). */
+export function describeSlotVerify(row: SlotVerifyInput): HealthCell {
+  const when = row.lastVerifyAt ? ` ${timeAgo(row.lastVerifyAt, row.now)}` : '';
+  switch (row.lastVerifyStatus) {
+    case 'pass':
+      return { text: `Verified${when}`, tone: 'pass' };
+    case 'bypass_warning':
+      return { text: `Verify bypassed${when}`, tone: 'warn' };
+    case null:
+    case undefined:
+    case '':
+      return { text: 'Not verified', tone: 'neutral' };
+    default:
+      return { text: `Verify ${row.lastVerifyStatus}${when}`, tone: 'fail' };
+  }
+}

--- a/control/src/lib/slot-timeline.test.ts
+++ b/control/src/lib/slot-timeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildTimelineRows, describeTimeline, summarizeTimeline } from './slot-timeline';
+import { buildTimelineRows, describeSession, describeTimeline, formatDurationShort, pickDefaultSession, summarizeTimeline } from './slot-timeline';
 
 const t = (iso: string) => new Date(iso);
 
@@ -170,5 +170,35 @@ describe('summarizeTimeline', () => {
       sessions: 2, runs: 2, verifyPassed: 1, snapshots: 0, commits: 0, tokensTotal: 1500, costUsd: 1.5,
     });
     expect(describeTimeline(totals)).toBe('2 agent sessions · 2 runs (1 passed) · 0 snapshots · 0 commits · 1.5k tokens · $1.50');
+  });
+});
+
+describe('pickDefaultSession / describeSession (#339)', () => {
+  const session = (key: string, at: string, tokens: number, sources: string[] = []) => ({
+    sessionKey: key, agentTool: 'cursor', agentId: 1, models: ['gpt-5'], tokensTotal: tokens, costUsd: tokens ? 0.004 : null,
+    costSource: tokens ? 'estimated' : null, sources, firstSeenAt: t(at), lastSeenAt: t(at.replace('T10', 'T11')), firstPrompt: null,
+  });
+
+  it('prefers the newest session that has content over a metadata-only stub', () => {
+    const rows = buildTimelineRows({
+      sessions: [session('stub', '2026-09-03T10:00:00Z', 0), session('real', '2026-09-02T10:00:00Z', 900), session('older', '2026-09-01T10:00:00Z', 5)],
+    });
+    expect(pickDefaultSession(rows)?.session?.sessionKey).toBe('real');
+    const trajectoryOnly = buildTimelineRows({ sessions: [session('stub', '2026-09-03T10:00:00Z', 0), session('traj', '2026-09-02T10:00:00Z', 0, ['trajectory'])] });
+    expect(pickDefaultSession(trajectoryOnly)?.session?.sessionKey).toBe('traj');
+    expect(pickDefaultSession(buildTimelineRows({ sessions: [session('only', '2026-09-03T10:00:00Z', 0)] }))?.session?.sessionKey).toBe('only');
+    expect(pickDefaultSession([])).toBeUndefined();
+  });
+
+  it('labels a session with model, duration, tokens and cost provenance', () => {
+    const [row] = buildTimelineRows({ sessions: [session('real', '2026-09-02T10:00:00Z', 900)] });
+    expect(describeSession(row)).toBe('gpt-5 · 1h · 900 tokens · $0.0040 est.');
+  });
+
+  it('formats durations without raw milliseconds', () => {
+    expect(formatDurationShort(400)).toBe('<1s');
+    expect(formatDurationShort(42_000)).toBe('42s');
+    expect(formatDurationShort(125_000)).toBe('2m 5s');
+    expect(formatDurationShort(3_600_000)).toBe('1h');
   });
 });

--- a/control/src/lib/slot-timeline.ts
+++ b/control/src/lib/slot-timeline.ts
@@ -28,6 +28,8 @@ export interface TimelineSessionDetail {
   durationMs: number | null;
   tokensTotal: number;
   costUsd: number | null;
+  /** 'reported' by the agent, 'estimated' via genai-prices, or null when unknown (#339). */
+  costSource: string | null;
   firstPrompt: string | null;
   sources: string[];
 }
@@ -130,6 +132,7 @@ export interface TimelineSessionInput {
   models: string[];
   tokensTotal: number;
   costUsd: number | null;
+  costSource?: string | null;
   sources: string[];
   firstSeenAt: Date;
   lastSeenAt: Date;
@@ -255,6 +258,7 @@ export function buildTimelineRows(input: TimelineInput): TimelineRow[] {
         durationMs: durationMs > 0 ? durationMs : null,
         tokensTotal: session.tokensTotal,
         costUsd: cost,
+        costSource: session.costSource ?? null,
         firstPrompt: session.firstPrompt,
         sources: session.sources,
       },
@@ -409,4 +413,45 @@ export function describeTimeline(totals: TimelineTotals): string {
     parts.push(`${formatTokenCount(totals.tokensTotal)} tokens${totals.costUsd != null ? ` · $${totals.costUsd.toFixed(2)}` : ''}`);
   }
   return parts.join(' · ');
+}
+
+/**
+ * The session to open by default: the newest one that has content — tokens counted or a
+ * trajectory captured — so a metadata-only stub never hides the real session (#339).
+ */
+export function pickDefaultSession(rows: TimelineRow[]): TimelineRow | undefined {
+  const sessions = rows.filter((row) => row.kind === 'session');
+  return (
+    sessions.find((row) => (row.session?.tokensTotal ?? 0) > 0 || row.session?.sources.includes('trajectory')) ??
+    sessions[0]
+  );
+}
+
+/** Compact one-line label for a session (#339): tool · model · duration · tokens · cost. */
+export function describeSession(row: TimelineRow): string {
+  const session = row.session;
+  if (!session) return row.title;
+  const cost =
+    session.costUsd == null
+      ? null
+      : `$${session.costUsd < 0.01 ? session.costUsd.toFixed(4) : session.costUsd.toFixed(2)}${session.costSource === 'estimated' ? ' est.' : ''}`;
+  return [
+    session.models[0] ?? null,
+    session.durationMs != null ? formatDurationShort(session.durationMs) : null,
+    session.tokensTotal > 0 ? `${formatTokenCount(session.tokensTotal)} tokens` : null,
+    cost,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+}
+
+/** Durations in seconds or minutes — never raw milliseconds (#339). */
+export function formatDurationShort(ms: number): string {
+  if (ms < 1000) return '<1s';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return s % 60 ? `${m}m ${s % 60}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  return m % 60 ? `${h}h ${m % 60}m` : `${h}h`;
 }

--- a/control/src/lib/time.ts
+++ b/control/src/lib/time.ts
@@ -4,8 +4,8 @@ const UNITS: Array<[label: string, ms: number]> = [
   ['m', 60 * 1000],
 ];
 
-export function timeAgo(date: Date | string): string {
-  const elapsed = Date.now() - new Date(date).getTime();
+export function timeAgo(date: Date | string, now: Date = new Date()): string {
+  const elapsed = now.getTime() - new Date(date).getTime();
   if (elapsed < 60 * 1000) return 'just now';
   for (const [label, ms] of UNITS) {
     if (elapsed >= ms) return `${Math.floor(elapsed / ms)}${label} ago`;

--- a/control/src/lib/usage-filters.test.ts
+++ b/control/src/lib/usage-filters.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { filterUsageRows } from './usage-filters';
+
+const now = new Date('2026-09-03T12:00:00Z');
+const rows = [
+  { id: 'a', repositoryId: 'r1', lastSeenAt: new Date('2026-09-03T10:00:00Z') },
+  { id: 'b', repositoryId: 'r2', lastSeenAt: new Date('2026-08-30T10:00:00Z') },
+  { id: 'c', repositoryId: 'r1', lastSeenAt: '2026-07-01T10:00:00Z' },
+];
+
+describe('filterUsageRows (#339)', () => {
+  it('keeps everything by default', () => {
+    expect(filterUsageRows(rows, { repositoryId: null, period: 'all', now }).map((r) => r.id)).toEqual(['a', 'b', 'c']);
+  });
+  it('filters by repository and period together', () => {
+    expect(filterUsageRows(rows, { repositoryId: 'r1', period: 'all', now }).map((r) => r.id)).toEqual(['a', 'c']);
+    expect(filterUsageRows(rows, { repositoryId: null, period: '7d', now }).map((r) => r.id)).toEqual(['a', 'b']);
+    expect(filterUsageRows(rows, { repositoryId: 'r1', period: '1d', now }).map((r) => r.id)).toEqual(['a']);
+  });
+});

--- a/control/src/lib/usage-filters.ts
+++ b/control/src/lib/usage-filters.ts
@@ -1,0 +1,26 @@
+/** Repository and period filters of the Cost page (#339); pure so they can be unit-tested. */
+
+interface UsageFilterRow {
+  repositoryId: string;
+  lastSeenAt: Date | string;
+}
+
+/** Period presets for the Cost page (#339). */
+export const USAGE_PERIODS = [
+  { id: 'all', label: 'All time', days: null },
+  { id: '1d', label: 'Last 24 hours', days: 1 },
+  { id: '7d', label: 'Last 7 days', days: 7 },
+  { id: '30d', label: 'Last 30 days', days: 30 },
+] as const;
+export type UsagePeriodId = (typeof USAGE_PERIODS)[number]['id'];
+
+export function filterUsageRows<T extends UsageFilterRow>(rows: T[], filters: { repositoryId: string | null; period: UsagePeriodId; now?: Date }): T[] {
+  const days = USAGE_PERIODS.find((period) => period.id === filters.period)?.days ?? null;
+  const since = days == null ? null : (filters.now ?? new Date()).getTime() - days * 86_400_000;
+  return rows.filter((row) => {
+    if (filters.repositoryId && row.repositoryId !== filters.repositoryId) return false;
+    if (since != null && new Date(row.lastSeenAt).getTime() < since) return false;
+    return true;
+  });
+}
+

--- a/control/src/server/attempt-record.ts
+++ b/control/src/server/attempt-record.ts
@@ -80,7 +80,7 @@ function relatedLinks(value: unknown): WorkUnitRelatedLink[] {
  * attempt owned its work dir: from the attempt start until the next attempt that
  * reused the same work dir on the same slot.
  */
-async function legacyWindow(repositoryId: string, attempt: WorkAttempt) {
+export async function legacyWindow(repositoryId: string, attempt: WorkAttempt) {
   if (!attempt.workDir) return null;
   const next = await prisma.workAttempt.findFirst({
     where: {
@@ -100,9 +100,9 @@ async function legacyWindow(repositoryId: string, attempt: WorkAttempt) {
   };
 }
 
-type Window = NonNullable<Awaited<ReturnType<typeof legacyWindow>>>;
+export type LegacyWindow = NonNullable<Awaited<ReturnType<typeof legacyWindow>>>;
 
-function inWindow(window: Window | null, row: { agentId: number | null; workDir: string | null; at: Date }) {
+export function inWindow(window: LegacyWindow | null, row: { agentId: number | null; workDir: string | null; at: Date }) {
   if (!window) return false;
   if (row.agentId !== window.agentId || row.workDir !== window.workDir) return false;
   if (row.at < window.from) return false;
@@ -124,7 +124,7 @@ export async function getAttemptRecord(repositoryId: string, occupancyKey: strin
   if (!attempt && !slot) return null;
 
   const agentId = attempt?.agentId ?? slot?.slotId ?? null;
-  const window = attempt ? await legacyWindow(repositoryId, attempt) : null;
+  const window: LegacyWindow | null = attempt ? await legacyWindow(repositoryId, attempt) : null;
   const boundValidationIds = attempt?.validationBindings.map((row) => row.validationId) ?? [];
 
   const [runs, snapshots, usageRows, streams] = await Promise.all([

--- a/control/src/server/slot-timeline.ts
+++ b/control/src/server/slot-timeline.ts
@@ -142,6 +142,7 @@ export function sessionInputs(
     models: modelsFromBreakdown(row.modelBreakdown),
     tokensTotal: Number(row.tokensTotal),
     costUsd: row.costUsd == null ? null : Number(row.costUsd),
+    costSource: row.costSource,
     sources: row.sources,
     firstSeenAt: row.firstSeenAt,
     lastSeenAt: row.lastSeenAt,

--- a/control/src/server/slot-verify.test.ts
+++ b/control/src/server/slot-verify.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { latestVerifyBySlot } from './slot-verify';
+
+const t = (iso: string) => new Date(iso);
+const slot = { repositoryId: 'r', slotId: 1, sessionCreatedAt: t('2026-09-01T10:00:00Z'), workDir: '/wt/a', occupancyKey: null };
+const run = (over: Record<string, unknown>) => ({
+  repositoryId: 'r', agentId: 1, stageId: 'verify', status: 'pass', startedAt: t('2026-09-01T11:00:00Z'), workDir: '/wt/a', occupancyKey: null, runId: 'x', ...over,
+});
+
+describe('latestVerifyBySlot (#339)', () => {
+  it('picks the newest verify run of the current occupancy, ignoring other stages', () => {
+    const out = latestVerifyBySlot(
+      [
+        run({ runId: 'teardown', stageId: 'teardown', startedAt: t('2026-09-01T12:00:00Z') }),
+        run({ runId: 'old', startedAt: t('2026-09-01T09:00:00Z'), status: 'fail' }),
+        run({ runId: 'other-dir', workDir: '/wt/b', startedAt: t('2026-09-01T11:30:00Z') }),
+        run({ runId: 'latest', startedAt: t('2026-09-01T11:00:00Z') }),
+        run({ runId: 'earlier', startedAt: t('2026-09-01T10:30:00Z'), status: 'fail' }),
+      ],
+      [slot],
+    );
+    expect(out.get('r:1')).toMatchObject({ runId: 'latest', status: 'pass' });
+  });
+
+  it('uses occupancy keys when both sides carry one', () => {
+    const keyed = { ...slot, occupancyKey: 'attempt::a' };
+    const out = latestVerifyBySlot(
+      [run({ runId: 'prev', occupancyKey: 'attempt::z', startedAt: t('2026-09-01T12:00:00Z') }), run({ runId: 'mine', occupancyKey: 'attempt::a' })],
+      [keyed],
+    );
+    expect(out.get('r:1')?.runId).toBe('mine');
+    expect(latestVerifyBySlot([], [keyed]).size).toBe(0);
+  });
+});

--- a/control/src/server/slot-verify.ts
+++ b/control/src/server/slot-verify.ts
@@ -1,0 +1,48 @@
+import type { AgentSlot, Run } from '@prisma/client';
+import { prisma } from '@/lib/db';
+
+export interface LatestVerify {
+  status: string;
+  startedAt: Date;
+  runId: string;
+}
+
+/** Pure part: newest verify run of each slot's current occupancy (#316, #339). */
+export function latestVerifyBySlot(
+  runs: Array<Pick<Run, 'repositoryId' | 'agentId' | 'stageId' | 'status' | 'startedAt' | 'workDir' | 'occupancyKey' | 'runId'>>,
+  slots: Array<Pick<AgentSlot, 'repositoryId' | 'slotId' | 'sessionCreatedAt' | 'workDir' | 'occupancyKey'>>,
+): Map<string, LatestVerify> {
+  const key = (repositoryId: string, slotId: number) => `${repositoryId}:${slotId}`;
+  const bySlot = new Map(slots.map((slot) => [key(slot.repositoryId, slot.slotId), slot]));
+  const out = new Map<string, LatestVerify>();
+  for (const run of [...runs].sort((a, b) => b.startedAt.getTime() - a.startedAt.getTime())) {
+    if (run.stageId !== 'verify' || run.agentId == null) continue;
+    const k = key(run.repositoryId, run.agentId);
+    if (out.has(k)) continue;
+    const slot = bySlot.get(k);
+    if (!slot) continue;
+    const inOccupancy =
+      slot.occupancyKey && run.occupancyKey
+        ? run.occupancyKey === slot.occupancyKey
+        : (!slot.sessionCreatedAt || run.startedAt >= slot.sessionCreatedAt) &&
+          (!slot.workDir || !run.workDir || run.workDir === slot.workDir);
+    if (!inOccupancy) continue;
+    out.set(k, { status: run.status, startedAt: run.startedAt, runId: run.runId });
+  }
+  return out;
+}
+
+/** Latest verify run per slot, scoped to the current occupancy — "Last verify" must never read a launch or teardown. */
+export async function loadLatestVerifyBySlot(
+  slots: Array<Pick<AgentSlot, 'repositoryId' | 'slotId' | 'sessionCreatedAt' | 'workDir' | 'occupancyKey'>>,
+): Promise<Map<string, LatestVerify>> {
+  const repositoryIds = [...new Set(slots.map((slot) => slot.repositoryId))];
+  if (repositoryIds.length === 0) return new Map();
+  const runs = await prisma.run.findMany({
+    where: { repositoryId: { in: repositoryIds }, stageId: 'verify' },
+    orderBy: { startedAt: 'desc' },
+    take: 100 * repositoryIds.length,
+    select: { repositoryId: true, agentId: true, stageId: true, status: true, startedAt: true, workDir: true, occupancyKey: true, runId: true },
+  });
+  return latestVerifyBySlot(runs, slots);
+}

--- a/control/src/server/usage.ts
+++ b/control/src/server/usage.ts
@@ -88,6 +88,13 @@ function mergeModelBreakdown(
 
 export type UsageUpsertInput = AgentSessionUsage;
 
+/** Provenance of a session's `costUsd` (#339). */
+export type CostSource = 'reported' | 'estimated';
+
+export function toCostSource(value: unknown): CostSource | null {
+  return value === 'reported' || value === 'estimated' ? value : null;
+}
+
 /**
  * Max-merge upsert so OTEL and harvest never double-count cumulative counters,
  * unless a newer `harvestVersion` supersedes the stored row.
@@ -160,6 +167,14 @@ export async function upsertSessionUsage(repositoryId: string, input: UsageUpser
       : new Prisma.Decimal(
           Math.max(Number(reportedCost ?? 0), priced.costUsd) || priced.costUsd,
         );
+  // #339: say where the number comes from. The estimate wins only when it is
+  // higher than what the agent reported, so "estimated" means the row reads high.
+  const costSource: CostSource | null =
+    costUsd == null
+      ? null
+      : priced.costUsd != null && priced.costUsd > Number(reportedCost ?? 0)
+        ? 'estimated'
+        : 'reported';
 
   const fields = {
     agentId: input.agentId,
@@ -175,6 +190,7 @@ export async function upsertSessionUsage(repositoryId: string, input: UsageUpser
     tokensCacheCreation,
     tokensTotal,
     costUsd,
+    costSource,
     // Prisma reads `undefined` as "leave unchanged", so a superseding harvest
     // with no breakdown has to clear the stored one explicitly.
     modelBreakdown: nextModelBreakdown

--- a/control/src/server/work-unit-usage.test.ts
+++ b/control/src/server/work-unit-usage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { selectWorkUnitUsageRows, summarizeWorkUnitUsage } from './work-unit-usage';
+
+const t = (iso: string) => new Date(iso);
+const base = { workUnitId: null, attemptId: null, occupancyKey: null, agentId: 3, workDir: '/wt/a', firstSeenAt: t('2026-09-01T10:30:00Z') };
+
+describe('selectWorkUnitUsageRows (#339)', () => {
+  const attempts = [{ attemptId: 'att-1' }];
+  const windows = [{ agentId: 3, workDir: '/wt/a', from: t('2026-09-01T10:00:00Z'), to: t('2026-09-01T12:00:00Z') }];
+
+  it('takes sessions stamped with the unit, an attempt or an occupancy key', () => {
+    const rows = [
+      { ...base, id: 'unit', workUnitId: '338' },
+      { ...base, id: 'attempt', attemptId: 'att-1' },
+      { ...base, id: 'key', occupancyKey: 'attempt::att-1' },
+      { ...base, id: 'other-unit', workUnitId: '999', attemptId: 'att-9', occupancyKey: 'attempt::att-9' },
+    ];
+    expect(selectWorkUnitUsageRows(rows, '338', attempts, windows).map((r) => r.id)).toEqual(['unit', 'attempt', 'key']);
+  });
+
+  it('recovers unstamped sessions from the attempt work-dir window only', () => {
+    const rows = [
+      { ...base, id: 'in-window' },
+      { ...base, id: 'before', firstSeenAt: t('2026-09-01T09:00:00Z') },
+      { ...base, id: 'after', firstSeenAt: t('2026-09-01T13:00:00Z') },
+      { ...base, id: 'other-dir', workDir: '/wt/b' },
+      { ...base, id: 'other-slot', agentId: 1 },
+    ];
+    expect(selectWorkUnitUsageRows(rows, '338', attempts, windows).map((r) => r.id)).toEqual(['in-window']);
+  });
+});
+
+describe('summarizeWorkUnitUsage', () => {
+  it('sums tokens and cost and reports the cost provenance', () => {
+    expect(
+      summarizeWorkUnitUsage([
+        { tokensTotal: BigInt(1000), costUsd: 1.5, costSource: 'reported' },
+        { tokensTotal: BigInt(500), costUsd: null, costSource: null },
+      ]),
+    ).toEqual({ tokensTotal: BigInt(1500), costUsd: 1.5, costSource: 'reported', sessionCount: 2 });
+    expect(
+      summarizeWorkUnitUsage([
+        { tokensTotal: BigInt(1), costUsd: 1, costSource: 'reported' },
+        { tokensTotal: BigInt(1), costUsd: 2, costSource: 'estimated' },
+      ]).costSource,
+    ).toBe('mixed');
+    expect(summarizeWorkUnitUsage([])).toEqual({ tokensTotal: null, costUsd: null, costSource: null, sessionCount: 0 });
+  });
+});

--- a/control/src/server/work-unit-usage.ts
+++ b/control/src/server/work-unit-usage.ts
@@ -1,0 +1,92 @@
+import type { AgentSessionUsage, Prisma, WorkAttempt } from '@prisma/client';
+import { prisma } from '@/lib/db';
+import { inWindow, legacyWindow, type LegacyWindow } from '@/server/attempt-record';
+import { occupancyKeyForAttempt } from '@/server/occupancy';
+import { toCostSource, type CostSource } from '@/server/usage';
+
+export interface WorkUnitUsage {
+  tokensTotal: bigint | null;
+  costUsd: number | null;
+  /** How the cost was obtained across the unit's sessions. */
+  costSource: CostSource | 'mixed' | null;
+  sessionCount: number;
+}
+
+/** Pure part of the attribution, unit-tested: which usage rows belong to the unit. */
+export function selectWorkUnitUsageRows<T extends Pick<AgentSessionUsage, 'workUnitId' | 'attemptId' | 'occupancyKey' | 'agentId' | 'workDir' | 'firstSeenAt'>>(
+  rows: T[],
+  workUnitId: string,
+  attempts: Array<Pick<WorkAttempt, 'attemptId'>>,
+  windows: LegacyWindow[],
+): T[] {
+  const attemptIds = new Set(attempts.map((attempt) => attempt.attemptId));
+  const keys = new Set(attempts.map((attempt) => occupancyKeyForAttempt(attempt.attemptId)));
+  return rows.filter(
+    (row) =>
+      row.workUnitId === workUnitId ||
+      (row.attemptId != null && attemptIds.has(row.attemptId)) ||
+      (row.occupancyKey != null && keys.has(row.occupancyKey)) ||
+      (row.workUnitId == null &&
+        row.attemptId == null &&
+        row.occupancyKey == null &&
+        windows.some((window) => inWindow(window, { agentId: row.agentId, workDir: row.workDir, at: row.firstSeenAt }))),
+  );
+}
+
+export function summarizeWorkUnitUsage(
+  rows: Array<{ tokensTotal: bigint | number; costUsd: Prisma.Decimal | number | null; costSource: string | null }>,
+): WorkUnitUsage {
+  let tokens = BigInt(0);
+  let cost = 0;
+  let hasCost = false;
+  const sources = new Set<CostSource>();
+  for (const row of rows) {
+    tokens += BigInt(row.tokensTotal);
+    if (row.costUsd != null) {
+      cost += Number(row.costUsd);
+      hasCost = true;
+      const source = toCostSource(row.costSource);
+      if (source) sources.add(source);
+    }
+  }
+  return {
+    tokensTotal: rows.length ? tokens : null,
+    costUsd: hasCost ? cost : null,
+    costSource: sources.size > 1 ? 'mixed' : ([...sources][0] ?? null),
+    sessionCount: rows.length,
+  };
+}
+
+/**
+ * Usage of a work unit through its attempts (#339, #348): sessions stamped with the
+ * unit, an attempt, or an attempt's occupancy key, plus legacy rows that fall in the
+ * window an attempt owned its work dir. `workUnitId` alone misses every session that
+ * OTEL attributed to a slot before the work binding was known.
+ */
+export async function attributeWorkUnitUsage(
+  repositoryId: string,
+  workUnitId: string,
+  attempts: WorkAttempt[],
+): Promise<WorkUnitUsage> {
+  const [rows, windows] = await Promise.all([
+    prisma.agentSessionUsage.findMany({
+      where: {
+        repositoryId,
+        OR: [
+          { workUnitId },
+          ...(attempts.length
+            ? [
+                { attemptId: { in: attempts.map((attempt) => attempt.attemptId) } },
+                { occupancyKey: { in: attempts.map((attempt) => occupancyKeyForAttempt(attempt.attemptId)) } },
+                { workUnitId: null, attemptId: null, occupancyKey: null, agentId: { in: [...new Set(attempts.map((a) => a.agentId))] } },
+              ]
+            : []),
+        ],
+      },
+    }),
+    Promise.all(attempts.map((attempt) => legacyWindow(repositoryId, attempt))).then((list) =>
+      list.filter((window): window is LegacyWindow => window != null),
+    ),
+  ]);
+  return summarizeWorkUnitUsage(selectWorkUnitUsageRows(rows, workUnitId, attempts, windows));
+}

--- a/control/src/server/work-units.ts
+++ b/control/src/server/work-units.ts
@@ -4,6 +4,7 @@ import {
   SyncWorkUnitsInputSchema,
 } from '@har/schemas';
 import { prisma } from '@/lib/db';
+import { attributeWorkUnitUsage } from '@/server/work-unit-usage';
 
 export async function syncWorkUnits(repositoryId: string, input: unknown) {
   const { workUnits, attempts } = SyncWorkUnitsInputSchema.parse(input);
@@ -156,10 +157,7 @@ export async function listFactoryWorkUnits(repositoryId?: string) {
           orderBy: { startedAt: 'desc' },
           take: 100,
         }),
-        prisma.agentSessionUsage.aggregate({
-          where: { repositoryId: unit.repositoryId, workUnitId: unit.workUnitId },
-          _sum: { tokensTotal: true, costUsd: true },
-        }),
+        attributeWorkUnitUsage(unit.repositoryId, unit.workUnitId, unit.attempts),
         prisma.changeBatch.findMany({
           where: {
             repositoryId: unit.repositoryId,
@@ -170,7 +168,7 @@ export async function listFactoryWorkUnits(repositoryId?: string) {
         }),
       ]);
       const slot = slots.find((candidate) => candidate.active) ?? null;
-      return { ...unit, slot, slots, runs, usage: usage._sum, validations };
+      return { ...unit, slot, slots, runs, usage, validations };
     }),
   );
 }

--- a/control/tests/frontend/home.spec.js
+++ b/control/tests/frontend/home.spec.js
@@ -106,8 +106,14 @@ test.describe('Factory and operations', () => {
     expect(href).toBeTruthy();
 
     const row = slotLink.locator('xpath=ancestor::tr[1]');
-    // Click Status cell (non-link) so nested preview/repo links stay intact.
-    await row.getByRole('cell').nth(2).click();
+    // #339: one Health sentence and one Verify cell replace the six status columns.
+    await expect(table.getByRole('columnheader', { name: 'Health' })).toBeVisible();
+    await expect(table.getByRole('columnheader', { name: 'Verify' })).toBeVisible();
+    for (const header of ['Status', 'Drift', 'Last verify', 'Harness', 'Build', 'Cleanup']) {
+      await expect(table.getByRole('columnheader', { name: header, exact: true })).toHaveCount(0);
+    }
+    // Click the Health cell (non-link) so nested preview/repo links stay intact.
+    await row.getByTestId('slot-health').click();
     await page.waitForURL((url) => url.pathname.includes('/slots/'), { timeout: 10_000 });
     expect(new URL(page.url()).pathname).toBe(href);
   });

--- a/control/tests/frontend/session-history.spec.js
+++ b/control/tests/frontend/session-history.spec.js
@@ -11,7 +11,9 @@ async function openHistory(page) {
   const historyTab = page.getByRole('tab', { name: 'History' });
   await expect(historyTab).toBeVisible();
   await historyTab.click();
-  await expect(page.getByTestId('history-how-toggle')).toBeVisible();
+  // The tab is URL-driven, so the History card renders after a server round-trip; give a
+  // cold dev server (first compile) time instead of the 5s default.
+  await expect(page.getByTestId('history-how-toggle')).toBeVisible({ timeout: 20_000 });
 }
 
 test.describe('Repository history', () => {

--- a/control/tests/frontend/usage.spec.js
+++ b/control/tests/frontend/usage.spec.js
@@ -7,7 +7,9 @@ test.describe('Usage page', () => {
     // Summary card titles can also appear as column headers when rows exist.
     await expect(page.getByText('Sessions', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('Tokens', { exact: true }).first()).toBeVisible();
-    await expect(page.getByText('Estimated cost', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Cost', { exact: true }).first()).toBeVisible();
+    // #339: period filter is always offered; repository filter appears with more than one repo.
+    await expect(page.getByRole('combobox', { name: 'Filter usage by period' })).toBeVisible();
 
     const empty = page.getByText(/no usage recorded yet/i);
     const table = page.getByRole('table');


### PR DESCRIPTION
Phase 3 of the **Mission Control redesign** milestone (#339): legible sessions, cost attribution and the slot health cell. Stacked on #350 (which is stacked on #349) — merge those first; this PR's base is #350's branch.

## What changed

**Cost attribution through attempts** (`server/work-unit-usage.ts`)
- A work unit's usage is the union of sessions stamped with the unit, with one of its attempt ids, or with an attempt's occupancy key, plus unstamped sessions that fall in the window an attempt owned its work dir. Before, only `workUnitId` counted, which OTEL rarely knows at ingest time — hence `0.0000 USD` on most units. On the seeded fixture the unit worked in slot 3 now shows $5.69.
- Pure selection and summary are unit-tested.

**Cost provenance**
- `AgentSessionUsage.costSource` = `reported` (agent USD) or `estimated` (genai-prices won because it read higher). Shown in the session detail label, as `est.` on the Cost table, and as a count on the Cost summary card.

**Legible sessions**
- Trajectory drawer: title is the session's first prompt when known; description is `start · tool · model · duration · tokens · cost · slot`, built from the timeline row (deep links keep working — rows are server-rendered).
- Default expanded session is the newest one **with content** (tokens or trajectory), not a metadata-only stub (`pickDefaultSession`).
- The two session counts are already one definition since #346: timeline rows = usage rows ∪ trajectory streams.

**Durations**: seconds/minutes everywhere (`formatDurationShort`); stage badges reuse the verify graph formatter.

**Cost page**: repository and period (24h / 7d / 30d / all) filters; the table scrolls inside the page instead of paginating.

**Slot health cell** (second commit)
- **Health** — one sentence replaces Status · Drift · Harness · Build · Cleanup on the repository Slots table and the Now worktrees table: `Active · 2 commits ahead, 113 behind main, uncommitted changes`, `Active · worktree path missing on disk` (registry says active, path gone), `Idle · safe to tear down (14d)`. Tones meet WCAG AA on both themes (the a11y spec runs axe on Now).
- **Verify** — `Verified 14m ago` / `Verify fail 2h ago` / `Verify bypassed` / `Not verified`, absolute time on hover. Read from the **latest verify run of the slot's current occupancy** (`server/slot-verify.ts`), never the last run of any kind.
- `Bypass?` is gone as a column; it was already an Attention item on Now. Task cell truncates; Tokens and Path stay hidden by default.
- Not done: a "verified but tree changed since" marker needs the worktree's current tree hash, which the status sync does not carry today — left as a note on #339.

## Verification
`har env verify 3 --full` passes on both commits (typecheck, unit tests incl. `work-unit-usage`, `usage-filters`, `slot-timeline`, `slot-health`, `slot-verify`, api-health, lint, readiness, browser-e2e incl. axe, docker-build). `usage.spec.js` asserts the period filter; `home.spec.js` asserts the Health/Verify headers and that the six old headers are gone.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
