### PR TITLE
feat(control): commands on every slot and work row, plus a work-unit Handoff (#340)

### DIFF
--- a/control/package-lock.json
+++ b/control/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/control",
-  "version": "1.8.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/control",
-      "version": "1.8.0",
+      "version": "1.12.0",
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.6.0",
@@ -66,7 +66,7 @@
     },
     "../packages/schemas": {
       "name": "@har/schemas",
-      "version": "1.8.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.1.5",

--- a/control/src/app/repos/[id]/page.tsx
+++ b/control/src/app/repos/[id]/page.tsx
@@ -179,6 +179,7 @@ export default async function RepoDetailPage({
                   }
                   return {
                     repoId: id,
+                    repoPath: repo.path,
                     slotId: s.slotId,
                     active: s.active,
                     workDir: s.workDir,

--- a/control/src/app/repos/[id]/slots/[slotId]/page.tsx
+++ b/control/src/app/repos/[id]/slots/[slotId]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import type { WorkUnitRelatedLink } from '@har/schemas';
 import { ExternalLinkIcon } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -13,6 +14,7 @@ import { listSessionEventsForSlot } from '@/server/session-events';
 import { pickDefaultSession } from '@/lib/slot-timeline';
 import { getSlotTimeline } from '@/server/slot-timeline';
 import { getValidationStages } from '@/server/validation-stages';
+import { getWorkUnitRef } from '@/server/work-units';
 
 export const dynamic = 'force-dynamic';
 
@@ -34,11 +36,13 @@ export default async function SlotDetailPage({
   // #316 / #348: this page is LIVE data, scoped to the slot's current occupancy. A slot
   // number is reused after complete/teardown; a working session is not. Earlier
   // occupants are records — they live in the repository History and on work units.
-  const [validation, timeline, events] = await Promise.all([
+  const [validation, timeline, events, workUnit] = await Promise.all([
     getValidationStages(id, { agentId: slotId, since: slot.sessionCreatedAt, workDir: slot.workDir }),
     getSlotTimeline(id, slot),
     listSessionEventsForSlot(id, slotId),
+    slot.workUnitId ? getWorkUnitRef(id, slot.workUnitId) : Promise.resolve(null),
   ]);
+  const relatedLinks = (workUnit?.relatedLinks as WorkUnitRelatedLink[] | null) ?? [];
 
   // Open the newest agent session that has content so its trajectory is readable without a click.
   const newestSession = pickDefaultSession(timeline);
@@ -78,6 +82,36 @@ export default async function SlotDetailPage({
           <p className="text-sm" title={slot.purpose}>
             <span className="text-muted-foreground">Task: </span>
             {slot.purpose}
+          </p>
+        ) : null}
+        {workUnit ? (
+          <p className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm" data-testid="slot-work-unit">
+            <Link href={`/work/${workUnit.id}`} className="text-primary underline-offset-2 hover:underline">
+              {workUnit.title ?? workUnit.workUnitId}
+            </Link>
+            {workUnit.sourceUrl ? (
+              <a
+                href={workUnit.sourceUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary underline-offset-2 hover:underline"
+              >
+                {workUnit.source ?? 'tracker'}
+                <ExternalLinkIcon className="size-3" aria-hidden />
+              </a>
+            ) : null}
+            {relatedLinks.map((link) => (
+              <a
+                key={link.url}
+                href={link.url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary underline-offset-2 hover:underline"
+              >
+                {link.label ?? link.source}
+                <ExternalLinkIcon className="size-3" aria-hidden />
+              </a>
+            ))}
           </p>
         ) : null}
         <p className="break-all font-mono text-xs text-muted-foreground" data-testid="slot-worktree-path">
@@ -130,6 +164,8 @@ export default async function SlotDetailPage({
           <SlotTimeline
             repositoryId={id}
             rows={timeline}
+            gitRemote={repo.gitRemote}
+            liveSlotId={slot.active ? slotId : null}
             defaultExpandedId={newestSession?.id ?? null}
             rawEvents={events.map((ev) => ({
               id: ev.id,

--- a/control/src/app/work/[id]/page.tsx
+++ b/control/src/app/work/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import type { WorkUnitRelatedLink } from '@har/schemas';
+import { AttemptHandoff } from '@/components/attempt-handoff';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { WorkUnitAttempts } from '@/components/work-unit-attempts';
@@ -35,6 +36,7 @@ export default async function WorkUnitPage({
   const verified = records.filter((record) => record.verification?.latestRun?.status === 'pass').length;
 
   const relatedLinks = (unit.relatedLinks as WorkUnitRelatedLink[] | null) ?? [];
+  const liveRecord = records.find((record) => record.attempt.live) ?? null;
 
   return (
     <div className="min-w-0 space-y-6 overflow-x-hidden px-4 py-4 md:px-6 md:py-6">
@@ -130,6 +132,21 @@ export default async function WorkUnitPage({
           </CardContent>
         </Card>
       </div>
+
+      {liveRecord ? (
+        <Card className="min-w-0" data-testid="work-unit-handoff">
+          <CardHeader>
+            <CardTitle>Handoff</CardTitle>
+            <CardDescription>
+              The live attempt in slot {liveRecord.attempt.agentId}. Copy the next command — Mission Control
+              cannot run har itself.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <AttemptHandoff record={liveRecord} showHeading={false} />
+          </CardContent>
+        </Card>
+      ) : null}
 
       <Card className="min-w-0">
         <CardHeader>

--- a/control/src/components/attempt-handoff.tsx
+++ b/control/src/components/attempt-handoff.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { ExternalLinkIcon } from 'lucide-react';
+import { CopyCommand } from '@/components/copy-command';
+import { matchingCommit } from '@/lib/handoff';
+import { gitRemoteCommitUrl } from '@/lib/git-remote-url';
+import { slotCommands } from '@/lib/slot-commands';
+import { shortSha } from '@/lib/slot-timeline';
+import type { AttemptRecord } from '@/server/attempt-record';
+
+/**
+ * What a developer copies to finish a *live* attempt (#340): verify + complete,
+ * whether complete would be accepted, the branch, matching commit, and tracker/PR
+ * links. Finished attempts have nothing to act on.
+ */
+export function AttemptHandoff({ record, showHeading = true }: { record: AttemptRecord; showHeading?: boolean }) {
+  const { attempt, workUnit, verification, repositoryPath } = record;
+  if (!attempt.live || attempt.agentId == null || !repositoryPath) return null;
+
+  const latest = verification?.latestRun ?? null;
+  const commit = matchingCommit(record.timeline);
+  const commitUrl = gitRemoteCommitUrl(record.gitRemote, commit?.sha);
+  const links = [
+    ...(workUnit?.sourceUrl
+      ? [{ url: workUnit.sourceUrl, label: workUnit.source ?? 'tracker' }]
+      : []),
+    ...(workUnit?.relatedLinks ?? []).map((link) => ({
+      url: link.url,
+      label: link.label ?? link.source,
+    })),
+  ];
+
+  return (
+    <section className="space-y-2" data-testid="attempt-handoff">
+      {showHeading ? <h4 className="text-sm font-medium">Handoff</h4> : null}
+      <p className="text-sm text-muted-foreground">
+        {latest?.status === 'pass'
+          ? 'The latest verify passed. Complete keeps the branch and frees the slot; push it and open the PR from your terminal.'
+          : 'Run a full verify first — complete refuses a tree without a passing full validation.'}
+      </p>
+      <dl className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+        <div>
+          <dt className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Branch</dt>
+          <dd className="mt-0.5">
+            {attempt.branch ? (
+              <code className="font-mono text-xs">{attempt.branch}</code>
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Matching commit</dt>
+          <dd className="mt-0.5">
+            {commit ? (
+              commitUrl ? (
+                <a
+                  href={commitUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 font-mono text-xs text-primary underline-offset-2 hover:underline"
+                  data-testid="handoff-commit"
+                >
+                  {shortSha(commit.sha)}
+                  <ExternalLinkIcon className="size-3" aria-hidden />
+                </a>
+              ) : (
+                <code className="font-mono text-xs" data-testid="handoff-commit">
+                  {shortSha(commit.sha)}
+                </code>
+              )
+            ) : (
+              <span className="text-muted-foreground">No commit recorded yet</span>
+            )}
+          </dd>
+        </div>
+        {links.length > 0 ? (
+          <div>
+            <dt className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Tracker / PR</dt>
+            <dd className="mt-0.5 flex flex-wrap gap-x-3 gap-y-1">
+              {links.map((link) => (
+                <a
+                  key={link.url}
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-primary underline-offset-2 hover:underline"
+                  data-testid="handoff-link"
+                >
+                  {link.label}
+                  <ExternalLinkIcon className="size-3" aria-hidden />
+                </a>
+              ))}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+      <div className="grid gap-1.5 sm:grid-cols-2">
+        {slotCommands(repositoryPath, attempt.agentId, true)
+          .filter((entry) => entry.label === 'Verify' || entry.label === 'Complete')
+          .map((entry) => (
+            <CopyCommand key={entry.label} label={entry.label} command={entry.command} />
+          ))}
+      </div>
+    </section>
+  );
+}

--- a/control/src/components/attempt-record.tsx
+++ b/control/src/components/attempt-record.tsx
@@ -2,9 +2,8 @@
 
 import Link from 'next/link';
 import { ExternalLinkIcon } from 'lucide-react';
-import { CopyCommand } from '@/components/copy-command';
+import { AttemptHandoff } from '@/components/attempt-handoff';
 import { SlotTimeline } from '@/components/slot-timeline';
-import { slotCommands } from '@/lib/slot-commands';
 import { Badge } from '@/components/ui/badge';
 import { ValidationFlow } from '@/components/validation-flow';
 import { shortSha } from '@/lib/slot-timeline';
@@ -29,11 +28,14 @@ export function AttemptRecordView({
   repositoryId,
   record,
   showWorkUnit = true,
+  showHandoff = true,
   defaultExpandedId = null,
 }: {
   repositoryId: string;
   record: AttemptRecord;
   showWorkUnit?: boolean;
+  /** History keeps the Handoff on the record; the work-unit page lifts it into its own card. */
+  showHandoff?: boolean;
   defaultExpandedId?: string | null;
 }) {
   const { attempt, workUnit, verification } = record;
@@ -109,23 +111,7 @@ export function AttemptRecordView({
         </Fact>
       </dl>
 
-      {attempt.live && attempt.agentId != null && record.repositoryPath ? (
-        <section className="space-y-2" data-testid="attempt-handoff">
-          <h4 className="text-sm font-medium">Handoff</h4>
-          <p className="text-sm text-muted-foreground">
-            {latest?.status === 'pass'
-              ? 'The latest verify passed. Complete keeps the branch and frees the slot; push it and open the PR from your terminal.'
-              : 'Run a full verify first — complete refuses a tree without a passing full validation.'}
-          </p>
-          <div className="grid gap-1.5 sm:grid-cols-2">
-            {slotCommands(record.repositoryPath, attempt.agentId, true)
-              .filter((entry) => entry.label === 'Verify' || entry.label === 'Complete')
-              .map((entry) => (
-                <CopyCommand key={entry.label} label={entry.label} command={entry.command} />
-              ))}
-          </div>
-        </section>
-      ) : null}
+      {showHandoff ? <AttemptHandoff record={record} /> : null}
 
       <section className="space-y-3">
         <h4 className="text-sm font-medium">Verification</h4>
@@ -156,6 +142,8 @@ export function AttemptRecordView({
         <SlotTimeline
           repositoryId={repositoryId}
           rows={record.timeline}
+          gitRemote={record.gitRemote}
+          liveSlotId={attempt.live ? attempt.agentId : null}
           defaultExpandedId={defaultExpandedId}
           emptyMessage="Nothing recorded for this attempt yet."
         />

--- a/control/src/components/columns/slot-columns.tsx
+++ b/control/src/components/columns/slot-columns.tsx
@@ -5,9 +5,11 @@ import { ExternalLinkIcon } from 'lucide-react';
 import Link from 'next/link';
 import { type ColumnDef } from '@tanstack/react-table';
 
+import { CopyCommandButtons } from '@/components/copy-command';
 import { Badge } from '@/components/ui/badge';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
 import { describeSlotHealth, describeSlotVerify, type HealthTone } from '@/lib/slot-health';
+import { slotCommands } from '@/lib/slot-commands';
 
 export interface SlotRow {
   slotId: number;
@@ -36,6 +38,8 @@ export interface SlotRow {
   cleanupHint?: string | null;
   /** When set, Slot column links to the detail page. */
   repoId?: string;
+  /** Registered repository path — `--repo` for copy-able next commands (#340). */
+  repoPath?: string;
   tokensTotal?: number | null;
   costUsd?: number | null;
   agentTools?: string[];
@@ -175,6 +179,17 @@ export const slotColumns: ColumnDef<SlotRow>[] = [
         {row.original.worktreePath ?? row.original.workDir ?? '—'}
       </span>
     ),
+  },
+  {
+    id: 'next',
+    accessorFn: (row) => (row.repoPath ? slotCommands(row.repoPath, row.slotId, row.active).map((c) => c.command).join(' ') : ''),
+    header: 'Next',
+    enableSorting: false,
+    cell: ({ row }) => {
+      const path = row.original.repoPath;
+      if (!path) return <span className="text-muted-foreground">—</span>;
+      return <CopyCommandButtons commands={slotCommands(path, row.original.slotId, row.original.active)} />;
+    },
   },
   {
     id: 'preview',

--- a/control/src/components/columns/work-unit-columns.tsx
+++ b/control/src/components/columns/work-unit-columns.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import Link from 'next/link';
+import { ExternalLinkIcon } from 'lucide-react';
 import { type ColumnDef } from '@tanstack/react-table';
 
+import { CopyCommandButtons } from '@/components/copy-command';
 import { Badge } from '@/components/ui/badge';
+import { slotCommands } from '@/lib/slot-commands';
 import { timeAgo } from '@/lib/time';
 import { formatDurationMs, type WorkUnitState } from '@/lib/work-unit-state';
 
@@ -40,9 +43,23 @@ export const workUnitColumns: ColumnDef<WorkRow>[] = [
     header: 'Work unit',
     cell: ({ row }) => (
       <div className="min-w-0 max-w-md">
-        <Link href={`/work/${row.original.id}`} className="block truncate font-medium underline-offset-2 hover:underline" title={row.original.title ?? row.original.workUnitId}>
-          {row.original.title ?? row.original.workUnitId}
-        </Link>
+        <span className="flex items-center gap-1.5">
+          <Link href={`/work/${row.original.id}`} className="block truncate font-medium underline-offset-2 hover:underline" title={row.original.title ?? row.original.workUnitId}>
+            {row.original.title ?? row.original.workUnitId}
+          </Link>
+          {row.original.sourceUrl ? (
+            <a
+              href={row.original.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              title={row.original.sourceUrl}
+              className="shrink-0 text-muted-foreground hover:text-primary"
+              aria-label="Open tracker"
+            >
+              <ExternalLinkIcon className="size-3" />
+            </a>
+          ) : null}
+        </span>
         {row.original.title && (
           <span className="font-mono text-xs text-muted-foreground">{row.original.workUnitId}</span>
         )}
@@ -90,6 +107,19 @@ export const workUnitColumns: ColumnDef<WorkRow>[] = [
       if (cost == null || cost === 0) return <span className="text-muted-foreground">—</span>;
       return <span className="tabular-nums">${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}</span>;
     },
+  },
+  {
+    id: 'next',
+    accessorFn: (row) =>
+      row.activeSlotId != null ? slotCommands(row.repoPath, row.activeSlotId, true).map((c) => c.command).join(' ') : '',
+    header: 'Next',
+    enableSorting: false,
+    cell: ({ row }) =>
+      row.original.activeSlotId != null ? (
+        <CopyCommandButtons commands={slotCommands(row.original.repoPath, row.original.activeSlotId, true)} />
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
   },
   {
     accessorKey: 'updatedAt',

--- a/control/src/components/copy-command.tsx
+++ b/control/src/components/copy-command.tsx
@@ -4,6 +4,16 @@ import { useState } from 'react';
 import { Check, Copy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
+async function writeClipboard(command: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(command);
+    return true;
+  } catch {
+    /* clipboard unavailable: the command is selectable text */
+    return false;
+  }
+}
+
 /**
  * One exact shell command with a copy button (#340). Mission Control cannot run
  * `har` itself — it may be in a container — so the next step is always a command the
@@ -12,13 +22,9 @@ import { Button } from '@/components/ui/button';
 export function CopyCommand({ label, command }: { label: string; command: string }) {
   const [copied, setCopied] = useState(false);
   const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      /* clipboard unavailable: the command is selectable text */
-    }
+    if (!(await writeClipboard(command))) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
   };
   return (
     <div className="flex min-w-0 items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5" data-testid="copy-command">
@@ -29,6 +35,40 @@ export function CopyCommand({ label, command }: { label: string; command: string
       <Button variant="ghost" size="sm" className="h-6 px-1.5" onClick={() => void copy()} aria-label={`Copy: ${command}`}>
         {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
       </Button>
+    </div>
+  );
+}
+
+/**
+ * Compact label-only copy buttons for table cells (#340). The full command lives
+ * in the title and accessible name so a row stays one line.
+ */
+export function CopyCommandButtons({ commands }: { commands: Array<{ label: string; command: string }> }) {
+  const [copied, setCopied] = useState<string | null>(null);
+  if (commands.length === 0) return <span className="text-muted-foreground">—</span>;
+  return (
+    <div className="flex flex-wrap gap-1" data-testid="slot-commands">
+      {commands.map((entry) => (
+        <Button
+          key={entry.label}
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          title={entry.command}
+          aria-label={`Copy: ${entry.command}`}
+          onClick={() => {
+            void writeClipboard(entry.command).then((ok) => {
+              if (!ok) return;
+              setCopied(entry.command);
+              setTimeout(() => setCopied((current) => (current === entry.command ? null : current)), 1500);
+            });
+          }}
+        >
+          {copied === entry.command ? <Check className="size-3" /> : null}
+          {entry.label}
+        </Button>
+      ))}
     </div>
   );
 }

--- a/control/src/components/slot-timeline.tsx
+++ b/control/src/components/slot-timeline.tsx
@@ -14,11 +14,13 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { formatAgentToolLabel } from '@/lib/agent-tool';
+import { gitRemoteCommitUrl } from '@/lib/git-remote-url';
 import {
   TIMELINE_KIND_LABEL,
   describeTimeline,
   formatDurationShort,
   formatTokenCount,
+  shortSha,
   summarizeTimeline,
   type TimelineKind,
   type TimelineRow,
@@ -141,8 +143,26 @@ function Field({ label, value, mono = false }: { label: string; value: React.Rea
   );
 }
 
-function RunDetail({ row }: { row: TimelineRow }) {
+function RunDetail({
+  row,
+  repositoryId,
+  liveSlotId,
+}: {
+  row: TimelineRow;
+  repositoryId: string;
+  liveSlotId: number | null;
+}) {
   const run = row.run!;
+  const slotLink =
+    liveSlotId != null && row.agentId === liveSlotId ? (
+      <Link
+        href={`/repos/${repositoryId}/slots/${liveSlotId}`}
+        className="text-xs text-primary underline-offset-2 hover:underline"
+        data-testid="timeline-run-slot"
+      >
+        Open slot {liveSlotId}
+      </Link>
+    ) : null;
   return (
     <div className="space-y-3" data-testid="timeline-run-detail">
       <dl className="grid gap-3 sm:grid-cols-4">
@@ -151,6 +171,7 @@ function RunDetail({ row }: { row: TimelineRow }) {
         <Field label="Trigger" value={run.trigger} />
         <Field label="Run id" value={run.runId} mono />
       </dl>
+      {slotLink}
       {run.stages.length > 0 ? (
         <ul className="flex flex-wrap gap-1.5" aria-label="Stage results">
           {run.stages.map((stage) => (
@@ -169,9 +190,20 @@ function RunDetail({ row }: { row: TimelineRow }) {
   );
 }
 
-function SnapshotDetail({ row, repositoryId, onOpenDiff }: { row: TimelineRow; repositoryId: string; onOpenDiff: (row: TimelineRow) => void }) {
+function SnapshotDetail({
+  row,
+  repositoryId,
+  gitRemote,
+  onOpenDiff,
+}: {
+  row: TimelineRow;
+  repositoryId: string;
+  gitRemote: string | null;
+  onOpenDiff: (row: TimelineRow) => void;
+}) {
   const snapshot = row.snapshot!;
   const files = snapshot.changedFiles;
+  const commitUrl = gitRemoteCommitUrl(gitRemote, snapshot.commitSha);
   return (
     <div className="space-y-3" data-testid="timeline-snapshot-detail">
       <dl className="grid gap-3 sm:grid-cols-4">
@@ -180,7 +212,25 @@ function SnapshotDetail({ row, repositoryId, onOpenDiff }: { row: TimelineRow; r
         <Field label="Branch" value={snapshot.branch ?? '—'} mono />
         <Field
           label="Commit"
-          value={snapshot.commitSha ? snapshot.commitSha.slice(0, 7) : 'not committed'}
+          value={
+            snapshot.commitSha ? (
+              commitUrl ? (
+                <a
+                  href={commitUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline-offset-2 hover:underline"
+                  data-testid="timeline-commit-host"
+                >
+                  {shortSha(snapshot.commitSha)}
+                </a>
+              ) : (
+                shortSha(snapshot.commitSha)
+              )
+            ) : (
+              'not committed'
+            )
+          }
           mono
         />
       </dl>
@@ -214,12 +264,31 @@ function SnapshotDetail({ row, repositoryId, onOpenDiff }: { row: TimelineRow; r
   );
 }
 
-function CommitDetail({ row }: { row: TimelineRow }) {
+function CommitDetail({ row, gitRemote }: { row: TimelineRow; gitRemote: string | null }) {
   const commit = row.commit!;
+  const commitUrl = gitRemoteCommitUrl(gitRemote, commit.sha);
   return (
     <div className="space-y-3" data-testid="timeline-commit-detail">
       <dl className="grid gap-3 sm:grid-cols-3">
-        <Field label="Commit" value={commit.sha} mono />
+        <Field
+          label="Commit"
+          value={
+            commitUrl ? (
+              <a
+                href={commitUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary underline-offset-2 hover:underline"
+                data-testid="timeline-commit-host"
+              >
+                {commit.sha}
+              </a>
+            ) : (
+              commit.sha
+            )
+          }
+          mono
+        />
         <Field label="Tree hash" value={commit.treeHash} mono />
         <Field label="Branch" value={commit.branch ?? (commit.refs[0] ?? '—')} mono />
       </dl>
@@ -306,6 +375,10 @@ export interface SlotTimelineProps {
   searchPlaceholder?: string;
   /** Row opened on first render, e.g. the newest agent session so its trajectory is visible without a click. */
   defaultExpandedId?: string | null;
+  /** Git remote for snapshot/commit links on the code host (#340). */
+  gitRemote?: string | null;
+  /** Only a live occupancy may link a run back to its slot (#340 / #348). */
+  liveSlotId?: number | null;
 }
 
 export function SlotTimeline({
@@ -316,6 +389,8 @@ export function SlotTimeline({
   emptyMessage = 'Nothing recorded yet. Runs, snapshots, commits and agent sessions appear here as they happen.',
   searchPlaceholder = 'Search timeline…',
   defaultExpandedId = null,
+  gitRemote = null,
+  liveSlotId = null,
 }: SlotTimelineProps) {
   const [expandedId, setExpandedId] = useState<string | null>(defaultExpandedId);
   const [kinds, setKinds] = useState<Set<TimelineKind>>(() => new Set(KIND_ORDER));
@@ -330,11 +405,11 @@ export function SlotTimeline({
   const renderExpanded = (row: TimelineRow) => {
     switch (row.kind) {
       case 'run':
-        return <RunDetail row={row} />;
+        return <RunDetail row={row} repositoryId={repositoryId} liveSlotId={liveSlotId} />;
       case 'snapshot':
-        return <SnapshotDetail row={row} repositoryId={repositoryId} onOpenDiff={setDiffRow} />;
+        return <SnapshotDetail row={row} repositoryId={repositoryId} gitRemote={gitRemote} onOpenDiff={setDiffRow} />;
       case 'commit':
-        return <CommitDetail row={row} />;
+        return <CommitDetail row={row} gitRemote={gitRemote} />;
       case 'occupancy':
         return <OccupancyDetail row={row} />;
       case 'session':

--- a/control/src/components/work-unit-attempts.tsx
+++ b/control/src/components/work-unit-attempts.tsx
@@ -74,6 +74,7 @@ export function WorkUnitAttempts({ repositoryId, records }: { repositoryId: stri
                   repositoryId={repositoryId}
                   record={record}
                   showWorkUnit={false}
+                  showHandoff={false}
                   defaultExpandedId={pickDefaultSession(record.timeline)?.id ?? null}
                 />
               </CollapsibleContent>

--- a/control/src/lib/git-remote-url.test.ts
+++ b/control/src/lib/git-remote-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { gitRemoteBrowseUrl } from './git-remote-url';
+import { gitRemoteBrowseUrl, gitRemoteCommitUrl } from './git-remote-url';
 
 describe('gitRemoteBrowseUrl', () => {
   it('keeps https remotes and strips .git', () => {
@@ -18,5 +18,27 @@ describe('gitRemoteBrowseUrl', () => {
     expect(gitRemoteBrowseUrl(null)).toBeNull();
     expect(gitRemoteBrowseUrl('')).toBeNull();
     expect(gitRemoteBrowseUrl('file:///tmp/repo')).toBeNull();
+  });
+});
+
+describe('gitRemoteCommitUrl (#340)', () => {
+  it('points GitHub and GitLab remotes at /commit/<sha>', () => {
+    expect(gitRemoteCommitUrl('https://github.com/os-factory/har.git', 'abc1234')).toBe(
+      'https://github.com/os-factory/har/commit/abc1234',
+    );
+    expect(gitRemoteCommitUrl('git@gitlab.com:acme/app.git', 'def5678')).toBe(
+      'https://gitlab.com/acme/app/commit/def5678',
+    );
+  });
+
+  it('points Bitbucket remotes at /commits/<sha>', () => {
+    expect(gitRemoteCommitUrl('git@bitbucket.org:acme/app.git', 'abc1234')).toBe(
+      'https://bitbucket.org/acme/app/commits/abc1234',
+    );
+  });
+
+  it('returns null without a remote or sha', () => {
+    expect(gitRemoteCommitUrl(null, 'abc')).toBeNull();
+    expect(gitRemoteCommitUrl('https://github.com/os-factory/har.git', null)).toBeNull();
   });
 });

--- a/control/src/lib/git-remote-url.ts
+++ b/control/src/lib/git-remote-url.ts
@@ -24,3 +24,19 @@ export function gitRemoteBrowseUrl(remote: string | null | undefined): string | 
 
   return null;
 }
+
+/** Browser URL for a commit on the code host (#340). */
+export function gitRemoteCommitUrl(remote: string | null | undefined, sha: string | null | undefined): string | null {
+  if (!sha) return null;
+  const base = gitRemoteBrowseUrl(remote);
+  if (!base) return null;
+  const host = (() => {
+    try {
+      return new URL(base).hostname;
+    } catch {
+      return '';
+    }
+  })();
+  if (host.includes('bitbucket.org')) return `${base}/commits/${sha}`;
+  return `${base}/commit/${sha}`;
+}

--- a/control/src/lib/handoff.test.ts
+++ b/control/src/lib/handoff.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { matchingCommit } from './handoff';
+import { buildTimelineRows } from './slot-timeline';
+
+const t = (iso: string) => new Date(iso);
+
+describe('matchingCommit (#340)', () => {
+  it('prefers the newest verified-tree commit', () => {
+    const timeline = buildTimelineRows({
+      snapshots: [
+        {
+          validationId: 'v1',
+          treeHash: 'tree-1',
+          branch: 'feature',
+          agentId: 1,
+          status: 'pass',
+          full: true,
+          runId: null,
+          changedFiles: [],
+          commitSha: 'aaaaaaaaaaaaaaaa',
+          committedAt: t('2026-09-01T10:00:00Z'),
+          createdAt: t('2026-09-01T10:00:00Z'),
+        },
+      ],
+      commits: [
+        {
+          commitSha: 'bbbbbbbbbbbbbbbb',
+          treeHash: 'tree-2',
+          message: 'wip',
+          refs: [],
+          branch: 'feature',
+          agentId: 1,
+          at: t('2026-09-01T09:00:00Z'),
+        },
+      ],
+    });
+    expect(matchingCommit(timeline)).toEqual({ sha: 'aaaaaaaaaaaaaaaa', branch: 'feature' });
+  });
+
+  it('falls back to the newest commit when none is verified', () => {
+    const timeline = buildTimelineRows({
+      snapshots: [
+        {
+          validationId: 'v1',
+          treeHash: 'tree-1',
+          branch: 'wip',
+          agentId: 1,
+          status: 'fail',
+          full: true,
+          runId: null,
+          changedFiles: [],
+          commitSha: 'cccccccccccccccc',
+          committedAt: t('2026-09-01T10:00:00Z'),
+          createdAt: t('2026-09-01T10:00:00Z'),
+        },
+      ],
+    });
+    expect(matchingCommit(timeline)).toEqual({ sha: 'cccccccccccccccc', branch: 'wip' });
+  });
+
+  it('returns null when the attempt has no commit', () => {
+    expect(matchingCommit([])).toBeNull();
+  });
+});

--- a/control/src/lib/handoff.ts
+++ b/control/src/lib/handoff.ts
@@ -1,0 +1,18 @@
+import type { TimelineRow } from '@/lib/slot-timeline';
+
+export interface MatchingCommit {
+  sha: string;
+  branch: string | null;
+}
+
+/**
+ * The commit a live attempt can hand off: prefer the newest verified-tree
+ * commit, otherwise the newest commit on the timeline (#340).
+ */
+export function matchingCommit(timeline: TimelineRow[]): MatchingCommit | null {
+  const commits = timeline.filter((row) => row.kind === 'commit' && row.commit);
+  const verified = commits.find((row) => row.status === 'Verified tree');
+  const row = verified ?? commits[0];
+  if (!row?.commit) return null;
+  return { sha: row.commit.sha, branch: row.commit.branch ?? row.branch };
+}

--- a/control/src/server/attempt-record.ts
+++ b/control/src/server/attempt-record.ts
@@ -25,6 +25,8 @@ export interface AttemptRecord {
   occupancyKey: string;
   /** Registered repository path — the `--repo` for copy-able commands (#340). */
   repositoryPath: string | null;
+  /** Git remote, so Handoff and timeline rows can link a commit on the code host (#340). */
+  gitRemote: string | null;
   attempt: {
     attemptId: string | null;
     agentId: number | null;
@@ -122,7 +124,7 @@ export async function getAttemptRecord(repositoryId: string, occupancyKey: strin
         })
       : null,
     prisma.agentSlot.findFirst({ where: { repositoryId, occupancyKey } }),
-    prisma.repository.findUnique({ where: { id: repositoryId }, select: { path: true } }),
+    prisma.repository.findUnique({ where: { id: repositoryId }, select: { path: true, gitRemote: true } }),
   ]);
   if (!attempt && !slot) return null;
 
@@ -220,6 +222,7 @@ export async function getAttemptRecord(repositoryId: string, occupancyKey: strin
   return {
     occupancyKey,
     repositoryPath: repository?.path ?? null,
+    gitRemote: repository?.gitRemote ?? null,
     attempt: {
       attemptId,
       agentId,

--- a/control/src/server/work-units.ts
+++ b/control/src/server/work-units.ts
@@ -186,3 +186,11 @@ export async function getFactoryWorkUnitById(id: string) {
   if (!record) return null;
   return getFactoryWorkUnit(record.repositoryId, record.workUnitId);
 }
+
+/** Lightweight work-unit facts for slot headers (tracker / PR links, #340). */
+export async function getWorkUnitRef(repositoryId: string, workUnitId: string) {
+  return prisma.workUnit.findUnique({
+    where: { repositoryId_workUnitId: { repositoryId, workUnitId } },
+    select: { id: true, workUnitId: true, title: true, source: true, sourceUrl: true, relatedLinks: true },
+  });
+}

--- a/control/tests/frontend/factory-work-unit.spec.js
+++ b/control/tests/frontend/factory-work-unit.spec.js
@@ -36,5 +36,21 @@ test.describe('Factory work unit detail', () => {
 
     // Repository card links into Mission Control repo pages.
     await expect(page.locator('a[href^="/repos/"]').first()).toBeVisible();
+
+    // #340: a live attempt gets a Handoff card (verify + complete, tracker links). Finished
+    // units stay command-free.
+    const handoff = page.getByTestId('work-unit-handoff');
+    if (await handoff.count()) {
+      await expect(handoff.getByTestId('attempt-handoff')).toBeVisible();
+      await expect(handoff.getByTestId('copy-command').first()).toContainText(/har env (verify|complete) \d+/);
+      await expect(handoff.getByTestId('copy-command').first()).toContainText('--repo ');
+    }
+  });
+
+  test('Work table exposes next commands on a live slot', async ({ page }) => {
+    await page.goto('/work');
+    const next = page.getByTestId('slot-commands').first();
+    if ((await next.count()) === 0) test.skip(true, 'No live work-unit slot in this environment');
+    await expect(next.getByRole('button').first()).toHaveAttribute('aria-label', /Copy: har env /);
   });
 });

--- a/control/tests/frontend/home.spec.js
+++ b/control/tests/frontend/home.spec.js
@@ -109,6 +109,11 @@ test.describe('Factory and operations', () => {
     // #339: one Health sentence and one Verify cell replace the six status columns.
     await expect(table.getByRole('columnheader', { name: 'Health' })).toBeVisible();
     await expect(table.getByRole('columnheader', { name: 'Verify' })).toBeVisible();
+    // #340: every slot row offers the exact next har commands to copy.
+    await expect(table.getByRole('columnheader', { name: 'Next' })).toBeVisible();
+    const next = table.getByTestId('slot-commands').first();
+    await expect(next).toBeVisible();
+    await expect(next.getByRole('button').first()).toHaveAttribute('aria-label', /Copy: har env (verify|launch) \d+/);
     for (const header of ['Status', 'Drift', 'Last verify', 'Harness', 'Build', 'Cleanup']) {
       await expect(table.getByRole('columnheader', { name: header, exact: true })).toHaveCount(0);
     }

--- a/control/tests/frontend/slot-timeline.spec.js
+++ b/control/tests/frontend/slot-timeline.spec.js
@@ -31,6 +31,11 @@ test.describe('Slot timeline', () => {
     expect(await commands.count()).toBeGreaterThan(0);
     await expect(commands.first()).toContainText(/har env (verify|launch) \d+/);
     await expect(commands.first()).toContainText('--repo ');
+    // #340: a bound slot links to its work unit (and the tracker when one exists).
+    const workUnit = page.getByTestId('slot-work-unit');
+    if (await workUnit.count()) {
+      await expect(workUnit.locator('a[href^="/work/"]').first()).toBeVisible();
+    }
     await expect(page.getByText('Verify', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('Timeline', { exact: true }).first()).toBeVisible();
 

--- a/packages/schemas/package-lock.json
+++ b/packages/schemas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@har/schemas",
-  "version": "1.8.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@har/schemas",
-      "version": "1.8.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pydantic/genai-prices": "^0.1.5",


### PR DESCRIPTION
## Summary
- Second slice of #340 after #355: every Now / repo-slot / Work row copies the exact next `har env` command with `--repo` prefilled.
- A live work unit gets a **Handoff** card (latest verify, branch, matching commit, tracker/PR links, verify + complete).
- Timeline rows link a live run back to its slot and a snapshot/commit to the SHA on the code host; the slot page links to the bound work unit.

Left in #340: the local action-bridge go/no-go, and Settings retention inputs.

## Test plan
- [x] `har env verify 1 --full` (control harness) — typecheck, unit tests, lint, browser-e2e, docker-build
- [ ] On Now, copy Verify / Complete from an active slot row and confirm `--repo` is the registered path
- [ ] Open a live work unit and check the Handoff card (commands, branch, matching commit, tracker link)
- [ ] Open a bound slot and confirm the work-unit + tracker links in the header
- [ ] Expand a snapshot/commit on a repo with `gitRemote` set and confirm the code-host commit link

Refs #340


Made with [Cursor](https://cursor.com)