### PR TITLE
feat(control): copy-able next commands on the slot page and a Handoff block on live attempts (#340)

### DIFF
--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -3,7 +3,9 @@ import { notFound } from 'next/navigation';
 import { ExternalLinkIcon } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { CopyCommand } from '@/components/copy-command';
 import { SlotTimeline } from '@/components/slot-timeline';
+import { slotCommands } from '@/lib/slot-commands';
 import { VerifySummary } from '@/components/verify-summary';
 import { ValidationFlow } from '@/components/validation-flow';
 import { getRepository } from '@/server/repositories';
@@ -82,6 +84,12 @@ export default async function SlotDetailPage({
           {slot.worktreePath ?? slot.workDir ?? 'No worktree recorded'}
           {!slot.active && slot.worktreePath ? ' · last session' : ''}
         </p>
+        {/* #340: Mission Control cannot run har; offer the exact next commands instead. */}
+        <div className="grid gap-1.5 pt-1 sm:grid-cols-2 xl:grid-cols-4" data-testid="slot-commands">
+          {slotCommands(repo.path, slotId, slot.active).map((entry) => (
+            <CopyCommand key={entry.label} label={entry.label} command={entry.command} />
+          ))}
+        </div>
       </div>
 
       <Card>

--- a/control/src/components/attempt-record.tsx
+++ b/control/src/components/attempt-record.tsx
@@ -2,7 +2,9 @@
 
 import Link from 'next/link';
 import { ExternalLinkIcon } from 'lucide-react';
+import { CopyCommand } from '@/components/copy-command';
 import { SlotTimeline } from '@/components/slot-timeline';
+import { slotCommands } from '@/lib/slot-commands';
 import { Badge } from '@/components/ui/badge';
 import { ValidationFlow } from '@/components/validation-flow';
 import { shortSha } from '@/lib/slot-timeline';
@@ -106,6 +108,24 @@ export function AttemptRecordView({
           )}
         </Fact>
       </dl>
+
+      {attempt.live && attempt.agentId != null && record.repositoryPath ? (
+        <section className="space-y-2" data-testid="attempt-handoff">
+          <h4 className="text-sm font-medium">Handoff</h4>
+          <p className="text-sm text-muted-foreground">
+            {latest?.status === 'pass'
+              ? 'The latest verify passed. Complete keeps the branch and frees the slot; push it and open the PR from your terminal.'
+              : 'Run a full verify first — complete refuses a tree without a passing full validation.'}
+          </p>
+          <div className="grid gap-1.5 sm:grid-cols-2">
+            {slotCommands(record.repositoryPath, attempt.agentId, true)
+              .filter((entry) => entry.label === 'Verify' || entry.label === 'Complete')
+              .map((entry) => (
+                <CopyCommand key={entry.label} label={entry.label} command={entry.command} />
+              ))}
+          </div>
+        </section>
+      ) : null}
 
       <section className="space-y-3">
         <h4 className="text-sm font-medium">Verification</h4>

--- a/control/src/components/copy-command.tsx
+++ b/control/src/components/copy-command.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+/**
+ * One exact shell command with a copy button (#340). Mission Control cannot run
+ * `har` itself — it may be in a container — so the next step is always a command the
+ * developer pastes into their own terminal.
+ */
+export function CopyCommand({ label, command }: { label: string; command: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable: the command is selectable text */
+    }
+  };
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5" data-testid="copy-command">
+      <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
+      <code className="min-w-0 flex-1 truncate font-mono text-xs" title={command}>
+        {command}
+      </code>
+      <Button variant="ghost" size="sm" className="h-6 px-1.5" onClick={() => void copy()} aria-label={`Copy: ${command}`}>
+        {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+      </Button>
+    </div>
+  );
+}

--- a/control/src/lib/slot-commands.test.ts
+++ b/control/src/lib/slot-commands.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { shellQuote, slotCommands } from './slot-commands';
+
+describe('slotCommands (#340)', () => {
+  it('prefills --repo so the command runs from any directory', () => {
+    expect(slotCommands('/home/me/app', 3, true).map((c) => c.command)).toEqual([
+      'har env verify 3 --full --repo /home/me/app',
+      'har env complete 3 --repo /home/me/app',
+      'har env teardown 3 --repo /home/me/app',
+      'har env recover 3 --repo /home/me/app',
+    ]);
+    expect(slotCommands('/home/me/app', 1, false)).toEqual([{ label: 'Launch', command: 'har env launch 1 --repo /home/me/app' }]);
+  });
+  it('quotes paths that need it', () => {
+    expect(shellQuote('/home/me/my app')).toBe("'/home/me/my app'");
+    expect(shellQuote("/it's")).toBe("'/it'\\''s'");
+  });
+});

--- a/control/src/lib/slot-commands.ts
+++ b/control/src/lib/slot-commands.ts
@@ -1,0 +1,17 @@
+/** Exact `har env` commands Mission Control offers to copy (#340). */
+
+/** The `har env` commands that move a slot forward, with `--repo` prefilled so they run from anywhere. */
+export function slotCommands(repoPath: string, slotId: number, active: boolean): Array<{ label: string; command: string }> {
+  const repo = `--repo ${shellQuote(repoPath)}`;
+  if (!active) return [{ label: 'Launch', command: `har env launch ${slotId} ${repo}` }];
+  return [
+    { label: 'Verify', command: `har env verify ${slotId} --full ${repo}` },
+    { label: 'Complete', command: `har env complete ${slotId} ${repo}` },
+    { label: 'Teardown', command: `har env teardown ${slotId} ${repo}` },
+    { label: 'Recover', command: `har env recover ${slotId} ${repo}` },
+  ];
+}
+
+export function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/control/src/server/attempt-record.ts
+++ b/control/src/server/attempt-record.ts
@@ -23,6 +23,8 @@ import { getValidationStages, type ValidationStagesSummary } from '@/server/vali
  */
 export interface AttemptRecord {
   occupancyKey: string;
+  /** Registered repository path — the `--repo` for copy-able commands (#340). */
+  repositoryPath: string | null;
   attempt: {
     attemptId: string | null;
     agentId: number | null;
@@ -112,7 +114,7 @@ export function inWindow(window: LegacyWindow | null, row: { agentId: number | n
 
 export async function getAttemptRecord(repositoryId: string, occupancyKey: string): Promise<AttemptRecord | null> {
   const attemptId = attemptIdFromOccupancyKey(occupancyKey);
-  const [attempt, slot] = await Promise.all([
+  const [attempt, slot, repository] = await Promise.all([
     attemptId
       ? prisma.workAttempt.findUnique({
           where: { repositoryId_attemptId: { repositoryId, attemptId } },
@@ -120,6 +122,7 @@ export async function getAttemptRecord(repositoryId: string, occupancyKey: strin
         })
       : null,
     prisma.agentSlot.findFirst({ where: { repositoryId, occupancyKey } }),
+    prisma.repository.findUnique({ where: { id: repositoryId }, select: { path: true } }),
   ]);
   if (!attempt && !slot) return null;
 
@@ -216,6 +219,7 @@ export async function getAttemptRecord(repositoryId: string, occupancyKey: strin
 
   return {
     occupancyKey,
+    repositoryPath: repository?.path ?? null,
     attempt: {
       attemptId,
       agentId,

--- a/control/tests/frontend/slot-timeline.spec.js
+++ b/control/tests/frontend/slot-timeline.spec.js
@@ -21,10 +21,16 @@ async function openFirstSlot(page, { needSession = false } = {}) {
 
 test.describe('Slot timeline', () => {
   test('slot page collapses to header, verify and one timeline table', async ({ page }) => {
+    // (#340) the header offers the exact next har commands to copy
     if (!(await openFirstSlot(page))) test.skip(true, 'No slot fixture exists');
 
     await expect(page.getByRole('heading', { name: /^Slot \d+/ })).toBeVisible();
     await expect(page.getByTestId('slot-worktree-path')).toBeVisible();
+    // #340: the exact next har commands, --repo prefilled, ready to copy.
+    const commands = page.getByTestId('slot-commands').getByTestId('copy-command');
+    expect(await commands.count()).toBeGreaterThan(0);
+    await expect(commands.first()).toContainText(/har env (verify|launch) \d+/);
+    await expect(commands.first()).toContainText('--repo ');
     await expect(page.getByText('Verify', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('Timeline', { exact: true }).first()).toBeVisible();
 


### PR DESCRIPTION
First slice of #340 (Phase 4 of the **Mission Control redesign** milestone): the parts that need no backend. Stacked on #354 → #350 → #349; this PR's base is #354's branch.

## What changed
- **Slot page header** offers the exact next commands with `--repo <path>` prefilled, each behind a copy button: `har env verify <n> --full`, `complete`, `teardown`, `recover` for an active slot, `launch` for an idle one (`lib/slot-commands.ts`, unit-tested incl. shell quoting).
- **Attempt record** (History detail and work-unit attempts) shows a **Handoff** block for a *live* attempt only: the verify and complete commands plus one line saying whether complete would be accepted (latest verify passed) or a full verify is needed first. Records of finished attempts stay command-free — nothing to act on.
- `AttemptRecord.repositoryPath` carries the registered path for the `--repo` prefix.

Left in #340 for later: tracker/PR links on the Handoff (needs `WorkUnit.sourceUrl`/`relatedLinks` — already shown on the work-unit fact of the record), the local action bridge (a go/no-go decision), and Settings retention inputs.

## Verification
`har env verify 3 --full` passes. `slot-timeline.spec.js` asserts the command row (`har env … --repo`).

Refs #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
